### PR TITLE
Move health and offerings routes from definitions to instances

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -47,6 +47,7 @@
 | GET | /api/tenants/:tenantId/agents/instances/:instanceId | Get instance detail |
 | DELETE | /api/tenants/:tenantId/agents/instances/:instanceId | Stop an instance |
 | GET | /api/tenants/:tenantId/agents/instances/:instanceId/health | Get instance health |
+| GET | /api/tenants/:tenantId/agents/instances/:instanceId/offerings | List instance offerings |
 | GET | /api/tenants/:tenantId/agents/instances/:instanceId/events | SSE event stream |
 | POST | /api/tenants/:tenantId/agents/instances/:instanceId/abort | Abort current operation |
 | POST | /api/tenants/:tenantId/agents/instances/:instanceId/mail | Send mail to the agent |
@@ -532,6 +533,14 @@ Returns liveness and readiness for a running instance. Liveness reflects whether
 200: AgentHealth -- Health status
 404: ErrorResponse -- Instance not found
 410: ErrorResponse -- Instance stopped
+
+### GET /api/tenants/:tenantId/agents/instances/:instanceId/offerings
+List instance offerings
+
+Returns the offerings associated with the instance's agent definition. These represent the capabilities the instance can provide.
+
+200: OfferingDetail[] -- List of offerings
+404: ErrorResponse -- Instance not found
 
 ### GET /api/tenants/:tenantId/agents/instances/:instanceId/events
 SSE event stream

--- a/docs/API.md
+++ b/docs/API.md
@@ -40,8 +40,6 @@
 | DELETE | /api/tenants/:tenantId/agents/definitions/:agentId | Retire an agent |
 | GET | /api/tenants/:tenantId/agents/definitions/:agentId/versions | List agent versions |
 | POST | /api/tenants/:tenantId/agents/definitions/:agentId/rollback | Rollback to a previous version |
-| GET | /api/tenants/:tenantId/agents/definitions/:agentId/health | Get agent health status |
-| GET | /api/tenants/:tenantId/agents/definitions/:agentId/offerings | List agent offerings |
 | POST | /api/tenants/:tenantId/agents/instances | Deploy an agent instance |
 | GET | /api/tenants/:tenantId/agents/instances | List agent instances |
 | GET | /api/tenants/:tenantId/agents/instances/:instanceId | Get instance detail |
@@ -468,21 +466,6 @@ Body: RollbackRequest
 
 200: AgentResponse -- Rollback initiated
 400: ErrorResponse -- Invalid version
-
-### GET /api/tenants/:tenantId/agents/definitions/:agentId/health
-Get agent health status
-
-Returns liveness and readiness status.
-
-200: AgentHealth -- Health status
-404: ErrorResponse -- Agent not found
-
-### GET /api/tenants/:tenantId/agents/definitions/:agentId/offerings
-List agent offerings
-
-Returns the agent's exposed offerings with pricing metadata.
-
-200: Offering[] -- List of offerings
 
 ## Instances
 
@@ -1073,10 +1056,6 @@ Source: packages/types/src/models.ts
 ### OAuthClientResponse
 `{ createdAt: string, id: string, name: string, providerId: string, tenantId: string, updatedAt: string, defaultScopes?: string[] | null, metadata?: { [string]: unknown } | null, redirectUris?: string[] | null }`
 Source: packages/types/src/oauth-clients.ts
-
-### Offering
-`{ agentId: string, id: string, name: string, description?: string | null, pricing?: { base?: { amount: string, currency: string }, bounds?: { max?: string, min?: string }, methods?: string[], negotiable?: boolean } }`
-Source: packages/types/src/agents.ts
 
 ### OfferingDetail
 `{ agentId: string, agentName: string, id: string, name: string, tenantId: string, description?: string | null, pricing?: { base?: { amount: string, currency: string }, bounds?: { max?: string, min?: string }, methods?: string[], negotiable?: boolean }, schema?: { [string]: unknown } | null }`

