### PR TITLE
Introduce a Makefile and expand bin/check-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+export PATH := $(PWD)/bin:$(PATH)
+
+all: lint build test
+
+build: FORCE
+	bun run check
+
+lint: FORCE
+	bun run lint
+
+test: FORCE
+	bun run test
+
+format: FORCE
+	bun run format
+
+docs: FORCE
+	bun run docs
+
+clean:
+	rm -f .env-checked .eslintcache
+	find . -type f -name tsconfig.tsbuildinfo -a ! -path '*/node_modules/*' | xargs rm -f
+	find . -type d -name dist -a ! -path '*/node_modules/*' | xargs rm -rf
+
+.env-checked: bin/check-env
+	./bin/check-env
+	touch .env-checked
+
+include .env-checked
+
+.PHONY: all build lint test format docs clean
+FORCE:

--- a/bin/check-env
+++ b/bin/check-env
@@ -3,15 +3,35 @@
 opsh::version::require v0.7.0
 lib::import step-runner
 
+REQUIRED_BUN_VERSION=1.2.0
+
 explain-githooks() {
 	log::fatal "Please configure your git hooks: git config core.hooksPath .githooks"
 }
 
-step::10::check_git_hooks() {
+step::10::check_git_repo() {
 	git rev-parse --git-dir >/dev/null 2>&1 || log::fatal "Not inside a git repository"
+}
+
+step::20::check_git_hooks() {
 	hookspath=$(git config core.hooksPath) || explain-githooks
 	[[ $hookspath = .githooks ]] || explain-githooks
 	[[ -d "$hookspath" ]] || log::fatal "Hooks directory does not exist: $hookspath"
+}
+
+step::30::check_bun() {
+	command -v bun >/dev/null 2>&1 \
+		|| log::fatal "bun not found on PATH (see DEV.md; install from https://bun.sh/)"
+	local version
+	version=$(bun --version) \
+		|| log::fatal "failed to invoke 'bun --version'"
+	semver::test "$version" -ge "$REQUIRED_BUN_VERSION" \
+		|| log::fatal "bun >=$REQUIRED_BUN_VERSION required (have $version)"
+}
+
+step::40::check_node_modules() {
+	[[ -d node_modules ]] \
+		|| log::fatal "node_modules missing - run 'bun install'"
 }
 
 steps::run step


### PR DESCRIPTION
## Summary

- Add a top-level `Makefile` matching the verbs used in the sibling `faremeter/faremeter` tree (`all`, `build`, `lint`, `test`, `format`, `docs`, `clean`), adapted to this tree's bun + `tsc -b` tooling. Each target delegates to the corresponding `bun run` script so `package.json` remains the single source of truth.
- Expand `bin/check-env` to verify `bun` is on `PATH` at the version required by `DEV.md` and that `node_modules` exists, in addition to the existing git-hooks check.
- The `Makefile`'s `include .env-checked` pattern forces `bin/check-env` to run before any target, so prerequisites are validated up front.

Linear: [INTR-57](https://linear.app/abklabs/issue/INTR-57/introduce-makefile-and-expand-bincheck-env)

## Test plan

- [ ] `make all` succeeds on a healthy tree
- [ ] `make lint`, `make build`, `make test`, `make format`, `make docs` each run their respective `bun run` script
- [ ] `bin/check-env` fails with an actionable message when run outside a git repo, when git hooks aren't configured, when `bun` is missing or too old, and when `node_modules` is missing
- [ ] `make clean` removes `.env-checked`, `.eslintcache`, non-`node_modules` `tsconfig.tsbuildinfo` files, and non-`node_modules` `dist/` directories