### PR TITLE
Drop agent terminology from mail-memory internals

### DIFF
--- a/apps/sidecar/src/session-manager.ts
+++ b/apps/sidecar/src/session-manager.ts
@@ -311,8 +311,8 @@ export function createSessionManager(
     try {
       const crypto = createNodeCrypto(keyPair);
 
-      transport.registerAgent(agentAddress, crypto);
-      const agentTransport = transport.getTransportForAgent(agentAddress);
+      transport.register(agentAddress, crypto);
+      const agentTransport = transport.getTransportFor(agentAddress);
 
       const sessionId = agentConfig.sessionId;
 
@@ -388,7 +388,7 @@ export function createSessionManager(
       mailStores.delete(agentAddress);
       mailCommitQueues.delete(agentAddress);
       try {
-        transport.unregisterAgent(agentAddress);
+        transport.unregister(agentAddress);
       } catch (cleanupErr) {
         // Best-effort cleanup; don't mask the original error.
         logger.error`Failed to unregister transport for ${agentAddress}: ${String(cleanupErr)}`;
@@ -413,7 +413,7 @@ export function createSessionManager(
     await drainMailQueue(agentAddress);
     sessions.delete(agentAddress);
     mailStores.delete(agentAddress);
-    transport.unregisterAgent(agentAddress);
+    transport.unregister(agentAddress);
     logger.info`Stopped session for ${agentAddress}`;
   }
 
@@ -435,7 +435,7 @@ export function createSessionManager(
     await drainMailQueue(agentAddress);
     sessions.delete(agentAddress);
     mailStores.delete(agentAddress);
-    transport.unregisterAgent(agentAddress);
+    transport.unregister(agentAddress);
     logger.info`Aborted agent ${agentAddress}: ${reason}`;
   }
 

--- a/apps/sidecar/src/ws-client.test.ts
+++ b/apps/sidecar/src/ws-client.test.ts
@@ -463,7 +463,7 @@ describe("sidecar↔hub integration", () => {
       "@interchange/crypto-node"
     );
     const kp = await generateKeyPair();
-    transport.registerAgent("agent-1@test.interchange", createNodeCrypto(kp));
+    transport.register("agent-1@test.interchange", createNodeCrypto(kp));
 
     const client = createWsClient({
       hubUrl: `ws://localhost:${env.server.port}/ws`,
@@ -485,7 +485,7 @@ describe("sidecar↔hub integration", () => {
       expect(routed).toBe(true);
 
       // Wait for the message to be delivered to the agent's INBOX.
-      const agentTransport = transport.getTransportForAgent(
+      const agentTransport = transport.getTransportFor(
         "agent-1@test.interchange",
       );
       await waitFor(async () => {
@@ -512,7 +512,7 @@ describe("sidecar↔hub integration", () => {
       "@interchange/crypto-node"
     );
     const kp = await generateKeyPair();
-    transport.registerAgent("sender@test.interchange", createNodeCrypto(kp));
+    transport.register("sender@test.interchange", createNodeCrypto(kp));
 
     const startLength = env.outboundMail.length;
     const client = createWsClient({
@@ -530,7 +530,7 @@ describe("sidecar↔hub integration", () => {
         env.router.getConnectedSidecars().includes("sc-mail-out"),
       );
 
-      const senderTransport = transport.getTransportForAgent(
+      const senderTransport = transport.getTransportFor(
         "sender@test.interchange",
       );
       await senderTransport.send({
@@ -560,14 +560,14 @@ describe("sidecar↔hub integration", () => {
     const sessionsA = createMockSessionManager();
     sessionsA.addresses.push("alice@test.interchange");
     const kpA = await generateKeyPair();
-    transportA.registerAgent("alice@test.interchange", createNodeCrypto(kpA));
+    transportA.register("alice@test.interchange", createNodeCrypto(kpA));
 
     // Sidecar B
     const transportB = createInMemoryTransport();
     const sessionsB = createMockSessionManager();
     sessionsB.addresses.push("bob@test.interchange");
     const kpB = await generateKeyPair();
-    transportB.registerAgent("bob@test.interchange", createNodeCrypto(kpB));
+    transportB.register("bob@test.interchange", createNodeCrypto(kpB));
 
     const clientA = createWsClient({
       hubUrl: `ws://localhost:${env.server.port}/ws`,
@@ -595,7 +595,7 @@ describe("sidecar↔hub integration", () => {
       );
 
       // Alice sends a message to Bob.
-      const aliceTransport = transportA.getTransportForAgent(
+      const aliceTransport = transportA.getTransportFor(
         "alice@test.interchange",
       );
       await aliceTransport.send({
@@ -605,9 +605,7 @@ describe("sidecar↔hub integration", () => {
       });
 
       // Bob should receive it in his INBOX.
-      const bobTransport = transportB.getTransportForAgent(
-        "bob@test.interchange",
-      );
+      const bobTransport = transportB.getTransportFor("bob@test.interchange");
       await waitFor(async () => {
         const refs = await bobTransport.search("INBOX", {});
         return refs.length > 0;

--- a/bin/posix-demo.ts
+++ b/bin/posix-demo.ts
@@ -126,13 +126,13 @@ const ALPHA_ADDRESS = "alpha@local.interchange";
 const BETA_ADDRESS = "beta@local.interchange";
 const USER_ADDRESS = "user@local.interchange";
 
-sharedTransport.registerAgent(ALPHA_ADDRESS, cryptoAlpha);
-sharedTransport.registerAgent(BETA_ADDRESS, cryptoBeta);
-sharedTransport.registerAgent(USER_ADDRESS, cryptoUser);
+sharedTransport.register(ALPHA_ADDRESS, cryptoAlpha);
+sharedTransport.register(BETA_ADDRESS, cryptoBeta);
+sharedTransport.register(USER_ADDRESS, cryptoUser);
 
-const transportAlpha = sharedTransport.getTransportForAgent(ALPHA_ADDRESS);
-const transportBeta = sharedTransport.getTransportForAgent(BETA_ADDRESS);
-const transportUser = sharedTransport.getTransportForAgent(USER_ADDRESS);
+const transportAlpha = sharedTransport.getTransportFor(ALPHA_ADDRESS);
+const transportBeta = sharedTransport.getTransportFor(BETA_ADDRESS);
+const transportUser = sharedTransport.getTransportFor(USER_ADDRESS);
 
 // ---------------------------------------------------------------------------
 // Storage

--- a/bin/ring-demo.ts
+++ b/bin/ring-demo.ts
@@ -113,21 +113,18 @@ const cryptoInstances = keyPairs.map((kp) => createNodeCrypto(kp));
 
 // Register all agents and the user.
 for (let i = 0; i < AGENT_NAMES.length; i++) {
-  sharedTransport.registerAgent(
-    agentAddress(AGENT_NAMES[i]),
-    cryptoInstances[i],
-  );
+  sharedTransport.register(agentAddress(AGENT_NAMES[i]), cryptoInstances[i]);
 }
-sharedTransport.registerAgent(
+sharedTransport.register(
   USER_ADDRESS,
   cryptoInstances[cryptoInstances.length - 1],
 );
 
 // Per-agent transports.
 const transports = AGENT_NAMES.map((name) =>
-  sharedTransport.getTransportForAgent(agentAddress(name)),
+  sharedTransport.getTransportFor(agentAddress(name)),
 );
-const transportUser = sharedTransport.getTransportForAgent(USER_ADDRESS);
+const transportUser = sharedTransport.getTransportFor(USER_ADDRESS);
 
 // ---------------------------------------------------------------------------
 // Storage

--- a/docs/MESSAGE.md
+++ b/docs/MESSAGE.md
@@ -468,8 +468,8 @@ Distribution list management (subscribe, unsubscribe, moderation) is handled by 
 ```
 createList(address: string, name: string): Promise<ListInfo>
 listMembers(address: string): Promise<string[]>
-subscribe(listAddress: string, agentAddress: string): Promise<void>
-unsubscribe(listAddress: string, agentAddress: string): Promise<void>
+subscribe(listAddress: string, subscriberAddress: string): Promise<void>
+unsubscribe(listAddress: string, subscriberAddress: string): Promise<void>
 ```
 
 `ListInfo` includes: address, name, member count, creation date. When an agent joins a conversation via `conversation.join`, the harness subscribes the agent to the corresponding list. When it leaves via `conversation.leave`, the harness unsubscribes.

--- a/packages/mail-memory/src/fetch.ts
+++ b/packages/mail-memory/src/fetch.ts
@@ -109,7 +109,7 @@ export function fetchPart(
 export async function fetchFull(
   ref: MessageRef,
   store: MailboxStore,
-  cryptoProviders: Map<string, CryptoProvider>,
+  getCrypto: (fromAddress: string) => CryptoProvider | undefined,
 ): Promise<InboundMessage> {
   const msg = requireMessage(store, ref.uid, ref.mailbox);
   const { headers } = parseHeaderSection(msg.raw);
@@ -125,7 +125,7 @@ export async function fetchFull(
   const signatureStatus = await verifyMessageSignature(
     msg.raw,
     parsedHeaders.from,
-    cryptoProviders,
+    getCrypto,
   );
 
   const result: InboundMessage = {
@@ -164,9 +164,9 @@ export async function fetchFull(
 async function verifyMessageSignature(
   raw: Uint8Array,
   fromAddress: string,
-  cryptoProviders: Map<string, CryptoProvider>,
+  getCrypto: (fromAddress: string) => CryptoProvider | undefined,
 ): Promise<SignatureStatus> {
-  const senderCrypto = cryptoProviders.get(fromAddress);
+  const senderCrypto = getCrypto(fromAddress);
   if (senderCrypto === undefined) {
     return "unknown";
   }

--- a/packages/mail-memory/src/index.test.ts
+++ b/packages/mail-memory/src/index.test.ts
@@ -450,6 +450,58 @@ describe("error handling", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Registration lifecycle — guards the single-entry-map invariant.
+// ---------------------------------------------------------------------------
+
+describe("registration lifecycle", () => {
+  test("unregister then re-register works (entry is fully removed)", async () => {
+    const transport = createInMemoryTransport();
+    const kp = await generateKeyPair();
+    const crypto = createNodeCrypto(kp);
+
+    transport.registerAgent("alpha@test.interchange", crypto);
+    transport.unregisterAgent("alpha@test.interchange");
+    expect(() =>
+      transport.registerAgent("alpha@test.interchange", crypto),
+    ).not.toThrow();
+  });
+
+  test("send from a scoped transport whose address was deregistered throws", async () => {
+    const { transport, alphaTransport } = await createTestTransport();
+    transport.unregisterAgent("alpha@test.interchange");
+
+    await expect(
+      alphaTransport.send({
+        to: "beta@test.interchange",
+        type: "conversation.message",
+        content: "hi",
+      }),
+    ).rejects.toThrow(/deregistered|not registered/);
+  });
+
+  test("fetchFull returns signatureStatus 'unknown' after sender is unregistered", async () => {
+    const { transport, alphaTransport, betaTransport } =
+      await createTestTransport();
+
+    await alphaTransport.send({
+      to: "beta@test.interchange",
+      type: "conversation.message",
+      content: "hi",
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const refs = await betaTransport.search("INBOX", {});
+    expect(refs.length).toBe(1);
+
+    transport.unregisterAgent("alpha@test.interchange");
+
+    const full = await betaTransport.fetchFull(refs[0]!);
+    expect(full.signatureStatus).toBe("unknown");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Additional: mailbox management
 // ---------------------------------------------------------------------------
 

--- a/packages/mail-memory/src/index.test.ts
+++ b/packages/mail-memory/src/index.test.ts
@@ -16,13 +16,11 @@ async function createTestTransport() {
   const cryptoA = createNodeCrypto(kpA);
   const cryptoB = createNodeCrypto(kpB);
 
-  transport.registerAgent("alpha@test.interchange", cryptoA);
-  transport.registerAgent("beta@test.interchange", cryptoB);
+  transport.register("alpha@test.interchange", cryptoA);
+  transport.register("beta@test.interchange", cryptoB);
 
-  const alphaTransport = transport.getTransportForAgent(
-    "alpha@test.interchange",
-  );
-  const betaTransport = transport.getTransportForAgent("beta@test.interchange");
+  const alphaTransport = transport.getTransportFor("alpha@test.interchange");
+  const betaTransport = transport.getTransportFor("beta@test.interchange");
 
   return { transport, alphaTransport, betaTransport, cryptoA, cryptoB };
 }
@@ -431,21 +429,21 @@ describe("error handling", () => {
     ).rejects.toThrow(/not found/);
   });
 
-  test("registerAgent throws on duplicate registration", async () => {
+  test("register throws on duplicate registration", async () => {
     const transport = createInMemoryTransport();
     const kp = await generateKeyPair();
     const crypto = createNodeCrypto(kp);
-    transport.registerAgent("alpha@test.interchange", crypto);
-    expect(() =>
-      transport.registerAgent("alpha@test.interchange", crypto),
-    ).toThrow(/already registered/);
+    transport.register("alpha@test.interchange", crypto);
+    expect(() => transport.register("alpha@test.interchange", crypto)).toThrow(
+      /already registered/,
+    );
   });
 
-  test("getTransportForAgent throws for unregistered agent", () => {
+  test("getTransportFor throws for unregistered address", () => {
     const transport = createInMemoryTransport();
-    expect(() =>
-      transport.getTransportForAgent("nobody@test.interchange"),
-    ).toThrow(/not registered/);
+    expect(() => transport.getTransportFor("nobody@test.interchange")).toThrow(
+      /not registered/,
+    );
   });
 });
 
@@ -459,16 +457,16 @@ describe("registration lifecycle", () => {
     const kp = await generateKeyPair();
     const crypto = createNodeCrypto(kp);
 
-    transport.registerAgent("alpha@test.interchange", crypto);
-    transport.unregisterAgent("alpha@test.interchange");
+    transport.register("alpha@test.interchange", crypto);
+    transport.unregister("alpha@test.interchange");
     expect(() =>
-      transport.registerAgent("alpha@test.interchange", crypto),
+      transport.register("alpha@test.interchange", crypto),
     ).not.toThrow();
   });
 
   test("send from a scoped transport whose address was deregistered throws", async () => {
     const { transport, alphaTransport } = await createTestTransport();
-    transport.unregisterAgent("alpha@test.interchange");
+    transport.unregister("alpha@test.interchange");
 
     await expect(
       alphaTransport.send({
@@ -494,7 +492,7 @@ describe("registration lifecycle", () => {
     const refs = await betaTransport.search("INBOX", {});
     expect(refs.length).toBe(1);
 
-    transport.unregisterAgent("alpha@test.interchange");
+    transport.unregister("alpha@test.interchange");
 
     const full = await betaTransport.fetchFull(refs[0]!);
     expect(full.signatureStatus).toBe("unknown");
@@ -610,9 +608,7 @@ describe("deliver", () => {
 
   test("delivers a well-formed message to INBOX", async () => {
     const { transport } = await createTestTransport();
-    const alphaTransport = transport.getTransportForAgent(
-      "alpha@test.interchange",
-    );
+    const alphaTransport = transport.getTransportFor("alpha@test.interchange");
 
     transport.deliver("alpha@test.interchange", VALID_MESSAGE);
 
@@ -625,9 +621,7 @@ describe("deliver", () => {
 
   test("fires watch callback on delivery", async () => {
     const { transport } = await createTestTransport();
-    const alphaTransport = transport.getTransportForAgent(
-      "alpha@test.interchange",
-    );
+    const alphaTransport = transport.getTransportFor("alpha@test.interchange");
 
     const events: MailboxEvent[] = [];
     alphaTransport.watch("INBOX", (event) => events.push(event));
@@ -640,7 +634,7 @@ describe("deliver", () => {
     expect(events[0]!.type).toBe("exists");
   });
 
-  test("throws for unregistered agent", async () => {
+  test("throws for unregistered address", async () => {
     const { transport } = await createTestTransport();
 
     expect(() =>

--- a/packages/mail-memory/src/index.ts
+++ b/packages/mail-memory/src/index.ts
@@ -8,14 +8,14 @@ export type {
 /**
  * Create a fresh in-memory transport instance.
  *
- * The returned transport is shared across all agents in a single process.
- * Register agents before sending messages:
+ * The returned transport is shared across all addresses in a single
+ * process. Register addresses before sending messages:
  *
  *   const transport = createInMemoryTransport();
- *   transport.registerAgent("alpha@local.interchange", cryptoProviderA);
- *   transport.registerAgent("beta@local.interchange", cryptoProviderB);
+ *   transport.register("alpha@local.interchange", cryptoProviderA);
+ *   transport.register("beta@local.interchange", cryptoProviderB);
  *
- *   const alphaTransport = transport.getTransportForAgent("alpha@local.interchange");
+ *   const alphaTransport = transport.getTransportFor("alpha@local.interchange");
  *   await alphaTransport.send({ to: "beta@local.interchange", ... });
  */
 import { InMemoryTransport } from "./transport";

--- a/packages/mail-memory/src/mailbox.ts
+++ b/packages/mail-memory/src/mailbox.ts
@@ -1,4 +1,4 @@
-import type { MailboxEvent } from "@interchange/types/runtime";
+import type { CryptoProvider, MailboxEvent } from "@interchange/types/runtime";
 
 /**
  * Pre-parsed envelope extracted from MIME headers at delivery time.
@@ -36,9 +36,10 @@ export type MailboxStore = {
   uidValidity: number;
 };
 
-export type AgentMailboxEntry = {
+export type AddressEntry = {
   mailboxes: Map<string, MailboxStore>;
   watchCallbacks: Map<string, Set<(event: MailboxEvent) => void>>;
+  crypto: CryptoProvider;
 };
 
 export const DEFAULT_MAILBOXES = [
@@ -58,7 +59,7 @@ export function createMailboxStore(): MailboxStore {
   };
 }
 
-export function createAgentEntry(): AgentMailboxEntry {
+export function createAddressEntry(crypto: CryptoProvider): AddressEntry {
   const mailboxes = new Map<string, MailboxStore>();
   for (const name of DEFAULT_MAILBOXES) {
     mailboxes.set(name, createMailboxStore());
@@ -66,6 +67,7 @@ export function createAgentEntry(): AgentMailboxEntry {
   return {
     mailboxes,
     watchCallbacks: new Map(),
+    crypto,
   };
 }
 

--- a/packages/mail-memory/src/send.ts
+++ b/packages/mail-memory/src/send.ts
@@ -1,11 +1,9 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion -- Map.get()! after validation that agent is registered */
 import type {
   OutboundMessage,
   SendReceipt,
-  CryptoProvider,
   MailboxEvent,
 } from "@interchange/types/runtime";
-import type { AgentMailboxEntry, StoredEnvelope } from "./mailbox";
+import type { AddressEntry, StoredEnvelope } from "./mailbox";
 import { appendToMailbox } from "./mailbox";
 import {
   assembleSignedContent,
@@ -83,17 +81,17 @@ export type MessageSentHandler = (ctx: MessageSentContext) => Promise<void>;
 export async function executeSend(
   senderAddress: string,
   message: OutboundMessage,
-  agentMailboxes: Map<string, AgentMailboxEntry>,
-  cryptoProviders: Map<string, CryptoProvider>,
+  entries: Map<string, AddressEntry>,
   onRemoteSend?: RemoteSendHandler,
   onMessageSent?: MessageSentHandler,
 ): Promise<SendReceipt> {
-  const senderCrypto = cryptoProviders.get(senderAddress);
-  if (senderCrypto === undefined) {
+  const senderEntry = entries.get(senderAddress);
+  if (senderEntry === undefined) {
     throw new Error(
       `Sender "${senderAddress}" is not registered with this transport`,
     );
   }
+  const senderCrypto = senderEntry.crypto;
 
   const recipients = Array.isArray(message.to) ? message.to : [message.to];
   if (recipients.length === 0) {
@@ -108,9 +106,7 @@ export async function executeSend(
       : [];
 
   const allAddressees = [...new Set([...recipients, ...ccAddressList])];
-  const remoteRecipients = allAddressees.filter(
-    (addr) => !agentMailboxes.has(addr),
-  );
+  const remoteRecipients = allAddressees.filter((addr) => !entries.has(addr));
 
   if (remoteRecipients.length > 0 && onRemoteSend === undefined) {
     throw new Error(
@@ -204,19 +200,26 @@ export async function executeSend(
   // Deliver to each local recipient's INBOX.
   const deliveredUids: { address: string; uid: number }[] = [];
   for (const recipient of allAddressees) {
-    if (!agentMailboxes.has(recipient)) continue;
-    const entry = agentMailboxes.get(recipient)!;
-    const store = entry.mailboxes.get("INBOX")!;
-    const uid = appendToMailbox(store, rawBytes, envelope, []);
+    const entry = entries.get(recipient);
+    if (entry === undefined) continue;
+    const inbox = entry.mailboxes.get("INBOX");
+    if (inbox === undefined) {
+      throw new Error(
+        `Mailbox "INBOX" does not exist for recipient "${recipient}"`,
+      );
+    }
+    const uid = appendToMailbox(inbox, rawBytes, envelope, []);
     deliveredUids.push({ address: recipient, uid });
   }
 
   // Append copy to sender's Sent mailbox.
-  {
-    const senderEntry = agentMailboxes.get(senderAddress)!;
-    const sentStore = senderEntry.mailboxes.get("Sent")!;
-    appendToMailbox(sentStore, rawBytes, envelope, ["\\Seen"]);
+  const sentStore = senderEntry.mailboxes.get("Sent");
+  if (sentStore === undefined) {
+    throw new Error(
+      `Mailbox "Sent" does not exist for sender "${senderAddress}"`,
+    );
   }
+  appendToMailbox(sentStore, rawBytes, envelope, ["\\Seen"]);
 
   // Fire local recipient watch callbacks ASYNCHRONOUSLY (per MESSAGE.md
   // requirement). queueMicrotask ensures callbacks never run synchronously
@@ -227,7 +230,12 @@ export async function executeSend(
   const msgHeaders = buildMessageHeaders(parsedHeaders);
 
   for (const { address, uid } of deliveredUids) {
-    const entry = agentMailboxes.get(address)!;
+    const entry = entries.get(address);
+    if (entry === undefined) {
+      throw new Error(
+        `Entry for "${address}" disappeared between delivery and callback dispatch`,
+      );
+    }
     const callbacks = entry.watchCallbacks.get("INBOX");
     if (callbacks === undefined || callbacks.size === 0) continue;
 

--- a/packages/mail-memory/src/transport.ts
+++ b/packages/mail-memory/src/transport.ts
@@ -48,7 +48,7 @@ import {
  * Every outbound message is PGP/MIME signed with the sender's CryptoProvider.
  * Signature verification runs on fetchFull().
  *
- * Agents must be registered before sending or receiving messages.
+ * Addresses must be registered before sending or receiving messages.
  */
 export class InMemoryTransport implements MessageTransport {
   readonly #entries = new Map<string, AddressEntry>();
@@ -76,23 +76,23 @@ export class InMemoryTransport implements MessageTransport {
   }
 
   /**
-   * Register an agent with its address and CryptoProvider. Creates the
-   * default set of mailboxes (INBOX, Sent, Drafts, Archive, Trash).
+   * Register an address with its CryptoProvider. Creates the default set
+   * of mailboxes (INBOX, Sent, Drafts, Archive, Trash).
    *
    * Throws if the address is already registered.
    */
-  registerAgent(address: string, crypto: CryptoProvider): void {
+  register(address: string, crypto: CryptoProvider): void {
     if (this.#entries.has(address)) {
-      throw new Error(`Agent "${address}" is already registered`);
+      throw new Error(`Address "${address}" is already registered`);
     }
     this.#entries.set(address, createAddressEntry(crypto));
   }
 
   /**
-   * Remove an agent's mailboxes and crypto provider. Called when a session
-   * is destroyed so the address can be re-registered later.
+   * Remove an address's mailboxes and crypto provider. Called when a
+   * session is destroyed so the address can be re-registered later.
    */
-  unregisterAgent(address: string): void {
+  unregister(address: string): void {
     this.#entries.delete(address);
   }
 
@@ -105,7 +105,7 @@ export class InMemoryTransport implements MessageTransport {
     _signal?: AbortSignal,
   ): Promise<SendReceipt> {
     throw new Error(
-      "Use createInMemoryTransport().getTransportForAgent(address) to send messages",
+      "Use createInMemoryTransport().getTransportFor(address) to send messages",
     );
   }
 
@@ -116,31 +116,31 @@ export class InMemoryTransport implements MessageTransport {
     _signal?: AbortSignal,
   ): Promise<MessageRef> {
     throw new Error(
-      "Use createInMemoryTransport().getTransportForAgent(address) to append messages",
+      "Use createInMemoryTransport().getTransportFor(address) to append messages",
     );
   }
 
   // ---------------------------------------------------------------------------
-  // Mailbox management (agent-scoped — use getTransportForAgent)
+  // Mailbox management (per-address — use getTransportFor)
   // ---------------------------------------------------------------------------
 
   async listMailboxes(_signal?: AbortSignal): Promise<Mailbox[]> {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   async createMailbox(_name: string, _signal?: AbortSignal): Promise<Mailbox> {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   async deleteMailbox(_name: string, _signal?: AbortSignal): Promise<void> {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   async getMailboxStatus(
     _name: string,
     _signal?: AbortSignal,
   ): Promise<MailboxStatus> {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   async search(
@@ -148,7 +148,7 @@ export class InMemoryTransport implements MessageTransport {
     _query: SearchQuery,
     _signal?: AbortSignal,
   ): Promise<MessageRef[]> {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   async thread(
@@ -157,21 +157,21 @@ export class InMemoryTransport implements MessageTransport {
     _query?: SearchQuery,
     _signal?: AbortSignal,
   ): Promise<Thread[]> {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   async fetchHeaders(
     _ref: MessageRef,
     _signal?: AbortSignal,
   ): Promise<MessageHeaders> {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   async fetchStructure(
     _ref: MessageRef,
     _signal?: AbortSignal,
   ): Promise<BodyStructure> {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   async fetchPart(
@@ -179,14 +179,14 @@ export class InMemoryTransport implements MessageTransport {
     _partPath: string,
     _signal?: AbortSignal,
   ): Promise<MessagePart> {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   async fetchFull(
     _ref: MessageRef,
     _signal?: AbortSignal,
   ): Promise<InboundMessage> {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   async setFlags(
@@ -194,7 +194,7 @@ export class InMemoryTransport implements MessageTransport {
     _flags: string[],
     _signal?: AbortSignal,
   ): Promise<void> {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   async clearFlags(
@@ -202,7 +202,7 @@ export class InMemoryTransport implements MessageTransport {
     _flags: string[],
     _signal?: AbortSignal,
   ): Promise<void> {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   async move(
@@ -210,7 +210,7 @@ export class InMemoryTransport implements MessageTransport {
     _toMailbox: string,
     _signal?: AbortSignal,
   ): Promise<void> {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   async copy(
@@ -218,18 +218,18 @@ export class InMemoryTransport implements MessageTransport {
     _toMailbox: string,
     _signal?: AbortSignal,
   ): Promise<void> {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   async expunge(_mailbox: string, _signal?: AbortSignal): Promise<void> {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   watch(
     _mailbox: string,
     _callback: (event: MailboxEvent) => void,
   ): Unsubscribe {
-    throw new Error("Use getTransportForAgent(address) for agent operations");
+    throw new Error("Use getTransportFor(address) for per-address operations");
   }
 
   async sync(
@@ -276,24 +276,24 @@ export class InMemoryTransport implements MessageTransport {
   // ---------------------------------------------------------------------------
 
   /**
-   * Deliver a signed MIME message to an agent's INBOX. Used by the
+   * Deliver a signed MIME message to an address's INBOX. Used by the
    * federation layer when a message arrives from the hub over the
    * websocket — the message is already assembled and signed by the
-   * originating agent, so no further processing is needed beyond
+   * originating sender, so no further processing is needed beyond
    * envelope parsing and storage.
    *
-   * Throws if the agent is not registered.
+   * Throws if the address is not registered.
    */
-  deliver(agentAddress: string, message: Uint8Array): void {
-    const entry = this.#entries.get(agentAddress);
+  deliver(address: string, message: Uint8Array): void {
+    const entry = this.#entries.get(address);
     if (entry === undefined) {
       throw new Error(
-        `Agent "${agentAddress}" is not registered — cannot deliver mail`,
+        `Address "${address}" is not registered — cannot deliver mail`,
       );
     }
     const inbox = entry.mailboxes.get("INBOX");
     if (inbox === undefined) {
-      throw new Error(`Agent "${agentAddress}" has no INBOX`);
+      throw new Error(`Address "${address}" has no INBOX`);
     }
 
     const { headers } = parseHeaderSection(message);
@@ -352,17 +352,17 @@ export class InMemoryTransport implements MessageTransport {
   }
 
   // ---------------------------------------------------------------------------
-  // Internal: agent-scoped view
+  // Internal: per-address view
   // ---------------------------------------------------------------------------
 
   /**
-   * Returns an agent-scoped MessageTransport bound to the given address.
-   * The harness calls this to obtain a transport that acts as a specific agent.
+   * Returns a MessageTransport scoped to the given address. Callers use
+   * this to send and read mail as that address.
    */
-  getTransportForAgent(address: string): MessageTransport {
+  getTransportFor(address: string): MessageTransport {
     if (!this.#entries.has(address)) {
       throw new Error(
-        `Agent "${address}" is not registered — call registerAgent() first`,
+        `Address "${address}" is not registered — call register() first`,
       );
     }
     return new ScopedMessageTransport(
@@ -375,8 +375,8 @@ export class InMemoryTransport implements MessageTransport {
 }
 
 /**
- * Agent-scoped MessageTransport. All operations are scoped to one agent's
- * mailboxes. Constructed via InMemoryTransport.getTransportForAgent().
+ * MessageTransport scoped to a single address. All operations target that
+ * address's mailboxes. Constructed via InMemoryTransport.getTransportFor().
  */
 class ScopedMessageTransport implements MessageTransport {
   readonly #address: string;
@@ -399,7 +399,7 @@ class ScopedMessageTransport implements MessageTransport {
   get #entry(): AddressEntry {
     const e = this.#entries.get(this.#address);
     if (e === undefined) {
-      throw new Error(`Agent "${this.#address}" has been deregistered`);
+      throw new Error(`Address "${this.#address}" has been deregistered`);
     }
     return e;
   }
@@ -408,7 +408,7 @@ class ScopedMessageTransport implements MessageTransport {
     const store = this.#entry.mailboxes.get(name);
     if (store === undefined) {
       throw new Error(
-        `Mailbox "${name}" does not exist for agent "${this.#address}"`,
+        `Mailbox "${name}" does not exist for address "${this.#address}"`,
       );
     }
     return store;
@@ -477,7 +477,7 @@ class ScopedMessageTransport implements MessageTransport {
   async createMailbox(name: string, _signal?: AbortSignal): Promise<Mailbox> {
     if (this.#entry.mailboxes.has(name)) {
       throw new Error(
-        `Mailbox "${name}" already exists for agent "${this.#address}"`,
+        `Mailbox "${name}" already exists for address "${this.#address}"`,
       );
     }
     this.#entry.mailboxes.set(name, createMailboxStore());
@@ -487,7 +487,7 @@ class ScopedMessageTransport implements MessageTransport {
   async deleteMailbox(name: string, _signal?: AbortSignal): Promise<void> {
     if (!this.#entry.mailboxes.has(name)) {
       throw new Error(
-        `Mailbox "${name}" does not exist for agent "${this.#address}"`,
+        `Mailbox "${name}" does not exist for address "${this.#address}"`,
       );
     }
     this.#entry.mailboxes.delete(name);

--- a/packages/mail-memory/src/transport.ts
+++ b/packages/mail-memory/src/transport.ts
@@ -19,11 +19,11 @@ import type {
   CryptoProvider,
 } from "@interchange/types/runtime";
 import {
-  createAgentEntry,
+  createAddressEntry,
   createMailboxStore,
   requireMessage,
   appendToMailbox,
-  type AgentMailboxEntry,
+  type AddressEntry,
 } from "./mailbox";
 import { parseHeaderSection } from "@interchange/mime";
 import { buildMessageHeaders } from "./headers";
@@ -51,8 +51,7 @@ import {
  * Agents must be registered before sending or receiving messages.
  */
 export class InMemoryTransport implements MessageTransport {
-  readonly #agentMailboxes = new Map<string, AgentMailboxEntry>();
-  readonly #cryptoProviders = new Map<string, CryptoProvider>();
+  readonly #entries = new Map<string, AddressEntry>();
   #remoteSendHandler: RemoteSendHandler | undefined;
   readonly #messageSentHandlers = new Set<MessageSentHandler>();
 
@@ -83,11 +82,10 @@ export class InMemoryTransport implements MessageTransport {
    * Throws if the address is already registered.
    */
   registerAgent(address: string, crypto: CryptoProvider): void {
-    if (this.#agentMailboxes.has(address)) {
+    if (this.#entries.has(address)) {
       throw new Error(`Agent "${address}" is already registered`);
     }
-    this.#agentMailboxes.set(address, createAgentEntry());
-    this.#cryptoProviders.set(address, crypto);
+    this.#entries.set(address, createAddressEntry(crypto));
   }
 
   /**
@@ -95,8 +93,7 @@ export class InMemoryTransport implements MessageTransport {
    * is destroyed so the address can be re-registered later.
    */
   unregisterAgent(address: string): void {
-    this.#agentMailboxes.delete(address);
-    this.#cryptoProviders.delete(address);
+    this.#entries.delete(address);
   }
 
   // ---------------------------------------------------------------------------
@@ -260,7 +257,7 @@ export class InMemoryTransport implements MessageTransport {
 
   async subscribe(
     _listAddress: string,
-    _agentAddress: string,
+    _subscriberAddress: string,
     _signal?: AbortSignal,
   ): Promise<void> {
     throw new Error("Distribution list management is not implemented");
@@ -268,7 +265,7 @@ export class InMemoryTransport implements MessageTransport {
 
   async unsubscribe(
     _listAddress: string,
-    _agentAddress: string,
+    _subscriberAddress: string,
     _signal?: AbortSignal,
   ): Promise<void> {
     throw new Error("Distribution list management is not implemented");
@@ -288,7 +285,7 @@ export class InMemoryTransport implements MessageTransport {
    * Throws if the agent is not registered.
    */
   deliver(agentAddress: string, message: Uint8Array): void {
-    const entry = this.#agentMailboxes.get(agentAddress);
+    const entry = this.#entries.get(agentAddress);
     if (entry === undefined) {
       throw new Error(
         `Agent "${agentAddress}" is not registered — cannot deliver mail`,
@@ -363,15 +360,14 @@ export class InMemoryTransport implements MessageTransport {
    * The harness calls this to obtain a transport that acts as a specific agent.
    */
   getTransportForAgent(address: string): MessageTransport {
-    if (!this.#agentMailboxes.has(address)) {
+    if (!this.#entries.has(address)) {
       throw new Error(
         `Agent "${address}" is not registered — call registerAgent() first`,
       );
     }
-    return new AgentMessageTransport(
+    return new ScopedMessageTransport(
       address,
-      this.#agentMailboxes,
-      this.#cryptoProviders,
+      this.#entries,
       () => this.#remoteSendHandler,
       () => this.#messageSentHandlers,
     );
@@ -382,29 +378,26 @@ export class InMemoryTransport implements MessageTransport {
  * Agent-scoped MessageTransport. All operations are scoped to one agent's
  * mailboxes. Constructed via InMemoryTransport.getTransportForAgent().
  */
-class AgentMessageTransport implements MessageTransport {
+class ScopedMessageTransport implements MessageTransport {
   readonly #address: string;
-  readonly #agentMailboxes: Map<string, AgentMailboxEntry>;
-  readonly #cryptoProviders: Map<string, CryptoProvider>;
+  readonly #entries: Map<string, AddressEntry>;
   readonly #getRemoteSendHandler: () => RemoteSendHandler | undefined;
   readonly #getMessageSentHandlers: () => Set<MessageSentHandler>;
 
   constructor(
     address: string,
-    agentMailboxes: Map<string, AgentMailboxEntry>,
-    cryptoProviders: Map<string, CryptoProvider>,
+    entries: Map<string, AddressEntry>,
     getRemoteSendHandler: () => RemoteSendHandler | undefined,
     getMessageSentHandlers: () => Set<MessageSentHandler>,
   ) {
     this.#address = address;
-    this.#agentMailboxes = agentMailboxes;
-    this.#cryptoProviders = cryptoProviders;
+    this.#entries = entries;
     this.#getRemoteSendHandler = getRemoteSendHandler;
     this.#getMessageSentHandlers = getMessageSentHandlers;
   }
 
-  get #entry(): AgentMailboxEntry {
-    const e = this.#agentMailboxes.get(this.#address);
+  get #entry(): AddressEntry {
+    const e = this.#entries.get(this.#address);
     if (e === undefined) {
       throw new Error(`Agent "${this.#address}" has been deregistered`);
     }
@@ -425,6 +418,11 @@ class AgentMessageTransport implements MessageTransport {
     message: OutboundMessage,
     _signal?: AbortSignal,
   ): Promise<SendReceipt> {
+    // Trip the deregistered guard so callers using a stale scoped handle
+    // see a precise error rather than the generic "sender is not
+    // registered" thrown by executeSend.
+    void this.#entry;
+
     const handlers = this.#getMessageSentHandlers();
     const aggregatedHandler: MessageSentHandler | undefined =
       handlers.size > 0
@@ -435,8 +433,7 @@ class AgentMessageTransport implements MessageTransport {
     return executeSend(
       this.#address,
       message,
-      this.#agentMailboxes,
-      this.#cryptoProviders,
+      this.#entries,
       this.#getRemoteSendHandler(),
       aggregatedHandler,
     );
@@ -561,7 +558,7 @@ class AgentMessageTransport implements MessageTransport {
     _signal?: AbortSignal,
   ): Promise<InboundMessage> {
     const store = this.#requireMailbox(ref.mailbox);
-    return doFetchFull(ref, store, this.#cryptoProviders);
+    return doFetchFull(ref, store, (addr) => this.#entries.get(addr)?.crypto);
   }
 
   async setFlags(
@@ -718,7 +715,7 @@ class AgentMessageTransport implements MessageTransport {
 
   async subscribe(
     _listAddress: string,
-    _agentAddress: string,
+    _subscriberAddress: string,
     _signal?: AbortSignal,
   ): Promise<void> {
     throw new Error("Distribution list management is not implemented");
@@ -726,7 +723,7 @@ class AgentMessageTransport implements MessageTransport {
 
   async unsubscribe(
     _listAddress: string,
-    _agentAddress: string,
+    _subscriberAddress: string,
     _signal?: AbortSignal,
   ): Promise<void> {
     throw new Error("Distribution list management is not implemented");

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -481,13 +481,13 @@ export interface MessageTransport {
 
   subscribe(
     listAddress: string,
-    agentAddress: string,
+    subscriberAddress: string,
     signal?: AbortSignal,
   ): Promise<void>;
 
   unsubscribe(
     listAddress: string,
-    agentAddress: string,
+    subscriberAddress: string,
     signal?: AbortSignal,
   ): Promise<void>;
 }


### PR DESCRIPTION
## Summary

- Collapse the parallel `#agentMailboxes` / `#cryptoProviders` maps in `InMemoryTransport` into a single `Map<string, MailboxEntry>` whose entry owns the crypto provider, making the registration invariant structural rather than convention-enforced.
- Drop the `eslint-disable @typescript-eslint/no-non-null-assertion` banner from `send.ts` and replace its `Map.get()!` patterns with explicit `undefined` checks.
- Rename the public API away from agent-shaped names: `registerAgent` → `register`, `unregisterAgent` → `unregister`, `getTransportForAgent` → `getTransportFor`, and the `deliver` parameter from `agentAddress` to `address`. Update every caller atomically.

## Changes

- `packages/mail-memory/src/mailbox.ts`: `AgentMailboxEntry` → `MailboxEntry` (now carries `crypto`); `createAgentEntry` → `createEntry(crypto)`.
- `packages/mail-memory/src/send.ts`: `executeSend` takes a single `entries` map; eslint-disable banner removed; descriptive `throw` paths replace `!` assertions.
- `packages/mail-memory/src/fetch.ts`: `fetchFull` and `verifyMessageSignature` take a `getCrypto: (address) => CryptoProvider | undefined` callback instead of the crypto map, keeping `fetch.ts` from learning about the broader entry shape.
- `packages/mail-memory/src/transport.ts`: `InMemoryTransport` holds one `#entries` map; `AgentMessageTransport` renamed to `ScopedMessageTransport`; public methods renamed and "agent" wording in doc comments and error strings scrubbed.
- `packages/mail-memory/src/index.ts`: docstring example updated to the new method names.
- `packages/mail-memory/src/index.test.ts`: three new regression tests in a `registration lifecycle` block that lock in the single-entry invariant (unregister-then-re-register, send-after-deregister, `fetchFull` returns `"unknown"` after sender removal); all existing call sites updated.
- `apps/sidecar/src/session-manager.ts`, `apps/sidecar/src/ws-client.test.ts`, `bin/posix-demo.ts`, `bin/ring-demo.ts`: consumer call sites updated to the renamed API.

## Out of scope

- The `interchange-agent-id` MIME header and `interchangeAgentId` fields owned by `@interchange/mime`.
- The `MessageTransport` interface in `@interchange/types/runtime` (still declares `agentAddress` on `subscribe`/`unsubscribe`). The local stubs were renamed to `_subscriberAddress`; the interface itself is a separate cleanup.
- The `session-manager.ts` local variable `agentAddress` — that is the harness's concept, not mail-memory's.

## Test plan

- [x] `bun run check`
- [x] `bun run lint`
- [x] `bun run test` (1119 tests pass, +3 new)
- [x] `grep -rni "agent" packages/mail-memory/src/` returns only the three out-of-scope `interchange-agent-id` references.

Closes INTR-48