--- a/docs/API.md
+++ b/docs/API.md
@@ -46,6 +46,7 @@
 | GET | /api/tenants/:tenantId/agents/instances | List agent instances |
 | GET | /api/tenants/:tenantId/agents/instances/:instanceId | Get instance detail |
 | DELETE | /api/tenants/:tenantId/agents/instances/:instanceId | Stop an instance |
+| GET | /api/tenants/:tenantId/agents/instances/:instanceId/health | Get instance health |
 | GET | /api/tenants/:tenantId/agents/instances/:instanceId/events | SSE event stream |
 | POST | /api/tenants/:tenantId/agents/instances/:instanceId/abort | Abort current operation |
 | POST | /api/tenants/:tenantId/agents/instances/:instanceId/mail | Send mail to the agent |
@@ -522,6 +523,15 @@ Stops the running instance and undeploys the agent from the sidecar.
 404: ErrorResponse -- Instance not found
 409: ErrorResponse -- Instance already stopped
 502: ErrorResponse -- Sidecar unavailable
+
+### GET /api/tenants/:tenantId/agents/instances/:instanceId/health
+Get instance health
+
+Returns liveness and readiness for a running instance. Liveness reflects whether the instance's sidecar connection is active. Readiness reflects whether the instance has an active event collector and can process work.
+
+200: AgentHealth -- Health status
+404: ErrorResponse -- Instance not found
+410: ErrorResponse -- Instance stopped
 
 ### GET /api/tenants/:tenantId/agents/instances/:instanceId/events
 SSE event stream

--- a/packages/hub/src/app.ts
+++ b/packages/hub/src/app.ts
@@ -26,7 +26,7 @@ import { agentDataRoutes } from "./routes/agent-data";
 import { createSidecarRoutes } from "./routes/sidecars";
 
 import { type DB, createGrantStore } from "@interchange/db";
-import type { ConditionRegistry } from "@interchange/types/authz";
+import type { ConditionRegistry, GrantStore } from "@interchange/types/authz";
 import { timeWindowEvaluator } from "@interchange/authz";
 import type { SessionService } from "./session-service";
 import type { SidecarRouter } from "./ws/sidecar-handler";
@@ -38,6 +38,7 @@ export type CreateAppOpts = {
   sidecarRouter: SidecarRouter;
   sessionService: SessionService;
   eventCollectors: EventCollectorRegistry;
+  grantStore?: GrantStore;
   sidecarWsHandler?: Handler<AppEnv>;
 };
 
