### PR TITLE
Rename LLM conversation types from Message to Turn and tools from message to mail

### DIFF
--- a/bin/posix-demo.ts
+++ b/bin/posix-demo.ts
@@ -78,7 +78,7 @@ const betaProvider = readAgentProvider("BETA");
 
 const DEMO_SEED =
   process.env["DEMO_SEED"] ??
-  "Use the message_send tool to send a message to beta@local.interchange asking: What do you want to be when you grow up? Then tell me what Beta says.";
+  "Use the mail_send tool to send a message to beta@local.interchange asking: What do you want to be when you grow up? Then tell me what Beta says.";
 
 log.info("alpha: {provider} / {model}", {
   provider: alphaProvider.provider,
@@ -266,9 +266,9 @@ const harnessAlpha = createHarness({
   address: ALPHA_ADDRESS,
   systemPrompt: `You are Alpha, an agent that relays messages between the user and other agents.
 
-IMPORTANT: When the user mentions another agent by name, you MUST immediately call the message_send tool to contact that agent. Do NOT reply to the user asking what to send. Do NOT introduce yourself. Just call the tool.
+IMPORTANT: When the user mentions another agent by name, you MUST immediately call the mail_send tool to contact that agent. Do NOT reply to the user asking what to send. Do NOT introduce yourself. Just call the tool.
 
-Example: If the user says "Ask Beta what his favorite color is", you call message_send with to="${BETA_ADDRESS}" and content="What is your favorite color?"
+Example: If the user says "Ask Beta what his favorite color is", you call mail_send with to="${BETA_ADDRESS}" and content="What is your favorite color?"
 
 Known agents:
   Beta: ${BETA_ADDRESS}

--- a/bin/ring-demo.ts
+++ b/bin/ring-demo.ts
@@ -292,8 +292,8 @@ ${role.perspective}
 
 When the user poses a question or problem:
 1. Write a brief framing of the problem (2-3 sentences) that identifies the core tension.
-2. Use message_send to send the user's original question along with your framing to ${nextAddress} (${nextRole.title}).
-3. Use message_wait with {"from": "${lastAddress}", "timeout": 300} to wait for the discussion to complete the ring. This will block until ${lastName} sends you the final analysis.
+2. Use mail_send to send the user's original question along with your framing to ${nextAddress} (${nextRole.title}).
+3. Use mail_wait with {"from": "${lastAddress}", "timeout": 300} to wait for the discussion to complete the ring. This will block until ${lastName} sends you the final analysis.
 4. Synthesize the entire braintrust's input into a clear recommendation for the user.
 
 Your message to ${nextName} should include the original question and your framing, clearly labeled. The braintrust will build on it as it circulates.`;
@@ -306,7 +306,7 @@ ${role.perspective}
 When you receive a message, it contains a question being discussed by the braintrust along with analysis from previous advisors. Your job:
 1. Read what's been said so far.
 2. Add your perspective as ${role.title} in 2-4 sentences. Be specific and direct. Disagree with earlier points if warranted.
-3. Use message_send to forward the entire discussion (previous analysis plus your addition) to ${nextAddress} (${nextRole.title}).
+3. Use mail_send to forward the entire discussion (previous analysis plus your addition) to ${nextAddress} (${nextRole.title}).
 
 Format your addition as:
 **${name} (${role.title}):** [your analysis]

--- a/docs/INFERENCE.md
+++ b/docs/INFERENCE.md
@@ -272,9 +272,9 @@ Inbound messages arrive at the reactor regardless of current state. Correlated m
 
 ### INBOX Consumption
 
-The harness consumes messages from the agent's INBOX after delivering them to the reactor. Messages that belong to the active connector thread or that are responses to agent-initiated outbound sends are fetched, delivered via `reactor.deliver()`, and then flagged as deleted and expunged from the INBOX. Unsolicited messages (new threads, untracked threads) remain in the INBOX for the agent to discover via message tools.
+The harness consumes messages from the agent's INBOX after delivering them to the reactor. Messages that belong to the active connector thread or that are responses to agent-initiated outbound sends are fetched, delivered via `reactor.deliver()`, and then flagged as deleted and expunged from the INBOX. Unsolicited messages (new threads, untracked threads) remain in the INBOX for the agent to discover via mail tools.
 
-This means messages routed through the connector or matched as agent-initiated responses are not visible to `message_search` after delivery. The message content enters the conversation history through the reactor's event processing, not through the INBOX. The model cannot poll for these messages — they arrive as `message.received` events and are appended to the history by the reactor when the event is processed.
+This means messages routed through the connector or matched as agent-initiated responses are not visible to `mail_search` after delivery. The message content enters the conversation history through the reactor's event processing, not through the INBOX. The model cannot poll for these messages — they arrive as `message.received` events and are appended to the history by the reactor when the event is processed.
 
 ### Correlation
 

--- a/docs/MESSAGE.md
+++ b/docs/MESSAGE.md
@@ -618,13 +618,13 @@ Efficient reconnection using QRESYNC semantics. The harness provides its last kn
 
 If UIDVALIDITY has changed (mailbox was recreated), the transport signals a full resync is required.
 
-## Messaging Tools
+## Mail Tools
 
 The agent interacts with the message transport through tools exposed by the harness. These tools are what the inference layer presents to the model. They map to the transport interface operations.
 
 ### Tool Definitions
 
-**message.send** — Send a message to one or more recipients.
+**mail.send** — Send mail to one or more recipients.
 
 Parameters:
 
@@ -643,7 +643,7 @@ Returns on success: `{ messageId: string }` if delivery is fire-and-forget, or `
 
 Returns on error: `{ error: string, code: string }`. Error codes: `invalid_address` (unresolvable recipient), `invalid_type` (unknown payload type), `too_large` (message exceeds size limit), `send_failed` (SMTP submission rejected).
 
-**message.reply** — Reply to a specific message. Convenience wrapper around `message.send` that automatically sets `inReplyTo` and extends the `References` chain from the parent message.
+**mail.reply** — Reply to a specific message. Convenience wrapper around `mail.send` that automatically sets `inReplyTo` and extends the `References` chain from the parent message.
 
 Parameters:
 
@@ -653,9 +653,9 @@ Parameters:
 - `type`: Interchange payload type (default: `conversation.message` — use `offering.response` when replying to an offering request)
 - `attachments`: optional
 
-Returns: same as `message.send`
+Returns: same as `mail.send`
 
-**message.search** — Search the inbox.
+**mail.search** — Search the inbox.
 
 Parameters:
 
@@ -667,7 +667,7 @@ Returns: array of message summaries (message ref, headers, payload type, preview
 
 Returns on error: `{ error: string, code: string }`. Error codes: `invalid_mailbox` (mailbox does not exist), `invalid_query` (malformed search criteria).
 
-**message.read** — Read a specific message.
+**mail.read** — Read a specific message.
 
 Parameters:
 
@@ -678,7 +678,7 @@ Returns: the requested content. For `"payload"`, returns the parsed `application
 
 Returns on error: `{ error: string, code: string }`. Error codes: `not_found` (message no longer exists), `invalid_part` (requested MIME part does not exist).
 
-**message.threads** — Get conversation threads.
+**mail.threads** — Get conversation threads.
 
 Parameters:
 
@@ -688,7 +688,7 @@ Parameters:
 
 Returns: array of thread trees, each with message summaries and child threads.
 
-**message.flag** — Set or clear flags on a message.
+**mail.flag** — Set or clear flags on a message.
 
 Parameters:
 
@@ -700,7 +700,7 @@ Returns: `{ ok: true }`
 
 Returns on error: `{ error: string, code: string }`. Error codes: `not_found`, `invalid_flag` (flag name not permitted by server).
 
-**message.move** — Move a message to a different mailbox.
+**mail.move** — Move a message to a different mailbox.
 
 Parameters:
 
@@ -711,11 +711,11 @@ Returns: `{ ok: true }`
 
 Returns on error: `{ error: string, code: string }`. Error codes: `not_found`, `invalid_mailbox`.
 
-**message.wait** — Block until a message matching a query arrives.
+**mail.wait** — Block until a message matching a query arrives.
 
 Parameters:
 
-- `query`: search criteria (same shape as `message.search` query — e.g. `{ from: "agent@..." }`)
+- `query`: search criteria (same shape as `mail.search` query — e.g. `{ from: "agent@..." }`)
 - `timeout`: maximum seconds to wait (default: 120)
 - `mailbox`: mailbox to watch (default: `INBOX`)
 
@@ -725,7 +725,7 @@ Returns on success: `{ ref, from, subject, content }` — the matched message's 
 
 Returns on error: `{ error: string, code: string }`. Error codes: `timeout` (no matching message arrived within the deadline), `aborted` (reactor shut down while waiting).
 
-Use this instead of polling `message.search` in a loop. The blocking behavior is transparent to the reactor — the tool's promise simply takes longer to resolve, and the agent naturally idles until it does.
+Use this instead of polling `mail.search` in a loop. The blocking behavior is transparent to the reactor — the tool's promise simply takes longer to resolve, and the agent naturally idles until it does.
 
 ### Offering Tools
 
@@ -757,7 +757,7 @@ Returns: `{ messageId: string, status: "pending", correlationId: string }`
 
 ### Pending Marker Pattern
 
-When `message.send` is used for an offering request (type `offering.request`), the tool returns a pending marker:
+When `mail.send` is used for an offering request (type `offering.request`), the tool returns a pending marker:
 
 ```json
 {

--- a/packages/harness/src/harness.test.ts
+++ b/packages/harness/src/harness.test.ts
@@ -40,7 +40,7 @@ import type {
 } from "@interchange/types/runtime";
 
 import { createHarness } from "./harness";
-import { buildMessageToolHandlers, buildCombinedRunner } from "./tools";
+import { buildMailToolHandlers, buildCombinedRunner } from "./tools";
 import { createDefaultPlugin } from "./plugin";
 import type { HarnessConfig } from "./config";
 
@@ -527,9 +527,9 @@ describe("Message delivery pipeline", () => {
 // ---------------------------------------------------------------------------
 
 describe("Tool name collision detection", () => {
-  test("buildCombinedRunner throws when caller provides a message.* tool", () => {
+  test("buildCombinedRunner throws when caller provides a mail_* tool", () => {
     const transport = makeMockTransport();
-    const messageHandlers = buildMessageToolHandlers(transport);
+    const mailHandlers = buildMailToolHandlers(transport);
     const callerTools: ToolRunner = {
       async run(call) {
         return { callId: call.id, content: "ok" };
@@ -537,15 +537,15 @@ describe("Tool name collision detection", () => {
     };
 
     expect(() =>
-      buildCombinedRunner(messageHandlers, callerTools, [
-        { name: "message_send", description: "test", inputSchema: {} },
+      buildCombinedRunner(mailHandlers, callerTools, [
+        { name: "mail_send", description: "test", inputSchema: {} },
       ]),
-    ).toThrow('Tool name collision: "message_send"');
+    ).toThrow('Tool name collision: "mail_send"');
   });
 
   test("buildCombinedRunner succeeds when no name collisions", () => {
     const transport = makeMockTransport();
-    const messageHandlers = buildMessageToolHandlers(transport);
+    const mailHandlers = buildMailToolHandlers(transport);
     const callerTools: ToolRunner = {
       async run(call) {
         return { callId: call.id, content: "ok" };
@@ -553,27 +553,27 @@ describe("Tool name collision detection", () => {
     };
 
     expect(() =>
-      buildCombinedRunner(messageHandlers, callerTools, [
+      buildCombinedRunner(mailHandlers, callerTools, [
         { name: "read_file", description: "test", inputSchema: {} },
         { name: "write_file", description: "test", inputSchema: {} },
       ]),
     ).not.toThrow();
   });
 
-  test("combined runner dispatches message tools to message handlers", async () => {
+  test("combined runner dispatches mail tools to mail handlers", async () => {
     const transport = makeMockTransport();
-    const messageHandlers = buildMessageToolHandlers(transport);
+    const mailHandlers = buildMailToolHandlers(transport);
     const callerTools: ToolRunner = {
       async run(call) {
         return { callId: call.id, content: "caller-result" };
       },
     };
 
-    const runner = buildCombinedRunner(messageHandlers, callerTools, []);
+    const runner = buildCombinedRunner(mailHandlers, callerTools, []);
 
     const call: ToolCall = {
       id: "c1",
-      name: "message_send",
+      name: "mail_send",
       arguments: {
         to: "user@test",
         content: "hello",
@@ -589,16 +589,16 @@ describe("Tool name collision detection", () => {
     expect(transport.getSentMessages().length).toBe(1);
   });
 
-  test("combined runner dispatches non-message tools to caller runner", async () => {
+  test("combined runner dispatches non-mail tools to caller runner", async () => {
     const transport = makeMockTransport();
-    const messageHandlers = buildMessageToolHandlers(transport);
+    const mailHandlers = buildMailToolHandlers(transport);
     const callerTools: ToolRunner = {
       async run(call) {
         return { callId: call.id, content: "caller-handled" };
       },
     };
 
-    const runner = buildCombinedRunner(messageHandlers, callerTools, []);
+    const runner = buildCombinedRunner(mailHandlers, callerTools, []);
 
     const call: ToolCall = {
       id: "c2",
@@ -612,19 +612,19 @@ describe("Tool name collision detection", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 4. Message tool: message_send
+// 4. Mail tool: mail_send
 // ---------------------------------------------------------------------------
 
-describe("message_send tool", () => {
+describe("mail_send tool", () => {
   test("sends a conversation message and returns messageId", async () => {
     const transport = makeMockTransport();
-    const handlers = buildMessageToolHandlers(transport);
-    const sendHandler = handlers.get("message_send");
+    const handlers = buildMailToolHandlers(transport);
+    const sendHandler = handlers.get("mail_send");
     if (sendHandler === undefined) throw new Error("handler not found");
 
     const call: ToolCall = {
       id: "s1",
-      name: "message_send",
+      name: "mail_send",
       arguments: {
         to: "user@test",
         content: "Hello from agent",
@@ -650,13 +650,13 @@ describe("message_send tool", () => {
 
   test("returns error when 'to' is missing", async () => {
     const transport = makeMockTransport();
-    const handlers = buildMessageToolHandlers(transport);
-    const sendHandler = handlers.get("message_send");
+    const handlers = buildMailToolHandlers(transport);
+    const sendHandler = handlers.get("mail_send");
     if (sendHandler === undefined) throw new Error("handler not found");
 
     const call: ToolCall = {
       id: "s2",
-      name: "message_send",
+      name: "mail_send",
       arguments: { content: "No recipient" },
     };
 
@@ -666,13 +666,13 @@ describe("message_send tool", () => {
 
   test("returns error when both content and payload are provided", async () => {
     const transport = makeMockTransport();
-    const handlers = buildMessageToolHandlers(transport);
-    const sendHandler = handlers.get("message_send");
+    const handlers = buildMailToolHandlers(transport);
+    const sendHandler = handlers.get("mail_send");
     if (sendHandler === undefined) throw new Error("handler not found");
 
     const call: ToolCall = {
       id: "s3",
-      name: "message_send",
+      name: "mail_send",
       arguments: {
         to: "user@test",
         content: "text",
@@ -686,13 +686,13 @@ describe("message_send tool", () => {
 
   test("returns result without pending marker when no correlationId", async () => {
     const transport = makeMockTransport();
-    const handlers = buildMessageToolHandlers(transport);
-    const sendHandler = handlers.get("message_send");
+    const handlers = buildMailToolHandlers(transport);
+    const sendHandler = handlers.get("mail_send");
     if (sendHandler === undefined) throw new Error("handler not found");
 
     const call: ToolCall = {
       id: "s4",
-      name: "message_send",
+      name: "mail_send",
       arguments: {
         to: "peer@test",
         content: "invoke request",
@@ -706,10 +706,10 @@ describe("message_send tool", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 5. Message tool: message_reply
+// 5. Mail tool: mail_reply
 // ---------------------------------------------------------------------------
 
-describe("message_reply tool", () => {
+describe("mail_reply tool", () => {
   test("fetches parent headers and sends reply with inReplyTo", async () => {
     const transport = makeMockTransport();
 
@@ -729,13 +729,13 @@ describe("message_reply tool", () => {
     };
     transport.enqueueMessage(parentRef, parentMsg);
 
-    const handlers = buildMessageToolHandlers(transport);
-    const replyHandler = handlers.get("message_reply");
+    const handlers = buildMailToolHandlers(transport);
+    const replyHandler = handlers.get("mail_reply");
     if (replyHandler === undefined) throw new Error("handler not found");
 
     const call: ToolCall = {
       id: "r1",
-      name: "message_reply",
+      name: "mail_reply",
       arguments: {
         ref: parentRef,
         content: "This is the reply",
@@ -757,13 +757,13 @@ describe("message_reply tool", () => {
 
   test("returns error when ref is missing", async () => {
     const transport = makeMockTransport();
-    const handlers = buildMessageToolHandlers(transport);
-    const replyHandler = handlers.get("message_reply");
+    const handlers = buildMailToolHandlers(transport);
+    const replyHandler = handlers.get("mail_reply");
     if (replyHandler === undefined) throw new Error("handler not found");
 
     const call: ToolCall = {
       id: "r2",
-      name: "message_reply",
+      name: "mail_reply",
       arguments: { content: "no ref" },
     };
 
@@ -773,19 +773,19 @@ describe("message_reply tool", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 6. Message tool: message_search
+// 6. Mail tool: mail_search
 // ---------------------------------------------------------------------------
 
-describe("message_search tool", () => {
+describe("mail_search tool", () => {
   test("calls transport.search and returns summaries", async () => {
     const transport = makeMockTransport();
-    const handlers = buildMessageToolHandlers(transport);
-    const searchHandler = handlers.get("message_search");
+    const handlers = buildMailToolHandlers(transport);
+    const searchHandler = handlers.get("mail_search");
     if (searchHandler === undefined) throw new Error("handler not found");
 
     const call: ToolCall = {
       id: "q1",
-      name: "message_search",
+      name: "mail_search",
       arguments: {
         mailbox: "INBOX",
         query: { from: "user@test" },
@@ -803,13 +803,13 @@ describe("message_search tool", () => {
 
   test("defaults mailbox to INBOX when not specified", async () => {
     const transport = makeMockTransport();
-    const handlers = buildMessageToolHandlers(transport);
-    const searchHandler = handlers.get("message_search");
+    const handlers = buildMailToolHandlers(transport);
+    const searchHandler = handlers.get("mail_search");
     if (searchHandler === undefined) throw new Error("handler not found");
 
     const call: ToolCall = {
       id: "q2",
-      name: "message_search",
+      name: "mail_search",
       arguments: { query: {} },
     };
 
@@ -819,10 +819,10 @@ describe("message_search tool", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 7. Message tool: message_read
+// 7. Mail tool: mail_read
 // ---------------------------------------------------------------------------
 
-describe("message_read tool", () => {
+describe("mail_read tool", () => {
   test("fetches full message when parts='full'", async () => {
     const transport = makeMockTransport();
     const ref: MessageRef = { uid: 5, mailbox: "INBOX" };
@@ -830,13 +830,13 @@ describe("message_read tool", () => {
     const storedMsg = { ...msg, ref };
     transport.enqueueMessage(ref, storedMsg);
 
-    const handlers = buildMessageToolHandlers(transport);
-    const readHandler = handlers.get("message_read");
+    const handlers = buildMailToolHandlers(transport);
+    const readHandler = handlers.get("mail_read");
     if (readHandler === undefined) throw new Error("handler not found");
 
     const call: ToolCall = {
       id: "rd1",
-      name: "message_read",
+      name: "mail_read",
       arguments: { ref, parts: "full" },
     };
 
@@ -855,13 +855,13 @@ describe("message_read tool", () => {
     const msg = makeInboundMessage();
     transport.enqueueMessage(ref, { ...msg, ref });
 
-    const handlers = buildMessageToolHandlers(transport);
-    const readHandler = handlers.get("message_read");
+    const handlers = buildMailToolHandlers(transport);
+    const readHandler = handlers.get("mail_read");
     if (readHandler === undefined) throw new Error("handler not found");
 
     const call: ToolCall = {
       id: "rd2",
-      name: "message_read",
+      name: "mail_read",
       arguments: { ref, parts: "headers" },
     };
 
@@ -875,13 +875,13 @@ describe("message_read tool", () => {
 
   test("returns error when ref is missing", async () => {
     const transport = makeMockTransport();
-    const handlers = buildMessageToolHandlers(transport);
-    const readHandler = handlers.get("message_read");
+    const handlers = buildMailToolHandlers(transport);
+    const readHandler = handlers.get("mail_read");
     if (readHandler === undefined) throw new Error("handler not found");
 
     const call: ToolCall = {
       id: "rd3",
-      name: "message_read",
+      name: "mail_read",
       arguments: { parts: "full" },
     };
 

--- a/packages/harness/src/harness.test.ts
+++ b/packages/harness/src/harness.test.ts
@@ -22,7 +22,7 @@ import type {
   ListInfo,
   MailboxEvent,
   Unsubscribe,
-  ConversationMessage,
+  ConversationTurn,
   PendingOperation,
   TokenUsage,
   ContextCommit,
@@ -55,10 +55,10 @@ function emptyUsage(): TokenUsage {
 function makeContextStore(): ContextStore {
   return {
     async load() {
-      const messages: ConversationMessage[] = [];
+      const turns: ConversationTurn[] = [];
       const pendingOperations: PendingOperation[] = [];
       return {
-        messages,
+        turns,
         pendingOperations,
         tokenUsage: emptyUsage(),
         connectorState: null,
@@ -68,7 +68,7 @@ function makeContextStore(): ContextStore {
       /* noop */
     },
     async commit(
-      _msgs: ConversationMessage[],
+      _msgs: ConversationTurn[],
       _ops: PendingOperation[],
       _usage: TokenUsage,
       message: string,
@@ -81,7 +81,7 @@ function makeContextStore(): ContextStore {
     async log(): Promise<ContextCommit[]> {
       return [];
     },
-    async readAt(): Promise<ConversationMessage[]> {
+    async readAt(): Promise<ConversationTurn[]> {
       return [];
     },
   };
@@ -954,7 +954,7 @@ describe("Default plugin", () => {
 
   function makeState(): import("@interchange/types/runtime").ReactorState {
     return {
-      messages: [],
+      turns: [],
       activeForks: [],
       pendingOperations: [],
       activeGates: [],
@@ -986,7 +986,7 @@ describe("Default plugin", () => {
 
     const event: ReactorInboundEvent = {
       type: "inference.done",
-      message: {
+      turn: {
         role: "assistant",
         model: "claude-test",
         content: [
@@ -1015,7 +1015,7 @@ describe("Default plugin", () => {
 
     const doneEvent: ReactorInboundEvent = {
       type: "inference.done",
-      message: {
+      turn: {
         role: "assistant",
         model: "claude-test",
         content: [{ type: "text", text: "Here is my response." }],
@@ -1100,7 +1100,7 @@ describe("Default plugin", () => {
 
     const event: ReactorInboundEvent = {
       type: "inference.done",
-      message: {
+      turn: {
         role: "assistant",
         model: "claude-test",
         content: [],
@@ -1124,7 +1124,7 @@ describe("Default plugin", () => {
 
     const event: ReactorInboundEvent = {
       type: "inference.done",
-      message: {
+      turn: {
         role: "assistant",
         model: "claude-test",
         content: [{ type: "text", text: "   \n\t  " }],
@@ -1150,7 +1150,7 @@ describe("Default plugin", () => {
 
     const event: ReactorInboundEvent = {
       type: "inference.done",
-      message: {
+      turn: {
         role: "assistant",
         model: "claude-test",
         content: [{ type: "text", text: "done processing" }],
@@ -1192,7 +1192,7 @@ describe("Default plugin", () => {
     // First trigger inference.done with 2 tool calls to set pendingToolResults.
     const inferDone: ReactorInboundEvent = {
       type: "inference.done",
-      message: {
+      turn: {
         role: "assistant",
         model: "claude-test",
         content: [

--- a/packages/harness/src/harness.ts
+++ b/packages/harness/src/harness.ts
@@ -42,9 +42,9 @@ import type { ErrorRecord } from "@interchange/types/audit";
 import type { HarnessConfig } from "./config";
 import { validateConfig } from "./config";
 import {
-  buildMessageToolHandlers,
+  buildMailToolHandlers,
   buildCombinedRunner,
-  getMessageToolDefinitions,
+  getMailToolDefinitions,
 } from "./tools";
 import { createDefaultPlugin } from "./plugin";
 import { type } from "arktype";
@@ -97,17 +97,17 @@ export function createHarness(config: HarnessConfig): Harness {
     plugin = createDefaultPlugin(
       provider.model,
       config.systemPrompt,
-      [...getMessageToolDefinitions(), ...deployToolDefs],
+      [...getMailToolDefinitions(), ...deployToolDefs],
       config.pluginPolicy ?? {},
     );
   }
 
-  // Build message tool handlers and the combined runner. Name collision
+  // Build mail tool handlers and the combined runner. Name collision
   // detection happens here at construction time — startup fails loudly.
-  const messageHandlers = buildMessageToolHandlers(transport);
+  const mailHandlers = buildMailToolHandlers(transport);
 
   const combinedRunner = buildCombinedRunner(
-    messageHandlers,
+    mailHandlers,
     tools,
     deployToolDefs,
   );

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -7,8 +7,8 @@ export type { BeforeToolExtension } from "@interchange/types/runtime";
 
 export { createDefaultPlugin, DefaultPlugin } from "./plugin";
 
-export { buildMessageToolHandlers, buildCombinedRunner } from "./tools";
-export type { MessageToolName } from "./tools";
+export { buildMailToolHandlers, buildCombinedRunner } from "./tools";
+export type { MailToolName } from "./tools";
 
 export { readDeployTree } from "./deploy-tree";
 export type { DeployTree, DeployToolInfo } from "./deploy-tree";

--- a/packages/harness/src/plugin.ts
+++ b/packages/harness/src/plugin.ts
@@ -20,7 +20,7 @@ import type {
   ReactorState,
   ReactorCapabilities,
   ReactorAction,
-  AssistantMessage,
+  AssistantTurn,
   ToolCall,
   ToolDefinition,
 } from "@interchange/types/runtime";
@@ -28,9 +28,9 @@ import type { PluginPolicy } from "./config";
 
 const logger = getLogger(["interchange", "harness", "plugin"]);
 
-function extractToolCalls(message: AssistantMessage): ToolCall[] {
+function extractToolCalls(turn: AssistantTurn): ToolCall[] {
   const calls: ToolCall[] = [];
-  for (const block of message.content) {
+  for (const block of turn.content) {
     if (block.type === "tool_call") {
       calls.push({
         id: block.id,
@@ -42,9 +42,9 @@ function extractToolCalls(message: AssistantMessage): ToolCall[] {
   return calls;
 }
 
-function extractTextContent(message: AssistantMessage): string {
+function extractTextContent(turn: AssistantTurn): string {
   const parts: string[] = [];
-  for (const block of message.content) {
+  for (const block of turn.content) {
     if (block.type === "text") {
       parts.push(block.text);
     }
@@ -112,7 +112,7 @@ export class DefaultPlugin implements ReactorPlugin {
       }
 
       case "inference.done": {
-        const toolCalls = extractToolCalls(event.message);
+        const toolCalls = extractToolCalls(event.turn);
         if (toolCalls.length > 0) {
           this.pendingToolResults = toolCalls.length;
           return [
@@ -130,7 +130,7 @@ export class DefaultPlugin implements ReactorPlugin {
         }
 
         // Conversational agent: send reply via the connector.
-        const replyContent = extractTextContent(event.message);
+        const replyContent = extractTextContent(event.turn);
         if (replyContent.length > 0) {
           return [
             capabilities.checkpoint("inference-done"),

--- a/packages/harness/src/tools.ts
+++ b/packages/harness/src/tools.ts
@@ -491,6 +491,35 @@ export function getMessageToolDefinitions(): ToolDefinition[] {
       },
     },
     {
+      name: "message_reply",
+      description:
+        "Reply to a message by reference. Addresses the reply to the original sender and sets inReplyTo for threading.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          ref: {
+            type: "object",
+            description: "Message reference { uid, mailbox }",
+            properties: {
+              uid: { type: "number" },
+              mailbox: { type: "string" },
+            },
+            required: ["uid", "mailbox"],
+          },
+          content: {
+            type: "string",
+            description: "Reply text content",
+          },
+          type: {
+            type: "string",
+            description: "Message type (default: conversation.message)",
+            default: "conversation.message",
+          },
+        },
+        required: ["ref", "content"],
+      },
+    },
+    {
       name: "message_search",
       description:
         "Search for messages in a mailbox. Returns message summaries.",

--- a/packages/harness/src/tools.ts
+++ b/packages/harness/src/tools.ts
@@ -1,10 +1,10 @@
-// Message tool implementations for the harness.
+// Mail tool implementations for the harness.
 //
 // Each tool wraps the MessageTransport interface, translating model-supplied
 // arguments into transport calls and returning structured results the model
 // can reason about.
 //
-// (MESSAGE.md § Messaging Tools)
+// (MESSAGE.md § Mail Tools)
 
 import { type } from "arktype";
 import type {
@@ -82,7 +82,7 @@ const WaitArgs = type({
 // Individual tool handlers
 // ---------------------------------------------------------------------------
 
-function makeMessageSendHandler(transport: MessageTransport): ToolHandler {
+function makeMailSendHandler(transport: MessageTransport): ToolHandler {
   return async (call, signal) => {
     const args = SendArgs(call.arguments);
     if (args instanceof type.errors) {
@@ -131,7 +131,7 @@ function makeMessageSendHandler(transport: MessageTransport): ToolHandler {
   };
 }
 
-function makeMessageReplyHandler(transport: MessageTransport): ToolHandler {
+function makeMailReplyHandler(transport: MessageTransport): ToolHandler {
   return async (call, signal) => {
     const args = ReplyArgs(call.arguments);
     if (args instanceof type.errors) {
@@ -204,7 +204,7 @@ function makeMessageReplyHandler(transport: MessageTransport): ToolHandler {
   };
 }
 
-function makeMessageSearchHandler(transport: MessageTransport): ToolHandler {
+function makeMailSearchHandler(transport: MessageTransport): ToolHandler {
   return async (call, signal) => {
     const args = SearchArgs(call.arguments);
     if (args instanceof type.errors) {
@@ -251,7 +251,7 @@ function makeMessageSearchHandler(transport: MessageTransport): ToolHandler {
   };
 }
 
-function makeMessageReadHandler(transport: MessageTransport): ToolHandler {
+function makeMailReadHandler(transport: MessageTransport): ToolHandler {
   return async (call, signal) => {
     const args = ReadArgs(call.arguments);
     if (args instanceof type.errors) {
@@ -346,7 +346,7 @@ function makeMessageReadHandler(transport: MessageTransport): ToolHandler {
   };
 }
 
-function makeMessageWaitHandler(transport: MessageTransport): ToolHandler {
+function makeMailWaitHandler(transport: MessageTransport): ToolHandler {
   return async (call, signal) => {
     const args = WaitArgs(call.arguments);
     if (args instanceof type.errors) {
@@ -445,23 +445,23 @@ function makeMessageWaitHandler(transport: MessageTransport): ToolHandler {
 // Tool name registry
 // ---------------------------------------------------------------------------
 
-export type MessageToolName =
-  | "message_send"
-  | "message_reply"
-  | "message_search"
-  | "message_read"
-  | "message_wait";
+export type MailToolName =
+  | "mail_send"
+  | "mail_reply"
+  | "mail_search"
+  | "mail_read"
+  | "mail_wait";
 
 /**
- * Tool definitions for the built-in message tools, suitable for passing to
+ * Tool definitions for the built-in mail tools, suitable for passing to
  * the inference provider so the model knows these tools exist.
  */
-export function getMessageToolDefinitions(): ToolDefinition[] {
+export function getMailToolDefinitions(): ToolDefinition[] {
   return [
     {
-      name: "message_send",
+      name: "mail_send",
       description:
-        "Send a message to another agent or address. Use this to initiate conversations or send information to other agents.",
+        "Send mail to another agent or address. Use this to initiate conversations or send information to other agents.",
       inputSchema: {
         type: "object",
         properties: {
@@ -491,9 +491,9 @@ export function getMessageToolDefinitions(): ToolDefinition[] {
       },
     },
     {
-      name: "message_reply",
+      name: "mail_reply",
       description:
-        "Reply to a message by reference. Addresses the reply to the original sender and sets inReplyTo for threading.",
+        "Reply to mail by reference. Addresses the reply to the original sender and sets inReplyTo for threading.",
       inputSchema: {
         type: "object",
         properties: {
@@ -520,9 +520,8 @@ export function getMessageToolDefinitions(): ToolDefinition[] {
       },
     },
     {
-      name: "message_search",
-      description:
-        "Search for messages in a mailbox. Returns message summaries.",
+      name: "mail_search",
+      description: "Search mail in a mailbox. Returns message summaries.",
       inputSchema: {
         type: "object",
         properties: {
@@ -544,8 +543,8 @@ export function getMessageToolDefinitions(): ToolDefinition[] {
       },
     },
     {
-      name: "message_read",
-      description: "Read a specific message by reference.",
+      name: "mail_read",
+      description: "Read a specific mail message by reference.",
       inputSchema: {
         type: "object",
         properties: {
@@ -569,9 +568,9 @@ export function getMessageToolDefinitions(): ToolDefinition[] {
       },
     },
     {
-      name: "message_wait",
+      name: "mail_wait",
       description:
-        "Wait for a message matching a query to arrive. Blocks until a matching message is delivered or the timeout expires. Use this instead of polling message_search in a loop.",
+        "Wait for a message matching a query to arrive. Blocks until a matching message is delivered or the timeout expires. Use this instead of polling mail_search in a loop.",
       inputSchema: {
         type: "object",
         properties: {
@@ -599,45 +598,45 @@ export function getMessageToolDefinitions(): ToolDefinition[] {
 }
 
 /**
- * Build a map of message tool name → handler for the given transport.
+ * Build a map of mail tool name → handler for the given transport.
  */
-export function buildMessageToolHandlers(
+export function buildMailToolHandlers(
   transport: MessageTransport,
 ): Map<string, ToolHandler> {
   const handlers = new Map<string, ToolHandler>();
-  handlers.set("message_send", makeMessageSendHandler(transport));
-  handlers.set("message_reply", makeMessageReplyHandler(transport));
-  handlers.set("message_search", makeMessageSearchHandler(transport));
-  handlers.set("message_read", makeMessageReadHandler(transport));
-  handlers.set("message_wait", makeMessageWaitHandler(transport));
+  handlers.set("mail_send", makeMailSendHandler(transport));
+  handlers.set("mail_reply", makeMailReplyHandler(transport));
+  handlers.set("mail_search", makeMailSearchHandler(transport));
+  handlers.set("mail_read", makeMailReadHandler(transport));
+  handlers.set("mail_wait", makeMailWaitHandler(transport));
   return handlers;
 }
 
 /**
- * Combine message tool handlers with a caller-supplied ToolRunner into a
+ * Combine mail tool handlers with a caller-supplied ToolRunner into a
  * single unified ToolRunner. Throws at call time if a name collision exists
- * between message tools and the caller-supplied tools.
+ * between mail tools and the caller-supplied tools.
  *
  * The collision check runs at construction time (startup), not at invocation
  * time, so it fails loudly before any inference happens.
  */
 export function buildCombinedRunner(
-  messageHandlers: Map<string, ToolHandler>,
+  mailHandlers: Map<string, ToolHandler>,
   callerTools: ToolRunner,
   callerToolDefs: ToolDefinition[],
 ): ToolRunner {
   // Check for collisions at startup.
   for (const def of callerToolDefs) {
-    if (messageHandlers.has(def.name)) {
+    if (mailHandlers.has(def.name)) {
       throw new Error(
-        `Tool name collision: "${def.name}" is registered by both the message tools and the caller-provided ToolRunner`,
+        `Tool name collision: "${def.name}" is registered by both the mail tools and the caller-provided ToolRunner`,
       );
     }
   }
 
   return {
     async run(call: ToolCall, signal: AbortSignal): Promise<ToolResult> {
-      const handler = messageHandlers.get(call.name);
+      const handler = mailHandlers.get(call.name);
       if (handler !== undefined) {
         return handler(call, signal);
       }

--- a/packages/hub-client/src/session.test.ts
+++ b/packages/hub-client/src/session.test.ts
@@ -1116,7 +1116,7 @@ describe("activity state machine", () => {
       type: "inference.done",
       seq: 2,
       data: {
-        message: {
+        turn: {
           role: "assistant",
           content: [],
           model: "gpt-4",

--- a/packages/hub/src/event-collector.test.ts
+++ b/packages/hub/src/event-collector.test.ts
@@ -121,7 +121,7 @@ describe("EventCollector", () => {
     await collector.onEvent(event("inference.start", 1, { model: "gpt-4" }));
     await collector.onEvent(
       event("inference.done", 5, {
-        message: {
+        turn: {
           role: "assistant",
           content: [
             { type: "text", text: "Hello world" },
@@ -221,7 +221,7 @@ describe("EventCollector", () => {
   test("parts before inference.start are dropped", async () => {
     await collector.onEvent(
       event("inference.done", 5, {
-        message: {
+        turn: {
           role: "assistant",
           content: [{ type: "text", text: "orphan" }],
           model: "gpt-4",
@@ -238,7 +238,7 @@ describe("EventCollector", () => {
     await collector.onEvent(event("inference.start", 1, { model: "gpt-4" }));
     await collector.onEvent(
       event("inference.done", 5, {
-        message: {
+        turn: {
           role: "assistant",
           content: [
             { type: "text", text: "hello" },
@@ -275,7 +275,7 @@ describe("EventCollector", () => {
     await collector.onEvent(event("inference.start", 1, { model: "gpt-4" }));
     await collector.onEvent(
       event("inference.done", 5, {
-        message: {
+        turn: {
           role: "assistant",
           content: [
             {
@@ -334,7 +334,7 @@ describe("EventCollector", () => {
     await collector.onEvent(event("inference.start", 2, { model: "claude-3" }));
     await collector.onEvent(
       event("inference.done", 5, {
-        message: {
+        turn: {
           role: "assistant",
           content: [
             { type: "text", text: "Let me search" },
@@ -362,7 +362,7 @@ describe("EventCollector", () => {
     await collector.onEvent(event("inference.start", 8, { model: "claude-3" }));
     await collector.onEvent(
       event("inference.done", 12, {
-        message: {
+        turn: {
           role: "assistant",
           content: [{ type: "text", text: "Here are the results" }],
           model: "claude-3",
@@ -513,7 +513,7 @@ describe("EventCollector", () => {
       );
       await notifyCollector.onEvent(
         event("inference.done", 5, {
-          message: {
+          turn: {
             role: "assistant",
             content: [{ type: "text", text: "Hello world" }],
             model: "gpt-4",
@@ -536,7 +536,7 @@ describe("EventCollector", () => {
       );
       await notifyCollector.onEvent(
         event("inference.done", 5, {
-          message: {
+          turn: {
             role: "assistant",
             content: [
               { type: "thinking", thinking: "Let me think..." },
@@ -559,7 +559,7 @@ describe("EventCollector", () => {
       );
       await notifyCollector.onEvent(
         event("inference.done", 3, {
-          message: {
+          turn: {
             role: "assistant",
             content: [{ type: "text", text: "Searching" }],
             model: "gpt-4",
@@ -573,7 +573,7 @@ describe("EventCollector", () => {
       );
       await notifyCollector.onEvent(
         event("inference.done", 8, {
-          message: {
+          turn: {
             role: "assistant",
             content: [{ type: "text", text: "Results" }],
             model: "gpt-4",
@@ -596,7 +596,7 @@ describe("EventCollector", () => {
       );
       await notifyCollector.onEvent(
         event("inference.done", 5, {
-          message: {
+          turn: {
             role: "assistant",
             content: [{ type: "text", text: "Some text" }],
             model: "gpt-4",
@@ -635,7 +635,7 @@ describe("EventCollector", () => {
       );
       await notifyCollector.onEvent(
         event("inference.done", 3, {
-          message: {
+          turn: {
             role: "assistant",
             content: [
               {
@@ -710,7 +710,7 @@ describe("EventCollector", () => {
       );
       await notifyCollector.onEvent(
         event("inference.done", 3, {
-          message: {
+          turn: {
             role: "assistant",
             content: [
               {
@@ -754,7 +754,7 @@ describe("EventCollector", () => {
       );
       await notifyCollector.onEvent(
         event("inference.done", 5, {
-          message: {
+          turn: {
             role: "assistant",
             content: [{ type: "text", text: "Continuing" }],
             model: "gpt-4",
@@ -798,7 +798,7 @@ describe("EventCollector", () => {
       );
       await notifyCollector.onEvent(
         event("inference.done", 5, {
-          message: {
+          turn: {
             role: "assistant",
             content: [{ type: "text", text: "All good" }],
             model: "gpt-4",
@@ -822,7 +822,7 @@ describe("EventCollector", () => {
       await collector.onEvent(event("inference.start", 1, { model: "gpt-4" }));
       await collector.onEvent(
         event("inference.done", 5, {
-          message: {
+          turn: {
             role: "assistant",
             content: [{ type: "text", text: "Hello " }],
             model: "gpt-4",
@@ -832,7 +832,7 @@ describe("EventCollector", () => {
       );
       await collector.onEvent(
         event("inference.done", 6, {
-          message: {
+          turn: {
             role: "assistant",
             content: [{ type: "text", text: "world" }],
             model: "gpt-4",
@@ -848,7 +848,7 @@ describe("EventCollector", () => {
       await collector.onEvent(event("inference.start", 1, { model: "gpt-4" }));
       await collector.onEvent(
         event("inference.done", 5, {
-          message: {
+          turn: {
             role: "assistant",
             content: [{ type: "text", text: "First turn text" }],
             model: "gpt-4",
@@ -910,7 +910,7 @@ describe("EventCollectorRegistry getAccumulatedText", () => {
     registry.dispatch(
       address,
       event("inference.done", 5, {
-        message: {
+        turn: {
           role: "assistant",
           content: [{ type: "text", text: "streaming text" }],
           model: "gpt-4",

--- a/packages/hub/src/event-collector.ts
+++ b/packages/hub/src/event-collector.ts
@@ -78,7 +78,7 @@ export function createEventCollector(
         await insertPart("step-start", null, { model: event.data.model });
         break;
       case "inference.done":
-        await handleInferenceDone(event.data.message.content);
+        await handleInferenceDone(event.data.turn.content);
         break;
       case "tool.done": {
         const isError = event.data.result.isError ?? false;

--- a/packages/hub/src/timeline-reconstruction.test.ts
+++ b/packages/hub/src/timeline-reconstruction.test.ts
@@ -8,7 +8,7 @@ import {
   initAgentRepo,
   createMailAuditStore,
 } from "@interchange/storage-isogit";
-import type { ConversationMessage } from "@interchange/types/runtime";
+import type { ConversationTurn } from "@interchange/types/runtime";
 import type { ErrorRecord } from "@interchange/types/audit";
 import { reconstructTimeline } from "./timeline-reconstruction";
 
@@ -37,17 +37,14 @@ const NO_USAGE = {
   thinking: 0,
 };
 
-function userMessage(
-  text: string,
-  timestamp = Date.now(),
-): ConversationMessage {
+function userMessage(text: string, timestamp = Date.now()): ConversationTurn {
   return { role: "user", content: [{ type: "text", text }], timestamp };
 }
 
 function assistantMessage(
   text: string,
   timestamp = Date.now(),
-): ConversationMessage {
+): ConversationTurn {
   return {
     role: "assistant",
     content: [{ type: "text", text }],
@@ -61,7 +58,7 @@ function toolCallMessage(
   name: string,
   args: Record<string, unknown>,
   timestamp = Date.now(),
-): ConversationMessage {
+): ConversationTurn {
   return {
     role: "assistant",
     content: [{ type: "tool_call", id: callId, name, arguments: args }],
@@ -74,7 +71,7 @@ function toolResultMessage(
   callId: string,
   result: string,
   timestamp = Date.now(),
-): ConversationMessage {
+): ConversationTurn {
   return {
     role: "user",
     content: [
@@ -115,7 +112,7 @@ describe("reconstructTimeline", () => {
     const store = new IsogitStore(dir);
 
     const t = 1700000000000;
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       userMessage("Hello", t),
       assistantMessage("Hi there", t + 1000),
     ];
@@ -145,7 +142,7 @@ describe("reconstructTimeline", () => {
     const t = 1700000000000;
 
     // First turn
-    const messages1: ConversationMessage[] = [
+    const messages1: ConversationTurn[] = [
       userMessage("Hello", t),
       assistantMessage("Hi there", t + 1000),
     ];
@@ -157,7 +154,7 @@ describe("reconstructTimeline", () => {
     );
 
     // Second turn (appends to the same message array)
-    const messages2: ConversationMessage[] = [
+    const messages2: ConversationTurn[] = [
       ...messages1,
       userMessage("How are you?", t + 5000),
       assistantMessage("I'm doing well", t + 6000),
@@ -186,7 +183,7 @@ describe("reconstructTimeline", () => {
     await initAgentRepo(dir);
     const store = new IsogitStore(dir);
 
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       userMessage("What's the weather?"),
       toolCallMessage("call-1", "get_weather", { city: "SF" }),
       toolResultMessage("call-1", "72F and sunny"),
@@ -257,7 +254,7 @@ describe("reconstructTimeline", () => {
     const store = new IsogitStore(dir);
 
     const t = 1700000000000;
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       userMessage("Hello", t),
       assistantMessage("Hi there", t + 1000),
     ];
@@ -296,7 +293,7 @@ describe("reconstructTimeline", () => {
     const store = new IsogitStore(dir);
 
     // Write a conversation first
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       userMessage("Do something risky"),
       assistantMessage("Attempting..."),
     ];
@@ -340,7 +337,7 @@ describe("reconstructTimeline", () => {
     const store = new IsogitStore(dir);
 
     // First checkpoint with 4 messages
-    const messages1: ConversationMessage[] = [
+    const messages1: ConversationTurn[] = [
       userMessage("Hello"),
       assistantMessage("Hi"),
       userMessage("More"),
@@ -354,7 +351,7 @@ describe("reconstructTimeline", () => {
     );
 
     // Second checkpoint with only 2 messages (regression)
-    const messages2: ConversationMessage[] = [
+    const messages2: ConversationTurn[] = [
       userMessage("Fresh start"),
       assistantMessage("OK"),
     ];
@@ -392,7 +389,7 @@ describe("reconstructTimeline", () => {
     await mailStore.commitMail(inbound, "in");
 
     // Then a turn
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       userMessage("Hello"),
       assistantMessage("Hi there"),
     ];
@@ -425,7 +422,7 @@ describe("reconstructTimeline", () => {
     const store = new IsogitStore(dir);
 
     const t = 1700000000000;
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       userMessage("Hello", t),
       assistantMessage("Hi", t + 1000),
     ];
@@ -447,7 +444,7 @@ describe("reconstructTimeline", () => {
     const store = new IsogitStore(dir);
 
     const t = 1700000000000;
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       userMessage("Hello", t),
       assistantMessage("Something went wrong", t + 1000),
     ];
@@ -472,7 +469,7 @@ describe("reconstructTimeline", () => {
     const store = new IsogitStore(dir);
 
     const t = 1700000000000;
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       userMessage("What's the weather?", t),
       toolCallMessage("call-1", "get_weather", { city: "SF" }, t + 1000),
     ];
@@ -484,7 +481,7 @@ describe("reconstructTimeline", () => {
     );
 
     // Add tool result and final response
-    const messages2: ConversationMessage[] = [
+    const messages2: ConversationTurn[] = [
       ...messages,
       toolResultMessage("call-1", "72F", t + 2000),
       assistantMessage("It's 72F in SF", t + 3000),
@@ -521,7 +518,7 @@ describe("reconstructTimeline", () => {
     const store = new IsogitStore(dir);
 
     // Write a valid checkpoint first
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       userMessage("Hello"),
       assistantMessage("Hi"),
     ];
@@ -636,35 +633,35 @@ describe("reconstructTimeline", () => {
     await mailStore.commitMail(inbound, "in");
 
     // 2. First inference: agent decides to call a tool
-    const msgs1: ConversationMessage[] = [
+    const msgs1: ConversationTurn[] = [
       userMessage("What is the weather in SF and NYC?", t),
       toolCallMessage("call-1", "get_weather", { city: "SF" }, t + 1000),
     ];
     await store.commit(msgs1, NO_OPS, NO_USAGE, "checkpoint: tool-execution");
 
     // 3. Tool result comes back
-    const msgs2: ConversationMessage[] = [
+    const msgs2: ConversationTurn[] = [
       ...msgs1,
       toolResultMessage("call-1", "72F and sunny", t + 2000),
     ];
     await store.commit(msgs2, NO_OPS, NO_USAGE, "checkpoint: tool-done");
 
     // 4. Second inference: agent calls another tool
-    const msgs3: ConversationMessage[] = [
+    const msgs3: ConversationTurn[] = [
       ...msgs2,
       toolCallMessage("call-2", "get_weather", { city: "NYC" }, t + 3000),
     ];
     await store.commit(msgs3, NO_OPS, NO_USAGE, "checkpoint: tool-execution");
 
     // 5. Second tool result
-    const msgs4: ConversationMessage[] = [
+    const msgs4: ConversationTurn[] = [
       ...msgs3,
       toolResultMessage("call-2", "55F and rainy", t + 4000),
     ];
     await store.commit(msgs4, NO_OPS, NO_USAGE, "checkpoint: tool-done");
 
     // 6. Final inference: agent composes reply
-    const msgs5: ConversationMessage[] = [
+    const msgs5: ConversationTurn[] = [
       ...msgs4,
       assistantMessage("SF is 72F and sunny. NYC is 55F and rainy.", t + 5000),
     ];
@@ -688,7 +685,7 @@ describe("reconstructTimeline", () => {
     });
 
     // 8. An error occurs on a follow-up inference
-    const msgs6: ConversationMessage[] = [
+    const msgs6: ConversationTurn[] = [
       ...msgs5,
       userMessage("What about London?", t + 10000),
       assistantMessage("Let me check London weather.", t + 11000),

--- a/packages/hub/src/timeline-reconstruction.ts
+++ b/packages/hub/src/timeline-reconstruction.ts
@@ -6,7 +6,7 @@ import {
   listMail,
   type MailDirection,
 } from "@interchange/storage-isogit";
-import type { ConversationMessage } from "@interchange/types/runtime";
+import type { ConversationTurn } from "@interchange/types/runtime";
 import {
   ErrorRecord,
   type ErrorRecord as ErrorRecordType,
@@ -88,14 +88,14 @@ function reasonToStatus(
   }
 }
 
-function isToolResultMessage(msg: ConversationMessage): boolean {
+function isToolResultTurn(msg: ConversationTurn): boolean {
   const first = msg.content[0];
   return (
     msg.role === "user" && first !== undefined && first.type === "tool_result"
   );
 }
 
-function extractTextContent(msg: ConversationMessage): string {
+function extractTextContent(msg: ConversationTurn): string {
   return msg.content
     .filter((b) => b.type === "text")
     .map((b) => {
@@ -111,14 +111,14 @@ type TurnAccumulator = {
 };
 
 function extractTurns(
-  newMessages: ConversationMessage[],
+  newMessages: ConversationTurn[],
   status: "completed" | "error" | "in-progress",
 ): ReconstructedEvent[] {
   const events: ReconstructedEvent[] = [];
   let current: TurnAccumulator | null = null;
 
   for (const msg of newMessages) {
-    if (msg.role === "user" && !isToolResultMessage(msg)) {
+    if (msg.role === "user" && !isToolResultTurn(msg)) {
       // New user message (not a tool result) starts a new turn
       if (current !== null && current.texts.length > 0) {
         events.push({
@@ -285,7 +285,7 @@ export async function reconstructTimeline(
 
     const status = reasonToStatus(reason);
 
-    let messages: ConversationMessage[];
+    let messages: ConversationTurn[];
     try {
       messages = await store.readAt(commit.hash);
     } catch {

--- a/packages/inference/src/adapter.ts
+++ b/packages/inference/src/adapter.ts
@@ -1,5 +1,5 @@
 import type {
-  ConversationMessage,
+  ConversationTurn,
   InferenceEvent,
   InferenceOptions,
 } from "@interchange/types/runtime";
@@ -14,7 +14,7 @@ export type BuiltRequest = {
 // A request builder takes the internal message format and produces a
 // provider-specific HTTP request. Pure function — no state, no side effects.
 export type RequestBuilder = (
-  messages: ConversationMessage[],
+  messages: ConversationTurn[],
   model: string,
   options: InferenceOptions,
 ) => BuiltRequest;

--- a/packages/inference/src/authz-extension.test.ts
+++ b/packages/inference/src/authz-extension.test.ts
@@ -19,7 +19,7 @@ function emptyUsage(): TokenUsage {
 function makeState(): ReactorState {
   return {
     sessionId: "test",
-    messages: [],
+    turns: [],
     activeForks: [],
     pendingOperations: [],
     activeGates: [],

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -16,13 +16,13 @@
 import { type } from "arktype";
 
 import type {
-  ConversationMessage,
+  ConversationTurn,
   InferenceEvent,
   InferenceOptions,
   PartialMessage,
   ProviderConfig,
   TokenUsage,
-  AssistantMessage,
+  AssistantTurn,
   ContentBlock,
 } from "@interchange/types/runtime";
 
@@ -36,7 +36,7 @@ import {
 } from "./errors";
 
 export type InferenceHarnessOptions = {
-  messages: ConversationMessage[];
+  turns: ConversationTurn[];
   model: string;
   providerConfig: ProviderConfig;
   inferenceOptions?: InferenceOptions;
@@ -49,7 +49,7 @@ export async function* runInference(
   opts: InferenceHarnessOptions,
 ): AsyncIterable<InferenceEvent> {
   const {
-    messages,
+    turns,
     model,
     providerConfig,
     inferenceOptions = {},
@@ -107,7 +107,7 @@ export async function* runInference(
 
   let builtRequest;
   try {
-    builtRequest = adapter.buildRequest(messages, model, inferenceOptions);
+    builtRequest = adapter.buildRequest(turns, model, inferenceOptions);
   } catch (cause) {
     yield {
       type: "inference.error",
@@ -389,7 +389,7 @@ export async function* runInference(
   }
   contentBlocks.push(...completedToolCalls);
 
-  const finalMessage: AssistantMessage = {
+  const finalTurn: AssistantTurn = {
     role: "assistant",
     content: contentBlocks,
     model,
@@ -399,7 +399,7 @@ export async function* runInference(
   yield {
     type: "inference.done",
     seq: nextSeq(),
-    data: { message: finalMessage, usage: finalUsage },
+    data: { turn: finalTurn, usage: finalUsage },
   };
 }
 

--- a/packages/inference/src/providers/anthropic.test.ts
+++ b/packages/inference/src/providers/anthropic.test.ts
@@ -1,7 +1,7 @@
 import { type } from "arktype";
 import { describe, test, expect } from "bun:test";
 import { createAnthropicAdapter } from "./anthropic";
-import type { ConversationMessage } from "@interchange/types/runtime";
+import type { ConversationTurn } from "@interchange/types/runtime";
 
 const adapter = createAnthropicAdapter();
 
@@ -49,7 +49,7 @@ const AnthropicRequestBody = type({
 
 describe("Anthropic adapter: buildRequest", () => {
   test("builds a request with required fields", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "Hello" }],
@@ -74,7 +74,7 @@ describe("Anthropic adapter: buildRequest", () => {
   });
 
   test("extracts system messages into top-level system field", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "system",
         content: [{ type: "text", text: "You are helpful." }],
@@ -107,7 +107,7 @@ describe("Anthropic adapter: buildRequest", () => {
   });
 
   test("options.systemPrompt overrides system messages", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "system",
         content: [{ type: "text", text: "Original system." }],
@@ -134,7 +134,7 @@ describe("Anthropic adapter: buildRequest", () => {
   });
 
   test("includes thinking config when enabled", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "Think deeply." }],
@@ -151,7 +151,7 @@ describe("Anthropic adapter: buildRequest", () => {
   });
 
   test("converts tool_call blocks to tool_use type", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "assistant",
         content: [
@@ -179,7 +179,7 @@ describe("Anthropic adapter: buildRequest", () => {
   });
 
   test("serializes tool definitions with Anthropic wire format", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "Hi." }],
@@ -211,7 +211,7 @@ describe("Anthropic adapter: buildRequest", () => {
   });
 
   test("omits tools key when tools array is empty", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "Hi." }],
@@ -227,7 +227,7 @@ describe("Anthropic adapter: buildRequest", () => {
   });
 
   test("omits tools key when tools is undefined", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "Hi." }],
@@ -245,7 +245,7 @@ describe("Anthropic adapter: buildRequest", () => {
   });
 
   test("uses max_tokens from options", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "Hi." }],

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -2,7 +2,7 @@ import { type } from "arktype";
 
 import { getLogger } from "@interchange/log";
 import type {
-  ConversationMessage,
+  ConversationTurn,
   ContentBlock,
   InferenceEvent,
   InferenceOptions,
@@ -18,7 +18,7 @@ const logger = getLogger(["interchange", "inference", "anthropic"]);
 // ---------------------------------------------------------------------------
 
 function buildRequest(
-  messages: ConversationMessage[],
+  messages: ConversationTurn[],
   model: string,
   options: InferenceOptions,
 ): BuiltRequest {
@@ -97,7 +97,7 @@ function buildRequest(
 }
 
 function toAnthropicMessage(
-  msg: ConversationMessage,
+  msg: ConversationTurn,
   cacheLastBlock?: boolean,
 ): Record<string, unknown> {
   const role = msg.role === "assistant" ? "assistant" : "user";

--- a/packages/inference/src/providers/openai.test.ts
+++ b/packages/inference/src/providers/openai.test.ts
@@ -1,7 +1,7 @@
 import { type } from "arktype";
 import { describe, test, expect } from "bun:test";
 import { createOpenAIAdapter } from "./openai";
-import type { ConversationMessage } from "@interchange/types/runtime";
+import type { ConversationTurn } from "@interchange/types/runtime";
 
 const adapter = createOpenAIAdapter();
 
@@ -41,7 +41,7 @@ const OpenAIRequestBody = type({
 
 describe("OpenAI adapter: buildRequest", () => {
   test("builds a request with required fields", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "Hello" }],
@@ -62,7 +62,7 @@ describe("OpenAI adapter: buildRequest", () => {
   });
 
   test("converts text messages correctly", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "What is 2+2?" }],
@@ -79,7 +79,7 @@ describe("OpenAI adapter: buildRequest", () => {
   });
 
   test("converts system messages to system role", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "system",
         content: [{ type: "text", text: "Be concise." }],
@@ -100,7 +100,7 @@ describe("OpenAI adapter: buildRequest", () => {
   });
 
   test("prepends systemPrompt from options", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "Hi." }],
@@ -119,7 +119,7 @@ describe("OpenAI adapter: buildRequest", () => {
   });
 
   test("converts assistant tool_call blocks to tool_calls format", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "assistant",
         content: [
@@ -148,7 +148,7 @@ describe("OpenAI adapter: buildRequest", () => {
   });
 
   test("converts tool_result blocks to tool role messages", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "user",
         content: [
@@ -172,7 +172,7 @@ describe("OpenAI adapter: buildRequest", () => {
   });
 
   test("uses max_tokens from options", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "Hi." }],

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -2,7 +2,7 @@ import { type } from "arktype";
 
 import { getLogger } from "@interchange/log";
 import type {
-  ConversationMessage,
+  ConversationTurn,
   ContentBlock,
   InferenceEvent,
   InferenceOptions,
@@ -18,7 +18,7 @@ const logger = getLogger(["interchange", "inference", "openai"]);
 // ---------------------------------------------------------------------------
 
 function buildRequest(
-  messages: ConversationMessage[],
+  messages: ConversationTurn[],
   model: string,
   options: InferenceOptions,
 ): BuiltRequest {
@@ -65,7 +65,7 @@ function buildRequest(
   };
 }
 
-function toOpenAIMessage(msg: ConversationMessage): unknown[] {
+function toOpenAIMessage(msg: ConversationTurn): unknown[] {
   if (msg.role === "system") {
     const text = msg.content
       .filter((b): b is { type: "text"; text: string } => b.type === "text")

--- a/packages/inference/src/reactor.test.ts
+++ b/packages/inference/src/reactor.test.ts
@@ -15,11 +15,11 @@ import type {
   ToolRunner,
   InferenceEvent,
   InboundMessage,
-  ConversationMessage,
+  ConversationTurn,
   PendingOperation,
   TokenUsage,
   ContextCommit,
-  AssistantMessage,
+  AssistantTurn,
   InferenceError,
   PartialMessage,
   BeforeToolExtension,
@@ -37,11 +37,11 @@ function emptyUsage(): TokenUsage {
   return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, thinking: 0 };
 }
 
-function makeContextStore(messages: ConversationMessage[] = []): ContextStore {
+function makeContextStore(turns: ConversationTurn[] = []): ContextStore {
   return {
     async load() {
       return {
-        messages,
+        turns,
         pendingOperations: [],
         tokenUsage: emptyUsage(),
         connectorState: null,
@@ -1269,12 +1269,12 @@ describe("createReactor — tool runner failures", () => {
 
   test("addToHistory=false runs tools but skips history append", async () => {
     // We observe history indirectly via a checkpoint that captures the
-    // messages passed to contextStore.commit().
-    let committedMessages: ConversationMessage[] = [];
+    // turns passed to contextStore.commit().
+    let committedTurns: ConversationTurn[] = [];
     const capturingStore: ContextStore = {
       async load() {
         return {
-          messages: [],
+          turns: [],
           pendingOperations: [],
           tokenUsage: emptyUsage(),
           connectorState: null,
@@ -1284,7 +1284,7 @@ describe("createReactor — tool runner failures", () => {
         /* noop */
       },
       async commit(msgs, _ops, _usage, message): Promise<ContextCommit> {
-        committedMessages = [...msgs];
+        committedTurns = [...msgs];
         return { hash: "abc", message, timestamp: Date.now() };
       },
       async branch() {
@@ -1316,17 +1316,17 @@ describe("createReactor — tool runner failures", () => {
     await waitFor("reactor.done");
 
     // Verify commit was actually called before checking its contents.
-    expect(committedMessages.length).toBeGreaterThan(0);
+    expect(committedTurns.length).toBeGreaterThan(0);
 
     // The committed history should contain the inbound text message but
     // no tool_result message since addToHistory was false.
-    const hasToolResult = committedMessages.some((m) =>
+    const hasToolResult = committedTurns.some((m) =>
       m.content.some((b) => b.type === "tool_result"),
     );
     expect(hasToolResult).toBe(false);
 
     // The inbound user message should still be in history.
-    const hasUserText = committedMessages.some(
+    const hasUserText = committedTurns.some(
       (m) => m.role === "user" && m.content.some((b) => b.type === "text"),
     );
     expect(hasUserText).toBe(true);
@@ -1522,7 +1522,7 @@ describe("createReactor — checkpoint failure", () => {
     const failingStore: ContextStore = {
       async load() {
         return {
-          messages: [],
+          turns: [],
           pendingOperations: [],
           tokenUsage: emptyUsage(),
           connectorState: null,
@@ -1674,7 +1674,7 @@ describe("createReactor — dequeue priority", () => {
     // block. Using addToHistory=false on executeTools keeps this as the
     // last message, so historyHasPendingToolCalls() stays true when the
     // loop calls dequeueNext() after tools complete.
-    const seededMessages: ConversationMessage[] = [
+    const seededTurns: ConversationTurn[] = [
       {
         role: "assistant",
         content: [
@@ -1709,7 +1709,7 @@ describe("createReactor — dequeue priority", () => {
     };
 
     const { reactor, waitFor } = createTestReactor({
-      contextStore: makeContextStore(seededMessages),
+      contextStore: makeContextStore(seededTurns),
       plugin: {
         async decide(event, _state, caps) {
           order.push(event.type);
@@ -1963,12 +1963,12 @@ describe("createReactor — start guard", () => {
 // ---------------------------------------------------------------------------
 
 describe("createReactor — state snapshot inspection", () => {
-  test("state.messages contains delivered message text", async () => {
-    let capturedMessages: ConversationMessage[] = [];
+  test("state.turns contains delivered message text", async () => {
+    let capturedTurns: ConversationTurn[] = [];
     const { reactor, waitFor } = createTestReactor({
       plugin: pluginFromTable({
         "message.received": (_e, state, caps) => {
-          capturedMessages = state.messages;
+          capturedTurns = state.turns;
           return caps.done();
         },
       }),
@@ -1978,8 +1978,8 @@ describe("createReactor — state snapshot inspection", () => {
     reactor.deliver(makeInboundMessage());
     await waitFor("reactor.done");
 
-    expect(capturedMessages.length).toBe(1);
-    const last = capturedMessages.at(-1);
+    expect(capturedTurns.length).toBe(1);
+    const last = capturedTurns.at(-1);
     if (last === undefined) throw new Error("unreachable");
     expect(last.role).toBe("user");
     const textBlock = last.content.find((b) => b.type === "text");
@@ -2111,7 +2111,7 @@ describe("createReactor — state snapshot inspection", () => {
             messageCount++;
             if (messageCount === 1) {
               // Mutate the snapshot's content block.
-              const msg = state.messages[0];
+              const msg = state.turns[0];
               if (msg !== undefined) {
                 const block = msg.content[0];
                 if (block !== undefined && block.type === "text") {
@@ -2137,7 +2137,7 @@ describe("createReactor — state snapshot inspection", () => {
     await waitFor("reactor.done");
 
     if (secondSnapshot === undefined) throw new Error("unreachable");
-    const firstMsg = secondSnapshot.messages[0];
+    const firstMsg = secondSnapshot.turns[0];
     if (firstMsg === undefined) throw new Error("unreachable");
     const block = firstMsg.content[0];
     if (block === undefined || block.type !== "text")
@@ -2183,7 +2183,7 @@ describe("createReactor — deliver after done", () => {
 // 21. Inference path (infer action)
 // ---------------------------------------------------------------------------
 
-function makeAssistantMessage(text: string): AssistantMessage {
+function makeAssistantTurn(text: string): AssistantTurn {
   return {
     role: "assistant",
     content: [{ type: "text", text }],
@@ -2194,7 +2194,7 @@ function makeAssistantMessage(text: string): AssistantMessage {
 
 function makeInferenceRunner(
   result:
-    | { type: "done"; message: AssistantMessage; usage: TokenUsage }
+    | { type: "done"; turn: AssistantTurn; usage: TokenUsage }
     | { type: "error"; error: InferenceError; partial: PartialMessage },
 ): (opts: InferenceHarnessOptions) => AsyncGenerator<InferenceEvent> {
   return async function* (opts) {
@@ -2202,7 +2202,7 @@ function makeInferenceRunner(
       const event: InferenceEvent = {
         type: "inference.done",
         seq: opts.nextSeq(),
-        data: { message: result.message, usage: result.usage },
+        data: { turn: result.turn, usage: result.usage },
       };
       yield event;
     } else {
@@ -2225,7 +2225,7 @@ describe("createReactor — inference path", () => {
       cacheWrite: 5,
       thinking: 20,
     };
-    const assistantMsg = makeAssistantMessage("Hello from the model");
+    const assistantMsg = makeAssistantTurn("Hello from the model");
 
     let stateAtInferenceDone: ReactorState | undefined;
 
@@ -2239,7 +2239,7 @@ describe("createReactor — inference path", () => {
       }),
       inferenceRunner: makeInferenceRunner({
         type: "done",
-        message: assistantMsg,
+        turn: assistantMsg,
         usage: inferUsage,
       }),
     });
@@ -2250,7 +2250,7 @@ describe("createReactor — inference path", () => {
 
     // The emitted event stream should contain inference.done.
     const inferDone = getEvent(events, "inference.done");
-    expect(inferDone.data.message.content[0]).toEqual({
+    expect(inferDone.data.turn.content[0]).toEqual({
       type: "text",
       text: "Hello from the model",
     });
@@ -2264,7 +2264,7 @@ describe("createReactor — inference path", () => {
 
     // The assistant message should have been appended to the conversation.
     const lastMsg =
-      stateAtInferenceDone.messages[stateAtInferenceDone.messages.length - 1];
+      stateAtInferenceDone.turns[stateAtInferenceDone.turns.length - 1];
     if (lastMsg === undefined) throw new Error("no messages in state snapshot");
     expect(lastMsg.role).toBe("assistant");
     expect(lastMsg.content[0]).toEqual({
@@ -2357,7 +2357,7 @@ describe("createReactor — inference path", () => {
 // ---------------------------------------------------------------------------
 
 describe("createReactor — beforeToolExtensions", () => {
-  const toolCallMsg: AssistantMessage = {
+  const toolCallMsg: AssistantTurn = {
     role: "assistant",
     content: [
       {
@@ -2382,7 +2382,7 @@ describe("createReactor — beforeToolExtensions", () => {
   function inferenceRunnerWithToolCall() {
     return makeInferenceRunner({
       type: "done",
-      message: toolCallMsg,
+      turn: toolCallMsg,
       usage: inferUsage,
     });
   }
@@ -2625,7 +2625,7 @@ describe("createReactor — beforeToolExtensions", () => {
     if (capturedState === undefined)
       throw new Error("extension was never called");
     // State should contain the inbound message and the assistant tool_call message.
-    expect(capturedState.messages.length).toBeGreaterThanOrEqual(2);
+    expect(capturedState.turns.length).toBeGreaterThanOrEqual(2);
     expect(capturedState.sessionId).toContain("test-sess-");
   });
 
@@ -2639,7 +2639,7 @@ describe("createReactor — beforeToolExtensions", () => {
 
     const toolsRun: string[] = [];
 
-    const twoToolCallMsg: AssistantMessage = {
+    const twoToolCallMsg: AssistantTurn = {
       role: "assistant",
       content: [
         {
@@ -2694,7 +2694,7 @@ describe("createReactor — beforeToolExtensions", () => {
       }),
       inferenceRunner: makeInferenceRunner({
         type: "done",
-        message: twoToolCallMsg,
+        turn: twoToolCallMsg,
         usage: inferUsage,
       }),
       beforeToolExtensions: [blockBash],

--- a/packages/inference/src/reactor.ts
+++ b/packages/inference/src/reactor.ts
@@ -23,7 +23,7 @@ import type {
   ContextStore,
   ToolRunner,
   TokenUsage,
-  ConversationMessage,
+  ConversationTurn,
   ToolResult,
   ToolCall,
   AbortReason,
@@ -39,13 +39,13 @@ import { createGateManager } from "./gates";
 import { createCorrelationRegistry } from "./correlation";
 import { createStateManager } from "./state";
 import { validateActions } from "./actions";
-import { createToolResultMessage, createInboundMessage } from "./messages";
+import { createToolResultTurn, createInboundTurn } from "./turns";
 import type { CorrelationValidator } from "./correlation";
 
 const logger = getLogger(["interchange", "reactor"]);
 
 function buildHarnessOpts(
-  messages: ConversationMessage[],
+  turns: ConversationTurn[],
   model: string,
   providerConfig: ProviderConfig,
   options: InferenceOptions | undefined,
@@ -54,7 +54,7 @@ function buildHarnessOpts(
 ): InferenceHarnessOptions {
   if (options !== undefined) {
     return {
-      messages,
+      turns,
       model,
       providerConfig,
       inferenceOptions: options,
@@ -62,7 +62,7 @@ function buildHarnessOpts(
       nextSeq,
     };
   }
-  return { messages, model, providerConfig, signal, nextSeq };
+  return { turns, model, providerConfig, signal, nextSeq };
 }
 
 export type ReactorEmittedEvent =
@@ -172,10 +172,10 @@ export function createReactor(config: ReactorConfig): Reactor {
 
   function historyHasPendingToolCalls(): boolean {
     if (stateManager === null) return false;
-    const messages = stateManager.getMessages();
-    if (messages.length === 0) return false;
+    const turns = stateManager.getTurns();
+    if (turns.length === 0) return false;
 
-    const last = messages.at(-1);
+    const last = turns.at(-1);
     if (last === undefined || last.role !== "assistant") return false;
 
     return last.content.some((b) => b.type === "tool_call");
@@ -278,9 +278,9 @@ export function createReactor(config: ReactorConfig): Reactor {
 
       // Append the correlated message to conversation history so the model
       // sees the response content when it re-infers after the gate clears.
-      const msg = createInboundMessage(message);
+      const msg = createInboundTurn(message);
       if (msg !== null) {
-        stateManager.appendMessage(msg);
+        stateManager.appendTurn(msg);
       }
     }
 
@@ -304,11 +304,11 @@ export function createReactor(config: ReactorConfig): Reactor {
     if (stateManager === null) return;
 
     const signal = operationController.signal;
-    const messages = stateManager.getMessages();
+    const turns = stateManager.getTurns();
 
     const p = (async () => {
       const harnessOpts = buildHarnessOpts(
-        messages,
+        turns,
         model,
         config.providerConfig,
         options,
@@ -331,12 +331,12 @@ export function createReactor(config: ReactorConfig): Reactor {
 
       if (lastDone !== undefined) {
         if (stateManager !== null) {
-          stateManager.appendMessage(lastDone.data.message);
+          stateManager.appendTurn(lastDone.data.turn);
           stateManager.accumUsage(lastDone.data.usage);
         }
         enqueue({
           type: "inference.done",
-          message: lastDone.data.message,
+          turn: lastDone.data.turn,
           usage: lastDone.data.usage,
         });
       } else if (lastError !== undefined) {
@@ -438,7 +438,7 @@ export function createReactor(config: ReactorConfig): Reactor {
     }
 
     if (addToHistory && stateManager !== null) {
-      stateManager.appendMessage(createToolResultMessage(results));
+      stateManager.appendTurn(createToolResultTurn(results));
     }
 
     for (const result of results) {
@@ -474,9 +474,9 @@ export function createReactor(config: ReactorConfig): Reactor {
 
       // Append inbound messages to conversation history so the provider sees them.
       if (event.type === "message.received" && stateManager !== null) {
-        const msg = createInboundMessage(event.message);
+        const msg = createInboundTurn(event.message);
         if (msg !== null) {
-          stateManager.appendMessage(msg);
+          stateManager.appendTurn(msg);
         }
       }
 
@@ -647,7 +647,7 @@ export function createReactor(config: ReactorConfig): Reactor {
     lastCheckpointHash = undefined;
     try {
       const commit = await contextStore.commit(
-        stateManager.getMessages(),
+        stateManager.getTurns(),
         stateManager.getPendingOperations(),
         stateManager.getTokenUsage(),
         message,
@@ -722,12 +722,12 @@ export function createReactor(config: ReactorConfig): Reactor {
     running = true;
 
     void (async () => {
-      let initialMessages: ConversationMessage[];
+      let initialTurns: ConversationTurn[];
       let initialOps;
       let initialUsage: TokenUsage;
       try {
         const loaded = await contextStore.load();
-        initialMessages = loaded.messages;
+        initialTurns = loaded.turns;
         initialOps = loaded.pendingOperations;
         initialUsage = loaded.tokenUsage;
       } catch (cause) {
@@ -742,7 +742,7 @@ export function createReactor(config: ReactorConfig): Reactor {
 
       stateManager = createStateManager(
         sessionId,
-        initialMessages,
+        initialTurns,
         initialOps,
         initialUsage,
       );

--- a/packages/inference/src/state.ts
+++ b/packages/inference/src/state.ts
@@ -1,4 +1,4 @@
-// Reactor state management: message history, async operations, usage tracking.
+// Reactor state management: turn history, async operations, usage tracking.
 //
 // The state object is the authoritative view the plugin receives on every
 // decision. It is mutable by the reactor only — the plugin receives a
@@ -7,7 +7,7 @@
 // (INFERENCE.md § Agent Reactor › Plugin Decision Function)
 
 import type {
-  ConversationMessage,
+  ConversationTurn,
   PendingOperation,
   TokenUsage,
   ReactorState,
@@ -22,11 +22,11 @@ export type ReactorStateManager = ReturnType<typeof createStateManager>;
  */
 export function createStateManager(
   sessionId: string,
-  initialMessages: ConversationMessage[],
+  initialTurns: ConversationTurn[],
   initialOps: PendingOperation[],
   initialUsage: TokenUsage,
 ) {
-  const messages: ConversationMessage[] = [...initialMessages];
+  const turns: ConversationTurn[] = [...initialTurns];
   const pendingOperations = new Map<string, PendingOperation>(
     initialOps.map((op) => [op.correlationId, op]),
   );
@@ -34,8 +34,8 @@ export function createStateManager(
   let activeGatesSnapshot: GateSnapshot[] = [];
   const activeForks: { forkId: string; mode: "independent" | "child" }[] = [];
 
-  function appendMessage(msg: ConversationMessage): void {
-    messages.push(msg);
+  function appendTurn(msg: ConversationTurn): void {
+    turns.push(msg);
   }
 
   function addPendingOperation(op: PendingOperation): void {
@@ -67,8 +67,8 @@ export function createStateManager(
     if (idx !== -1) activeForks.splice(idx, 1);
   }
 
-  function getMessages(): ConversationMessage[] {
-    return messages;
+  function getTurns(): ConversationTurn[] {
+    return turns;
   }
 
   function getPendingOperations(): PendingOperation[] {
@@ -82,7 +82,7 @@ export function createStateManager(
   function snapshot(): ReactorState {
     return {
       sessionId,
-      messages: messages.map((m) => ({
+      turns: turns.map((m) => ({
         ...m,
         content: m.content.map((b) => structuredClone(b)),
       })),
@@ -100,14 +100,14 @@ export function createStateManager(
   }
 
   return {
-    appendMessage,
+    appendTurn,
     addPendingOperation,
     removePendingOperation,
     accumUsage,
     setGatesSnapshot,
     addFork,
     removeFork,
-    getMessages,
+    getTurns,
     getPendingOperations,
     getTokenUsage,
     snapshot,

--- a/packages/inference/src/transform.test.ts
+++ b/packages/inference/src/transform.test.ts
@@ -1,10 +1,10 @@
 import { describe, test, expect } from "bun:test";
 import { transformMessages, createIDNormalizer } from "./transform";
-import type { ConversationMessage } from "@interchange/types/runtime";
+import type { ConversationTurn } from "@interchange/types/runtime";
 
 describe("transformMessages", () => {
   test("preserves messages when target model matches originating model", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "assistant",
         model: "claude-3-5-sonnet",
@@ -28,7 +28,7 @@ describe("transformMessages", () => {
   });
 
   test("strips thinking blocks when replaying to a different model", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "assistant",
         model: "claude-3-5-sonnet",
@@ -51,7 +51,7 @@ describe("transformMessages", () => {
   });
 
   test("strips thinking blocks when keepThinkingForSameModel is false", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "assistant",
         model: "claude-3-5-sonnet",
@@ -74,7 +74,7 @@ describe("transformMessages", () => {
   });
 
   test("injects synthetic tool results for orphaned tool calls", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "Do something." }],
@@ -110,7 +110,7 @@ describe("transformMessages", () => {
   });
 
   test("does not inject when tool results are present", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "Do something." }],
@@ -146,7 +146,7 @@ describe("transformMessages", () => {
   });
 
   test("preserves user and system messages unchanged", () => {
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "system",
         content: [{ type: "text", text: "You are helpful." }],

--- a/packages/inference/src/transform.ts
+++ b/packages/inference/src/transform.ts
@@ -10,7 +10,7 @@
 // not per-conversation.
 
 import type {
-  ConversationMessage,
+  ConversationTurn,
   ContentBlock,
 } from "@interchange/types/runtime";
 
@@ -22,14 +22,14 @@ export type TransformOptions = {
 };
 
 export function transformMessages(
-  messages: ConversationMessage[],
+  messages: ConversationTurn[],
   options: TransformOptions,
-): ConversationMessage[] {
+): ConversationTurn[] {
   const { targetModel, keepThinkingForSameModel = true } = options;
 
   // First pass: strip thinking blocks and filter aborted assistant messages.
   const filtered = messages
-    .map((msg): ConversationMessage | null => {
+    .map((msg): ConversationTurn | null => {
       if (msg.role === "assistant") {
         const isSameModel = msg.model === targetModel;
         const keepThinking = keepThinkingForSameModel && isSameModel;
@@ -54,16 +54,16 @@ export function transformMessages(
       }
       return msg;
     })
-    .filter((msg): msg is ConversationMessage => msg !== null);
+    .filter((msg): msg is ConversationTurn => msg !== null);
 
   // Second pass: inject synthetic tool results for orphaned tool calls.
   return injectOrphanedToolResults(filtered);
 }
 
 function injectOrphanedToolResults(
-  messages: ConversationMessage[],
-): ConversationMessage[] {
-  const result: ConversationMessage[] = [];
+  messages: ConversationTurn[],
+): ConversationTurn[] {
+  const result: ConversationTurn[] = [];
 
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];

--- a/packages/inference/src/turns.ts
+++ b/packages/inference/src/turns.ts
@@ -1,13 +1,13 @@
 import type {
-  ConversationMessage,
+  ConversationTurn,
   ContentBlock,
-  AssistantMessage,
+  AssistantTurn,
   InboundMessage,
   ToolCall,
   ToolResult,
 } from "@interchange/types/runtime";
 
-export type { ConversationMessage, ContentBlock, AssistantMessage };
+export type { ConversationTurn, ContentBlock, AssistantTurn };
 
 export type TextBlock = { type: "text"; text: string };
 
@@ -44,9 +44,9 @@ export type ToolResultBlock = {
 
 export type { ToolCall, ToolResult };
 
-export function createInboundMessage(
+export function createInboundTurn(
   message: InboundMessage,
-): ConversationMessage | null {
+): ConversationTurn | null {
   const content = message.content ?? "";
   if (content.length === 0) return null;
 
@@ -66,7 +66,7 @@ export function createInboundMessage(
   };
 }
 
-export function createSystemMessage(text: string): ConversationMessage {
+export function createSystemMessage(text: string): ConversationTurn {
   return {
     role: "system",
     content: [{ type: "text", text }],
@@ -77,13 +77,11 @@ export function createSystemMessage(text: string): ConversationMessage {
 export function createAssistantMessage(
   blocks: ContentBlock[],
   model: string,
-): AssistantMessage {
+): AssistantTurn {
   return { role: "assistant", content: blocks, model, timestamp: Date.now() };
 }
 
-export function createToolResultMessage(
-  results: ToolResult[],
-): ConversationMessage {
+export function createToolResultTurn(results: ToolResult[]): ConversationTurn {
   const blocks: ContentBlock[] = results.map((r) => {
     const block: Extract<ContentBlock, { type: "tool_result" }> = {
       type: "tool_result",

--- a/packages/inference/src/turns.ts
+++ b/packages/inference/src/turns.ts
@@ -66,21 +66,6 @@ export function createInboundTurn(
   };
 }
 
-export function createSystemMessage(text: string): ConversationTurn {
-  return {
-    role: "system",
-    content: [{ type: "text", text }],
-    timestamp: Date.now(),
-  };
-}
-
-export function createAssistantMessage(
-  blocks: ContentBlock[],
-  model: string,
-): AssistantTurn {
-  return { role: "assistant", content: blocks, model, timestamp: Date.now() };
-}
-
 export function createToolResultTurn(results: ToolResult[]): ConversationTurn {
   const blocks: ContentBlock[] = results.map((r) => {
     const block: Extract<ContentBlock, { type: "tool_result" }> = {

--- a/packages/storage-isogit/src/init.ts
+++ b/packages/storage-isogit/src/init.ts
@@ -62,7 +62,7 @@ export async function initAgentRepo(dir: string): Promise<void> {
     contextPath,
     JSON.stringify(
       {
-        messages: [],
+        turns: [],
         pendingOperations: [],
         tokenUsage: {
           input: 0,

--- a/packages/storage-isogit/src/store.test.ts
+++ b/packages/storage-isogit/src/store.test.ts
@@ -13,10 +13,7 @@ import {
 } from "./index";
 import { IsogitStore } from "./store";
 import { initAgentRepo } from "./init";
-import type {
-  ConversationMessage,
-  TokenUsage,
-} from "@interchange/types/runtime";
+import type { ConversationTurn, TokenUsage } from "@interchange/types/runtime";
 import type { AuditRecord, ErrorRecord } from "@interchange/types/audit";
 
 const ZERO_USAGE: TokenUsage = {
@@ -50,9 +47,9 @@ describe("createIsogitStore", () => {
   test("initializes a new agent repo and returns a usable store", async () => {
     const dir = await tempDir();
     const store = await createIsogitStore(dir);
-    const { messages, pendingOperations, tokenUsage } = await store.load();
+    const { turns, pendingOperations, tokenUsage } = await store.load();
 
-    expect(messages).toEqual([]);
+    expect(turns).toEqual([]);
     expect(pendingOperations).toEqual([]);
     expect(tokenUsage).toEqual(ZERO_USAGE);
   });
@@ -61,8 +58,8 @@ describe("createIsogitStore", () => {
     const dir = await tempDir();
     await createIsogitStore(dir);
     const store = await createIsogitStore(dir);
-    const { messages } = await store.load();
-    expect(messages).toEqual([]);
+    const { turns } = await store.load();
+    expect(turns).toEqual([]);
   });
 });
 
@@ -71,7 +68,7 @@ describe("save and load round-trip", () => {
     const dir = await tempDir();
     const store = await createIsogitStore(dir);
 
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "Hello" }],
@@ -86,7 +83,7 @@ describe("save and load round-trip", () => {
     ];
 
     await store.commit(messages, [], ZERO_USAGE, "first checkpoint");
-    const { messages: loaded } = await store.load();
+    const { turns: loaded } = await store.load();
 
     expect(loaded).toEqual(messages);
   });
@@ -95,14 +92,14 @@ describe("save and load round-trip", () => {
     const dir = await tempDir();
     const store = await createIsogitStore(dir);
 
-    const first: ConversationMessage[] = [
+    const first: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "step 1" }],
         timestamp: 1000,
       },
     ];
-    const second: ConversationMessage[] = [
+    const second: ConversationTurn[] = [
       ...first,
       {
         role: "assistant",
@@ -115,8 +112,8 @@ describe("save and load round-trip", () => {
     await store.commit(first, [], ZERO_USAGE, "step 1");
     await store.commit(second, [], ZERO_USAGE, "step 2");
 
-    const { messages } = await store.load();
-    expect(messages).toEqual(second);
+    const { turns } = await store.load();
+    expect(turns).toEqual(second);
   });
 });
 
@@ -168,30 +165,30 @@ describe("branch operations", () => {
     const dir = await tempDir();
     const store = await createIsogitStore(dir);
 
-    const mainMessages: ConversationMessage[] = [
+    const mainTurns: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "on main" }],
         timestamp: 1000,
       },
     ];
-    await store.commit(mainMessages, [], ZERO_USAGE, "main work");
+    await store.commit(mainTurns, [], ZERO_USAGE, "main work");
 
     await createAndSwitchBranch(dir, "experiment");
 
-    const branchMessages: ConversationMessage[] = [
+    const branchTurns: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "on branch" }],
         timestamp: 2000,
       },
     ];
-    await store.commit(branchMessages, [], ZERO_USAGE, "branch work");
+    await store.commit(branchTurns, [], ZERO_USAGE, "branch work");
 
     await switchBranch(dir, "main");
 
-    const { messages } = await store.load();
-    expect(messages).toEqual(mainMessages);
+    const { turns } = await store.load();
+    expect(turns).toEqual(mainTurns);
   });
 
   test("listBranches includes main and created branches", async () => {
@@ -240,7 +237,7 @@ describe("readAt", () => {
     const dir = await tempDir();
     const store = await createIsogitStore(dir);
 
-    const v1: ConversationMessage[] = [
+    const v1: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "version 1" }],
@@ -249,7 +246,7 @@ describe("readAt", () => {
     ];
     const first = await store.commit(v1, [], ZERO_USAGE, "v1");
 
-    const v2: ConversationMessage[] = [
+    const v2: ConversationTurn[] = [
       ...v1,
       {
         role: "assistant",
@@ -590,7 +587,7 @@ describe("load reads from git HEAD, not working tree", () => {
     const dir = await tempDir();
     const store = await createIsogitStore(dir);
 
-    const messages: ConversationMessage[] = [
+    const messages: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "committed data" }],
@@ -604,7 +601,7 @@ describe("load reads from git HEAD, not working tree", () => {
     await fs.promises.writeFile(contextPath, "NOT VALID JSON }{");
 
     // load() should read from git HEAD, not the corrupt working-tree file.
-    const { messages: loaded } = await store.load();
+    const { turns: loaded } = await store.load();
     expect(loaded).toEqual(messages);
   });
 
@@ -612,14 +609,14 @@ describe("load reads from git HEAD, not working tree", () => {
     const dir = await tempDir();
     const store = await createIsogitStore(dir);
 
-    const goodMessages: ConversationMessage[] = [
+    const goodTurns: ConversationTurn[] = [
       {
         role: "user",
         content: [{ type: "text", text: "good data" }],
         timestamp: 1000,
       },
     ];
-    await store.commit(goodMessages, [], ZERO_USAGE, "good checkpoint");
+    await store.commit(goodTurns, [], ZERO_USAGE, "good checkpoint");
 
     // Commit garbage directly into context.json via the git plumbing to
     // simulate a corrupt HEAD blob. We write the garbage, stage it, and
@@ -635,8 +632,8 @@ describe("load reads from git HEAD, not working tree", () => {
     });
 
     // load() should walk back and find the last good checkpoint.
-    const { messages: loaded } = await store.load();
-    expect(loaded).toEqual(goodMessages);
+    const { turns: loaded } = await store.load();
+    expect(loaded).toEqual(goodTurns);
   });
 });
 
@@ -693,7 +690,7 @@ describe("connector thread state", () => {
     // Write a context.json that mimics an old commit without connectorState.
     const contextPath = path.join(dir, "state", "context.json");
     const oldFormat = {
-      messages: [],
+      turns: [],
       pendingOperations: [],
       tokenUsage: ZERO_USAGE,
     };

--- a/packages/storage-isogit/src/store.ts
+++ b/packages/storage-isogit/src/store.ts
@@ -7,7 +7,7 @@ import {
   type ContextStore,
   type AuditStore,
   type ContextCommit,
-  type ConversationMessage,
+  type ConversationTurn,
   type ConnectorThreadState,
   type PendingOperation,
 } from "@interchange/types/runtime";
@@ -30,7 +30,7 @@ const ConnectorThreadStateSchema = type({
   "subject?": "string",
 });
 
-const ConversationMessageSchema = type({
+const ConversationTurnSchema = type({
   role: "'user' | 'assistant' | 'system'",
   content: ContentBlock.array(),
   "model?": "string",
@@ -45,14 +45,14 @@ const PendingOperationSchema = type({
 });
 
 const ContextDataSchema = type({
-  messages: ConversationMessageSchema.array(),
+  turns: ConversationTurnSchema.array(),
   pendingOperations: PendingOperationSchema.array(),
   tokenUsage: TokenUsage,
   "connectorState?": type("null").or(ConnectorThreadStateSchema),
 });
 
 type ContextData = {
-  messages: ConversationMessage[];
+  turns: ConversationTurn[];
   pendingOperations: PendingOperation[];
   tokenUsage: TokenUsage;
   connectorState: ConnectorThreadState | null;
@@ -64,7 +64,7 @@ function parseContextData(raw: unknown): ContextData {
     throw new Error(`context data has unexpected structure: ${result.summary}`);
   }
   return {
-    messages: result.messages,
+    turns: result.turns,
     pendingOperations: result.pendingOperations,
     tokenUsage: result.tokenUsage,
     connectorState: result.connectorState ?? null,
@@ -127,7 +127,7 @@ export class IsogitStore implements ContextStore, AuditStore {
   }
 
   async load(_signal?: AbortSignal): Promise<{
-    messages: ConversationMessage[];
+    turns: ConversationTurn[];
     pendingOperations: PendingOperation[];
     tokenUsage: TokenUsage;
     connectorState: ConnectorThreadState | null;
@@ -164,14 +164,14 @@ export class IsogitStore implements ContextStore, AuditStore {
   }
 
   async commit(
-    messages: ConversationMessage[],
+    turns: ConversationTurn[],
     pendingOperations: PendingOperation[],
     tokenUsage: TokenUsage,
     message: string,
     _signal?: AbortSignal,
   ): Promise<ContextCommit> {
     const data: ContextData = {
-      messages,
+      turns,
       pendingOperations,
       tokenUsage,
       connectorState: this.pendingConnectorState,
@@ -215,7 +215,7 @@ export class IsogitStore implements ContextStore, AuditStore {
   async readAt(
     hash: string,
     _signal?: AbortSignal,
-  ): Promise<ConversationMessage[]> {
+  ): Promise<ConversationTurn[]> {
     const { blob } = await git.readBlob({
       fs,
       dir: this.dir,
@@ -225,7 +225,7 @@ export class IsogitStore implements ContextStore, AuditStore {
     const text = new TextDecoder().decode(blob);
     const parsed = JSON.parse(text) as unknown;
     const data = parseContextData(parsed);
-    return data.messages;
+    return data.turns;
   }
 
   async commitAudit(

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -637,7 +637,7 @@ export type ContentBlock = typeof ContentBlock.infer;
  *
  * (INFERENCE.md § Message Format)
  */
-export type ConversationMessage = {
+export type ConversationTurn = {
   role: "user" | "assistant" | "system";
   content: ContentBlock[];
   model?: string;
@@ -645,16 +645,16 @@ export type ConversationMessage = {
 };
 
 /**
- * A completed assistant message returned in `inference.done`. Distinct type
- * from ConversationMessage to make the inference boundary explicit.
+ * A completed assistant turn returned in `inference.done`. Distinct type
+ * from ConversationTurn to make the inference boundary explicit.
  */
-export const AssistantMessage = type({
+export const AssistantTurn = type({
   role: "'assistant'",
   content: ContentBlock.array(),
   model: "string",
   timestamp: "number",
 });
-export type AssistantMessage = typeof AssistantMessage.infer;
+export type AssistantTurn = typeof AssistantTurn.infer;
 
 // ---------------------------------------------------------------------------
 // Error Classification (INFERENCE.md § Error Classification)
@@ -786,7 +786,7 @@ export const InferenceEvent = type({
   .or({
     type: "'inference.done'",
     seq: "number",
-    data: { message: AssistantMessage, usage: TokenUsage },
+    data: { turn: AssistantTurn, usage: TokenUsage },
   })
   .or({
     type: "'inference.error'",
@@ -927,7 +927,7 @@ export type InferenceEvent =
   | {
       type: "inference.done";
       seq: number;
-      data: { message: AssistantMessage; usage: TokenUsage };
+      data: { turn: AssistantTurn; usage: TokenUsage };
     }
   | {
       type: "inference.error";
@@ -1033,7 +1033,7 @@ export type PendingOperation = {
  * (INFERENCE.md § Agent Reactor › Plugin Decision Function)
  */
 export type ReactorState = {
-  messages: ConversationMessage[];
+  turns: ConversationTurn[];
   activeForks: { forkId: string; mode: ForkMode }[];
   pendingOperations: PendingOperation[];
   activeGates: { gateId: string; type: GateType; timeoutAt: number }[];
@@ -1122,7 +1122,7 @@ export type ReactorCapabilities = {
  */
 export type ReactorInboundEvent =
   | { type: "message.received"; message: InboundMessage }
-  | { type: "inference.done"; message: AssistantMessage; usage: TokenUsage }
+  | { type: "inference.done"; turn: AssistantTurn; usage: TokenUsage }
   | { type: "inference.error"; error: InferenceError; partial: PartialMessage }
   | { type: "tool.done"; result: ToolResult }
   | {
@@ -1187,9 +1187,9 @@ export interface AfterToolExtension {
  */
 export interface ContextTransformExtension {
   transformContext(
-    messages: ConversationMessage[],
+    turns: ConversationTurn[],
     state: ReactorState,
-  ): Promise<ConversationMessage[]>;
+  ): Promise<ConversationTurn[]>;
 }
 
 /**
@@ -1298,11 +1298,11 @@ export type ConnectorThreadState = {
  */
 export interface ContextStore {
   /**
-   * Load the current message history and reactor metadata from the store.
+   * Load the current turn history and reactor metadata from the store.
    * Called during reactor initialization.
    */
   load(signal?: AbortSignal): Promise<{
-    messages: ConversationMessage[];
+    turns: ConversationTurn[];
     pendingOperations: PendingOperation[];
     tokenUsage: TokenUsage;
     connectorState: ConnectorThreadState | null;
@@ -1316,11 +1316,11 @@ export interface ContextStore {
   setConnectorState(state: ConnectorThreadState | null): void;
 
   /**
-   * Commit the current message history and reactor metadata to the store.
+   * Commit the current turn history and reactor metadata to the store.
    * May be called during a checkpoint, suspension, compaction, or shutdown.
    */
   commit(
-    messages: ConversationMessage[],
+    turns: ConversationTurn[],
     pendingOperations: PendingOperation[],
     tokenUsage: TokenUsage,
     message: string,
@@ -1339,10 +1339,10 @@ export interface ContextStore {
   log(limit?: number, signal?: AbortSignal): Promise<ContextCommit[]>;
 
   /**
-   * Read the message history at a specific commit hash. Used for history
+   * Read the turn history at a specific commit hash. Used for history
    * inspection and rollback.
    */
-  readAt(hash: string, signal?: AbortSignal): Promise<ConversationMessage[]>;
+  readAt(hash: string, signal?: AbortSignal): Promise<ConversationTurn[]>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -588,11 +588,11 @@ export const TokenUsage = type({
 export type TokenUsage = typeof TokenUsage.infer;
 
 // ---------------------------------------------------------------------------
-// Internal Message Format (INFERENCE.md § Message Format)
+// Internal Turn Format (INFERENCE.md § Message Format)
 // ---------------------------------------------------------------------------
 
 /**
- * A single content block within a conversation message. Provider-agnostic.
+ * A single content block within a conversation turn. Provider-agnostic.
  *
  * (INFERENCE.md § Message Format › Content Types)
  */
@@ -630,9 +630,9 @@ export const ContentBlock = TextBlock.or(ThinkingBlock)
 export type ContentBlock = typeof ContentBlock.infer;
 
 /**
- * A message in the internal conversation history. The `model` field records
- * which provider model produced this message (present only on assistant
- * messages). Used by cross-provider transformation to strip or preserve
+ * A turn in the internal conversation history. The `model` field records
+ * which provider model produced this turn (present only on assistant
+ * turns). Used by cross-provider transformation to strip or preserve
  * thinking blocks.
  *
  * (INFERENCE.md § Message Format)
@@ -645,8 +645,8 @@ export type ConversationTurn = {
 };
 
 /**
- * A completed assistant turn returned in `inference.done`. Distinct type
- * from ConversationTurn to make the inference boundary explicit.
+ * A completed assistant turn returned in `inference.done`. Narrower type
+ * than ConversationTurn to make the inference boundary explicit.
  */
 export const AssistantTurn = type({
   role: "'assistant'",
@@ -1179,7 +1179,7 @@ export interface AfterToolExtension {
 }
 
 /**
- * Extension that transforms the message array before each inference call.
+ * Extension that transforms the turn array before each inference call.
  * Modifications are ephemeral — they affect the inference call but are not
  * committed to the context store. Extensions run in order.
  *
@@ -1190,17 +1190,6 @@ export interface ContextTransformExtension {
     turns: ConversationTurn[],
     state: ReactorState,
   ): Promise<ConversationTurn[]>;
-}
-
-/**
- * Extension that intercepts inbound messages before the core plugin sees
- * them. Returning `null` drops the message.
- */
-export interface MessageRoutingExtension {
-  routeMessage(
-    message: InboundMessage,
-    state: ReactorState,
-  ): Promise<InboundMessage | null>;
 }
 
 // ---------------------------------------------------------------------------
@@ -1291,7 +1280,7 @@ export type ConnectorThreadState = {
  * (filesystem, in-memory, or virtual) depending on the execution environment.
  * The reactor accepts any implementation that satisfies this interface.
  *
- * The store holds the message history and reactor metadata. Forking creates
+ * The store holds the turn history and reactor metadata. Forking creates
  * a git branch. Compaction commits the compacted history.
  *
  * (INFERENCE.md § Context Management › Context Store)

--- a/test/integration/deploy-flow.test.ts
+++ b/test/integration/deploy-flow.test.ts
@@ -486,7 +486,7 @@ describe("deploy flow integration", () => {
     const toolNames = tools.map((t) => t.name);
 
     expect(toolNames).toContain("greet");
-    expect(toolNames).toContain("message_send");
+    expect(toolNames).toContain("mail_send");
 
     const greetTool = tools.find((t) => t.name === "greet");
     expect(greetTool).toBeDefined();


### PR DESCRIPTION
## Summary

- Adds `mail_reply` tool definition to close a pre-existing gap in tool coverage
- Renames all LLM tool names from `message_*` to `mail_*` (aligning with SMTP "mail" terminology for the delivery system)
- Renames conversation types from `*Message` to `*Turn` (aligning with conversation analysis terminology for LLM turn-taking)
- Renames `InferenceEvent.data.message` and `ReactorInboundEvent.message` to `.turn` where the field holds an `AssistantTurn`
- Deletes dead code (`MessageRoutingExtension`, `createAssistantMessage`, `createSystemMessage`)

## Changes

- `packages/types/src/runtime.ts`: `ConversationMessage` → `ConversationTurn`, `AssistantMessage` → `AssistantTurn`, `ReactorState.messages` → `.turns`, `InferenceEvent.data.message` → `.data.turn`, `ReactorInboundEvent.message` → `.turn` (on inference.done), `ContextStore` signatures updated, `MessageRoutingExtension` deleted
- `packages/inference/src/turns.ts` (renamed from `messages.ts`): turn construction functions renamed, dead helpers removed
- `packages/inference/src/state.ts`: `appendMessage` → `appendTurn`, `getMessages` → `getTurns`
- `packages/inference/src/reactor.ts`: all call sites updated
- `packages/inference/src/harness.ts`: `finalMessage` → `finalTurn`, event data field updated
- `packages/harness/src/tools.ts`: tool names `message_*` → `mail_*`, handler factories renamed
- `packages/harness/src/plugin.ts`: `event.message` → `event.turn` in inference.done handler, function params renamed
- `packages/storage-isogit/src/store.ts`: persisted JSON key `"messages"` → `"turns"`
- `packages/hub/src/event-collector.ts`: `event.data.message` → `event.data.turn`
- `docs/MESSAGE.md`, `docs/INFERENCE.md`, `bin/posix-demo.ts`, `bin/ring-demo.ts`: documentation and demo references updated

## Testing

- 885 tests pass across 40 files after each commit
- Full pipeline (typecheck, prettier, eslint, docs check, test) green at every stage
- Breaking change to persisted `context.json` format is intentional (requires local state reset)

Closes INTR-36