### PR TITLE
Reconstruct UI timeline from git and identify data gaps

### DIFF
--- a/apps/sidecar/src/session-manager.ts
+++ b/apps/sidecar/src/session-manager.ts
@@ -186,6 +186,18 @@ export function createSessionManager(
   const pending = new Set<string>();
   const mailStores = new Map<string, MailAuditStore>();
 
+  // Checkpoint hash captured from the most recent connector.reply event for
+  // each agent. Consumed (deleted) by the MessageSentHandler so that only
+  // the connector reply mail commit receives the linkage — subsequent
+  // tool-initiated sends do not carry a stale hash.
+  //
+  // Ordering guarantee: the harness calls onEvent() synchronously inside
+  // handleEvent(), which fires before the detached transport.send() resolves.
+  // Because executeSend() always awaits at least once (signature generation)
+  // before calling MessageSentHandler, the map write in onEvent completes
+  // before the handler reads it.
+  const lastCheckpointHashes = new Map<string, string>();
+
   // Per-agent promise chain to serialize mail commits and avoid concurrent
   // git operations on the same repository.
   const mailCommitQueues = new Map<string, Promise<void>>();
@@ -218,9 +230,12 @@ export function createSessionManager(
         logger.warn`No mail store for sender ${senderAddress}, skipping outbound audit for ${messageId}`;
         return;
       }
+      const checkpointHash = lastCheckpointHashes.get(senderAddress);
+      lastCheckpointHashes.delete(senderAddress);
       enqueueMailCommit(senderAddress, async () => {
         const result = await store.commitMail(rawMessage, "out", {
           ignoreDuplicate: true,
+          ...(checkpointHash !== undefined ? { checkpointHash } : {}),
         });
         if (result !== null) {
           logger.info`Committed outbound mail ${messageId} for ${senderAddress}`;
@@ -332,6 +347,12 @@ export function createSessionManager(
         deployTools: deployToolDefs,
         tools: toolDispatch,
         onEvent(event: InferenceEvent) {
+          if (
+            event.type === "connector.reply" &&
+            event.data.checkpointHash !== undefined
+          ) {
+            lastCheckpointHashes.set(agentAddress, event.data.checkpointHash);
+          }
           onEvent(agentAddress, sessionId, event);
         },
       });

--- a/bun.lock
+++ b/bun.lock
@@ -117,6 +117,7 @@
         "@interchange/log": "workspace:*",
         "@interchange/mime": "workspace:*",
         "@interchange/pack-transport": "workspace:*",
+        "@interchange/storage-isogit": "workspace:*",
         "@interchange/types": "workspace:*",
         "arktype": "catalog:",
         "better-auth": "^1.4.18",

--- a/packages/harness/src/harness.test.ts
+++ b/packages/harness/src/harness.test.ts
@@ -997,6 +997,7 @@ describe("Default plugin", () => {
             arguments: { path: "/test" },
           },
         ],
+        timestamp: 1000,
       },
       usage: emptyUsage(),
     };
@@ -1018,6 +1019,7 @@ describe("Default plugin", () => {
         role: "assistant",
         model: "claude-test",
         content: [{ type: "text", text: "Here is my response." }],
+        timestamp: 1000,
       },
       usage: emptyUsage(),
     };
@@ -1102,6 +1104,7 @@ describe("Default plugin", () => {
         role: "assistant",
         model: "claude-test",
         content: [],
+        timestamp: 1000,
       },
       usage: emptyUsage(),
     };
@@ -1125,6 +1128,7 @@ describe("Default plugin", () => {
         role: "assistant",
         model: "claude-test",
         content: [{ type: "text", text: "   \n\t  " }],
+        timestamp: 1000,
       },
       usage: emptyUsage(),
     };
@@ -1150,6 +1154,7 @@ describe("Default plugin", () => {
         role: "assistant",
         model: "claude-test",
         content: [{ type: "text", text: "done processing" }],
+        timestamp: 1000,
       },
       usage: emptyUsage(),
     };
@@ -1204,6 +1209,7 @@ describe("Default plugin", () => {
             arguments: { path: "/b" },
           },
         ],
+        timestamp: 1000,
       },
       usage: emptyUsage(),
     };