@@ -47,10 +48,11 @@ export function createApp({
   sidecarRouter,
   sessionService,
   eventCollectors,
+  grantStore: externalGrantStore,
   sidecarWsHandler,
 }: CreateAppOpts) {
   const app = new Hono<AppEnv>();
-  const grantStore = createGrantStore(db);
+  const grantStore = externalGrantStore ?? createGrantStore(db);
   const conditionRegistry: ConditionRegistry = {
     time_window: timeWindowEvaluator,
   };

--- a/packages/hub/src/routes/agents.ts
+++ b/packages/hub/src/routes/agents.ts
@@ -13,9 +13,7 @@ import {
   UpdateAgent,
   AgentResponse,
   AgentVersion,
-  AgentHealth,
   RollbackRequest,
-  Offering,
   ErrorResponse,
   paginatedSchema,
 } from "@interchange/types";
@@ -690,92 +688,6 @@ app.post(
 
     const roles = await loadAgentRoles(db, updated.id, tenantCtx.id);
     return c.json(formatAgent(updated, roles));
-  },
-);
-
-app.get(
-  "/:agentId/health",
-  requireGrant(idResource("agent", "agentId"), "read"),
-  describeRoute({
-    tags: ["Agents"],
-    summary: "Get agent health status",
-    description: "Returns liveness and readiness status.",
-    responses: {
-      200: {
-        description: "Health status",
-        content: {
-          "application/json": { schema: resolver(AgentHealth) },
-        },
-      },
-      404: {
-        description: "Agent not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const agentId = c.req.param("agentId");
-    const db = c.get("db");
-
-    const row = await db.query.agent.findFirst({
-      where: and(eq(agent.id, agentId), eq(agent.tenantId, tenantCtx.id)),
-    });
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Agent not found" } },
-        404,
-      );
-    }
-
-    // Placeholder health -- in production this would query the agent kernel
-    return c.json({
-      liveness: row.status === "deployed" ? "ok" : "unhealthy",
-      readiness: row.status === "deployed" ? "ok" : "not_ready",
-      lastCheckedAt: null,
-    });
-  },
-);
-
-app.get(
-  "/:agentId/offerings",
-  requireGrant(idResource("agent", "agentId"), "read"),
-  describeRoute({
-    tags: ["Agents"],
-    summary: "List agent offerings",
-    description: "Returns the agent's exposed offerings with pricing metadata.",
-    responses: {
-      200: {
-        description: "List of offerings",
-        content: {
-          "application/json": {
-            schema: resolver(Offering.array()),
-          },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const agentId = c.req.param("agentId");
-    const db = c.get("db");
-
-    const row = await db.query.agent.findFirst({
-      where: and(eq(agent.id, agentId), eq(agent.tenantId, tenantCtx.id)),
-    });
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Agent not found" } },
-        404,
-      );
-    }
-
-    // Offerings are stored as jsonb -- return empty array if none
-    return c.json([]);
   },
 );
 

--- a/packages/hub/src/routes/instances.test.ts
+++ b/packages/hub/src/routes/instances.test.ts
@@ -249,3 +249,117 @@ describe("instance route test infrastructure", () => {
     expect(res.status).toBe(403);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Health endpoint tests
+// ---------------------------------------------------------------------------
+
+describe("GET /agents/instances/:instanceId/health", () => {
+  test("returns ok/ok when address is routable and collector exists", async () => {
+    const app = createTestApp({
+      routableAddresses: [ADDRESS],
+      collectorStatuses: new Map([[ADDRESS, { status: "idle" }]]),
+    });
+
+    const res = await app.request(`${instanceURL()}/health`);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      liveness: "ok",
+      readiness: "ok",
+      lastCheckedAt: null,
+    });
+  });
+
+  test("returns unhealthy/not_ready when not routable and no collector", async () => {
+    const app = createTestApp({
+      routableAddresses: [],
+      collectorStatuses: new Map(),
+    });
+
+    const res = await app.request(`${instanceURL()}/health`);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      liveness: "unhealthy",
+      readiness: "not_ready",
+      lastCheckedAt: null,
+    });
+  });
+
+  test("returns ok/not_ready when routable but no collector", async () => {
+    const app = createTestApp({
+      routableAddresses: [ADDRESS],
+      collectorStatuses: new Map(),
+    });
+
+    const res = await app.request(`${instanceURL()}/health`);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      liveness: "ok",
+      readiness: "not_ready",
+      lastCheckedAt: null,
+    });
+  });
+
+  test("returns unhealthy/ok when not routable but collector exists", async () => {
+    const app = createTestApp({
+      routableAddresses: [],
+      collectorStatuses: new Map([[ADDRESS, { status: "busy" }]]),
+    });
+
+    const res = await app.request(`${instanceURL()}/health`);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      liveness: "unhealthy",
+      readiness: "ok",
+      lastCheckedAt: null,
+    });
+  });
+
+  test("returns 404 when instance does not exist", async () => {
+    const app = createTestApp({
+      db: {
+        tenant: testTenant,
+        principal: testPrincipal,
+        instance: undefined,
+        agent: testAgent,
+      },
+    });
+
+    const res = await app.request(`${instanceURL()}/health`);
+    expect(res.status).toBe(404);
+
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("not_found");
+  });
+
+  test("returns 410 when instance is stopped", async () => {
+    const stoppedInstance = {
+      ...testInstance,
+      status: "stopped" as const,
+      endedAt: new Date("2025-06-01"),
+    };
+
+    const app = createTestApp({
+      db: {
+        tenant: testTenant,
+        principal: testPrincipal,
+        instance: stoppedInstance,
+        agent: testAgent,
+      },
+    });
+
+    const res = await app.request(`${instanceURL()}/health`);
+    expect(res.status).toBe(410);
+
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("gone");
+  });
+});

