### PR TITLE
Route runInference through an injected Dependencies parameter

### DIFF
--- a/packages/harness/src/harness.ts
+++ b/packages/harness/src/harness.ts
@@ -22,6 +22,7 @@ import {
   createReactor,
   createAuditCollector,
   createAuthzExtension,
+  createDefaultDependencies,
   createSizeCapTransform,
 } from "@interchange/inference";
 import type {
@@ -410,6 +411,7 @@ export function createHarness(config: HarnessConfig): Harness {
     toolRunner: combinedRunner,
     contextStore,
     onEvent: handleEvent,
+    deps: createDefaultDependencies(),
     beforeToolExtensions,
     toolResultTransforms: [sizeCapTransform],
   };

--- a/packages/inference/src/harness.test.ts
+++ b/packages/inference/src/harness.test.ts
@@ -1,0 +1,302 @@
+import { describe, test, expect } from "bun:test";
+
+import {
+  createDefaultDependencies,
+  HarnessId,
+  runInference,
+  type Dependencies,
+  type InferenceHarnessOptions,
+} from "./harness";
+import type {
+  ConversationTurn,
+  InferenceEvent,
+} from "@interchange/types/runtime";
+
+const PROVIDER_CONFIG = {
+  provider: "anthropic" as const,
+  baseURL: "https://api.anthropic.com",
+  apiKey: "test",
+};
+
+function userTurn(text: string): ConversationTurn {
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+    timestamp: 0,
+  };
+}
+
+async function collect(
+  iter: AsyncIterable<InferenceEvent>,
+): Promise<InferenceEvent[]> {
+  const out: InferenceEvent[] = [];
+  for await (const ev of iter) out.push(ev);
+  return out;
+}
+
+// Only needed because `globalThis.fetch` reassignment must satisfy the
+// Bun-augmented type (which carries a `preconnect` static). `deps.fetch`
+// uses the narrow `Dependencies.fetch` shape and accepts a plain function.
+function makeGlobalFetchStub(
+  handler: (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => Promise<Response>,
+): typeof globalThis.fetch {
+  return Object.assign(handler, { preconnect: () => undefined });
+}
+
+describe("runInference — Dependencies parameter", () => {
+  test("invokes deps.fetch instead of globalThis.fetch", async () => {
+    const calls: { url: string; method: string | undefined }[] = [];
+
+    const deps: Dependencies = {
+      fetch: (input, init) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        calls.push({ url, method: init?.method });
+        return Promise.resolve(
+          new Response("", {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }),
+        );
+      },
+    };
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = makeGlobalFetchStub(() => {
+      throw new Error(
+        "globalThis.fetch must not be called when deps.fetch is provided",
+      );
+    });
+
+    let events: InferenceEvent[];
+    try {
+      let seq = 0;
+      events = await collect(
+        runInference({
+          turns: [userTurn("hello")],
+          model: "claude-3-5-sonnet-20240620",
+          providerConfig: PROVIDER_CONFIG,
+          nextSeq: () => ++seq,
+          deps,
+        }),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls).toHaveLength(1);
+    const firstCall = calls[0];
+    if (firstCall === undefined) {
+      throw new Error("expected one fetch call");
+    }
+    expect(firstCall.url).toBe("https://api.anthropic.com/v1/messages");
+    expect(firstCall.method).toBe("POST");
+
+    const startEvent = events.find((e) => e.type === "inference.start");
+    const doneEvent = events.find((e) => e.type === "inference.done");
+    if (startEvent === undefined) throw new Error("missing inference.start");
+    if (doneEvent === undefined) throw new Error("missing inference.done");
+  });
+
+  test("propagates errors from deps.fetch without falling back to globalThis.fetch", async () => {
+    const deps: Dependencies = {
+      fetch: () => Promise.reject(new Error("simulated network failure")),
+    };
+
+    const originalFetch = globalThis.fetch;
+    let globalFetchCalled = false;
+    globalThis.fetch = makeGlobalFetchStub(() => {
+      globalFetchCalled = true;
+      throw new Error("globalThis.fetch must not be called");
+    });
+
+    let events: InferenceEvent[];
+    try {
+      let seq = 0;
+      events = await collect(
+        runInference({
+          turns: [userTurn("hello")],
+          model: "claude-3-5-sonnet-20240620",
+          providerConfig: PROVIDER_CONFIG,
+          nextSeq: () => ++seq,
+          deps,
+        }),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(globalFetchCalled).toBe(false);
+    const errorEvent = events.find((e) => e.type === "inference.error");
+    if (errorEvent === undefined) throw new Error("missing inference.error");
+    expect(errorEvent.data.error.category).toBe("retryable");
+    expect(errorEvent.data.error.message).toContain(
+      "simulated network failure",
+    );
+  });
+
+  // The crash-loudly contract: a missing or malformed `deps.fetch` is a
+  // programmer bug, not a transport failure. `runInference` must throw a
+  // plain Error out of the generator (lazily, on first iteration — the
+  // throw fires from inside `for await`, not at the `runInference(...)`
+  // call site) and must not yield any event, including `inference.start`.
+
+  test("throws plainly when deps.fetch is undefined", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- modeling a JS caller that assigned undefined to deps.fetch
+    const deps = { fetch: undefined } as unknown as Dependencies;
+    const iter = runInference({
+      turns: [userTurn("hello")],
+      model: "claude-3-5-sonnet-20240620",
+      providerConfig: PROVIDER_CONFIG,
+      nextSeq: () => 1,
+      deps,
+    });
+
+    const events: InferenceEvent[] = [];
+    let thrown: unknown;
+    try {
+      for await (const ev of iter) events.push(ev);
+    } catch (e) {
+      thrown = e;
+    }
+
+    if (!(thrown instanceof Error)) {
+      throw new Error("expected runInference to throw an Error");
+    }
+    expect(thrown.message).toContain("deps.fetch must be a function");
+    expect(thrown.message).toContain("undefined");
+    expect(events).toEqual([]);
+  });
+
+  test("throws plainly when deps.fetch is a non-function value", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- modeling a JS caller that assigned a non-function value to deps.fetch
+    const deps = { fetch: "not a function" } as unknown as Dependencies;
+    const iter = runInference({
+      turns: [userTurn("hello")],
+      model: "claude-3-5-sonnet-20240620",
+      providerConfig: PROVIDER_CONFIG,
+      nextSeq: () => 1,
+      deps,
+    });
+
+    const events: InferenceEvent[] = [];
+    let thrown: unknown;
+    try {
+      for await (const ev of iter) events.push(ev);
+    } catch (e) {
+      thrown = e;
+    }
+
+    if (!(thrown instanceof Error)) {
+      throw new Error("expected runInference to throw an Error");
+    }
+    expect(thrown.message).toContain("deps.fetch must be a function");
+    expect(thrown.message).toContain("string");
+    expect(events).toEqual([]);
+  });
+
+  test("throws plainly when deps is omitted entirely", async () => {
+    const baseOpts: Omit<InferenceHarnessOptions, "deps"> = {
+      turns: [userTurn("hello")],
+      model: "claude-3-5-sonnet-20240620",
+      providerConfig: PROVIDER_CONFIG,
+      nextSeq: () => 1,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- modeling a JS caller that omitted the required `deps` field
+    const opts = baseOpts as unknown as InferenceHarnessOptions;
+    const iter = runInference(opts);
+
+    const events: InferenceEvent[] = [];
+    let thrown: unknown;
+    try {
+      for await (const ev of iter) events.push(ev);
+    } catch (e) {
+      thrown = e;
+    }
+
+    if (!(thrown instanceof Error)) {
+      throw new Error("expected runInference to throw an Error");
+    }
+    expect(thrown.message).toContain("deps.fetch must be a function");
+    expect(events).toEqual([]);
+  });
+});
+
+describe("createDefaultDependencies", () => {
+  test("delegates calls to globalThis.fetch as bound at factory-call time", async () => {
+    const calls: { url: string; method: string | undefined }[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = makeGlobalFetchStub((input, init) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      calls.push({ url, method: init?.method });
+      return Promise.resolve(new Response("", { status: 204 }));
+    });
+
+    try {
+      const deps = createDefaultDependencies();
+      const response = await deps.fetch("https://example.test/ping", {
+        method: "POST",
+      });
+      expect(response.status).toBe(204);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls).toEqual([
+      { url: "https://example.test/ping", method: "POST" },
+    ]);
+  });
+
+  test("does not stamp the HarnessId tag", () => {
+    const deps = createDefaultDependencies();
+    expect(Object.getOwnPropertySymbols(deps)).toEqual([]);
+  });
+});
+
+// The JSDoc on `Dependencies` documents which reflective APIs leak the
+// optional `[HarnessId]` tag. Pin those claims so a future refactor that
+// makes the tag enumerable (e.g., renaming it to a string key) cannot
+// silently turn a safe serializer into a leak.
+describe("Dependencies — reflective exposure of HarnessId", () => {
+  function stampedDeps(): Dependencies {
+    return {
+      fetch: () => Promise.resolve(new Response("")),
+      [HarnessId]: Symbol("test-harness"),
+    };
+  }
+
+  test("JSON.stringify ignores symbol-keyed fields", () => {
+    // Probe with a serializable string value at the symbol key. If
+    // `HarnessId` were ever changed from a symbol to a string key, the
+    // serializer would walk it and the assertion would fail. The
+    // string-keyed control proves the test isn't passing just because
+    // `JSON.stringify` produced an empty object for unrelated reasons.
+    const probe = {
+      visible: "yes",
+      [HarnessId]: "leaked-value",
+    };
+    expect(JSON.stringify(probe)).toBe('{"visible":"yes"}');
+  });
+
+  test("Object.getOwnPropertySymbols exposes the tag", () => {
+    const deps = stampedDeps();
+    expect(Object.getOwnPropertySymbols(deps)).toContain(HarnessId);
+  });
+
+  test("Reflect.ownKeys exposes the tag", () => {
+    const deps = stampedDeps();
+    expect(Reflect.ownKeys(deps)).toContain(HarnessId);
+  });
+});

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -35,6 +35,36 @@ import {
   classifyStreamError,
 } from "./errors";
 
+export const HarnessId: unique symbol = Symbol("HarnessId");
+
+/**
+ * Runtime dependencies injected into `runInference`. Code-only — not part of
+ * any persisted schema. Test harnesses substitute `fetch` (and stamp the
+ * `[HarnessId]` tag for per-harness identity) so production `runInference`
+ * never reaches `globalThis.fetch`.
+ *
+ * `fetch` is intentionally typed as a plain function rather than
+ * `typeof globalThis.fetch` — the latter is augmented per-runtime (Bun adds
+ * `preconnect`; Node and the DOM lib do not) and `runInference` only ever
+ * invokes the call signature.
+ *
+ * The `[HarnessId]` tag is enumerable via `Object.getOwnPropertySymbols`
+ * (and `Reflect.ownKeys`, which is the superset). Do not pass `Dependencies`
+ * instances through reflective serializers or expose them across trust
+ * boundaries. (`JSON.stringify` is safe — it walks string keys only.)
+ */
+export type Dependencies = {
+  readonly fetch: (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => Promise<Response>;
+  readonly [HarnessId]?: symbol;
+};
+
+export function createDefaultDependencies(): Dependencies {
+  return { fetch: globalThis.fetch.bind(globalThis) };
+}
+
 export type InferenceHarnessOptions = {
   turns: ConversationTurn[];
   model: string;
@@ -43,6 +73,7 @@ export type InferenceHarnessOptions = {
   signal?: AbortSignal;
   // Sequence number allocator — called once per event to get the next seq.
   nextSeq: () => number;
+  deps: Dependencies;
 };
 
 export async function* runInference(
@@ -55,7 +86,19 @@ export async function* runInference(
     inferenceOptions = {},
     signal,
     nextSeq,
+    deps,
   } = opts;
+
+  // Defensive guard for callers that bypass the type system (JS, `any`,
+  // unchecked casts). Missing or malformed `deps.fetch` is a programmer
+  // bug — surface it as an unhandled throw before any `yield`, so it does
+  // not get caught by the network try/catch below and misclassified as a
+  // retryable transport failure that callers might paper over with retries.
+  if (typeof deps?.fetch !== "function") {
+    throw new Error(
+      `runInference: deps.fetch must be a function (got ${typeof deps?.fetch}); pass createDefaultDependencies() or a test harness Dependencies object`,
+    );
+  }
 
   // Emit inference.start immediately.
   yield { type: "inference.start", seq: nextSeq(), data: { model } };
@@ -126,7 +169,7 @@ export async function* runInference(
 
   let response: Response;
   try {
-    response = await fetch(url, {
+    response = await deps.fetch(url, {
       method: "POST",
       headers,
       body: builtRequest.body,

--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -1,6 +1,6 @@
 export { parseSSE } from "./sse";
-export { runInference } from "./harness";
-export type { InferenceHarnessOptions } from "./harness";
+export { runInference, createDefaultDependencies, HarnessId } from "./harness";
+export type { Dependencies, InferenceHarnessOptions } from "./harness";
 export {
   hasProvider,
   lookupProvider,

--- a/packages/inference/src/reactor.test.ts
+++ b/packages/inference/src/reactor.test.ts
@@ -4,6 +4,7 @@ import { validateActions } from "./actions";
 import { createGateManager } from "./gates";
 import { createCorrelationRegistry } from "./correlation";
 import { createReactor } from "./reactor";
+import { createDefaultDependencies } from "./harness";
 
 import type {
   ReactorDirector,
@@ -255,6 +256,7 @@ function createTestReactor(
     toolRunner: overrides.toolRunner ?? noopToolRunner(),
     contextStore: overrides.contextStore ?? makeContextStore(),
     onEvent,
+    deps: createDefaultDependencies(),
     shutdownTimeoutMs: overrides.shutdownTimeoutMs ?? 100,
     ...(overrides.correlationValidator !== undefined
       ? { correlationValidator: overrides.correlationValidator }
@@ -906,6 +908,7 @@ describe("createReactor — director exception", () => {
       toolRunner: noopToolRunner(),
       contextStore: makeContextStore(),
       onEvent,
+      deps: createDefaultDependencies(),
       shutdownTimeoutMs: 100,
     });
 
@@ -3295,6 +3298,7 @@ function createDirectReactor(opts: {
     toolRunner: opts.toolRunner ?? noopToolRunner(),
     contextStore: opts.contextStore,
     onEvent,
+    deps: createDefaultDependencies(),
     shutdownTimeoutMs: 100,
     ...(opts.inferenceRunner !== undefined
       ? { inferenceRunner: opts.inferenceRunner }

--- a/packages/inference/src/reactor.ts
+++ b/packages/inference/src/reactor.ts
@@ -39,7 +39,7 @@ import type {
 
 import { getLogger } from "@interchange/log";
 import { runInference } from "./harness";
-import type { InferenceHarnessOptions } from "./harness";
+import type { Dependencies, InferenceHarnessOptions } from "./harness";
 import { createCapabilities } from "./director";
 import { createGateManager } from "./gates";
 import { createCorrelationRegistry } from "./correlation";
@@ -57,6 +57,7 @@ function buildHarnessOpts(
   options: InferenceOptions | undefined,
   signal: AbortSignal,
   nextSeq: () => number,
+  deps: Dependencies,
 ): InferenceHarnessOptions {
   if (options !== undefined) {
     return {
@@ -66,9 +67,10 @@ function buildHarnessOpts(
       inferenceOptions: options,
       signal,
       nextSeq,
+      deps,
     };
   }
-  return { turns, model, providerConfig, signal, nextSeq };
+  return { turns, model, providerConfig, signal, nextSeq, deps };
 }
 
 export type ReactorEmittedEvent =
@@ -87,6 +89,7 @@ export type ReactorConfig = {
   contextStore: ContextStore;
   correlationValidator?: CorrelationValidator;
   onEvent: (event: ReactorEmittedEvent) => void;
+  deps: Dependencies;
   inferenceRunner?: (
     opts: InferenceHarnessOptions,
   ) => AsyncGenerator<InferenceEvent>;
@@ -124,6 +127,7 @@ export function createReactor(config: ReactorConfig): Reactor {
     contextStore,
     correlationValidator,
     onEvent,
+    deps,
     inferenceRunner = runInference,
     beforeToolExtensions = [],
     toolResultTransforms = [],
@@ -397,6 +401,7 @@ export function createReactor(config: ReactorConfig): Reactor {
           options,
           signal,
           nextSeq,
+          deps,
         );
 
         let lastDone:

--- a/test/integration/transform-cutover.test.ts
+++ b/test/integration/transform-cutover.test.ts
@@ -14,6 +14,7 @@ import git from "isomorphic-git";
 
 import { createIsogitStore, initAgentRepo } from "@interchange/storage-isogit";
 import {
+  createDefaultDependencies,
   createReactor,
   createSizeCapTransform,
   type Reactor,
@@ -176,6 +177,7 @@ async function startReactor(opts: {
     toolRunner: opts.toolRunner,
     contextStore,
     onEvent: (e) => events.push(e),
+    deps: createDefaultDependencies(),
     shutdownTimeoutMs: 200,
     toolResultTransforms: [sizeCap],
     ...(opts.inferenceRunner !== undefined


### PR DESCRIPTION
## Summary

- Adds a `Dependencies` parameter (`fetch` + optional `[HarnessId]` symbol tag) threaded through `runInference` and `createReactor`, so the streaming harness reads `deps.fetch` instead of `globalThis.fetch`.
- Production callers wire `createDefaultDependencies()` at the reactor surface. Tests can substitute a stub `fetch` without monkey-patching globals.
- A guard at the top of `runInference` throws a plain `Error` if `deps.fetch` isn't callable, so a programmer bug never gets misclassified as a retryable transport error.
- `ProviderConfig` (the persisted arktype schema) stays unchanged.

## Test plan

- [x] `bun run check` (full project TypeScript graph)
- [x] `bun run lint` (Prettier, ESLint, API docs freshness)
- [x] `bun run test` — 1124 unit + 9 integration, all pass
- [x] New `packages/inference/src/harness.test.ts` covers: happy path (`deps.fetch` invoked, `globalThis.fetch` never reached), transport-error classification (`retryable` + preserved cause message), three crash-loudly cases (undefined `deps.fetch`, non-function `deps.fetch`, omitted `deps`), `createDefaultDependencies` binding contract, and the reflective-exposure claims the JSDoc makes about `[HarnessId]`.

Closes INTR-58