--- a/packages/harness/src/plugin.ts
+++ b/packages/harness/src/plugin.ts
@@ -116,26 +116,32 @@ export class DefaultPlugin implements ReactorPlugin {
         if (toolCalls.length > 0) {
           this.pendingToolResults = toolCalls.length;
           return [
-            capabilities.checkpoint(),
+            capabilities.checkpoint("tool-execution"),
             capabilities.executeTools(toolCalls, true),
           ];
         }
 
         // No tool calls — the model is done reasoning for this turn.
         if (this.policy.mode === "reactive") {
-          return [capabilities.checkpoint(), capabilities.wait()];
+          return [
+            capabilities.checkpoint("inference-done"),
+            capabilities.wait(),
+          ];
         }
 
         // Conversational agent: send reply via the connector.
         const replyContent = extractTextContent(event.message);
         if (replyContent.length > 0) {
-          return [capabilities.checkpoint(), capabilities.reply(replyContent)];
+          return [
+            capabilities.checkpoint("inference-done"),
+            capabilities.reply(replyContent),
+          ];
         }
 
         // Empty response (no text, no tool calls) — checkpoint and wait for
         // the next inbound message. The reactor only shuts down on explicit
         // stop (abort), never because the model produced an empty turn.
-        return [capabilities.checkpoint(), capabilities.wait()];
+        return [capabilities.checkpoint("inference-done"), capabilities.wait()];
       }
 
       case "tool.done": {
@@ -144,11 +150,11 @@ export class DefaultPlugin implements ReactorPlugin {
           return [];
         }
         if (this.policy.mode === "reactive") {
-          return [capabilities.checkpoint(), capabilities.wait()];
+          return [capabilities.checkpoint("tool-done"), capabilities.wait()];
         }
         // All tool results received — re-infer with complete context.
         return [
-          capabilities.checkpoint(),
+          capabilities.checkpoint("tool-done"),
           capabilities.infer(this.model, {
             systemPrompt: this.systemPrompt,
             tools: this.toolDefinitions,
@@ -165,12 +171,15 @@ export class DefaultPlugin implements ReactorPlugin {
         logger.error`Inference error in default plugin: ${event.error.message}${statusDetail} (category: ${event.error.category})`;
 
         const userMessage = formatInferenceError(event.error);
-        return [capabilities.checkpoint(), capabilities.reply(userMessage)];
+        return [
+          capabilities.checkpoint("inference-error"),
+          capabilities.reply(userMessage),
+        ];
       }
 
       case "reactor.gate.cleared": {
         return [
-          capabilities.checkpoint(),
+          capabilities.checkpoint("gate-cleared"),
           capabilities.infer(this.model, {
             systemPrompt: this.systemPrompt,
             tools: this.toolDefinitions,

--- a/packages/hub-client/src/session.test.ts
+++ b/packages/hub-client/src/session.test.ts
@@ -1120,6 +1120,7 @@ describe("activity state machine", () => {
           role: "assistant",
           content: [],
           model: "gpt-4",
+          timestamp: 1000,
         },
         usage: {
           input: 10,

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -17,6 +17,7 @@
     "@interchange/log": "workspace:*",
     "@interchange/mime": "workspace:*",
     "@interchange/pack-transport": "workspace:*",
+    "@interchange/storage-isogit": "workspace:*",
     "@interchange/types": "workspace:*",
     "arktype": "catalog:",
     "better-auth": "^1.4.18",

--- a/packages/hub/src/timeline-reconstruction.test.ts
+++ b/packages/hub/src/timeline-reconstruction.test.ts
@@ -257,7 +257,7 @@ describe("reconstructTimeline", () => {
     expect(linkGap).toBeDefined();
   });
 
-  test("surfaces error records and documents the turn association gap", async () => {
+  test("associates error records from git with the preceding turn", async () => {
     const dir = await makeTempDir();
     await initAgentRepo(dir);
     const store = new IsogitStore(dir);
@@ -274,7 +274,7 @@ describe("reconstructTimeline", () => {
       "checkpoint: inference-done",
     );
 
-    // Write error records
+    // Write error records (committed to git by the store)
     const errors: ErrorRecord[] = [
       {
         source: "inference",
@@ -290,27 +290,20 @@ describe("reconstructTimeline", () => {
 
     const result = await reconstructTimeline(dir);
 
-    // Errors should be surfaced
-    const errorEvents = result.events.filter(
-      (e) => e.kind === "turn" && e.isError === true,
-    );
-    expect(errorEvents).toHaveLength(1);
-    if (errorEvents[0] !== undefined && errorEvents[0].kind === "turn") {
-      expect(errorEvents[0].errors).toHaveLength(1);
-      expect(errorEvents[0].errors?.[0]?.category).toBe("rate_limit");
+    // Errors should be attached to the preceding turn, not a synthetic one
+    const turns = result.events.filter((e) => e.kind === "turn");
+    expect(turns).toHaveLength(1);
+    const turn = turns[0];
+    expect(turn?.kind === "turn" && turn.isError).toBe(true);
+    expect(turn?.kind === "turn" && turn.errors).toHaveLength(1);
+    if (turn?.kind === "turn") {
+      expect(turn.errors?.[0]?.category).toBe("rate_limit");
     }
 
-    // Gap: errors have no turn association
-    const errorGap = result.gaps.find(
-      (g) => g.kind === "no-error-turn-association",
-    );
-    expect(errorGap).toBeDefined();
-
-    // Gap: reading errors from working tree, not git objects
-    const workingTreeGap = result.gaps.find(
-      (g) => g.kind === "errors-from-working-tree",
-    );
-    expect(workingTreeGap).toBeDefined();
+    // No error-association or working-tree gaps should be present
+    const gapKinds = result.gaps.map((g) => g.kind);
+    expect(gapKinds).not.toContain("no-error-turn-association");
+    expect(gapKinds).not.toContain("errors-from-working-tree");
   });
 
   test("handles message-count regression gracefully", async () => {
@@ -418,11 +411,7 @@ describe("reconstructTimeline", () => {
     const result = await reconstructTimeline(dir);
 
     const gapKinds = result.gaps.map((g) => g.kind);
-    // With checkpoint reasons, turn boundaries/status/hadError are resolved
     expect(gapKinds).toContain("no-assistant-mail-linkage");
-    // These are only emitted when errors exist, not present here
-    expect(gapKinds).not.toContain("no-error-turn-association");
-    expect(gapKinds).not.toContain("errors-from-working-tree");
   });
 
   test("marks turns as error when checkpoint reason is inference-error", async () => {
@@ -540,7 +529,7 @@ describe("reconstructTimeline", () => {
     expect(corruptGaps).toHaveLength(1);
   });
 
-  test("records gaps for corrupt error record files", async () => {
+  test("records gaps for corrupt error record files in git", async () => {
     const dir = await makeTempDir();
     await initAgentRepo(dir);
     const store = new IsogitStore(dir);
@@ -549,15 +538,12 @@ describe("reconstructTimeline", () => {
       [userMessage("Hello"), assistantMessage("Hi")],
       NO_OPS,
       NO_USAGE,
-      "checkpoint",
+      "checkpoint: inference-done",
     );
 
-    // Write one valid and one corrupt error record
-    const errorsDir = path.join(dir, "state/errors/test-session");
-    await fs.promises.mkdir(errorsDir, { recursive: true });
-    await fs.promises.writeFile(
-      path.join(errorsDir, "00000000-valid.json"),
-      JSON.stringify({
+    // Commit a valid error record via the store
+    await store.commitErrors([
+      {
         source: "inference",
         category: "rate_limit",
         message: "Rate limited",
@@ -565,20 +551,37 @@ describe("reconstructTimeline", () => {
         timestamp: new Date().toISOString(),
         sessionId: "test-session",
         seq: 0,
-      }),
-    );
+      },
+    ]);
+
+    // Manually commit a corrupt error file directly via git
+    const errorsDir = path.join(dir, "state/errors/test-session");
     await fs.promises.writeFile(
       path.join(errorsDir, "00000001-corrupt.json"),
       "NOT VALID JSON",
     );
+    await git.add({
+      fs,
+      dir,
+      filepath: "state/errors/test-session/00000001-corrupt.json",
+    });
+    await git.commit({
+      fs,
+      dir,
+      message: "Record 1 error record",
+      author: { name: "test", email: "test@test.dev" },
+    });
 
     const result = await reconstructTimeline(dir);
 
-    // Valid error should be surfaced
-    const errorEvents = result.events.filter(
-      (e) => e.kind === "turn" && e.isError === true,
+    // Valid error should be associated with the preceding turn
+    const turns = result.events.filter((e) => e.kind === "turn");
+    expect(turns).toHaveLength(1);
+    const turn = turns[0];
+    expect(turn?.kind === "turn" && turn.isError).toBe(true);
+    expect(turn?.kind === "turn" && turn.errors?.length).toBeGreaterThanOrEqual(
+      1,
     );
-    expect(errorEvents).toHaveLength(1);
 
     // Corrupt file should produce a gap
     const corruptGaps = result.gaps.filter(

--- a/packages/hub/src/timeline-reconstruction.test.ts
+++ b/packages/hub/src/timeline-reconstruction.test.ts
@@ -1,0 +1,496 @@
+import { describe, test, expect, afterAll } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import git from "isomorphic-git";
+import {
+  IsogitStore,
+  initAgentRepo,
+  createMailAuditStore,
+} from "@interchange/storage-isogit";
+import type { ConversationMessage } from "@interchange/types/runtime";
+import type { ErrorRecord } from "@interchange/types/audit";
+import { reconstructTimeline } from "./timeline-reconstruction";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const d = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), "timeline-recon-"),
+  );
+  tempDirs.push(d);
+  return d;
+}
+
+afterAll(async () => {
+  for (const d of tempDirs) {
+    await fs.promises.rm(d, { recursive: true, force: true });
+  }
+});
+
+const NO_OPS: [] = [];
+const NO_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  thinking: 0,
+};
+
+function userMessage(text: string): ConversationMessage {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+function assistantMessage(text: string): ConversationMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    model: "test-model",
+  };
+}
+
+function toolCallMessage(
+  callId: string,
+  name: string,
+  args: Record<string, unknown>,
+): ConversationMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "tool_call", id: callId, name, arguments: args }],
+    model: "test-model",
+  };
+}
+
+function toolResultMessage(
+  callId: string,
+  result: string,
+): ConversationMessage {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        callId,
+        content: [{ type: "text", text: result }],
+      },
+    ],
+  };
+}
+
+function buildRawMessage(opts: {
+  messageId: string;
+  from?: string;
+  to?: string;
+  inReplyTo?: string;
+  body?: string;
+}): Uint8Array {
+  const lines: string[] = [];
+  lines.push(`Message-ID: ${opts.messageId}`);
+  lines.push(`From: ${opts.from ?? "sender@example.com"}`);
+  lines.push(`To: ${opts.to ?? "recipient@example.com"}`);
+  lines.push(`Date: ${new Date().toUTCString()}`);
+  if (opts.inReplyTo !== undefined) {
+    lines.push(`In-Reply-To: ${opts.inReplyTo}`);
+  }
+  lines.push("");
+  lines.push(opts.body ?? "test body");
+  return new TextEncoder().encode(lines.join("\r\n"));
+}
+
+describe("reconstructTimeline", () => {
+  test("reconstructs a single-turn conversation", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+    const store = new IsogitStore(dir);
+
+    const messages: ConversationMessage[] = [
+      userMessage("Hello"),
+      assistantMessage("Hi there"),
+    ];
+    await store.commit(messages, NO_OPS, NO_USAGE, "checkpoint");
+
+    const result = await reconstructTimeline(dir);
+
+    const turns = result.events.filter((e) => e.kind === "turn");
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.content).toBe("Hi there");
+    expect(turns[0]?.timestamp).toBeGreaterThan(0);
+
+    // Gap: no per-message timestamps
+    const timestampGap = result.gaps.find(
+      (g) => g.kind === "no-per-message-timestamps",
+    );
+    expect(timestampGap).toBeDefined();
+  });
+
+  test("reconstructs multi-turn conversations across checkpoints", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+    const store = new IsogitStore(dir);
+
+    // First turn
+    const messages1: ConversationMessage[] = [
+      userMessage("Hello"),
+      assistantMessage("Hi there"),
+    ];
+    await store.commit(messages1, NO_OPS, NO_USAGE, "checkpoint");
+
+    // Second turn (appends to the same message array)
+    const messages2: ConversationMessage[] = [
+      ...messages1,
+      userMessage("How are you?"),
+      assistantMessage("I'm doing well"),
+    ];
+    await store.commit(messages2, NO_OPS, NO_USAGE, "checkpoint");
+
+    const result = await reconstructTimeline(dir);
+
+    const turns = result.events.filter((e) => e.kind === "turn");
+    expect(turns).toHaveLength(2);
+    expect(turns[0]?.content).toBe("Hi there");
+    expect(turns[1]?.content).toBe("I'm doing well");
+
+    // Second turn should have a later or equal timestamp
+    if (turns[0] !== undefined && turns[1] !== undefined) {
+      expect(turns[1].timestamp).toBeGreaterThanOrEqual(turns[0].timestamp);
+    }
+  });
+
+  test("treats a tool-use loop as a single turn", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+    const store = new IsogitStore(dir);
+
+    const messages: ConversationMessage[] = [
+      userMessage("What's the weather?"),
+      toolCallMessage("call-1", "get_weather", { city: "SF" }),
+      toolResultMessage("call-1", "72F and sunny"),
+      assistantMessage("The weather in SF is 72F and sunny."),
+    ];
+    await store.commit(messages, NO_OPS, NO_USAGE, "checkpoint");
+
+    const result = await reconstructTimeline(dir);
+
+    const turns = result.events.filter((e) => e.kind === "turn");
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.content).toBe("The weather in SF is 72F and sunny.");
+
+    // Gap: turn boundaries are heuristic
+    const turnBoundaryGap = result.gaps.find(
+      (g) => g.kind === "no-turn-boundaries",
+    );
+    expect(turnBoundaryGap).toBeDefined();
+  });
+
+  test("reconstructs mail events", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+
+    const mailStore = await createMailAuditStore(dir);
+
+    const inbound = buildRawMessage({
+      messageId: "<msg-1@test>",
+      from: "alice@example.com",
+      to: "agent@example.com",
+      body: "Please help me",
+    });
+    await mailStore.commitMail(inbound, "in");
+
+    const outbound = buildRawMessage({
+      messageId: "<msg-2@test>",
+      from: "agent@example.com",
+      to: "alice@example.com",
+      inReplyTo: "<msg-1@test>",
+      body: "Sure, how can I help?",
+    });
+    await mailStore.commitMail(outbound, "out");
+
+    const result = await reconstructTimeline(dir);
+
+    const mailEvents = result.events.filter((e) => e.kind === "mail");
+    expect(mailEvents).toHaveLength(2);
+
+    const inboundEvent = mailEvents.find(
+      (e) => e.kind === "mail" && e.direction === "in",
+    );
+    expect(inboundEvent).toBeDefined();
+    if (inboundEvent !== undefined && inboundEvent.kind === "mail") {
+      expect(inboundEvent.messageId).toBe("<msg-1@test>");
+    }
+
+    const outboundEvent = mailEvents.find(
+      (e) => e.kind === "mail" && e.direction === "out",
+    );
+    expect(outboundEvent).toBeDefined();
+    if (outboundEvent !== undefined && outboundEvent.kind === "mail") {
+      expect(outboundEvent.messageId).toBe("<msg-2@test>");
+    }
+
+    // Gap: no link between assistant messages and outbound mail
+    const linkGap = result.gaps.find(
+      (g) => g.kind === "no-assistant-mail-linkage",
+    );
+    expect(linkGap).toBeDefined();
+  });
+
+  test("surfaces error records and documents the turn association gap", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+    const store = new IsogitStore(dir);
+
+    // Write a conversation first
+    const messages: ConversationMessage[] = [
+      userMessage("Do something risky"),
+      assistantMessage("Attempting..."),
+    ];
+    await store.commit(messages, NO_OPS, NO_USAGE, "checkpoint");
+
+    // Write error records
+    const errors: ErrorRecord[] = [
+      {
+        source: "inference",
+        category: "rate_limit",
+        message: "Rate limit exceeded",
+        fatal: false,
+        timestamp: new Date().toISOString(),
+        sessionId: "test-session",
+        seq: 0,
+      },
+    ];
+    await store.commitErrors(errors);
+
+    const result = await reconstructTimeline(dir);
+
+    // Errors should be surfaced
+    const errorEvents = result.events.filter(
+      (e) => e.kind === "turn" && e.isError === true,
+    );
+    expect(errorEvents).toHaveLength(1);
+    if (errorEvents[0] !== undefined && errorEvents[0].kind === "turn") {
+      expect(errorEvents[0].errors).toHaveLength(1);
+      expect(errorEvents[0].errors?.[0]?.category).toBe("rate_limit");
+    }
+
+    // Gap: errors have no turn association
+    const errorGap = result.gaps.find(
+      (g) => g.kind === "no-error-turn-association",
+    );
+    expect(errorGap).toBeDefined();
+
+    // Gap: reading errors from working tree, not git objects
+    const workingTreeGap = result.gaps.find(
+      (g) => g.kind === "errors-from-working-tree",
+    );
+    expect(workingTreeGap).toBeDefined();
+  });
+
+  test("handles message-count regression gracefully", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+    const store = new IsogitStore(dir);
+
+    // First checkpoint with 4 messages
+    const messages1: ConversationMessage[] = [
+      userMessage("Hello"),
+      assistantMessage("Hi"),
+      userMessage("More"),
+      assistantMessage("Sure"),
+    ];
+    await store.commit(messages1, NO_OPS, NO_USAGE, "checkpoint");
+
+    // Second checkpoint with only 2 messages (regression)
+    const messages2: ConversationMessage[] = [
+      userMessage("Fresh start"),
+      assistantMessage("OK"),
+    ];
+    await store.commit(messages2, NO_OPS, NO_USAGE, "checkpoint");
+
+    const result = await reconstructTimeline(dir);
+
+    // Should not crash — should produce a gap record
+    const regressionGap = result.gaps.find(
+      (g) => g.kind === "message-count-regression",
+    );
+    expect(regressionGap).toBeDefined();
+
+    // Should still produce turn events from what it can reconstruct
+    const turns = result.events.filter((e) => e.kind === "turn");
+    expect(turns.length).toBeGreaterThan(0);
+  });
+
+  test("interleaves mail and turn events by timestamp", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+    const store = new IsogitStore(dir);
+    const mailStore = await createMailAuditStore(dir);
+
+    // Inbound mail first
+    const inbound = buildRawMessage({
+      messageId: "<msg-1@test>",
+      body: "Hello agent",
+    });
+    await mailStore.commitMail(inbound, "in");
+
+    // Then a turn
+    const messages: ConversationMessage[] = [
+      userMessage("Hello"),
+      assistantMessage("Hi there"),
+    ];
+    await store.commit(messages, NO_OPS, NO_USAGE, "checkpoint");
+
+    const result = await reconstructTimeline(dir);
+
+    // Both kinds should be present
+    const mailEvents = result.events.filter((e) => e.kind === "mail");
+    const turnEvents = result.events.filter((e) => e.kind === "turn");
+    expect(mailEvents).toHaveLength(1);
+    expect(turnEvents).toHaveLength(1);
+
+    // Mail should come before turn (committed first)
+    if (result.events[0] !== undefined && result.events[1] !== undefined) {
+      expect(result.events[0].timestamp).toBeLessThanOrEqual(
+        result.events[1].timestamp,
+      );
+    }
+  });
+
+  test("produces all known gap types", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+    const store = new IsogitStore(dir);
+
+    const messages: ConversationMessage[] = [
+      userMessage("Hello"),
+      assistantMessage("Hi"),
+    ];
+    await store.commit(messages, NO_OPS, NO_USAGE, "checkpoint");
+
+    const result = await reconstructTimeline(dir);
+
+    const gapKinds = result.gaps.map((g) => g.kind);
+    expect(gapKinds).toContain("no-per-message-timestamps");
+    expect(gapKinds).toContain("no-turn-boundaries");
+    expect(gapKinds).toContain("no-assistant-mail-linkage");
+    expect(gapKinds).toContain("no-turn-status");
+    expect(gapKinds).toContain("no-had-error");
+  });
+
+  test("handles empty repo with no checkpoints", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+
+    const result = await reconstructTimeline(dir);
+
+    expect(result.events).toHaveLength(0);
+    expect(result.gaps).toBeDefined();
+  });
+
+  test("records a gap when a checkpoint commit has corrupt context", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+    const store = new IsogitStore(dir);
+
+    // Write a valid checkpoint first
+    const messages: ConversationMessage[] = [
+      userMessage("Hello"),
+      assistantMessage("Hi"),
+    ];
+    await store.commit(messages, NO_OPS, NO_USAGE, "checkpoint");
+
+    // Write a corrupt checkpoint directly via git
+    const contextPath = path.join(dir, "state/context.json");
+    await fs.promises.writeFile(contextPath, "NOT VALID JSON");
+    await git.add({ fs, dir, filepath: "state/context.json" });
+    await git.commit({
+      fs,
+      dir,
+      message: "checkpoint",
+      author: { name: "test", email: "test@test.dev" },
+    });
+
+    const result = await reconstructTimeline(dir);
+
+    // Should still have the valid turn from the first checkpoint
+    const turns = result.events.filter((e) => e.kind === "turn");
+    expect(turns).toHaveLength(1);
+
+    // Should record a gap for the corrupt checkpoint
+    const corruptGaps = result.gaps.filter(
+      (g) => g.kind === "corrupt-checkpoint",
+    );
+    expect(corruptGaps).toHaveLength(1);
+  });
+
+  test("records gaps for corrupt error record files", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+    const store = new IsogitStore(dir);
+
+    await store.commit(
+      [userMessage("Hello"), assistantMessage("Hi")],
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint",
+    );
+
+    // Write one valid and one corrupt error record
+    const errorsDir = path.join(dir, "state/errors/test-session");
+    await fs.promises.mkdir(errorsDir, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(errorsDir, "00000000-valid.json"),
+      JSON.stringify({
+        source: "inference",
+        category: "rate_limit",
+        message: "Rate limited",
+        fatal: false,
+        timestamp: new Date().toISOString(),
+        sessionId: "test-session",
+        seq: 0,
+      }),
+    );
+    await fs.promises.writeFile(
+      path.join(errorsDir, "00000001-corrupt.json"),
+      "NOT VALID JSON",
+    );
+
+    const result = await reconstructTimeline(dir);
+
+    // Valid error should be surfaced
+    const errorEvents = result.events.filter(
+      (e) => e.kind === "turn" && e.isError === true,
+    );
+    expect(errorEvents).toHaveLength(1);
+
+    // Corrupt file should produce a gap
+    const corruptGaps = result.gaps.filter(
+      (g) => g.kind === "corrupt-error-record",
+    );
+    expect(corruptGaps).toHaveLength(1);
+    expect(corruptGaps[0]?.description).toContain("00000001-corrupt.json");
+  });
+
+  test("records multiple gaps for multiple corrupt checkpoints", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+
+    // Write two corrupt checkpoints
+    for (let i = 0; i < 2; i++) {
+      const contextPath = path.join(dir, "state/context.json");
+      await fs.promises.writeFile(contextPath, `CORRUPT ${i}`);
+      await git.add({ fs, dir, filepath: "state/context.json" });
+      await git.commit({
+        fs,
+        dir,
+        message: "checkpoint",
+        author: { name: "test", email: "test@test.dev" },
+      });
+    }
+
+    const result = await reconstructTimeline(dir);
+
+    const corruptGaps = result.gaps.filter(
+      (g) => g.kind === "corrupt-checkpoint",
+    );
+    expect(corruptGaps).toHaveLength(2);
+  });
+});

--- a/packages/hub/src/timeline-reconstruction.test.ts
+++ b/packages/hub/src/timeline-reconstruction.test.ts
@@ -37,15 +37,22 @@ const NO_USAGE = {
   thinking: 0,
 };
 
-function userMessage(text: string): ConversationMessage {
-  return { role: "user", content: [{ type: "text", text }] };
+function userMessage(
+  text: string,
+  timestamp = Date.now(),
+): ConversationMessage {
+  return { role: "user", content: [{ type: "text", text }], timestamp };
 }
 
-function assistantMessage(text: string): ConversationMessage {
+function assistantMessage(
+  text: string,
+  timestamp = Date.now(),
+): ConversationMessage {
   return {
     role: "assistant",
     content: [{ type: "text", text }],
     model: "test-model",
+    timestamp,
   };
 }
 
@@ -53,17 +60,20 @@ function toolCallMessage(
   callId: string,
   name: string,
   args: Record<string, unknown>,
+  timestamp = Date.now(),
 ): ConversationMessage {
   return {
     role: "assistant",
     content: [{ type: "tool_call", id: callId, name, arguments: args }],
     model: "test-model",
+    timestamp,
   };
 }
 
 function toolResultMessage(
   callId: string,
   result: string,
+  timestamp = Date.now(),
 ): ConversationMessage {
   return {
     role: "user",
@@ -74,6 +84,7 @@ function toolResultMessage(
         content: [{ type: "text", text: result }],
       },
     ],
+    timestamp,
   };
 }
 
@@ -103,9 +114,10 @@ describe("reconstructTimeline", () => {
     await initAgentRepo(dir);
     const store = new IsogitStore(dir);
 
+    const t = 1700000000000;
     const messages: ConversationMessage[] = [
-      userMessage("Hello"),
-      assistantMessage("Hi there"),
+      userMessage("Hello", t),
+      assistantMessage("Hi there", t + 1000),
     ];
     await store.commit(messages, NO_OPS, NO_USAGE, "checkpoint");
 
@@ -114,13 +126,9 @@ describe("reconstructTimeline", () => {
     const turns = result.events.filter((e) => e.kind === "turn");
     expect(turns).toHaveLength(1);
     expect(turns[0]?.content).toBe("Hi there");
-    expect(turns[0]?.timestamp).toBeGreaterThan(0);
+    // Should use the per-message timestamp, not the git commit timestamp
+    expect(turns[0]?.timestamp).toBe(t + 1000);
 
-    // Gap: no per-message timestamps
-    const timestampGap = result.gaps.find(
-      (g) => g.kind === "no-per-message-timestamps",
-    );
-    expect(timestampGap).toBeDefined();
   });
 
   test("reconstructs multi-turn conversations across checkpoints", async () => {
@@ -128,18 +136,20 @@ describe("reconstructTimeline", () => {
     await initAgentRepo(dir);
     const store = new IsogitStore(dir);
 
+    const t = 1700000000000;
+
     // First turn
     const messages1: ConversationMessage[] = [
-      userMessage("Hello"),
-      assistantMessage("Hi there"),
+      userMessage("Hello", t),
+      assistantMessage("Hi there", t + 1000),
     ];
     await store.commit(messages1, NO_OPS, NO_USAGE, "checkpoint");
 
     // Second turn (appends to the same message array)
     const messages2: ConversationMessage[] = [
       ...messages1,
-      userMessage("How are you?"),
-      assistantMessage("I'm doing well"),
+      userMessage("How are you?", t + 5000),
+      assistantMessage("I'm doing well", t + 6000),
     ];
     await store.commit(messages2, NO_OPS, NO_USAGE, "checkpoint");
 
@@ -150,10 +160,9 @@ describe("reconstructTimeline", () => {
     expect(turns[0]?.content).toBe("Hi there");
     expect(turns[1]?.content).toBe("I'm doing well");
 
-    // Second turn should have a later or equal timestamp
-    if (turns[0] !== undefined && turns[1] !== undefined) {
-      expect(turns[1].timestamp).toBeGreaterThanOrEqual(turns[0].timestamp);
-    }
+    // Should use per-message timestamps
+    expect(turns[0]?.timestamp).toBe(t + 1000);
+    expect(turns[1]?.timestamp).toBe(t + 6000);
   });
 
   test("treats a tool-use loop as a single turn", async () => {
@@ -359,16 +368,16 @@ describe("reconstructTimeline", () => {
     await initAgentRepo(dir);
     const store = new IsogitStore(dir);
 
+    const t = 1700000000000;
     const messages: ConversationMessage[] = [
-      userMessage("Hello"),
-      assistantMessage("Hi"),
+      userMessage("Hello", t),
+      assistantMessage("Hi", t + 1000),
     ];
     await store.commit(messages, NO_OPS, NO_USAGE, "checkpoint");
 
     const result = await reconstructTimeline(dir);
 
     const gapKinds = result.gaps.map((g) => g.kind);
-    expect(gapKinds).toContain("no-per-message-timestamps");
     expect(gapKinds).toContain("no-turn-boundaries");
     expect(gapKinds).toContain("no-assistant-mail-linkage");
     expect(gapKinds).toContain("no-turn-status");

--- a/packages/hub/src/timeline-reconstruction.test.ts
+++ b/packages/hub/src/timeline-reconstruction.test.ts
@@ -332,11 +332,6 @@ describe("reconstructTimeline", () => {
     if (turn?.kind === "turn") {
       expect(turn.errors?.[0]?.category).toBe("rate_limit");
     }
-
-    // No error-association or working-tree gaps should be present
-    const gapKinds = result.gaps.map((g) => g.kind);
-    expect(gapKinds).not.toContain("no-error-turn-association");
-    expect(gapKinds).not.toContain("errors-from-working-tree");
   });
 
   test("handles message-count regression gracefully", async () => {

--- a/packages/hub/src/timeline-reconstruction.test.ts
+++ b/packages/hub/src/timeline-reconstruction.test.ts
@@ -249,12 +249,45 @@ describe("reconstructTimeline", () => {
     if (outboundEvent !== undefined && outboundEvent.kind === "mail") {
       expect(outboundEvent.messageId).toBe("<msg-2@test>");
     }
+  });
 
-    // Gap: no link between assistant messages and outbound mail
-    const linkGap = result.gaps.find(
-      (g) => g.kind === "no-assistant-mail-linkage",
+  test("links outbound mail to checkpoint via Checkpoint trailer", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+    const store = new IsogitStore(dir);
+
+    const t = 1700000000000;
+    const messages: ConversationMessage[] = [
+      userMessage("Hello", t),
+      assistantMessage("Hi there", t + 1000),
+    ];
+    const commit = await store.commit(
+      messages,
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint: inference-done",
     );
-    expect(linkGap).toBeDefined();
+
+    const mailStore = await createMailAuditStore(dir);
+    const outbound = buildRawMessage({
+      messageId: "<reply@test>",
+      from: "agent@example.com",
+      to: "alice@example.com",
+      body: "Hi there",
+    });
+    await mailStore.commitMail(outbound, "out", {
+      checkpointHash: commit.hash,
+    });
+
+    const result = await reconstructTimeline(dir);
+
+    const mailEvents = result.events.filter((e) => e.kind === "mail");
+    expect(mailEvents).toHaveLength(1);
+    const mailEvent = mailEvents[0];
+    expect(mailEvent).toBeDefined();
+    if (mailEvent !== undefined && mailEvent.kind === "mail") {
+      expect(mailEvent.checkpointHash).toBe(commit.hash);
+    }
   });
 
   test("associates error records from git with the preceding turn", async () => {
@@ -391,7 +424,7 @@ describe("reconstructTimeline", () => {
     }
   });
 
-  test("produces remaining gap types for a well-formed checkpoint", async () => {
+  test("produces no gaps for a well-formed checkpoint", async () => {
     const dir = await makeTempDir();
     await initAgentRepo(dir);
     const store = new IsogitStore(dir);
@@ -410,8 +443,7 @@ describe("reconstructTimeline", () => {
 
     const result = await reconstructTimeline(dir);
 
-    const gapKinds = result.gaps.map((g) => g.kind);
-    expect(gapKinds).toContain("no-assistant-mail-linkage");
+    expect(result.gaps).toHaveLength(0);
   });
 
   test("marks turns as error when checkpoint reason is inference-error", async () => {

--- a/packages/hub/src/timeline-reconstruction.test.ts
+++ b/packages/hub/src/timeline-reconstruction.test.ts
@@ -623,6 +623,163 @@ describe("reconstructTimeline", () => {
     expect(corruptGaps[0]?.description).toContain("00000001-corrupt.json");
   });
 
+  test("reconstructs a full multi-step session from git", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+    const store = new IsogitStore(dir);
+    const mailStore = await createMailAuditStore(dir);
+
+    const t = 1700000000000;
+
+    // 1. Inbound mail arrives
+    const inbound = buildRawMessage({
+      messageId: "<inbound-1@test>",
+      from: "alice@example.com",
+      to: "agent@example.com",
+      body: "What is the weather in SF and NYC?",
+    });
+    await mailStore.commitMail(inbound, "in");
+
+    // 2. First inference: agent decides to call a tool
+    const msgs1: ConversationMessage[] = [
+      userMessage("What is the weather in SF and NYC?", t),
+      toolCallMessage("call-1", "get_weather", { city: "SF" }, t + 1000),
+    ];
+    await store.commit(msgs1, NO_OPS, NO_USAGE, "checkpoint: tool-execution");
+
+    // 3. Tool result comes back
+    const msgs2: ConversationMessage[] = [
+      ...msgs1,
+      toolResultMessage("call-1", "72F and sunny", t + 2000),
+    ];
+    await store.commit(msgs2, NO_OPS, NO_USAGE, "checkpoint: tool-done");
+
+    // 4. Second inference: agent calls another tool
+    const msgs3: ConversationMessage[] = [
+      ...msgs2,
+      toolCallMessage("call-2", "get_weather", { city: "NYC" }, t + 3000),
+    ];
+    await store.commit(msgs3, NO_OPS, NO_USAGE, "checkpoint: tool-execution");
+
+    // 5. Second tool result
+    const msgs4: ConversationMessage[] = [
+      ...msgs3,
+      toolResultMessage("call-2", "55F and rainy", t + 4000),
+    ];
+    await store.commit(msgs4, NO_OPS, NO_USAGE, "checkpoint: tool-done");
+
+    // 6. Final inference: agent composes reply
+    const msgs5: ConversationMessage[] = [
+      ...msgs4,
+      assistantMessage("SF is 72F and sunny. NYC is 55F and rainy.", t + 5000),
+    ];
+    const finalCommit = await store.commit(
+      msgs5,
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint: inference-done",
+    );
+
+    // 7. Outbound mail sent with checkpoint linkage
+    const outbound = buildRawMessage({
+      messageId: "<outbound-1@test>",
+      from: "agent@example.com",
+      to: "alice@example.com",
+      inReplyTo: "<inbound-1@test>",
+      body: "SF is 72F and sunny. NYC is 55F and rainy.",
+    });
+    await mailStore.commitMail(outbound, "out", {
+      checkpointHash: finalCommit.hash,
+    });
+
+    // 8. An error occurs on a follow-up inference
+    const msgs6: ConversationMessage[] = [
+      ...msgs5,
+      userMessage("What about London?", t + 10000),
+      assistantMessage("Let me check London weather.", t + 11000),
+    ];
+    await store.commit(msgs6, NO_OPS, NO_USAGE, "checkpoint: inference-error");
+
+    // 9. Error record committed
+    await store.commitErrors([
+      {
+        source: "inference",
+        category: "rate_limit",
+        message: "Rate limited by provider",
+        fatal: false,
+        timestamp: new Date(t + 11000).toISOString(),
+        sessionId: "test-session",
+        seq: 0,
+      },
+    ]);
+
+    // --- Reconstruct and verify ---
+    const result = await reconstructTimeline(dir);
+
+    // No gaps — all data is well-formed and linked
+    expect(result.gaps).toHaveLength(0);
+
+    // Mail events
+    const mailEvents = result.events.filter((e) => e.kind === "mail");
+    expect(mailEvents).toHaveLength(2);
+
+    const inboundMail = mailEvents.find(
+      (e) => e.kind === "mail" && e.direction === "in",
+    );
+    expect(inboundMail).toBeDefined();
+    if (inboundMail !== undefined && inboundMail.kind === "mail") {
+      expect(inboundMail.messageId).toBe("<inbound-1@test>");
+    }
+
+    const outboundMail = mailEvents.find(
+      (e) => e.kind === "mail" && e.direction === "out",
+    );
+    expect(outboundMail).toBeDefined();
+    if (outboundMail !== undefined && outboundMail.kind === "mail") {
+      expect(outboundMail.messageId).toBe("<outbound-1@test>");
+      expect(outboundMail.checkpointHash).toBe(finalCommit.hash);
+    }
+
+    // Turn events
+    const turns = result.events.filter((e) => e.kind === "turn");
+
+    // Tool-only checkpoints (tool-execution, tool-done) produce no text
+    // content, so no turn events. Only inference-done and inference-error
+    // checkpoints that add assistant text produce turns.
+    expect(turns).toHaveLength(2);
+
+    const completedTurn = turns.find(
+      (e) => e.kind === "turn" && e.status === "completed",
+    );
+    expect(completedTurn).toBeDefined();
+    if (completedTurn !== undefined && completedTurn.kind === "turn") {
+      expect(completedTurn.content).toBe(
+        "SF is 72F and sunny. NYC is 55F and rainy.",
+      );
+    }
+
+    const errorTurn = turns.find(
+      (e) => e.kind === "turn" && e.status === "error",
+    );
+    expect(errorTurn).toBeDefined();
+    if (errorTurn !== undefined && errorTurn.kind === "turn") {
+      expect(errorTurn.content).toBe("Let me check London weather.");
+      expect(errorTurn.isError).toBe(true);
+      expect(errorTurn.errors).toBeDefined();
+      expect(errorTurn.errors?.length).toBe(1);
+      expect(errorTurn.errors?.[0]?.category).toBe("rate_limit");
+    }
+
+    // Events are sorted by timestamp — mail and turns interleaved correctly
+    for (let i = 1; i < result.events.length; i++) {
+      const prev = result.events[i - 1];
+      const curr = result.events[i];
+      if (prev !== undefined && curr !== undefined) {
+        expect(curr.timestamp).toBeGreaterThanOrEqual(prev.timestamp);
+      }
+    }
+  });
+
   test("records multiple gaps for multiple corrupt checkpoints", async () => {
     const dir = await makeTempDir();
     await initAgentRepo(dir);

--- a/packages/hub/src/timeline-reconstruction.test.ts
+++ b/packages/hub/src/timeline-reconstruction.test.ts
@@ -119,7 +119,12 @@ describe("reconstructTimeline", () => {
       userMessage("Hello", t),
       assistantMessage("Hi there", t + 1000),
     ];
-    await store.commit(messages, NO_OPS, NO_USAGE, "checkpoint");
+    await store.commit(
+      messages,
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint: inference-done",
+    );
 
     const result = await reconstructTimeline(dir);
 
@@ -128,7 +133,8 @@ describe("reconstructTimeline", () => {
     expect(turns[0]?.content).toBe("Hi there");
     // Should use the per-message timestamp, not the git commit timestamp
     expect(turns[0]?.timestamp).toBe(t + 1000);
-
+    // Status derived from checkpoint reason
+    expect(turns[0]?.kind === "turn" && turns[0].status).toBe("completed");
   });
 
   test("reconstructs multi-turn conversations across checkpoints", async () => {
@@ -143,7 +149,12 @@ describe("reconstructTimeline", () => {
       userMessage("Hello", t),
       assistantMessage("Hi there", t + 1000),
     ];
-    await store.commit(messages1, NO_OPS, NO_USAGE, "checkpoint");
+    await store.commit(
+      messages1,
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint: inference-done",
+    );
 
     // Second turn (appends to the same message array)
     const messages2: ConversationMessage[] = [
@@ -151,7 +162,12 @@ describe("reconstructTimeline", () => {
       userMessage("How are you?", t + 5000),
       assistantMessage("I'm doing well", t + 6000),
     ];
-    await store.commit(messages2, NO_OPS, NO_USAGE, "checkpoint");
+    await store.commit(
+      messages2,
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint: inference-done",
+    );
 
     const result = await reconstructTimeline(dir);
 
@@ -176,19 +192,18 @@ describe("reconstructTimeline", () => {
       toolResultMessage("call-1", "72F and sunny"),
       assistantMessage("The weather in SF is 72F and sunny."),
     ];
-    await store.commit(messages, NO_OPS, NO_USAGE, "checkpoint");
+    await store.commit(
+      messages,
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint: inference-done",
+    );
 
     const result = await reconstructTimeline(dir);
 
     const turns = result.events.filter((e) => e.kind === "turn");
     expect(turns).toHaveLength(1);
     expect(turns[0]?.content).toBe("The weather in SF is 72F and sunny.");
-
-    // Gap: turn boundaries are heuristic
-    const turnBoundaryGap = result.gaps.find(
-      (g) => g.kind === "no-turn-boundaries",
-    );
-    expect(turnBoundaryGap).toBeDefined();
   });
 
   test("reconstructs mail events", async () => {
@@ -252,7 +267,12 @@ describe("reconstructTimeline", () => {
       userMessage("Do something risky"),
       assistantMessage("Attempting..."),
     ];
-    await store.commit(messages, NO_OPS, NO_USAGE, "checkpoint");
+    await store.commit(
+      messages,
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint: inference-done",
+    );
 
     // Write error records
     const errors: ErrorRecord[] = [
@@ -305,14 +325,24 @@ describe("reconstructTimeline", () => {
       userMessage("More"),
       assistantMessage("Sure"),
     ];
-    await store.commit(messages1, NO_OPS, NO_USAGE, "checkpoint");
+    await store.commit(
+      messages1,
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint: inference-done",
+    );
 
     // Second checkpoint with only 2 messages (regression)
     const messages2: ConversationMessage[] = [
       userMessage("Fresh start"),
       assistantMessage("OK"),
     ];
-    await store.commit(messages2, NO_OPS, NO_USAGE, "checkpoint");
+    await store.commit(
+      messages2,
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint: inference-done",
+    );
 
     const result = await reconstructTimeline(dir);
 
@@ -345,7 +375,12 @@ describe("reconstructTimeline", () => {
       userMessage("Hello"),
       assistantMessage("Hi there"),
     ];
-    await store.commit(messages, NO_OPS, NO_USAGE, "checkpoint");
+    await store.commit(
+      messages,
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint: inference-done",
+    );
 
     const result = await reconstructTimeline(dir);
 
@@ -363,7 +398,7 @@ describe("reconstructTimeline", () => {
     }
   });
 
-  test("produces all known gap types", async () => {
+  test("produces remaining gap types for a well-formed checkpoint", async () => {
     const dir = await makeTempDir();
     await initAgentRepo(dir);
     const store = new IsogitStore(dir);
@@ -373,15 +408,85 @@ describe("reconstructTimeline", () => {
       userMessage("Hello", t),
       assistantMessage("Hi", t + 1000),
     ];
-    await store.commit(messages, NO_OPS, NO_USAGE, "checkpoint");
+    await store.commit(
+      messages,
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint: inference-done",
+    );
 
     const result = await reconstructTimeline(dir);
 
     const gapKinds = result.gaps.map((g) => g.kind);
-    expect(gapKinds).toContain("no-turn-boundaries");
+    // With checkpoint reasons, turn boundaries/status/hadError are resolved
     expect(gapKinds).toContain("no-assistant-mail-linkage");
-    expect(gapKinds).toContain("no-turn-status");
-    expect(gapKinds).toContain("no-had-error");
+    // These are only emitted when errors exist, not present here
+    expect(gapKinds).not.toContain("no-error-turn-association");
+    expect(gapKinds).not.toContain("errors-from-working-tree");
+  });
+
+  test("marks turns as error when checkpoint reason is inference-error", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+    const store = new IsogitStore(dir);
+
+    const t = 1700000000000;
+    const messages: ConversationMessage[] = [
+      userMessage("Hello", t),
+      assistantMessage("Something went wrong", t + 1000),
+    ];
+    await store.commit(
+      messages,
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint: inference-error",
+    );
+
+    const result = await reconstructTimeline(dir);
+
+    const turns = result.events.filter((e) => e.kind === "turn");
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.kind === "turn" && turns[0].status).toBe("error");
+    expect(turns[0]?.kind === "turn" && turns[0].isError).toBe(true);
+  });
+
+  test("marks turns as in-progress for mid-turn checkpoints", async () => {
+    const dir = await makeTempDir();
+    await initAgentRepo(dir);
+    const store = new IsogitStore(dir);
+
+    const t = 1700000000000;
+    const messages: ConversationMessage[] = [
+      userMessage("What's the weather?", t),
+      toolCallMessage("call-1", "get_weather", { city: "SF" }, t + 1000),
+    ];
+    await store.commit(
+      messages,
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint: tool-execution",
+    );
+
+    // Add tool result and final response
+    const messages2: ConversationMessage[] = [
+      ...messages,
+      toolResultMessage("call-1", "72F", t + 2000),
+      assistantMessage("It's 72F in SF", t + 3000),
+    ];
+    await store.commit(
+      messages2,
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint: inference-done",
+    );
+
+    const result = await reconstructTimeline(dir);
+
+    const turns = result.events.filter((e) => e.kind === "turn");
+    // tool-execution checkpoint has no text content, so no turn emitted
+    // inference-done checkpoint has the final response
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.kind === "turn" && turns[0].status).toBe("completed");
   });
 
   test("handles empty repo with no checkpoints", async () => {
@@ -404,7 +509,12 @@ describe("reconstructTimeline", () => {
       userMessage("Hello"),
       assistantMessage("Hi"),
     ];
-    await store.commit(messages, NO_OPS, NO_USAGE, "checkpoint");
+    await store.commit(
+      messages,
+      NO_OPS,
+      NO_USAGE,
+      "checkpoint: inference-done",
+    );
 
     // Write a corrupt checkpoint directly via git
     const contextPath = path.join(dir, "state/context.json");
@@ -413,7 +523,7 @@ describe("reconstructTimeline", () => {
     await git.commit({
       fs,
       dir,
-      message: "checkpoint",
+      message: "checkpoint: inference-done",
       author: { name: "test", email: "test@test.dev" },
     });
 
@@ -490,7 +600,7 @@ describe("reconstructTimeline", () => {
       await git.commit({
         fs,
         dir,
-        message: "checkpoint",
+        message: "checkpoint: inference-done",
         author: { name: "test", email: "test@test.dev" },
       });
     }

--- a/packages/hub/src/timeline-reconstruction.ts
+++ b/packages/hub/src/timeline-reconstruction.ts
@@ -1,0 +1,315 @@
+import fs from "node:fs";
+import path from "node:path";
+import { type } from "arktype";
+import {
+  IsogitStore,
+  listMail,
+  type MailDirection,
+} from "@interchange/storage-isogit";
+import type { ConversationMessage } from "@interchange/types/runtime";
+import { ErrorRecord } from "@interchange/types/audit";
+
+export type ReconstructedEvent =
+  | {
+      kind: "mail";
+      direction: MailDirection;
+      messageId: string;
+      timestamp: number;
+      raw: Uint8Array;
+    }
+  | {
+      kind: "turn";
+      content: string;
+      timestamp: number;
+      isError?: boolean;
+      errors?: { category: string; message: string }[];
+    };
+
+export type GapKind =
+  | "no-per-message-timestamps"
+  | "no-turn-boundaries"
+  | "no-assistant-mail-linkage"
+  | "no-turn-status"
+  | "no-had-error"
+  | "no-error-turn-association"
+  | "errors-from-working-tree"
+  | "message-count-regression"
+  | "corrupt-checkpoint"
+  | "corrupt-error-record";
+
+export type ReconstructionGap = {
+  kind: GapKind;
+  description: string;
+};
+
+export type ReconstructionResult = {
+  events: ReconstructedEvent[];
+  gaps: ReconstructionGap[];
+};
+
+const ERRORS_DIR = "state/errors";
+const MAX_LOG_DEPTH = 10000;
+
+function isToolResultMessage(msg: ConversationMessage): boolean {
+  const first = msg.content[0];
+  return (
+    msg.role === "user" && first !== undefined && first.type === "tool_result"
+  );
+}
+
+function extractTextContent(msg: ConversationMessage): string {
+  return msg.content
+    .filter((b) => b.type === "text")
+    .map((b) => {
+      if (b.type !== "text") return "";
+      return b.text;
+    })
+    .join("");
+}
+
+type TurnAccumulator = {
+  texts: string[];
+  timestamp: number;
+};
+
+function extractTurns(
+  newMessages: ConversationMessage[],
+  commitTimestamp: number,
+): ReconstructedEvent[] {
+  const events: ReconstructedEvent[] = [];
+  let current: TurnAccumulator | null = null;
+
+  for (const msg of newMessages) {
+    if (msg.role === "user" && !isToolResultMessage(msg)) {
+      // New user message (not a tool result) starts a new turn
+      if (current !== null && current.texts.length > 0) {
+        events.push({
+          kind: "turn",
+          content: current.texts.join(""),
+          timestamp: current.timestamp,
+        });
+      }
+      current = { texts: [], timestamp: commitTimestamp };
+    } else if (msg.role === "assistant") {
+      if (current === null) {
+        current = { texts: [], timestamp: commitTimestamp };
+      }
+      const text = extractTextContent(msg);
+      if (text.length > 0) {
+        current.texts.push(text);
+      }
+    }
+    // tool_result user messages and system messages are continuations, not new turns
+  }
+
+  if (current !== null && current.texts.length > 0) {
+    events.push({
+      kind: "turn",
+      content: current.texts.join(""),
+      timestamp: current.timestamp,
+    });
+  }
+
+  return events;
+}
+
+type ErrorReadResult = {
+  errors: { category: string; message: string; timestamp: string }[];
+  corruptFiles: string[];
+};
+
+async function readErrorRecords(dir: string): Promise<ErrorReadResult> {
+  const errorsDir = path.join(dir, ERRORS_DIR);
+  let sessionDirs: string[];
+  try {
+    sessionDirs = await fs.promises.readdir(errorsDir);
+  } catch (e: unknown) {
+    if (e instanceof Error && "code" in e && e.code === "ENOENT") {
+      return { errors: [], corruptFiles: [] };
+    }
+    throw e;
+  }
+
+  const errors: { category: string; message: string; timestamp: string }[] = [];
+  const corruptFiles: string[] = [];
+
+  for (const sessionId of sessionDirs) {
+    const sessionPath = path.join(errorsDir, sessionId);
+    const stat = await fs.promises.stat(sessionPath);
+    if (!stat.isDirectory()) continue;
+
+    const files = await fs.promises.readdir(sessionPath);
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      const fullPath = path.join(sessionPath, file);
+      const raw = await fs.promises.readFile(fullPath, "utf-8");
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        corruptFiles.push(`${sessionId}/${file}`);
+        continue;
+      }
+      const result = ErrorRecord(parsed);
+      if (result instanceof type.errors) {
+        corruptFiles.push(`${sessionId}/${file}`);
+        continue;
+      }
+      errors.push({
+        category: result.category,
+        message: result.message,
+        timestamp: result.timestamp,
+      });
+    }
+  }
+
+  return { errors, corruptFiles };
+}
+
+export async function reconstructTimeline(
+  dir: string,
+): Promise<ReconstructionResult> {
+  const store = new IsogitStore(dir);
+  const events: ReconstructedEvent[] = [];
+  const gaps: ReconstructionGap[] = [];
+  const gapKindsAdded = new Set<GapKind>();
+
+  function addGap(kind: GapKind, description: string): void {
+    if (gapKindsAdded.has(kind)) return;
+    gapKindsAdded.add(kind);
+    gaps.push({ kind, description });
+  }
+
+  // Walk the full commit log, oldest first
+  const commits = await store.log(MAX_LOG_DEPTH);
+  commits.reverse();
+
+  // Process checkpoint commits to extract turns
+  let prevMessageCount = 0;
+  let hasCheckpoints = false;
+
+  for (const commit of commits) {
+    if (commit.message !== "checkpoint") continue;
+
+    hasCheckpoints = true;
+    let messages: ConversationMessage[];
+    try {
+      messages = await store.readAt(commit.hash);
+    } catch {
+      gaps.push({
+        kind: "corrupt-checkpoint",
+        description: `Checkpoint commit ${commit.hash} could not be read; this checkpoint is missing from the reconstructed timeline`,
+      });
+      continue;
+    }
+
+    if (messages.length < prevMessageCount) {
+      addGap(
+        "message-count-regression",
+        `Message count dropped from ${prevMessageCount} to ${messages.length} at commit ${commit.hash}`,
+      );
+      // Treat the entire message array as new for this checkpoint
+      const turnEvents = extractTurns(messages, commit.timestamp);
+      events.push(...turnEvents);
+      prevMessageCount = messages.length;
+      continue;
+    }
+
+    const newMessages = messages.slice(prevMessageCount);
+    prevMessageCount = messages.length;
+
+    if (newMessages.length === 0) continue;
+
+    const turnEvents = extractTurns(newMessages, commit.timestamp);
+    events.push(...turnEvents);
+  }
+
+  // Process mail entries
+  const mailEntries = await listMail(dir);
+  // Correlate mail timestamps with git commits by matching commit messages
+  const mailCommitTimestamps = new Map<string, number>();
+  for (const commit of commits) {
+    const match = /^Record (?:inbound|outbound) mail (.+)$/.exec(
+      commit.message,
+    );
+    if (match?.[1] !== undefined) {
+      mailCommitTimestamps.set(match[1], commit.timestamp);
+    }
+  }
+
+  for (const entry of mailEntries) {
+    const timestamp = mailCommitTimestamps.get(entry.messageId) ?? 0;
+    events.push({
+      kind: "mail",
+      direction: entry.direction,
+      messageId: entry.messageId,
+      timestamp,
+      raw: entry.raw,
+    });
+  }
+
+  // Process error records from the working tree
+  const { errors, corruptFiles } = await readErrorRecords(dir);
+
+  for (const file of corruptFiles) {
+    gaps.push({
+      kind: "corrupt-error-record",
+      description: `Error record ${file} failed validation and was excluded from the timeline`,
+    });
+  }
+
+  if (errors.length > 0) {
+    // Errors have no turn association, so use the last checkpoint as a best-effort timestamp
+    const fallbackTimestamp =
+      commits.filter((c) => c.message === "checkpoint").at(-1)?.timestamp ?? 0;
+
+    events.push({
+      kind: "turn",
+      content: "",
+      timestamp: fallbackTimestamp,
+      isError: true,
+      errors: errors.map((e) => ({ category: e.category, message: e.message })),
+    });
+
+    addGap(
+      "no-error-turn-association",
+      "Error records have sessionId and seq but no turn ID; cannot associate errors with specific turns",
+    );
+    addGap(
+      "errors-from-working-tree",
+      "Error records are read from the working tree, not from git objects; this breaks audit integrity for bare repos",
+    );
+  }
+
+  // Sort all events by timestamp
+  events.sort((a, b) => a.timestamp - b.timestamp);
+
+  // Always-present gaps (structural limitations of the current git format)
+  if (hasCheckpoints) {
+    addGap(
+      "no-per-message-timestamps",
+      "ConversationMessage has no timestamp field; all messages in a checkpoint share the git commit timestamp",
+    );
+    addGap(
+      "no-turn-boundaries",
+      "Checkpoint commit messages are the literal string 'checkpoint' with no turn ID; turn boundaries are heuristically inferred from role sequences",
+    );
+    addGap(
+      "no-turn-status",
+      "Whether a turn completed or failed lives only in the inference_turn DB table; nothing in the git repo records this",
+    );
+    addGap(
+      "no-had-error",
+      "hadError is an in-memory flag in the event collector, never persisted to git",
+    );
+  }
+
+  if (mailEntries.length > 0 || hasCheckpoints) {
+    addGap(
+      "no-assistant-mail-linkage",
+      "The mail store has messageId and the context store has ConversationMessage, but nothing connects assistant messages to their corresponding outbound mail",
+    );
+  }
+
+  return { events, gaps };
+}

--- a/packages/hub/src/timeline-reconstruction.ts
+++ b/packages/hub/src/timeline-reconstruction.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import path from "node:path";
+import git from "isomorphic-git";
 import { type } from "arktype";
 import {
   IsogitStore,
@@ -7,7 +7,10 @@ import {
   type MailDirection,
 } from "@interchange/storage-isogit";
 import type { ConversationMessage } from "@interchange/types/runtime";
-import { ErrorRecord } from "@interchange/types/audit";
+import {
+  ErrorRecord,
+  type ErrorRecord as ErrorRecordType,
+} from "@interchange/types/audit";
 
 export type ReconstructedEvent =
   | {
@@ -28,8 +31,6 @@ export type ReconstructedEvent =
 
 export type GapKind =
   | "no-assistant-mail-linkage"
-  | "no-error-turn-association"
-  | "errors-from-working-tree"
   | "message-count-regression"
   | "corrupt-checkpoint"
   | "corrupt-error-record";
@@ -156,52 +157,70 @@ function extractTurns(
 }
 
 type ErrorReadResult = {
-  errors: { category: string; message: string; timestamp: string }[];
+  errors: ErrorRecordType[];
   corruptFiles: string[];
 };
 
-async function readErrorRecords(dir: string): Promise<ErrorReadResult> {
-  const errorsDir = path.join(dir, ERRORS_DIR);
-  let sessionDirs: string[];
-  try {
-    sessionDirs = await fs.promises.readdir(errorsDir);
-  } catch (e: unknown) {
-    if (e instanceof Error && "code" in e && e.code === "ENOENT") {
-      return { errors: [], corruptFiles: [] };
-    }
-    throw e;
-  }
+const ERROR_COMMIT_PATTERN = /^Record \d+ error records?$/;
 
-  const errors: { category: string; message: string; timestamp: string }[] = [];
+async function readErrorRecordsFromCommit(
+  dir: string,
+  oid: string,
+): Promise<ErrorReadResult> {
+  const errors: ErrorRecordType[] = [];
   const corruptFiles: string[] = [];
 
-  for (const sessionId of sessionDirs) {
-    const sessionPath = path.join(errorsDir, sessionId);
-    const stat = await fs.promises.stat(sessionPath);
-    if (!stat.isDirectory()) continue;
+  // Walk state/errors/ in the commit tree
+  let sessionTree;
+  try {
+    sessionTree = await git.readTree({ fs, dir, oid, filepath: ERRORS_DIR });
+  } catch {
+    return { errors: [], corruptFiles: [] };
+  }
 
-    const files = await fs.promises.readdir(sessionPath);
-    for (const file of files) {
-      if (!file.endsWith(".json")) continue;
-      const fullPath = path.join(sessionPath, file);
-      const raw = await fs.promises.readFile(fullPath, "utf-8");
+  for (const sessionEntry of sessionTree.tree) {
+    if (sessionEntry.type !== "tree") continue;
+    const sessionId = sessionEntry.path;
+
+    let fileTree;
+    try {
+      fileTree = await git.readTree({
+        fs,
+        dir,
+        oid,
+        filepath: `${ERRORS_DIR}/${sessionId}`,
+      });
+    } catch {
+      continue;
+    }
+
+    for (const fileEntry of fileTree.tree) {
+      if (fileEntry.type !== "blob" || !fileEntry.path.endsWith(".json"))
+        continue;
+
+      let blob: Uint8Array;
+      try {
+        ({ blob } = await git.readBlob({ fs, dir, oid: fileEntry.oid }));
+      } catch {
+        corruptFiles.push(`${sessionId}/${fileEntry.path}`);
+        continue;
+      }
+
+      const text = new TextDecoder().decode(blob);
       let parsed: unknown;
       try {
-        parsed = JSON.parse(raw);
+        parsed = JSON.parse(text);
       } catch {
-        corruptFiles.push(`${sessionId}/${file}`);
+        corruptFiles.push(`${sessionId}/${fileEntry.path}`);
         continue;
       }
+
       const result = ErrorRecord(parsed);
       if (result instanceof type.errors) {
-        corruptFiles.push(`${sessionId}/${file}`);
+        corruptFiles.push(`${sessionId}/${fileEntry.path}`);
         continue;
       }
-      errors.push({
-        category: result.category,
-        message: result.message,
-        timestamp: result.timestamp,
-      });
+      errors.push(result);
     }
   }
 
@@ -226,11 +245,41 @@ export async function reconstructTimeline(
   const commits = await store.log(MAX_LOG_DEPTH);
   commits.reverse();
 
-  // Process checkpoint commits to extract turns
+  // Process commits to extract turns and associate errors
   let prevMessageCount = 0;
   let hasCheckpoints = false;
+  // Track the index of the last turn event so error commits can attach to it
+  let lastTurnEventIndex = -1;
 
   for (const commit of commits) {
+    // Handle error commits — associate with the most recent turn
+    if (ERROR_COMMIT_PATTERN.test(commit.message)) {
+      const { errors: errorRecords, corruptFiles } =
+        await readErrorRecordsFromCommit(dir, commit.hash);
+
+      for (const file of corruptFiles) {
+        gaps.push({
+          kind: "corrupt-error-record",
+          description: `Error record ${file} failed validation and was excluded from the timeline`,
+        });
+      }
+
+      if (errorRecords.length > 0 && lastTurnEventIndex >= 0) {
+        const turnEvent = events[lastTurnEventIndex];
+        if (turnEvent !== undefined && turnEvent.kind === "turn") {
+          turnEvent.isError = true;
+          turnEvent.errors = [
+            ...(turnEvent.errors ?? []),
+            ...errorRecords.map((e) => ({
+              category: e.category,
+              message: e.message,
+            })),
+          ];
+        }
+      }
+      continue;
+    }
+
     const reason = parseCheckpointReason(commit.message);
     if (reason === null) continue;
 
@@ -256,6 +305,9 @@ export async function reconstructTimeline(
       // Treat the entire message array as new for this checkpoint
       const turnEvents = extractTurns(messages, status);
       events.push(...turnEvents);
+      if (turnEvents.length > 0) {
+        lastTurnEventIndex = events.length - 1;
+      }
       prevMessageCount = messages.length;
       continue;
     }
@@ -267,6 +319,9 @@ export async function reconstructTimeline(
 
     const turnEvents = extractTurns(newMessages, status);
     events.push(...turnEvents);
+    if (turnEvents.length > 0) {
+      lastTurnEventIndex = events.length - 1;
+    }
   }
 
   // Process mail entries
@@ -291,41 +346,6 @@ export async function reconstructTimeline(
       timestamp,
       raw: entry.raw,
     });
-  }
-
-  // Process error records from the working tree
-  const { errors, corruptFiles } = await readErrorRecords(dir);
-
-  for (const file of corruptFiles) {
-    gaps.push({
-      kind: "corrupt-error-record",
-      description: `Error record ${file} failed validation and was excluded from the timeline`,
-    });
-  }
-
-  if (errors.length > 0) {
-    // Errors have no turn association, so use the last checkpoint as a best-effort timestamp
-    const fallbackTimestamp =
-      commits.filter((c) => parseCheckpointReason(c.message) !== null).at(-1)
-        ?.timestamp ?? 0;
-
-    events.push({
-      kind: "turn",
-      content: "",
-      timestamp: fallbackTimestamp,
-      status: "error",
-      isError: true,
-      errors: errors.map((e) => ({ category: e.category, message: e.message })),
-    });
-
-    addGap(
-      "no-error-turn-association",
-      "Error records have sessionId and seq but no turn ID; cannot associate errors with specific turns",
-    );
-    addGap(
-      "errors-from-working-tree",
-      "Error records are read from the working tree, not from git objects; this breaks audit integrity for bare repos",
-    );
   }
 
   // Sort all events by timestamp

--- a/packages/hub/src/timeline-reconstruction.ts
+++ b/packages/hub/src/timeline-reconstruction.ts
@@ -19,6 +19,7 @@ export type ReconstructedEvent =
       messageId: string;
       timestamp: number;
       raw: Uint8Array;
+      checkpointHash?: string;
     }
   | {
       kind: "turn";
@@ -30,7 +31,6 @@ export type ReconstructedEvent =
     };
 
 export type GapKind =
-  | "no-assistant-mail-linkage"
   | "message-count-regression"
   | "corrupt-checkpoint"
   | "corrupt-error-record";
@@ -247,7 +247,6 @@ export async function reconstructTimeline(
 
   // Process commits to extract turns and associate errors
   let prevMessageCount = 0;
-  let hasCheckpoints = false;
   // Track the index of the last turn event so error commits can attach to it
   let lastTurnEventIndex = -1;
 
@@ -283,7 +282,6 @@ export async function reconstructTimeline(
     const reason = parseCheckpointReason(commit.message);
     if (reason === null) continue;
 
-    hasCheckpoints = true;
     const status = reasonToStatus(reason);
 
     let messages: ConversationMessage[];
@@ -326,37 +324,45 @@ export async function reconstructTimeline(
 
   // Process mail entries
   const mailEntries = await listMail(dir);
-  // Correlate mail timestamps with git commits by matching commit messages
-  const mailCommitTimestamps = new Map<string, number>();
+  // Correlate mail timestamps and checkpoint linkage with git commits.
+  // The Checkpoint trailer regex uses $ to anchor at end-of-string. This
+  // relies on IsogitStore.log() calling trimEnd() on commit messages to
+  // strip the trailing newline that isomorphic-git appends.
+  const mailCommitMeta = new Map<
+    string,
+    { timestamp: number; checkpointHash?: string }
+  >();
   for (const commit of commits) {
-    const match = /^Record (?:inbound|outbound) mail (.+)$/.exec(
+    const match = /^Record (?:inbound|outbound) mail (.+)$/m.exec(
       commit.message,
     );
     if (match?.[1] !== undefined) {
-      mailCommitTimestamps.set(match[1], commit.timestamp);
+      const checkpointMatch = /\nCheckpoint: ([0-9a-f]+)$/.exec(commit.message);
+      mailCommitMeta.set(match[1], {
+        timestamp: commit.timestamp,
+        ...(checkpointMatch?.[1] !== undefined
+          ? { checkpointHash: checkpointMatch[1] }
+          : {}),
+      });
     }
   }
 
   for (const entry of mailEntries) {
-    const timestamp = mailCommitTimestamps.get(entry.messageId) ?? 0;
+    const meta = mailCommitMeta.get(entry.messageId);
     events.push({
       kind: "mail",
       direction: entry.direction,
       messageId: entry.messageId,
-      timestamp,
+      timestamp: meta?.timestamp ?? 0,
       raw: entry.raw,
+      ...(meta?.checkpointHash !== undefined
+        ? { checkpointHash: meta.checkpointHash }
+        : {}),
     });
   }
 
   // Sort all events by timestamp
   events.sort((a, b) => a.timestamp - b.timestamp);
-
-  if (mailEntries.length > 0 || hasCheckpoints) {
-    addGap(
-      "no-assistant-mail-linkage",
-      "The mail store has messageId and the context store has ConversationMessage, but nothing connects assistant messages to their corresponding outbound mail",
-    );
-  }
 
   return { events, gaps };
 }

--- a/packages/hub/src/timeline-reconstruction.ts
+++ b/packages/hub/src/timeline-reconstruction.ts
@@ -33,7 +33,8 @@ export type ReconstructedEvent =
 export type GapKind =
   | "message-count-regression"
   | "corrupt-checkpoint"
-  | "corrupt-error-record";
+  | "corrupt-error-record"
+  | "orphan-mail";
 
 export type ReconstructionGap = {
   kind: GapKind;
@@ -349,6 +350,12 @@ export async function reconstructTimeline(
 
   for (const entry of mailEntries) {
     const meta = mailCommitMeta.get(entry.messageId);
+    if (meta === undefined) {
+      gaps.push({
+        kind: "orphan-mail",
+        description: `Mail entry ${entry.messageId} has no corresponding git commit; its timestamp is unreliable`,
+      });
+    }
     events.push({
       kind: "mail",
       direction: entry.direction,

--- a/packages/hub/src/timeline-reconstruction.ts
+++ b/packages/hub/src/timeline-reconstruction.ts
@@ -21,15 +21,13 @@ export type ReconstructedEvent =
       kind: "turn";
       content: string;
       timestamp: number;
+      status: "completed" | "error" | "in-progress";
       isError?: boolean;
       errors?: { category: string; message: string }[];
     };
 
 export type GapKind =
-  | "no-turn-boundaries"
   | "no-assistant-mail-linkage"
-  | "no-turn-status"
-  | "no-had-error"
   | "no-error-turn-association"
   | "errors-from-working-tree"
   | "message-count-regression"
@@ -48,6 +46,45 @@ export type ReconstructionResult = {
 
 const ERRORS_DIR = "state/errors";
 const MAX_LOG_DEPTH = 10000;
+
+type CheckpointReason =
+  | "inference-done"
+  | "tool-execution"
+  | "tool-done"
+  | "inference-error"
+  | "gate-cleared";
+
+function isCheckpointReason(value: string): value is CheckpointReason {
+  return (
+    value === "inference-done" ||
+    value === "tool-execution" ||
+    value === "tool-done" ||
+    value === "inference-error" ||
+    value === "gate-cleared"
+  );
+}
+
+function parseCheckpointReason(commitMessage: string): CheckpointReason | null {
+  const match = /^checkpoint: (.+)$/.exec(commitMessage);
+  if (match?.[1] === undefined) return null;
+  if (!isCheckpointReason(match[1])) return null;
+  return match[1];
+}
+
+function reasonToStatus(
+  reason: CheckpointReason,
+): "completed" | "error" | "in-progress" {
+  switch (reason) {
+    case "inference-done":
+      return "completed";
+    case "inference-error":
+      return "error";
+    case "tool-execution":
+    case "tool-done":
+    case "gate-cleared":
+      return "in-progress";
+  }
+}
 
 function isToolResultMessage(msg: ConversationMessage): boolean {
   const first = msg.content[0];
@@ -73,6 +110,7 @@ type TurnAccumulator = {
 
 function extractTurns(
   newMessages: ConversationMessage[],
+  status: "completed" | "error" | "in-progress",
 ): ReconstructedEvent[] {
   const events: ReconstructedEvent[] = [];
   let current: TurnAccumulator | null = null;
@@ -85,6 +123,7 @@ function extractTurns(
           kind: "turn",
           content: current.texts.join(""),
           timestamp: current.timestamp,
+          status,
         });
       }
       current = { texts: [], timestamp: msg.timestamp };
@@ -108,6 +147,8 @@ function extractTurns(
       kind: "turn",
       content: current.texts.join(""),
       timestamp: current.timestamp,
+      status,
+      ...(status === "error" ? { isError: true } : {}),
     });
   }
 
@@ -190,9 +231,12 @@ export async function reconstructTimeline(
   let hasCheckpoints = false;
 
   for (const commit of commits) {
-    if (commit.message !== "checkpoint") continue;
+    const reason = parseCheckpointReason(commit.message);
+    if (reason === null) continue;
 
     hasCheckpoints = true;
+    const status = reasonToStatus(reason);
+
     let messages: ConversationMessage[];
     try {
       messages = await store.readAt(commit.hash);
@@ -210,7 +254,7 @@ export async function reconstructTimeline(
         `Message count dropped from ${prevMessageCount} to ${messages.length} at commit ${commit.hash}`,
       );
       // Treat the entire message array as new for this checkpoint
-      const turnEvents = extractTurns(messages);
+      const turnEvents = extractTurns(messages, status);
       events.push(...turnEvents);
       prevMessageCount = messages.length;
       continue;
@@ -221,7 +265,7 @@ export async function reconstructTimeline(
 
     if (newMessages.length === 0) continue;
 
-    const turnEvents = extractTurns(newMessages);
+    const turnEvents = extractTurns(newMessages, status);
     events.push(...turnEvents);
   }
 
@@ -262,12 +306,14 @@ export async function reconstructTimeline(
   if (errors.length > 0) {
     // Errors have no turn association, so use the last checkpoint as a best-effort timestamp
     const fallbackTimestamp =
-      commits.filter((c) => c.message === "checkpoint").at(-1)?.timestamp ?? 0;
+      commits.filter((c) => parseCheckpointReason(c.message) !== null).at(-1)
+        ?.timestamp ?? 0;
 
     events.push({
       kind: "turn",
       content: "",
       timestamp: fallbackTimestamp,
+      status: "error",
       isError: true,
       errors: errors.map((e) => ({ category: e.category, message: e.message })),
     });
@@ -284,22 +330,6 @@ export async function reconstructTimeline(
 
   // Sort all events by timestamp
   events.sort((a, b) => a.timestamp - b.timestamp);
-
-  // Always-present gaps (structural limitations of the current git format)
-  if (hasCheckpoints) {
-    addGap(
-      "no-turn-boundaries",
-      "Checkpoint commit messages are the literal string 'checkpoint' with no turn ID; turn boundaries are heuristically inferred from role sequences",
-    );
-    addGap(
-      "no-turn-status",
-      "Whether a turn completed or failed lives only in the inference_turn DB table; nothing in the git repo records this",
-    );
-    addGap(
-      "no-had-error",
-      "hadError is an in-memory flag in the event collector, never persisted to git",
-    );
-  }
 
   if (mailEntries.length > 0 || hasCheckpoints) {
     addGap(

--- a/packages/hub/src/timeline-reconstruction.ts
+++ b/packages/hub/src/timeline-reconstruction.ts
@@ -26,7 +26,6 @@ export type ReconstructedEvent =
     };
 
 export type GapKind =
-  | "no-per-message-timestamps"
   | "no-turn-boundaries"
   | "no-assistant-mail-linkage"
   | "no-turn-status"
@@ -74,7 +73,6 @@ type TurnAccumulator = {
 
 function extractTurns(
   newMessages: ConversationMessage[],
-  commitTimestamp: number,
 ): ReconstructedEvent[] {
   const events: ReconstructedEvent[] = [];
   let current: TurnAccumulator | null = null;
@@ -89,10 +87,13 @@ function extractTurns(
           timestamp: current.timestamp,
         });
       }
-      current = { texts: [], timestamp: commitTimestamp };
+      current = { texts: [], timestamp: msg.timestamp };
     } else if (msg.role === "assistant") {
       if (current === null) {
-        current = { texts: [], timestamp: commitTimestamp };
+        current = { texts: [], timestamp: msg.timestamp };
+      } else {
+        // Update timestamp to the latest assistant message in this turn
+        current.timestamp = msg.timestamp;
       }
       const text = extractTextContent(msg);
       if (text.length > 0) {
@@ -209,7 +210,7 @@ export async function reconstructTimeline(
         `Message count dropped from ${prevMessageCount} to ${messages.length} at commit ${commit.hash}`,
       );
       // Treat the entire message array as new for this checkpoint
-      const turnEvents = extractTurns(messages, commit.timestamp);
+      const turnEvents = extractTurns(messages);
       events.push(...turnEvents);
       prevMessageCount = messages.length;
       continue;
@@ -220,7 +221,7 @@ export async function reconstructTimeline(
 
     if (newMessages.length === 0) continue;
 
-    const turnEvents = extractTurns(newMessages, commit.timestamp);
+    const turnEvents = extractTurns(newMessages);
     events.push(...turnEvents);
   }
 
@@ -286,10 +287,6 @@ export async function reconstructTimeline(
 
   // Always-present gaps (structural limitations of the current git format)
   if (hasCheckpoints) {
-    addGap(
-      "no-per-message-timestamps",
-      "ConversationMessage has no timestamp field; all messages in a checkpoint share the git commit timestamp",
-    );
     addGap(
       "no-turn-boundaries",
       "Checkpoint commit messages are the literal string 'checkpoint' with no turn ID; turn boundaries are heuristically inferred from role sequences",

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -393,6 +393,7 @@ export async function* runInference(
     role: "assistant",
     content: contentBlocks,
     model,
+    timestamp: Date.now(),
   };
 
   yield {

--- a/packages/inference/src/messages.ts
+++ b/packages/inference/src/messages.ts
@@ -59,18 +59,26 @@ export function createInboundMessage(
 
   const text =
     envelope.length > 0 ? `${envelope.join("\n")}\n\n${content}` : content;
-  return { role: "user", content: [{ type: "text", text }] };
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+    timestamp: Date.now(),
+  };
 }
 
 export function createSystemMessage(text: string): ConversationMessage {
-  return { role: "system", content: [{ type: "text", text }] };
+  return {
+    role: "system",
+    content: [{ type: "text", text }],
+    timestamp: Date.now(),
+  };
 }
 
 export function createAssistantMessage(
   blocks: ContentBlock[],
   model: string,
 ): AssistantMessage {
-  return { role: "assistant", content: blocks, model };
+  return { role: "assistant", content: blocks, model, timestamp: Date.now() };
 }
 
 export function createToolResultMessage(
@@ -93,5 +101,5 @@ export function createToolResultMessage(
     }
     return block;
   });
-  return { role: "user", content: blocks };
+  return { role: "user", content: blocks, timestamp: Date.now() };
 }

--- a/packages/inference/src/plugin.ts
+++ b/packages/inference/src/plugin.ts
@@ -66,8 +66,11 @@ export function createCapabilities(): ReactorCapabilities {
       return { type: "reply", content };
     },
 
-    checkpoint(message?: string): ReactorAction {
-      return { type: "checkpoint", message: message ?? "checkpoint" };
+    checkpoint(reason?: string): ReactorAction {
+      return {
+        type: "checkpoint",
+        message: reason !== undefined ? `checkpoint: ${reason}` : "checkpoint",
+      };
     },
 
     wait(): ReactorAction {

--- a/packages/inference/src/providers/anthropic.test.ts
+++ b/packages/inference/src/providers/anthropic.test.ts
@@ -50,7 +50,11 @@ const AnthropicRequestBody = type({
 describe("Anthropic adapter: buildRequest", () => {
   test("builds a request with required fields", () => {
     const messages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hello" }],
+        timestamp: 1000,
+      },
     ];
 
     const req = adapter.buildRequest(
@@ -71,8 +75,16 @@ describe("Anthropic adapter: buildRequest", () => {
 
   test("extracts system messages into top-level system field", () => {
     const messages: ConversationMessage[] = [
-      { role: "system", content: [{ type: "text", text: "You are helpful." }] },
-      { role: "user", content: [{ type: "text", text: "Hi." }] },
+      {
+        role: "system",
+        content: [{ type: "text", text: "You are helpful." }],
+        timestamp: 1000,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hi." }],
+        timestamp: 1000,
+      },
     ];
 
     const req = adapter.buildRequest(
@@ -96,8 +108,16 @@ describe("Anthropic adapter: buildRequest", () => {
 
   test("options.systemPrompt overrides system messages", () => {
     const messages: ConversationMessage[] = [
-      { role: "system", content: [{ type: "text", text: "Original system." }] },
-      { role: "user", content: [{ type: "text", text: "Hi." }] },
+      {
+        role: "system",
+        content: [{ type: "text", text: "Original system." }],
+        timestamp: 1000,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hi." }],
+        timestamp: 1000,
+      },
     ];
 
     const req = adapter.buildRequest(messages, "claude-3-5-sonnet-20241022", {
@@ -115,7 +135,11 @@ describe("Anthropic adapter: buildRequest", () => {
 
   test("includes thinking config when enabled", () => {
     const messages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "Think deeply." }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Think deeply." }],
+        timestamp: 1000,
+      },
     ];
 
     const req = adapter.buildRequest(messages, "claude-3-7-sonnet-20250219", {
@@ -138,6 +162,7 @@ describe("Anthropic adapter: buildRequest", () => {
             arguments: { path: "/etc/hosts" },
           },
         ],
+        timestamp: 1000,
       },
     ];
 
@@ -155,7 +180,11 @@ describe("Anthropic adapter: buildRequest", () => {
 
   test("serializes tool definitions with Anthropic wire format", () => {
     const messages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "Hi." }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hi." }],
+        timestamp: 1000,
+      },
     ];
 
     const req = adapter.buildRequest(messages, "claude-3-5-sonnet-20241022", {
@@ -183,7 +212,11 @@ describe("Anthropic adapter: buildRequest", () => {
 
   test("omits tools key when tools array is empty", () => {
     const messages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "Hi." }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hi." }],
+        timestamp: 1000,
+      },
     ];
 
     const req = adapter.buildRequest(messages, "claude-3-5-sonnet-20241022", {
@@ -195,7 +228,11 @@ describe("Anthropic adapter: buildRequest", () => {
 
   test("omits tools key when tools is undefined", () => {
     const messages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "Hi." }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hi." }],
+        timestamp: 1000,
+      },
     ];
 
     const req = adapter.buildRequest(
@@ -209,7 +246,11 @@ describe("Anthropic adapter: buildRequest", () => {
 
   test("uses max_tokens from options", () => {
     const messages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "Hi." }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hi." }],
+        timestamp: 1000,
+      },
     ];
 
     const req = adapter.buildRequest(messages, "claude-3-5-sonnet-20241022", {

--- a/packages/inference/src/providers/openai.test.ts
+++ b/packages/inference/src/providers/openai.test.ts
@@ -42,7 +42,11 @@ const OpenAIRequestBody = type({
 describe("OpenAI adapter: buildRequest", () => {
   test("builds a request with required fields", () => {
     const messages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hello" }],
+        timestamp: 1000,
+      },
     ];
 
     const req = adapter.buildRequest(messages, "gpt-4o", {});
@@ -59,7 +63,11 @@ describe("OpenAI adapter: buildRequest", () => {
 
   test("converts text messages correctly", () => {
     const messages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "What is 2+2?" }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "What is 2+2?" }],
+        timestamp: 1000,
+      },
     ];
 
     const req = adapter.buildRequest(messages, "gpt-4o", {});
@@ -72,8 +80,16 @@ describe("OpenAI adapter: buildRequest", () => {
 
   test("converts system messages to system role", () => {
     const messages: ConversationMessage[] = [
-      { role: "system", content: [{ type: "text", text: "Be concise." }] },
-      { role: "user", content: [{ type: "text", text: "Hi." }] },
+      {
+        role: "system",
+        content: [{ type: "text", text: "Be concise." }],
+        timestamp: 1000,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hi." }],
+        timestamp: 1000,
+      },
     ];
 
     const req = adapter.buildRequest(messages, "gpt-4o", {});
@@ -85,7 +101,11 @@ describe("OpenAI adapter: buildRequest", () => {
 
   test("prepends systemPrompt from options", () => {
     const messages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "Hi." }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hi." }],
+        timestamp: 1000,
+      },
     ];
 
     const req = adapter.buildRequest(messages, "gpt-4o", {
@@ -110,6 +130,7 @@ describe("OpenAI adapter: buildRequest", () => {
             arguments: { city: "London" },
           },
         ],
+        timestamp: 1000,
       },
     ];
 
@@ -137,6 +158,7 @@ describe("OpenAI adapter: buildRequest", () => {
             content: [{ type: "text", text: "Sunny, 22°C" }],
           },
         ],
+        timestamp: 1000,
       },
     ];
 
@@ -151,7 +173,11 @@ describe("OpenAI adapter: buildRequest", () => {
 
   test("uses max_tokens from options", () => {
     const messages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "Hi." }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hi." }],
+        timestamp: 1000,
+      },
     ];
 
     const req = adapter.buildRequest(messages, "gpt-4o", { maxTokens: 256 });

--- a/packages/inference/src/reactor.test.ts
+++ b/packages/inference/src/reactor.test.ts
@@ -1686,6 +1686,7 @@ describe("createReactor — dequeue priority", () => {
           },
         ],
         model: "test-model",
+        timestamp: 1000,
       },
     ];
 
@@ -2187,6 +2188,7 @@ function makeAssistantMessage(text: string): AssistantMessage {
     role: "assistant",
     content: [{ type: "text", text }],
     model: "mock-model",
+    timestamp: 1000,
   };
 }
 
@@ -2366,6 +2368,7 @@ describe("createReactor — beforeToolExtensions", () => {
       },
     ],
     model: "test-model",
+    timestamp: 1000,
   };
 
   const inferUsage: TokenUsage = {
@@ -2653,6 +2656,7 @@ describe("createReactor — beforeToolExtensions", () => {
         },
       ],
       model: "test-model",
+      timestamp: 1000,
     };
 
     let toolDoneCount = 0;

--- a/packages/inference/src/reactor.ts
+++ b/packages/inference/src/reactor.ts
@@ -601,7 +601,12 @@ export function createReactor(config: ReactorConfig): Reactor {
         emit({
           type: "connector.reply",
           seq: nextSeq(),
-          data: { content: replyAction.content },
+          data: {
+            content: replyAction.content,
+            ...(lastCheckpointHash !== undefined
+              ? { checkpointHash: lastCheckpointHash }
+              : {}),
+          },
         });
         // After replying, wait for the next inbound message.
         continue;
@@ -633,15 +638,21 @@ export function createReactor(config: ReactorConfig): Reactor {
     });
   }
 
+  let lastCheckpointHash: string | undefined;
+
   async function executeCheckpoint(message: string): Promise<void> {
     if (stateManager === null) return;
+    // Clear before attempting so a failed checkpoint never leaves a stale
+    // hash from a previous turn attached to the next connector.reply.
+    lastCheckpointHash = undefined;
     try {
-      await contextStore.commit(
+      const commit = await contextStore.commit(
         stateManager.getMessages(),
         stateManager.getPendingOperations(),
         stateManager.getTokenUsage(),
         message,
       );
+      lastCheckpointHash = commit.hash;
     } catch (cause) {
       logger.error`Checkpoint failed: ${cause}`;
       emitError(

--- a/packages/inference/src/transform.test.ts
+++ b/packages/inference/src/transform.test.ts
@@ -12,6 +12,7 @@ describe("transformMessages", () => {
           { type: "thinking", thinking: "Let me think..." },
           { type: "text", text: "Here is the answer." },
         ],
+        timestamp: 1000,
       },
     ];
 
@@ -35,6 +36,7 @@ describe("transformMessages", () => {
           { type: "thinking", thinking: "Some reasoning..." },
           { type: "text", text: "Answer." },
         ],
+        timestamp: 1000,
       },
     ];
 
@@ -57,6 +59,7 @@ describe("transformMessages", () => {
           { type: "thinking", thinking: "Reasoning..." },
           { type: "text", text: "Answer." },
         ],
+        timestamp: 1000,
       },
     ];
 
@@ -72,7 +75,11 @@ describe("transformMessages", () => {
 
   test("injects synthetic tool results for orphaned tool calls", () => {
     const messages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "Do something." }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Do something." }],
+        timestamp: 1000,
+      },
       {
         role: "assistant",
         content: [
@@ -83,6 +90,7 @@ describe("transformMessages", () => {
             arguments: { path: "/tmp/foo" },
           },
         ],
+        timestamp: 1000,
       },
       // No tool result follows — the conversation was interrupted.
     ];
@@ -103,7 +111,11 @@ describe("transformMessages", () => {
 
   test("does not inject when tool results are present", () => {
     const messages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "Do something." }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Do something." }],
+        timestamp: 1000,
+      },
       {
         role: "assistant",
         content: [
@@ -114,6 +126,7 @@ describe("transformMessages", () => {
             arguments: { path: "/tmp/foo" },
           },
         ],
+        timestamp: 1000,
       },
       {
         role: "user",
@@ -124,6 +137,7 @@ describe("transformMessages", () => {
             content: [{ type: "text", text: "file contents" }],
           },
         ],
+        timestamp: 1000,
       },
     ];
 
@@ -133,8 +147,16 @@ describe("transformMessages", () => {
 
   test("preserves user and system messages unchanged", () => {
     const messages: ConversationMessage[] = [
-      { role: "system", content: [{ type: "text", text: "You are helpful." }] },
-      { role: "user", content: [{ type: "text", text: "Hello." }] },
+      {
+        role: "system",
+        content: [{ type: "text", text: "You are helpful." }],
+        timestamp: 1000,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hello." }],
+        timestamp: 1000,
+      },
     ];
 
     const result = transformMessages(messages, { targetModel: "gpt-4o" });

--- a/packages/inference/src/transform.ts
+++ b/packages/inference/src/transform.ts
@@ -114,7 +114,11 @@ function injectOrphanedToolResults(
       isError: true,
     }));
 
-    result.push({ role: "user", content: syntheticBlocks });
+    result.push({
+      role: "user",
+      content: syntheticBlocks,
+      timestamp: Date.now(),
+    });
   }
 
   return result;

--- a/packages/storage-isogit/src/index.ts
+++ b/packages/storage-isogit/src/index.ts
@@ -19,10 +19,12 @@ export { createDeployPack } from "./pack-send";
 export { collectReachableObjects } from "./object-walk";
 export {
   createMailAuditStore,
+  listMail,
   type MailAuditStore,
   type MailCommitOptions,
   type MailDirection,
   type MailCommitResult,
+  type MailEntry,
 } from "./mail-store";
 
 /**

--- a/packages/storage-isogit/src/mail-store.test.ts
+++ b/packages/storage-isogit/src/mail-store.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { initAgentRepo } from "./init";
-import { createMailAuditStore } from "./mail-store";
+import { createMailAuditStore, listMail } from "./mail-store";
 
 function buildRawMessage(opts: {
   messageId: string;
@@ -179,5 +179,88 @@ describe("createMailAuditStore", () => {
     if (r2 === null) throw new Error("expected non-null r2");
 
     expect(r2.threadId).toBe(r1.threadId);
+  });
+});
+
+describe("listMail", () => {
+  test("returns empty array when no mail exists", async () => {
+    const entries = await listMail(testDir);
+    expect(entries).toEqual([]);
+  });
+
+  test("returns single entry after one commit", async () => {
+    const store = await createMailAuditStore(testDir);
+    const raw = buildRawMessage({ messageId: "<msg-1@test>" });
+    await store.commitMail(raw, "in");
+
+    const entries = await listMail(testDir);
+    expect(entries).toHaveLength(1);
+
+    const entry = entries[0];
+    if (entry === undefined) throw new Error("expected entry");
+    expect(entry.messageId).toBe("<msg-1@test>");
+    expect(entry.direction).toBe("in");
+    expect(entry.ordinal).toBe(1);
+    expect(entry.raw).toEqual(raw);
+  });
+
+  test("returns entries sorted by threadId then ordinal", async () => {
+    const store = await createMailAuditStore(testDir);
+
+    const msg1 = buildRawMessage({ messageId: "<msg-1@test>" });
+    const r1 = await store.commitMail(msg1, "in");
+    if (r1 === null) throw new Error("expected non-null r1");
+
+    const msg2 = buildRawMessage({
+      messageId: "<msg-2@test>",
+      inReplyTo: "<msg-1@test>",
+    });
+    await store.commitMail(msg2, "out");
+
+    const msg3 = buildRawMessage({ messageId: "<msg-3@test>" });
+    const r3 = await store.commitMail(msg3, "in");
+    if (r3 === null) throw new Error("expected non-null r3");
+
+    const entries = await listMail(testDir);
+    expect(entries).toHaveLength(3);
+
+    // Entries are sorted by threadId then ordinal — verify cross-thread
+    // ordering is lexicographic and entries within a thread are contiguous
+    const threadIds = entries.map((e) => e.threadId);
+    const uniqueThreadIds = [...new Set(threadIds)];
+    const sortedThreadIds = [...uniqueThreadIds].sort();
+    expect(uniqueThreadIds).toEqual(sortedThreadIds);
+
+    // Thread 1 entries should be grouped and ordered
+    const thread1 = entries.filter((e) => e.threadId === r1.threadId);
+    expect(thread1).toHaveLength(2);
+    expect(thread1[0]?.ordinal).toBe(1);
+    expect(thread1[0]?.direction).toBe("in");
+    expect(thread1[1]?.ordinal).toBe(2);
+    expect(thread1[1]?.direction).toBe("out");
+
+    // Thread 2
+    const thread2 = entries.filter((e) => e.threadId === r3.threadId);
+    expect(thread2).toHaveLength(1);
+    expect(thread2[0]?.ordinal).toBe(1);
+  });
+
+  test("reads correctly from a fresh directory without store", async () => {
+    // Write some mail via store, then read via standalone listMail
+    const store = await createMailAuditStore(testDir);
+    const raw = buildRawMessage({
+      messageId: "<msg-1@test>",
+      from: "alice@example.com",
+      to: "bob@example.com",
+      body: "hello from alice",
+    });
+    await store.commitMail(raw, "in");
+
+    // listMail should work without a store instance
+    const entries = await listMail(testDir);
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    if (entry === undefined) throw new Error("expected entry");
+    expect(new TextDecoder().decode(entry.raw)).toContain("hello from alice");
   });
 });

--- a/packages/storage-isogit/src/mail-store.ts
+++ b/packages/storage-isogit/src/mail-store.ts
@@ -21,6 +21,14 @@ export type MailCommitOptions = {
   ignoreDuplicate?: boolean;
 };
 
+export type MailEntry = {
+  threadId: string;
+  ordinal: number;
+  direction: MailDirection;
+  messageId: string;
+  raw: Uint8Array;
+};
+
 export type MailAuditStore = {
   commitMail(
     rawMessage: Uint8Array,
@@ -143,22 +151,48 @@ export async function createMailAuditStore(
   return { commitMail };
 }
 
-async function rebuildIndex(
-  dir: string,
-  messageIndex: Map<string, string>,
-  threads: Map<string, ThreadState>,
-): Promise<void> {
+function parseFilename(filename: string): {
+  ordinal: number;
+  direction: MailDirection;
+} {
+  const stem = filename.replace(/\.eml$/, "");
+  const dashIndex = stem.indexOf("-");
+  if (dashIndex === -1) {
+    throw new Error(`Malformed mail filename: ${filename}`);
+  }
+
+  const ordinalStr = stem.slice(0, dashIndex);
+  const ordinal = parseInt(ordinalStr, 10);
+  if (isNaN(ordinal)) {
+    throw new Error(`Malformed mail filename: ${filename}`);
+  }
+
+  const directionStr = stem.slice(dashIndex + 1);
+  if (directionStr !== "in" && directionStr !== "out") {
+    throw new Error(
+      `Invalid mail direction '${directionStr}' in filename: ${filename}`,
+    );
+  }
+
+  return { ordinal, direction: directionStr };
+}
+
+async function scanMail(dir: string): Promise<MailEntry[]> {
   const mailDir = path.join(dir, MAIL_DIR);
 
   let threadDirs: string[];
   try {
     threadDirs = await fs.promises.readdir(mailDir);
-  } catch (e) {
+  } catch (e: unknown) {
     if (e instanceof Error && "code" in e && e.code === "ENOENT") {
-      return;
+      return [];
     }
     throw e;
   }
+
+  threadDirs.sort();
+
+  const entries: MailEntry[] = [];
 
   for (const threadId of threadDirs) {
     const threadPath = path.join(mailDir, threadId);
@@ -168,22 +202,38 @@ async function rebuildIndex(
     const files = await fs.promises.readdir(threadPath);
     const emlFiles = files.filter((f) => f.endsWith(".eml")).sort();
 
-    let maxOrdinal = 0;
     for (const file of emlFiles) {
-      const ordinalStr = file.split("-")[0];
-      if (ordinalStr !== undefined) {
-        const ordinal = parseInt(ordinalStr, 10);
-        if (!isNaN(ordinal) && ordinal > maxOrdinal) {
-          maxOrdinal = ordinal;
-        }
-      }
-
+      const { ordinal, direction } = parseFilename(file);
       const fullPath = path.join(threadPath, file);
       const raw = await fs.promises.readFile(fullPath);
       const { messageId } = parseThreadingHeaders(raw);
-      messageIndex.set(messageId, threadId);
-    }
 
-    threads.set(threadId, { nextOrdinal: maxOrdinal + 1 });
+      entries.push({ threadId, ordinal, direction, messageId, raw });
+    }
+  }
+
+  return entries;
+}
+
+export async function listMail(dir: string): Promise<MailEntry[]> {
+  return scanMail(dir);
+}
+
+async function rebuildIndex(
+  dir: string,
+  messageIndex: Map<string, string>,
+  threads: Map<string, ThreadState>,
+): Promise<void> {
+  const entries = await scanMail(dir);
+
+  for (const entry of entries) {
+    messageIndex.set(entry.messageId, entry.threadId);
+
+    const state = threads.get(entry.threadId);
+    if (state === undefined) {
+      threads.set(entry.threadId, { nextOrdinal: entry.ordinal + 1 });
+    } else if (entry.ordinal >= state.nextOrdinal) {
+      state.nextOrdinal = entry.ordinal + 1;
+    }
   }
 }

--- a/packages/storage-isogit/src/mail-store.ts
+++ b/packages/storage-isogit/src/mail-store.ts
@@ -19,6 +19,7 @@ export type MailCommitResult = {
 
 export type MailCommitOptions = {
   ignoreDuplicate?: boolean;
+  checkpointHash?: string;
 };
 
 export type MailEntry = {
@@ -135,10 +136,15 @@ export async function createMailAuditStore(
     await git.add({ fs, dir, filepath });
 
     const label = direction === "in" ? "inbound" : "outbound";
+    const subject = `Record ${label} mail ${messageId}`;
+    const message =
+      options?.checkpointHash !== undefined
+        ? `${subject}\n\nCheckpoint: ${options.checkpointHash}`
+        : subject;
     await git.commit({
       fs,
       dir,
-      message: `Record ${label} mail ${messageId}`,
+      message,
       author: AUTHOR,
       ...signingArgs,
     });

--- a/packages/storage-isogit/src/store.test.ts
+++ b/packages/storage-isogit/src/store.test.ts
@@ -72,11 +72,16 @@ describe("save and load round-trip", () => {
     const store = await createIsogitStore(dir);
 
     const messages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hello" }],
+        timestamp: 1000,
+      },
       {
         role: "assistant",
         content: [{ type: "text", text: "Hi there" }],
         model: "test-model",
+        timestamp: 2000,
       },
     ];
 
@@ -91,7 +96,11 @@ describe("save and load round-trip", () => {
     const store = await createIsogitStore(dir);
 
     const first: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "step 1" }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "step 1" }],
+        timestamp: 1000,
+      },
     ];
     const second: ConversationMessage[] = [
       ...first,
@@ -99,6 +108,7 @@ describe("save and load round-trip", () => {
         role: "assistant",
         content: [{ type: "text", text: "step 2" }],
         model: "m",
+        timestamp: 2000,
       },
     ];
 
@@ -159,14 +169,22 @@ describe("branch operations", () => {
     const store = await createIsogitStore(dir);
 
     const mainMessages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "on main" }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "on main" }],
+        timestamp: 1000,
+      },
     ];
     await store.commit(mainMessages, [], ZERO_USAGE, "main work");
 
     await createAndSwitchBranch(dir, "experiment");
 
     const branchMessages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "on branch" }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "on branch" }],
+        timestamp: 2000,
+      },
     ];
     await store.commit(branchMessages, [], ZERO_USAGE, "branch work");
 
@@ -223,7 +241,11 @@ describe("readAt", () => {
     const store = await createIsogitStore(dir);
 
     const v1: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "version 1" }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "version 1" }],
+        timestamp: 1000,
+      },
     ];
     const first = await store.commit(v1, [], ZERO_USAGE, "v1");
 
@@ -233,6 +255,7 @@ describe("readAt", () => {
         role: "assistant",
         content: [{ type: "text", text: "version 2" }],
         model: "m",
+        timestamp: 2000,
       },
     ];
     await store.commit(v2, [], ZERO_USAGE, "v2");
@@ -568,7 +591,11 @@ describe("load reads from git HEAD, not working tree", () => {
     const store = await createIsogitStore(dir);
 
     const messages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "committed data" }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "committed data" }],
+        timestamp: 1000,
+      },
     ];
     await store.commit(messages, [], ZERO_USAGE, "checkpoint");
 
@@ -586,7 +613,11 @@ describe("load reads from git HEAD, not working tree", () => {
     const store = await createIsogitStore(dir);
 
     const goodMessages: ConversationMessage[] = [
-      { role: "user", content: [{ type: "text", text: "good data" }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "good data" }],
+        timestamp: 1000,
+      },
     ];
     await store.commit(goodMessages, [], ZERO_USAGE, "good checkpoint");
 

--- a/packages/storage-isogit/src/store.ts
+++ b/packages/storage-isogit/src/store.ts
@@ -34,6 +34,7 @@ const ConversationMessageSchema = type({
   role: "'user' | 'assistant' | 'system'",
   content: ContentBlock.array(),
   "model?": "string",
+  timestamp: "number",
 });
 
 const PendingOperationSchema = type({

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -641,6 +641,7 @@ export type ConversationMessage = {
   role: "user" | "assistant" | "system";
   content: ContentBlock[];
   model?: string;
+  timestamp: number;
 };
 
 /**
@@ -651,6 +652,7 @@ export const AssistantMessage = type({
   role: "'assistant'",
   content: ContentBlock.array(),
   model: "string",
+  timestamp: "number",
 });
 export type AssistantMessage = typeof AssistantMessage.infer;
 

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -821,7 +821,7 @@ export const InferenceEvent = type({
   .or({
     type: "'connector.reply'",
     seq: "number",
-    data: { content: "string" },
+    data: { content: "string", "checkpointHash?": "string" },
   })
   .or({
     type: "'reactor.start'",
@@ -954,7 +954,7 @@ export type InferenceEvent =
   | {
       type: "connector.reply";
       seq: number;
-      data: { content: string };
+      data: { content: string; checkpointHash?: string };
     }
   | { type: "reactor.start"; seq: number; data: Record<string, never> }
   | {


### PR DESCRIPTION
## Summary

- Add `reconstructTimeline()` module that walks the git commit log to rebuild a session timeline from checkpoint commits, mail audit commits, and error records
- Close all 7 structural data gaps identified in the initial implementation: per-message timestamps, checkpoint reasons, turn boundaries/status, error attribution, and outbound mail linkage
- Full integration test proving a multi-step session (tool use, error recovery, mail linkage) can be faithfully reconstructed from git data alone

## Changes

- `packages/types/src/runtime.ts`: Make `timestamp` required on `ConversationMessage`, add `checkpointHash` to `connector.reply` event
- `packages/inference/src/messages.ts`: Stamp `Date.now()` at message construction time
- `packages/inference/src/plugin.ts`: `capabilities.checkpoint()` prepends `"checkpoint: "` to reason strings
- `packages/harness/src/plugin.ts`: DefaultPlugin passes checkpoint reasons at all call sites
- `packages/inference/src/reactor.ts`: Capture `lastCheckpointHash` from context store commits, include in `connector.reply`
- `packages/storage-isogit/src/mail-store.ts`: Add `listMail()` export, `checkpointHash` option with `Checkpoint:` git trailer
- `packages/hub/src/timeline-reconstruction.ts`: New module — parses checkpoint reasons, reads error records from git trees, links mail to checkpoints
- `apps/sidecar/src/session-manager.ts`: Intercept `checkpointHash` from events and pass to mail audit commits

## Testing

- 885 tests pass (16 reconstruction tests including full session integration test)
- `bun run check`, `bun run lint`, `bun test` all green

Closes INTR-30