--- a/packages/hub/src/routes/instances.test.ts
+++ b/packages/hub/src/routes/instances.test.ts
@@ -363,3 +363,150 @@ describe("GET /agents/instances/:instanceId/health", () => {
     expect(body.error.code).toBe("gone");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Offerings endpoint tests
+// ---------------------------------------------------------------------------
+
+describe("GET /agents/instances/:instanceId/offerings", () => {
+  test("returns offerings for the instance's agent definition", async () => {
+    const offerings = [
+      {
+        id: "off_1",
+        agentId: AGENT_ID,
+        tenantId: TENANT_ID,
+        name: "Translation",
+        description: "Translate text",
+        pricing: { base: { amount: "10", currency: "USD" } },
+        schema: null,
+        createdAt: new Date("2025-01-01"),
+        updatedAt: new Date("2025-01-01"),
+      },
+      {
+        id: "off_2",
+        agentId: AGENT_ID,
+        tenantId: TENANT_ID,
+        name: "Summarization",
+        description: null,
+        pricing: null,
+        schema: null,
+        createdAt: new Date("2025-01-02"),
+        updatedAt: new Date("2025-01-02"),
+      },
+    ];
+
+    const app = createTestApp({
+      db: {
+        tenant: testTenant,
+        principal: testPrincipal,
+        instance: testInstance,
+        agent: testAgent,
+        offerings,
+      },
+    });
+
+    const res = await app.request(`${instanceURL()}/offerings`);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      id: string;
+      agentId: string;
+      agentName: string;
+      name: string;
+    }[];
+    expect(body).toHaveLength(2);
+
+    const first = body[0];
+    const second = body[1];
+    if (!first || !second) throw new Error("expected two offerings");
+
+    expect(first.id).toBe("off_1");
+    expect(first.agentName).toBe("Test Agent");
+    expect(first.name).toBe("Translation");
+    expect(second.id).toBe("off_2");
+    expect(second.name).toBe("Summarization");
+  });
+
+  test("returns empty array when no offerings exist", async () => {
+    const app = createTestApp({
+      db: {
+        tenant: testTenant,
+        principal: testPrincipal,
+        instance: testInstance,
+        agent: testAgent,
+        offerings: [],
+      },
+    });
+
+    const res = await app.request(`${instanceURL()}/offerings`);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  test("returns 404 when instance does not exist", async () => {
+    const app = createTestApp({
+      db: {
+        tenant: testTenant,
+        principal: testPrincipal,
+        instance: undefined,
+        agent: undefined,
+      },
+    });
+
+    const res = await app.request(`${instanceURL()}/offerings`);
+    expect(res.status).toBe(404);
+
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("not_found");
+  });
+
+  test("returns offerings for stopped instances", async () => {
+    const stoppedInstance = {
+      ...testInstance,
+      status: "stopped" as const,
+      endedAt: new Date("2025-06-01"),
+    };
+
+    const offerings = [
+      {
+        id: "off_1",
+        agentId: AGENT_ID,
+        tenantId: TENANT_ID,
+        name: "Translation",
+        description: "Translate text",
+        pricing: null,
+        schema: null,
+        createdAt: new Date("2025-01-01"),
+        updatedAt: new Date("2025-01-01"),
+      },
+    ];
+
+    const app = createTestApp({
+      db: {
+        tenant: testTenant,
+        principal: testPrincipal,
+        instance: stoppedInstance,
+        agent: testAgent,
+        offerings,
+      },
+    });
+
+    const res = await app.request(`${instanceURL()}/offerings`);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      id: string;
+      name: string;
+      agentName: string;
+    }[];
+    expect(body).toHaveLength(1);
+
+    const entry = body[0];
+    if (!entry) throw new Error("expected one offering");
+
+    expect(entry.id).toBe("off_1");
+    expect(entry.agentName).toBe("Test Agent");
+  });
+});

--- a/packages/hub/src/routes/instances.test.ts
+++ b/packages/hub/src/routes/instances.test.ts
@@ -1,0 +1,251 @@
+import { describe, test, expect } from "bun:test";
+
+import { createInMemoryGrantStore } from "@interchange/authz";
+import type { GrantRule } from "@interchange/types/authz";
+import type { SessionStatus } from "@interchange/types";
+
+import { createApp } from "../app";
+import type { Auth } from "../auth";
+import type { EventCollectorRegistry } from "../event-collector-registry";
+import type { SessionService } from "../session-service";
+import type { SidecarRouter } from "../ws/sidecar-handler";
+
+// ---------------------------------------------------------------------------
+// Test data constants
+// ---------------------------------------------------------------------------
+
+const TENANT_ID = "tnt_test";
+const PRINCIPAL_ID = "prn_test";
+const USER_ID = "usr_test";
+const INSTANCE_ID = "ins_test";
+const AGENT_ID = "agt_test";
+const ADDRESS = "ins_test@test.example.com";
+
+const testTenant = {
+  id: TENANT_ID,
+  name: "Test",
+  slug: "test",
+  domain: "test.example.com",
+  parentId: null,
+  config: null,
+  createdAt: new Date("2025-01-01"),
+  updatedAt: new Date("2025-01-01"),
+};
+
+const testPrincipal = {
+  id: PRINCIPAL_ID,
+  tenantId: TENANT_ID,
+  kind: "user" as const,
+  refId: USER_ID,
+  status: "active" as const,
+  createdAt: new Date("2025-01-01"),
+  updatedAt: new Date("2025-01-01"),
+};
+
+const testInstance = {
+  id: INSTANCE_ID,
+  agentId: AGENT_ID,
+  tenantId: TENANT_ID,
+  address: ADDRESS,
+  status: "running" as const,
+  principalId: "prn_agent",
+  kernelId: null,
+  sidecarId: null,
+  sessionId: "ses_test",
+  publicKey: null,
+  createdAt: new Date("2025-01-01"),
+  updatedAt: new Date("2025-01-01"),
+  endedAt: null,
+};
+
+const testAgent = { id: AGENT_ID, name: "Test Agent" };
+
+function makeGrant(overrides: Partial<GrantRule> = {}): GrantRule {
+  return {
+    id: "grant-test",
+    resource: "instance:*",
+    action: "read",
+    effect: "allow",
+    origin: "system",
+    conditions: null,
+    expiresAt: null,
+    roleId: null,
+    principalId: PRINCIPAL_ID,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock factories
+//
+// Each test sets up exactly the canned data it expects. The mock DB does NOT
+// evaluate drizzle where-clauses — it returns the canned data as-is. This
+// is intentional: we're testing route behavior, not drizzle's query builder.
+// If a test wants a 404, it omits the relevant data from the mock.
+// ---------------------------------------------------------------------------
+
+type TestInstance = Omit<typeof testInstance, "status" | "endedAt"> & {
+  status: string;
+  endedAt: Date | null;
+};
+
+type MockDBOpts = {
+  tenant?: typeof testTenant | undefined;
+  principal?: typeof testPrincipal | undefined;
+  instance?: TestInstance | undefined;
+  agent?: typeof testAgent | undefined;
+  offerings?: Record<string, unknown>[] | undefined;
+};
+
+function notImplemented(path: string) {
+  return () => {
+    throw new Error(`mock: ${path} not implemented`);
+  };
+}
+
+function createMockDB(opts: MockDBOpts) {
+  // Builder chain for db.select().from().innerJoin().where().limit()
+  // Simulates the instance+agent join used by the offerings handler.
+  function selectChain() {
+    const joinedRows =
+      opts.instance && opts.agent
+        ? [{ instance: opts.instance, agentName: opts.agent.name }]
+        : [];
+
+    return {
+      from: () => ({
+        innerJoin: () => ({
+          where: () => ({
+            limit: () => Promise.resolve(joinedRows),
+            orderBy: (..._args: unknown[]) => ({
+              limit: () => Promise.resolve(joinedRows),
+            }),
+          }),
+        }),
+      }),
+    };
+  }
+
+  return {
+    query: {
+      tenant: {
+        findFirst: async () => opts.tenant,
+        findMany: notImplemented("db.query.tenant.findMany"),
+      },
+      principal: {
+        findFirst: async () => opts.principal,
+        findMany: notImplemented("db.query.principal.findMany"),
+      },
+      agentInstance: {
+        findFirst: async () => opts.instance,
+        findMany: notImplemented("db.query.agentInstance.findMany"),
+      },
+      offering: {
+        findFirst: notImplemented("db.query.offering.findFirst"),
+        findMany: async () => opts.offerings ?? [],
+      },
+    },
+    select: selectChain,
+  } as unknown as Parameters<typeof createApp>[0]["db"];
+}
+
+function createMockAuth(userId: string) {
+  return {
+    api: {
+      getSession: async () => ({
+        user: { id: userId, email: "test@example.com", name: "Test User" },
+        session: { id: "session_test" },
+      }),
+    },
+    handler: async () => new Response("", { status: 404 }),
+  } as unknown as Auth;
+}
+
+function createMockSidecarRouter(
+  routableAddresses: string[] = [],
+): SidecarRouter {
+  const stub = notImplemented("sidecarRouter");
+  return {
+    handleOpen: stub,
+    handleMessage: stub,
+    handleClose: stub,
+    routeMail: stub as unknown as SidecarRouter["routeMail"],
+    sendAgentDeploy: stub as unknown as SidecarRouter["sendAgentDeploy"],
+    sendAgentUndeploy: stub as unknown as SidecarRouter["sendAgentUndeploy"],
+    sendSessionStart: stub as unknown as SidecarRouter["sendSessionStart"],
+    sendSessionAbort: stub as unknown as SidecarRouter["sendSessionAbort"],
+    sendGrantsUpdate: stub as unknown as SidecarRouter["sendGrantsUpdate"],
+    sendProvidersUpdate:
+      stub as unknown as SidecarRouter["sendProvidersUpdate"],
+    sendPack: stub as unknown as SidecarRouter["sendPack"],
+    sendSyncRequest: stub,
+    subscribeAgent: stub as unknown as SidecarRouter["subscribeAgent"],
+    dispatchAgentEvent: stub,
+    getConnectedSidecars: () => [],
+    getRoutableAddresses: () => routableAddresses,
+  };
+}
+
+function createMockEventCollectors(
+  statuses = new Map<string, SessionStatus>(),
+): EventCollectorRegistry {
+  return {
+    create: notImplemented("eventCollectors.create"),
+    dispatch: notImplemented("eventCollectors.dispatch"),
+    abandon: notImplemented("eventCollectors.abandon"),
+    has: (address) => statuses.has(address),
+    getStatus: (address) => statuses.get(address),
+    getAccumulatedText: () => undefined,
+  };
+}
+
+type TestAppOpts = {
+  db?: MockDBOpts;
+  grants?: GrantRule[];
+  routableAddresses?: string[];
+  collectorStatuses?: Map<string, SessionStatus>;
+};
+
+function createTestApp(opts: TestAppOpts = {}) {
+  const db = createMockDB(
+    opts.db ?? {
+      tenant: testTenant,
+      principal: testPrincipal,
+      instance: testInstance,
+      agent: testAgent,
+    },
+  );
+
+  return createApp({
+    auth: createMockAuth(USER_ID),
+    db,
+    grantStore: createInMemoryGrantStore(opts.grants ?? [makeGrant()]),
+    sidecarRouter: createMockSidecarRouter(opts.routableAddresses),
+    sessionService: notImplemented(
+      "sessionService",
+    ) as unknown as SessionService,
+    eventCollectors: createMockEventCollectors(opts.collectorStatuses),
+  });
+}
+
+function instanceURL(tenantId = TENANT_ID, instanceId = INSTANCE_ID): string {
+  return `/api/tenants/${tenantId}/agents/instances/${instanceId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Smoke test — verifies the mock infrastructure satisfies the middleware chain
+// ---------------------------------------------------------------------------
+
+describe("instance route test infrastructure", () => {
+  test("authenticated request reaches the route handler", async () => {
+    const app = createTestApp();
+    const res = await app.request(`${instanceURL()}/health`);
+    expect(res.status).toBe(200);
+  });
+
+  test("missing grant returns 403", async () => {
+    const app = createTestApp({ grants: [] });
+    const res = await app.request(`${instanceURL()}/health`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/packages/hub/src/routes/instances.ts
+++ b/packages/hub/src/routes/instances.ts
@@ -11,6 +11,7 @@ import {
   agentSession,
   grant as grantTable,
   inferenceTurn,
+  offering,
   principal as principalTable,
   principalRole,
   provider,
@@ -26,6 +27,7 @@ import {
   CreateAgentInstance,
   AgentInstanceResponse,
   AgentHealth,
+  OfferingDetail,
   GrantRequirement,
   SendMessage,
   MailResponse,
@@ -39,6 +41,7 @@ import type {
   ProviderConfig,
 } from "@interchange/types/runtime";
 import { SessionLaunchError } from "../session-service";
+import { formatOffering } from "./offerings";
 
 import type { TenantEnv } from "../context";
 import { requireGrant, idResource } from "../middleware/grant";
@@ -842,6 +845,69 @@ app.get(
     const readiness = status !== undefined ? "ok" : "not_ready";
 
     return c.json({ liveness, readiness, lastCheckedAt: null });
+  },
+);
+
+app.get(
+  "/:instanceId/offerings",
+  requireGrant(idResource("instance", "instanceId"), "read"),
+  describeRoute({
+    tags: ["Instances"],
+    summary: "List instance offerings",
+    description:
+      "Returns the offerings associated with the instance's agent definition. These represent the capabilities the instance can provide.",
+    responses: {
+      200: {
+        description: "List of offerings",
+        content: {
+          "application/json": {
+            schema: resolver(OfferingDetail.array()),
+          },
+        },
+      },
+      404: {
+        description: "Instance not found",
+        content: {
+          "application/json": { schema: resolver(ErrorResponse) },
+        },
+      },
+    },
+  }),
+  async (c) => {
+    const tenantCtx = c.get("tenant");
+    const db = c.get("db");
+    const instanceId = c.req.param("instanceId");
+
+    const [row] = await db
+      .select({
+        instance: agentInstance,
+        agentName: agent.name,
+      })
+      .from(agentInstance)
+      .innerJoin(agent, eq(agentInstance.agentId, agent.id))
+      .where(
+        and(
+          eq(agentInstance.id, instanceId),
+          eq(agentInstance.tenantId, tenantCtx.id),
+        ),
+      )
+      .limit(1);
+
+    if (!row) {
+      return c.json(
+        { error: { code: "not_found", message: "Instance not found" } },
+        404,
+      );
+    }
+
+    const offerings = await db.query.offering.findMany({
+      where: and(
+        eq(offering.agentId, row.instance.agentId),
+        eq(offering.tenantId, tenantCtx.id),
+      ),
+    });
+
+    return c.json(offerings.map((o) => formatOffering(o, row.agentName)));
   },
 );
 

--- a/packages/hub/src/routes/instances.ts
+++ b/packages/hub/src/routes/instances.ts
@@ -25,6 +25,7 @@ import { generateKeyPair, createNodeCrypto } from "@interchange/crypto-node";
 import {
   CreateAgentInstance,
   AgentInstanceResponse,
+  AgentHealth,
   GrantRequirement,
   SendMessage,
   MailResponse,
@@ -772,6 +773,75 @@ app.get(
     }
 
     return c.json(result);
+  },
+);
+
+app.get(
+  "/:instanceId/health",
+  requireGrant(idResource("instance", "instanceId"), "read"),
+  describeRoute({
+    tags: ["Instances"],
+    summary: "Get instance health",
+    description:
+      "Returns liveness and readiness for a running instance. Liveness reflects whether the instance's sidecar connection is active. Readiness reflects whether the instance has an active event collector and can process work.",
+    responses: {
+      200: {
+        description: "Health status",
+        content: {
+          "application/json": { schema: resolver(AgentHealth) },
+        },
+      },
+      404: {
+        description: "Instance not found",
+        content: {
+          "application/json": { schema: resolver(ErrorResponse) },
+        },
+      },
+      410: {
+        description: "Instance stopped",
+        content: {
+          "application/json": { schema: resolver(ErrorResponse) },
+        },
+      },
+    },
+  }),
+  async (c) => {
+    const tenantCtx = c.get("tenant");
+    const db = c.get("db");
+    const sidecarRouter = c.get("sidecarRouter");
+    const eventCollectors = c.get("eventCollectors");
+    const instanceId = c.req.param("instanceId");
+
+    const row = await db.query.agentInstance.findFirst({
+      where: and(
+        eq(agentInstance.id, instanceId),
+        eq(agentInstance.tenantId, tenantCtx.id),
+      ),
+    });
+
+    if (!row) {
+      return c.json(
+        { error: { code: "not_found", message: "Instance not found" } },
+        404,
+      );
+    }
+
+    if (row.status === "stopped") {
+      return c.json(
+        { error: { code: "gone", message: "Instance has stopped" } },
+        410,
+      );
+    }
+
+    const routableAddresses = sidecarRouter.getRoutableAddresses();
+    const liveness = routableAddresses.includes(row.address)
+      ? "ok"
+      : "unhealthy";
+
+    const status = eventCollectors.getStatus(row.address);
+    const readiness = status !== undefined ? "ok" : "not_ready";
+
+    return c.json({ liveness, readiness, lastCheckedAt: null });
   },
 );
 

--- a/packages/hub/src/routes/offerings.ts
+++ b/packages/hub/src/routes/offerings.ts
@@ -31,7 +31,10 @@ type Pricing = {
   bounds?: { min?: string; max?: string };
 };
 
-function formatOffering(row: typeof offering.$inferSelect, agentName: string) {
+export function formatOffering(
+  row: typeof offering.$inferSelect,
+  agentName: string,
+) {
   return {
     id: row.id,
     agentId: row.agentId,

--- a/packages/types/src/agents.ts
+++ b/packages/types/src/agents.ts
@@ -143,22 +143,3 @@ export const AgentHealth = type({
 export const RollbackRequest = type({
   version: "string",
 });
-
-export const Offering = type({
-  id: "string",
-  agentId: "string",
-  name: "string",
-  "description?": "string | null",
-  "pricing?": {
-    "base?": {
-      amount: "string",
-      currency: "string",
-    },
-    "methods?": "string[]",
-    "negotiable?": "boolean",
-    "bounds?": {
-      "min?": "string",
-      "max?": "string",
-    },
-  },
-});


### PR DESCRIPTION
## Summary

- Add `GET /agents/instances/:instanceId/health` with real liveness (sidecar connectivity) and readiness (event collector state), replacing the definition-level placeholder that just checked `agent.status`
- Add `GET /agents/instances/:instanceId/offerings` returning the instance's effective offerings from its parent agent definition
- Remove the stub definition-level health and offerings routes from `agents.ts`
- Make `grantStore` injectable in `createApp` for testability
- Add integration tests for health and offerings endpoints with mock infrastructure that exercises the full middleware chain

## Changes

- `packages/hub/src/routes/instances.ts`: Two new route handlers (health, offerings)
- `packages/hub/src/routes/instances.test.ts`: Test infrastructure and 12 integration tests
- `packages/hub/src/routes/offerings.ts`: Export `formatOffering` for reuse
- `packages/hub/src/routes/agents.ts`: Remove health and offerings handlers, clean up imports
- `packages/hub/src/app.ts`: Add optional `grantStore` field to `CreateAppOpts`
- `packages/types/src/agents.ts`: Remove dead `Offering` type (replaced by `OfferingDetail`)
- `docs/API.md`: Regenerated to reflect route changes

## Testing

- 865 tests pass (12 new), 0 failures
- Health: all four liveness/readiness combinations, 404 missing instance, 410 stopped instance
- Offerings: multiple offerings, empty list, 404 missing instance, 200 for stopped instances (static metadata)
- Infrastructure smoke tests verify middleware chain (auth, tenant resolution, grant authorization)

Closes INTR-33