### PR TITLE
Extract reactor-assembly helper and migrate harness onto it

### DIFF
--- a/packages/harness/src/harness.ts
+++ b/packages/harness/src/harness.ts
@@ -18,21 +18,10 @@
 // (ARCHITECTURE.md § Agent Harness, INFERENCE.md § Relationship to Harness)
 
 import { getLogger } from "@interchange/log";
-import {
-  createReactor,
-  createAuditCollector,
-  createAuthzExtension,
-  createDefaultDependencies,
-  createSizeCapTransform,
-} from "@interchange/inference";
-import type {
-  Reactor,
-  AuditCollector,
-  ReactorEmittedEvent,
-} from "@interchange/inference";
+import { createReactorAssembly } from "@interchange/inference";
+import type { ReactorEmittedEvent } from "@interchange/inference";
 import {
   ProviderConfig,
-  createBlobReader,
   type BlobReader,
   type ContextStore,
   type ConnectorThreadState,
@@ -126,29 +115,10 @@ export function createHarness(config: HarnessConfig): Harness {
 
   const sessionId = crypto.randomUUID();
 
-  // -------------------------------------------------------------------------
-  // Audit collector: correlates tool events with authz decisions.
-  // -------------------------------------------------------------------------
-
   const auditStore = config.auditStore;
-  const auditCollector: AuditCollector | undefined =
-    auditStore !== undefined ? createAuditCollector(sessionId) : undefined;
 
   const accumulatedErrors: ErrorRecord[] = [];
   let errorSeq = 0;
-
-  const authzExtension =
-    config.authorize !== undefined
-      ? createAuthzExtension({
-          authorize: config.authorize,
-          onDecision: (d) => auditCollector?.onDecision(d),
-        })
-      : undefined;
-
-  const beforeToolExtensions = [
-    ...(authzExtension !== undefined ? [authzExtension] : []),
-    ...(config.beforeToolExtensions ?? []),
-  ];
 
   // -------------------------------------------------------------------------
   // Connector state: track which thread(s) this reactor owns.
@@ -193,7 +163,7 @@ export function createHarness(config: HarnessConfig): Harness {
   // per-cycle writeMetadata picks up the live connector state via the underlying
   // store's setConnectorState buffer (Phase 4: connector state rides along with
   // metadata.json rather than being injected during commit).
-  const contextStore: ContextStore = {
+  const wrappedStore: ContextStore = {
     async load(signal) {
       const loaded = await storage.load(signal);
       restoreConnectorState(loaded.connectorState);
@@ -244,11 +214,6 @@ export function createHarness(config: HarnessConfig): Harness {
       return storage.readManifestHistory(limit, signal);
     },
   };
-
-  // BlobReader resolves tool-output:///{callId} URIs through the wrapped
-  // context store. Exposed on the Harness so the caller can wire it into
-  // its tool factory (e.g. `createPosixTools({ blobReader })`).
-  const blobReader = createBlobReader(contextStore);
 
   /**
    * Determine whether a message belongs to the active connector thread.
@@ -308,10 +273,6 @@ export function createHarness(config: HarnessConfig): Harness {
   // -------------------------------------------------------------------------
 
   function handleEvent(event: ReactorEmittedEvent): void {
-    if (event.type !== "message.received" && auditCollector !== undefined) {
-      auditCollector.onEvent(event);
-    }
-
     // Handle connector.reply: send the reply via transport.
     if (
       event.type === "connector.reply" &&
@@ -376,19 +337,6 @@ export function createHarness(config: HarnessConfig): Harness {
   // Reactor
   // -------------------------------------------------------------------------
 
-  async function flushAudit(): Promise<void> {
-    if (auditCollector === undefined) return;
-    if (auditStore === undefined) {
-      throw new Error(
-        "auditStore must be defined when auditCollector is present",
-      );
-    }
-    const records = auditCollector.flush();
-    if (records.length > 0) {
-      await auditStore.commitAudit(records);
-    }
-  }
-
   async function flushErrors(): Promise<void> {
     if (accumulatedErrors.length === 0) return;
     if (auditStore === undefined) return;
@@ -397,41 +345,33 @@ export function createHarness(config: HarnessConfig): Harness {
     accumulatedErrors.splice(0, count);
   }
 
-  const sizeCapTransform = createSizeCapTransform({
-    maxChars: 10_000,
-    contextStore,
-  });
+  // providerConfig is held as a single mutable object whose reference is
+  // shared with the reactor's config (via the assembly helper). The reactor
+  // reads providerConfig lazily at each inference call, so mutating the
+  // fields on this object hot-swaps credentials without restarting.
+  const providerConfig: ProviderConfig = { ...provider };
 
-  // The reactor reads config.providerConfig lazily at each inference call,
-  // so mutating this object hot-swaps credentials without restarting.
-  const reactorConfig: Parameters<typeof createReactor>[0] = {
+  const { reactor, blobReader } = createReactorAssembly({
     sessionId,
     director,
-    providerConfig: provider,
+    providerConfig,
     toolRunner: combinedRunner,
-    contextStore,
+    contextStore: wrappedStore,
     onEvent: handleEvent,
-    deps: createDefaultDependencies(),
-    beforeToolExtensions,
-    toolResultTransforms: [sizeCapTransform],
-  };
-
-  if (auditCollector !== undefined) {
-    reactorConfig.afterCheckpoint = async () => {
-      await flushAudit();
-      await flushErrors();
-    };
-    reactorConfig.onShutdown = async () => {
-      const inflight = auditCollector.pending();
-      if (inflight > 0) {
-        logger.warn`${inflight} audit records in flight at shutdown, these tool calls will not be recorded`;
-      }
-      await flushAudit();
-      await flushErrors();
-    };
-  }
-
-  const reactor: Reactor = createReactor(reactorConfig);
+    ...(config.authorize !== undefined ? { authorize: config.authorize } : {}),
+    ...(config.auditStore !== undefined
+      ? { auditStore: config.auditStore }
+      : {}),
+    ...(config.beforeToolExtensions !== undefined
+      ? { beforeToolExtensions: config.beforeToolExtensions }
+      : {}),
+    // flushErrors only runs when audit is wired — preserves today's
+    // behavior where harness.ts only invokes flushErrors inside the
+    // auditCollector branch.
+    ...(config.auditStore !== undefined
+      ? { afterCheckpoint: flushErrors, onShutdown: flushErrors }
+      : {}),
+  });
 
   let unsubscribe: Unsubscribe | null = null;
   let started = false;
@@ -511,7 +451,17 @@ export function createHarness(config: HarnessConfig): Harness {
     if (parsed instanceof type.errors) {
       throw new Error(`Invalid ProviderConfig: ${parsed.summary}`);
     }
-    reactorConfig.providerConfig = parsed;
+    // Mutate the shared providerConfig object in place so the reactor's
+    // next inference call (which reads providerConfig lazily through the
+    // same reference held by the assembly helper) observes the new fields.
+    providerConfig.provider = parsed.provider;
+    providerConfig.baseURL = parsed.baseURL;
+    providerConfig.apiKey = parsed.apiKey;
+    if (parsed.model !== undefined) {
+      providerConfig.model = parsed.model;
+    } else {
+      delete providerConfig.model;
+    }
   }
 
   return { start, stop, deliver, setProviderConfig, blobReader };

--- a/packages/inference/src/assembly.test.ts
+++ b/packages/inference/src/assembly.test.ts
@@ -1,0 +1,732 @@
+import { describe, test, expect } from "bun:test";
+
+import { createReactorAssembly } from "./assembly";
+import type { AuthzCallResult } from "./authz-extension";
+import type { ReactorEmittedEvent } from "./reactor";
+
+import type {
+  AuditStore,
+  BeforeToolExtension,
+  ContextCommit,
+  ContextStore,
+  ConversationTurn,
+  InboundMessage,
+  ProviderConfig,
+  ReactorCapabilities,
+  ReactorDirector,
+  ReactorState,
+  TokenUsage,
+  ToolResultTransform,
+  ToolRunner,
+} from "@interchange/types/runtime";
+
+import type { AuditRecord } from "@interchange/types/audit";
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+function emptyUsage(): TokenUsage {
+  return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, thinking: 0 };
+}
+
+type RecordingContextStore = ContextStore & {
+  blobs: Map<string, { bytes: Uint8Array; contentType: string | undefined }>;
+};
+
+function makeContextStore(
+  turns: ConversationTurn[] = [],
+): RecordingContextStore {
+  const blobs = new Map<
+    string,
+    { bytes: Uint8Array; contentType: string | undefined }
+  >();
+  async function commit(
+    options: { message: string },
+    _signal?: AbortSignal,
+  ): Promise<ContextCommit> {
+    return { hash: "abc", message: options.message, timestamp: Date.now() };
+  }
+  return {
+    blobs,
+    async load() {
+      return {
+        turns,
+        pendingOperations: [],
+        tokenUsage: emptyUsage(),
+        connectorState: null,
+      };
+    },
+    setConnectorState() {
+      /* noop */
+    },
+    commit,
+    async branch() {
+      /* noop */
+    },
+    async log() {
+      return [];
+    },
+    async readAt() {
+      return [];
+    },
+    async writeBlob(key, bytes, contentType) {
+      blobs.set(key, { bytes, contentType });
+    },
+    async readBlob(key) {
+      const entry = blobs.get(key);
+      if (entry === undefined) {
+        throw new Error(`no blob for key ${key}`);
+      }
+      return entry.bytes;
+    },
+    async writePrompt() {
+      /* noop */
+    },
+    async writeResponse() {
+      /* noop */
+    },
+    async writeManifest() {
+      /* noop */
+    },
+    async writeTurns() {
+      /* noop */
+    },
+    async writeMetadata() {
+      /* noop */
+    },
+    async readManifestHistory() {
+      return [];
+    },
+  };
+}
+
+function makeToolRunner(content: string | Record<string, unknown>): ToolRunner {
+  return {
+    async run(call) {
+      return { callId: call.id, content };
+    },
+  };
+}
+
+function makeInboundMessage(): InboundMessage {
+  return {
+    ref: { uid: 1, mailbox: "INBOX" },
+    headers: {
+      from: "test@example.com",
+      to: ["agent@example.com"],
+      date: new Date().toISOString(),
+      messageId: `msg-${Math.random()}`,
+    },
+    flags: [],
+    content: "hello",
+    signatureStatus: "missing",
+  };
+}
+
+// Director that executes a single tool call on message.received and ends on
+// tool.done, optionally with a checkpoint to trigger afterCheckpoint flush.
+function makeToolExecDirector(
+  toolName: string,
+  toolArgs: Record<string, unknown> = {},
+  options: { checkpoint?: boolean; callId?: string } = {},
+): ReactorDirector {
+  const callId = options.callId ?? `call-${toolName}`;
+  return {
+    async decide(
+      event: { type: string },
+      _state: ReactorState,
+      caps: ReactorCapabilities,
+    ) {
+      if (event.type === "message.received") {
+        return caps.executeTools([
+          { id: callId, name: toolName, arguments: toolArgs },
+        ]);
+      }
+      if (event.type === "tool.done") {
+        if (options.checkpoint === true) {
+          return [caps.checkpoint(), caps.done()];
+        }
+        return caps.done();
+      }
+      return caps.done();
+    },
+  };
+}
+
+function waitForDone(events: ReactorEmittedEvent[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = setTimeout(
+      () => reject(new Error("Timed out waiting for reactor.done")),
+      5000,
+    );
+    const check = () => {
+      if (events.some((e) => e.type === "reactor.done")) {
+        clearTimeout(deadline);
+        resolve();
+        return;
+      }
+      setTimeout(check, 10);
+    };
+    check();
+  });
+}
+
+function provider(): ProviderConfig {
+  return {
+    provider: "anthropic",
+    baseURL: "https://api.anthropic.com",
+    apiKey: "test",
+  };
+}
+
+function makeRecordingAuditStore(): AuditStore & {
+  getCommitted(): AuditRecord[][];
+} {
+  const committed: AuditRecord[][] = [];
+  return {
+    async commitAudit(records: AuditRecord[]) {
+      committed.push([...records]);
+    },
+    async loadAudit() {
+      return committed.flat();
+    },
+    async commitErrors() {
+      /* noop */
+    },
+    getCommitted() {
+      return committed;
+    },
+  };
+}
+
+function allowAuthorize(): Promise<AuthzCallResult> {
+  return Promise.resolve({
+    effect: "allow" as const,
+    matchingGrants: [],
+    resolvedBy: null,
+  });
+}
+
+// A recording before-tool extension that captures every call and the order in
+// which it ran relative to peers via the shared trace array.
+function makeRecordingExtension(
+  name: string,
+  trace: string[],
+): BeforeToolExtension {
+  return {
+    async beforeTool(_call) {
+      trace.push(name);
+      return undefined;
+    },
+  };
+}
+
+// A recording tool-result transform that captures the order of invocation.
+function makeRecordingTransform(
+  name: string,
+  trace: string[],
+): ToolResultTransform {
+  return {
+    name,
+    version: "1",
+    async apply(input) {
+      trace.push(name);
+      return {
+        output: input.result,
+        record: {
+          strategy: name,
+          version: "1",
+          parameters: {},
+          reason: "noop",
+          decisions: {},
+        },
+      };
+    },
+  };
+}
+
+function collectEvents(): {
+  events: ReactorEmittedEvent[];
+  onEvent: (e: ReactorEmittedEvent) => void;
+} {
+  const events: ReactorEmittedEvent[] = [];
+  return { events, onEvent: (e) => events.push(e) };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createReactorAssembly", () => {
+  test("default size-cap transform is the first tool-result transform when no caller transforms are provided", async () => {
+    // We observe the size-cap transform via its side effect: a large tool
+    // result spills to ContextStore.writeBlob. With no caller transforms,
+    // the helper-supplied size-cap is the only transform and the spill must
+    // appear in the blob store.
+    const contextStore = makeContextStore();
+    const events = collectEvents();
+    const big = "x".repeat(200);
+
+    const { reactor } = createReactorAssembly({
+      sessionId: "s1",
+      director: makeToolExecDirector("t", {}, { callId: "c1" }),
+      providerConfig: provider(),
+      toolRunner: makeToolRunner(big),
+      contextStore,
+      onEvent: events.onEvent,
+      sizeCapMaxChars: 50,
+      shutdownTimeoutMs: 100,
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitForDone(events.events);
+
+    const spill = contextStore.blobs.get("c1");
+    expect(spill).toBeDefined();
+    if (spill === undefined) throw new Error("expected spill");
+    expect(new TextDecoder().decode(spill.bytes)).toBe(big);
+  });
+
+  test("caller's toolResultTransforms run after the default size-cap transform (order preserved)", async () => {
+    // Drive an over-cap result. The caller's first transform should observe
+    // an already-truncated payload (size-cap ran first), and both caller
+    // transforms should run in the order supplied.
+    const trace: string[] = [];
+    const seen: string[] = [];
+    const captureTransform: ToolResultTransform = {
+      name: "capture",
+      version: "1",
+      async apply(input) {
+        trace.push("capture");
+        seen.push(
+          typeof input.result.content === "string"
+            ? input.result.content.slice(0, 5)
+            : "non-string",
+        );
+        return {
+          output: input.result,
+          record: {
+            strategy: "capture",
+            version: "1",
+            parameters: {},
+            reason: "noop",
+            decisions: {},
+          },
+        };
+      },
+    };
+    const tailTransform = makeRecordingTransform("tail", trace);
+
+    const contextStore = makeContextStore();
+    const events = collectEvents();
+    const big = "y".repeat(200);
+
+    const { reactor } = createReactorAssembly({
+      sessionId: "s2",
+      director: makeToolExecDirector("t", {}, { callId: "c2" }),
+      providerConfig: provider(),
+      toolRunner: makeToolRunner(big),
+      contextStore,
+      onEvent: events.onEvent,
+      sizeCapMaxChars: 20,
+      toolResultTransforms: [captureTransform, tailTransform],
+      shutdownTimeoutMs: 100,
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitForDone(events.events);
+
+    expect(trace).toEqual(["capture", "tail"]);
+    // The captured prefix is from `big`, confirming the caller transform
+    // saw the size-cap's truncated marker (which begins with the kept
+    // characters from `big`).
+    expect(seen[0]).toBe("yyyyy");
+  });
+
+  test("custom sizeCapMaxChars flows into the size-cap transform", async () => {
+    // Drive an over-cap result with maxChars=10 and assert the spilled blob's
+    // bytes equal the original content (size-cap always spills the full
+    // payload when it caps).
+    const contextStore = makeContextStore();
+    const events = collectEvents();
+    const payload = "z".repeat(50);
+
+    const { reactor } = createReactorAssembly({
+      sessionId: "s3",
+      director: makeToolExecDirector("t", {}, { callId: "c3" }),
+      providerConfig: provider(),
+      toolRunner: makeToolRunner(payload),
+      contextStore,
+      onEvent: events.onEvent,
+      sizeCapMaxChars: 10,
+      shutdownTimeoutMs: 100,
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitForDone(events.events);
+
+    const spill = contextStore.blobs.get("c3");
+    expect(spill).toBeDefined();
+    if (spill === undefined) throw new Error("expected spill");
+    expect(spill.bytes.byteLength).toBe(50);
+  });
+
+  test("with authorize set, an authz before-tool extension is composed in front of caller's beforeToolExtensions", async () => {
+    // No caller extensions: a deny authorize should still block the call by
+    // virtue of the assembly-built authz extension running first.
+    const contextStore = makeContextStore();
+    const events = collectEvents();
+    const auditStore = makeRecordingAuditStore();
+
+    const { reactor } = createReactorAssembly({
+      sessionId: "s4",
+      director: makeToolExecDirector("forbidden", {}, { callId: "c4" }),
+      providerConfig: provider(),
+      toolRunner: makeToolRunner("never runs"),
+      contextStore,
+      onEvent: events.onEvent,
+      authorize: () =>
+        Promise.resolve({
+          effect: "deny" as const,
+          matchingGrants: [],
+          resolvedBy: null,
+        }),
+      auditStore,
+      shutdownTimeoutMs: 100,
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitForDone(events.events);
+
+    const records = auditStore.getCommitted().flat();
+    expect(records.length).toBe(1);
+    const record = records[0];
+    if (record === undefined) throw new Error("expected record");
+    expect(record.tool).toBe("forbidden");
+    if (record.authz === null) throw new Error("expected authz");
+    expect(record.authz.blocked).toBe(true);
+    expect(record.authz.effect).toBe("deny");
+  });
+
+  test("with authorize + caller's beforeToolExtensions, authz runs first; caller's extensions follow in order", async () => {
+    // The authz extension allows; the recording extension records that it
+    // saw the call. If authz had been ordered after the recording extension,
+    // a deny would still block — but we want to verify ordering specifically,
+    // so we use allow and assert the recording extension still ran (proves
+    // authz didn't block) and we observe the order via the trace.
+    const contextStore = makeContextStore();
+    const events = collectEvents();
+    const trace: string[] = [];
+    const recordingExt = makeRecordingExtension("caller-ext", trace);
+
+    let authzRan = false;
+    const authorize = (): Promise<AuthzCallResult> => {
+      // Authz runs synchronously here; appending before the await guarantees
+      // ordering relative to the caller-ext (which appends in beforeTool).
+      authzRan = true;
+      trace.push("authz");
+      return Promise.resolve({
+        effect: "allow" as const,
+        matchingGrants: [],
+        resolvedBy: null,
+      });
+    };
+
+    const { reactor } = createReactorAssembly({
+      sessionId: "s5",
+      director: makeToolExecDirector("t", {}, { callId: "c5" }),
+      providerConfig: provider(),
+      toolRunner: makeToolRunner("ok"),
+      contextStore,
+      onEvent: events.onEvent,
+      authorize,
+      beforeToolExtensions: [recordingExt],
+      shutdownTimeoutMs: 100,
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitForDone(events.events);
+
+    expect(authzRan).toBe(true);
+    expect(trace).toEqual(["authz", "caller-ext"]);
+  });
+
+  test("with auditStore set, an audit collector is returned and afterCheckpoint flushes records to the store", async () => {
+    const contextStore = makeContextStore();
+    const events = collectEvents();
+    const auditStore = makeRecordingAuditStore();
+
+    const { reactor, auditCollector } = createReactorAssembly({
+      sessionId: "s6",
+      director: makeToolExecDirector(
+        "t",
+        { k: "v" },
+        {
+          checkpoint: true,
+          callId: "c6",
+        },
+      ),
+      providerConfig: provider(),
+      toolRunner: makeToolRunner("ok"),
+      contextStore,
+      onEvent: events.onEvent,
+      auditStore,
+      authorize: () => allowAuthorize(),
+      shutdownTimeoutMs: 100,
+    });
+
+    expect(auditCollector).toBeDefined();
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitForDone(events.events);
+
+    const batches = auditStore.getCommitted();
+    // Director checkpoints then done — flush happens at checkpoint and again
+    // at shutdown. The shutdown flush finds an empty buffer and skips.
+    expect(batches.length).toBe(1);
+    expect(batches[0]?.length).toBe(1);
+    expect(batches[0]?.[0]?.callId).toBe("c6");
+  });
+
+  test("with auditStore + authorize, authz onDecision decisions appear in the audit collector's flushed records", async () => {
+    const contextStore = makeContextStore();
+    const events = collectEvents();
+    const auditStore = makeRecordingAuditStore();
+
+    const { reactor } = createReactorAssembly({
+      sessionId: "s7",
+      director: makeToolExecDirector(
+        "t",
+        { x: 1 },
+        {
+          checkpoint: true,
+          callId: "c7",
+        },
+      ),
+      providerConfig: provider(),
+      toolRunner: makeToolRunner("ok"),
+      contextStore,
+      onEvent: events.onEvent,
+      auditStore,
+      authorize: () => allowAuthorize(),
+      shutdownTimeoutMs: 100,
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitForDone(events.events);
+
+    const records = auditStore.getCommitted().flat();
+    expect(records.length).toBe(1);
+    const record = records[0];
+    if (record === undefined) throw new Error("expected record");
+    if (record.authz === null) throw new Error("expected authz on record");
+    expect(record.authz.effect).toBe("allow");
+    expect(record.authz.blocked).toBe(false);
+  });
+
+  test("caller's afterCheckpoint runs after the helper's audit flush", async () => {
+    const contextStore = makeContextStore();
+    const events = collectEvents();
+    const auditStore = makeRecordingAuditStore();
+
+    const trace: string[] = [];
+    // Wrap commitAudit so we can record the moment of the helper's flush.
+    const wrappedAuditStore: AuditStore & { getCommitted(): AuditRecord[][] } =
+      {
+        ...auditStore,
+        async commitAudit(records) {
+          trace.push("helper-flush");
+          await auditStore.commitAudit(records);
+        },
+      };
+
+    const { reactor } = createReactorAssembly({
+      sessionId: "s8",
+      director: makeToolExecDirector(
+        "t",
+        {},
+        {
+          checkpoint: true,
+          callId: "c8",
+        },
+      ),
+      providerConfig: provider(),
+      toolRunner: makeToolRunner("ok"),
+      contextStore,
+      onEvent: events.onEvent,
+      auditStore: wrappedAuditStore,
+      authorize: () => allowAuthorize(),
+      afterCheckpoint: async () => {
+        trace.push("caller-after-checkpoint");
+      },
+      shutdownTimeoutMs: 100,
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitForDone(events.events);
+
+    expect(trace).toEqual(["helper-flush", "caller-after-checkpoint"]);
+  });
+
+  test("caller's onShutdown runs after the helper's audit-flush-on-shutdown", async () => {
+    const contextStore = makeContextStore();
+    const events = collectEvents();
+    const auditStore = makeRecordingAuditStore();
+
+    const trace: string[] = [];
+    const wrappedAuditStore: AuditStore & { getCommitted(): AuditRecord[][] } =
+      {
+        ...auditStore,
+        async commitAudit(records) {
+          trace.push("helper-flush");
+          await auditStore.commitAudit(records);
+        },
+      };
+
+    // Director that does NOT checkpoint — only the shutdown path flushes.
+    const director: ReactorDirector = {
+      async decide(
+        event: { type: string },
+        _state: ReactorState,
+        caps: ReactorCapabilities,
+      ) {
+        if (event.type === "message.received") {
+          return caps.executeTools([{ id: "c9", name: "t", arguments: {} }]);
+        }
+        if (event.type === "tool.done") {
+          return caps.done();
+        }
+        return caps.done();
+      },
+    };
+
+    const { reactor } = createReactorAssembly({
+      sessionId: "s9",
+      director,
+      providerConfig: provider(),
+      toolRunner: makeToolRunner("ok"),
+      contextStore,
+      onEvent: events.onEvent,
+      auditStore: wrappedAuditStore,
+      authorize: () => allowAuthorize(),
+      onShutdown: async () => {
+        trace.push("caller-shutdown");
+      },
+      shutdownTimeoutMs: 100,
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitForDone(events.events);
+
+    expect(trace).toEqual(["helper-flush", "caller-shutdown"]);
+  });
+
+  test("blobReader is wired against the supplied contextStore", async () => {
+    const contextStore = makeContextStore();
+    const { blobReader } = createReactorAssembly({
+      sessionId: "s10",
+      director: {
+        async decide(_e, _s, caps) {
+          return caps.done();
+        },
+      },
+      providerConfig: provider(),
+      toolRunner: makeToolRunner("ok"),
+      contextStore,
+      onEvent: () => {
+        /* noop */
+      },
+      shutdownTimeoutMs: 100,
+    });
+
+    const bytes = new TextEncoder().encode("hello-blob");
+    await contextStore.writeBlob("k1", bytes, "text/plain");
+    const out = await blobReader.read("tool-output:///k1");
+    expect(new TextDecoder().decode(out)).toBe("hello-blob");
+  });
+
+  test("without auditStore, auditCollector is undefined and afterCheckpoint is only wired when caller provided one", async () => {
+    const contextStore = makeContextStore();
+    const events = collectEvents();
+    let callerAfterCheckpointCalls = 0;
+
+    const { auditCollector, reactor } = createReactorAssembly({
+      sessionId: "s11",
+      director: makeToolExecDirector(
+        "t",
+        {},
+        {
+          checkpoint: true,
+          callId: "c11",
+        },
+      ),
+      providerConfig: provider(),
+      toolRunner: makeToolRunner("ok"),
+      contextStore,
+      onEvent: events.onEvent,
+      afterCheckpoint: async () => {
+        callerAfterCheckpointCalls++;
+      },
+      shutdownTimeoutMs: 100,
+    });
+
+    expect(auditCollector).toBeUndefined();
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitForDone(events.events);
+
+    // Caller's afterCheckpoint still fires — the helper passes it through
+    // unchanged when there is no audit collector to chain in front of it.
+    expect(callerAfterCheckpointCalls).toBe(1);
+  });
+
+  test("without authorize, the reactor's beforeToolExtensions is exactly the caller's array", async () => {
+    // Observable assertion: a caller-supplied extension that blocks should
+    // produce a blocked tool result, and no authz-supplied extension should
+    // be interposed (we'd otherwise see two extension invocations).
+    const contextStore = makeContextStore();
+    const events = collectEvents();
+    const trace: string[] = [];
+    const ext: BeforeToolExtension = {
+      async beforeTool() {
+        trace.push("caller-ext");
+        return "blocked-by-caller";
+      },
+    };
+
+    const { reactor } = createReactorAssembly({
+      sessionId: "s12",
+      director: makeToolExecDirector("t", {}, { callId: "c12" }),
+      providerConfig: provider(),
+      toolRunner: makeToolRunner("never reached"),
+      contextStore,
+      onEvent: events.onEvent,
+      beforeToolExtensions: [ext],
+      shutdownTimeoutMs: 100,
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitForDone(events.events);
+
+    expect(trace).toEqual(["caller-ext"]);
+    const toolDone = events.events.find(
+      (e): e is Extract<ReactorEmittedEvent, { type: "tool.done" }> =>
+        e.type === "tool.done",
+    );
+    if (toolDone === undefined) throw new Error("expected tool.done");
+    expect(toolDone.data.result.isError).toBe(true);
+    expect(toolDone.data.result.content).toBe("blocked-by-caller");
+  });
+});

--- a/packages/inference/src/assembly.ts
+++ b/packages/inference/src/assembly.ts
@@ -1,0 +1,250 @@
+// Reactor assembly helper.
+//
+// `createReactorAssembly` is the canonical way to construct a reactor when the
+// caller wants the standard wiring: a default size-cap tool-result transform,
+// authz as a before-tool extension, an audit collector that flushes at
+// checkpoint and shutdown boundaries, and a `BlobReader` over the supplied
+// context store. Future reactor consumers (the harness today; in-process agent
+// runtimes tomorrow) should use this helper rather than calling `createReactor`
+// directly so the wiring stays consistent across composition points.
+
+import { getLogger } from "@interchange/log";
+import {
+  createBlobReader,
+  type BlobReader,
+  type AuditStore,
+  type BeforeToolExtension,
+  type Compactor,
+  type ContextStore,
+  type ContextTransform,
+  type ProviderConfig,
+  type ReactorDirector,
+  type ToolResultTransform,
+  type ToolRunner,
+} from "@interchange/types/runtime";
+
+import { createAuditCollector, type AuditCollector } from "./audit-collector";
+import {
+  createAuthzExtension,
+  type AuthzExtensionOptions,
+} from "./authz-extension";
+import type { CorrelationValidator } from "./correlation";
+import { createDefaultDependencies, type Dependencies } from "./harness";
+import {
+  createReactor,
+  type Reactor,
+  type ReactorConfig,
+  type ReactorEmittedEvent,
+} from "./reactor";
+import { createSizeCapTransform } from "./transforms";
+
+const logger = getLogger(["interchange", "assembly"]);
+
+const DEFAULT_SIZE_CAP_MAX_CHARS = 10_000;
+
+/**
+ * Configuration for `createReactorAssembly`. Required fields mirror
+ * `ReactorConfig`. Optional fields toggle the composed extensions: the helper
+ * builds an authz before-tool extension when `authorize` is supplied, builds
+ * and wires an audit collector when `auditStore` is supplied, and always
+ * prepends a default size-cap tool-result transform.
+ *
+ * The helper does NOT wrap the supplied `contextStore`; callers that need
+ * additional behavior (the harness wraps for connector-thread state) layer
+ * that on themselves before passing the store in.
+ */
+export type ReactorAssemblyConfig = {
+  sessionId: string;
+  director: ReactorDirector;
+  providerConfig: ProviderConfig;
+  toolRunner: ToolRunner;
+  contextStore: ContextStore;
+  onEvent: (event: ReactorEmittedEvent) => void;
+
+  authorize?: AuthzExtensionOptions["authorize"];
+  auditStore?: AuditStore;
+  beforeToolExtensions?: BeforeToolExtension[];
+  toolResultTransforms?: ToolResultTransform[];
+  contextTransforms?: ContextTransform[];
+  compactors?: Record<string, Compactor>;
+  sizeCapMaxChars?: number;
+
+  afterCheckpoint?: () => Promise<void>;
+  onShutdown?: () => Promise<void>;
+
+  deps?: Dependencies;
+  correlationValidator?: CorrelationValidator;
+  inferenceRunner?: ReactorConfig["inferenceRunner"];
+  gateTimeout?: number;
+  shutdownTimeoutMs?: number;
+};
+
+/**
+ * Output of `createReactorAssembly`. The `reactor` is started by the caller as
+ * usual. `blobReader` is exposed so the caller can pass it to tool factories
+ * that resolve `tool-output:///{callId}` URIs against the same context store
+ * the reactor commits to. `auditCollector` is `undefined` when no `auditStore`
+ * was supplied.
+ */
+export type ReactorAssembly = {
+  reactor: Reactor;
+  blobReader: BlobReader;
+  auditCollector: AuditCollector | undefined;
+};
+
+/**
+ * Build the standard reactor wiring. This is the canonical reactor-assembly
+ * path: any consumer that needs the default size-cap transform, authz, audit
+ * collection, and blob reader should call this helper instead of constructing
+ * a `ReactorConfig` by hand. Direct `createReactor` use is reserved for
+ * reactor-internal tests and any future consumer that genuinely needs a
+ * different composition.
+ */
+export function createReactorAssembly(
+  config: ReactorAssemblyConfig,
+): ReactorAssembly {
+  const {
+    sessionId,
+    director,
+    providerConfig,
+    toolRunner,
+    contextStore,
+    onEvent,
+    authorize,
+    auditStore,
+    beforeToolExtensions: callerBeforeToolExtensions,
+    toolResultTransforms: callerToolResultTransforms,
+    contextTransforms,
+    compactors,
+    sizeCapMaxChars,
+    afterCheckpoint: callerAfterCheckpoint,
+    onShutdown: callerOnShutdown,
+    deps,
+    correlationValidator,
+    inferenceRunner,
+    gateTimeout,
+    shutdownTimeoutMs,
+  } = config;
+
+  // Audit collector is created up-front so the authz extension can route its
+  // decisions through `onDecision`. When no auditStore is supplied, no
+  // collector is created and authz runs without decision recording.
+  const auditCollector: AuditCollector | undefined =
+    auditStore !== undefined ? createAuditCollector(sessionId) : undefined;
+
+  // When an audit collector is present, intercept the reactor's event stream
+  // to feed it tool.start / tool.done events (the collector correlates these
+  // with authz decisions by callId). message.received is reactor-internal and
+  // is forwarded to the caller but not to the collector. Without a collector,
+  // the caller's onEvent is used directly.
+  const composedOnEvent =
+    auditCollector !== undefined
+      ? (event: ReactorEmittedEvent) => {
+          if (event.type !== "message.received") {
+            auditCollector.onEvent(event);
+          }
+          onEvent(event);
+        }
+      : onEvent;
+
+  // Authz is composed in front of any caller-supplied before-tool extensions
+  // so policy enforcement runs first. Without authz, the caller's list (if
+  // any) is passed through unchanged.
+  const authzExtension =
+    authorize !== undefined
+      ? createAuthzExtension({
+          authorize,
+          ...(auditCollector !== undefined
+            ? { onDecision: (d) => auditCollector.onDecision(d) }
+            : {}),
+        })
+      : undefined;
+
+  const composedBeforeToolExtensions: BeforeToolExtension[] | undefined =
+    authzExtension !== undefined
+      ? [authzExtension, ...(callerBeforeToolExtensions ?? [])]
+      : callerBeforeToolExtensions;
+
+  // The size-cap transform is always prepended so oversized payloads spill
+  // before any caller transform sees them. Caller transforms run after and
+  // can rely on the inline content already being bounded.
+  const sizeCapTransform = createSizeCapTransform({
+    maxChars: sizeCapMaxChars ?? DEFAULT_SIZE_CAP_MAX_CHARS,
+    contextStore,
+  });
+  const composedToolResultTransforms: ToolResultTransform[] = [
+    sizeCapTransform,
+    ...(callerToolResultTransforms ?? []),
+  ];
+
+  // Audit flush wraps the caller's lifecycle hooks: the helper's flush runs
+  // first so the records produced by the just-completed cycle are persisted
+  // before the caller's hook observes the checkpoint or shutdown boundary.
+  async function flushAudit(): Promise<void> {
+    if (auditCollector === undefined || auditStore === undefined) return;
+    const records = auditCollector.flush();
+    if (records.length > 0) {
+      await auditStore.commitAudit(records);
+    }
+  }
+
+  const composedAfterCheckpoint: (() => Promise<void>) | undefined =
+    auditCollector !== undefined
+      ? async () => {
+          await flushAudit();
+          if (callerAfterCheckpoint !== undefined) {
+            await callerAfterCheckpoint();
+          }
+        }
+      : callerAfterCheckpoint;
+
+  const composedOnShutdown: (() => Promise<void>) | undefined =
+    auditCollector !== undefined
+      ? async () => {
+          const inflight = auditCollector.pending();
+          if (inflight > 0) {
+            logger.warn`${inflight} audit records in flight at shutdown, these tool calls will not be recorded`;
+          }
+          await flushAudit();
+          if (callerOnShutdown !== undefined) {
+            await callerOnShutdown();
+          }
+        }
+      : callerOnShutdown;
+
+  // ReactorConfig.deps is required; default to createDefaultDependencies()
+  // when the caller did not supply one so we never pass `undefined`.
+  const resolvedDeps: Dependencies = deps ?? createDefaultDependencies();
+
+  // exactOptionalPropertyTypes is on: only set optional keys when defined.
+  const reactorConfig: ReactorConfig = {
+    sessionId,
+    director,
+    providerConfig,
+    toolRunner,
+    contextStore,
+    onEvent: composedOnEvent,
+    deps: resolvedDeps,
+    toolResultTransforms: composedToolResultTransforms,
+    ...(composedBeforeToolExtensions !== undefined
+      ? { beforeToolExtensions: composedBeforeToolExtensions }
+      : {}),
+    ...(contextTransforms !== undefined ? { contextTransforms } : {}),
+    ...(compactors !== undefined ? { compactors } : {}),
+    ...(composedAfterCheckpoint !== undefined
+      ? { afterCheckpoint: composedAfterCheckpoint }
+      : {}),
+    ...(composedOnShutdown !== undefined
+      ? { onShutdown: composedOnShutdown }
+      : {}),
+    ...(correlationValidator !== undefined ? { correlationValidator } : {}),
+    ...(inferenceRunner !== undefined ? { inferenceRunner } : {}),
+    ...(gateTimeout !== undefined ? { gateTimeout } : {}),
+    ...(shutdownTimeoutMs !== undefined ? { shutdownTimeoutMs } : {}),
+  };
+
+  const reactor = createReactor(reactorConfig);
+  const blobReader = createBlobReader(contextStore);
+
+  return { reactor, blobReader, auditCollector };
+}

--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -45,3 +45,5 @@ export { createAuditCollector } from "./audit-collector";
 export type { AuditCollector } from "./audit-collector";
 export { createSizeCapTransform } from "./transforms";
 export type { SizeCapTransformOptions } from "./transforms";
+export { createReactorAssembly } from "./assembly";
+export type { ReactorAssembly, ReactorAssemblyConfig } from "./assembly";


### PR DESCRIPTION
## Summary

- Add `createReactorAssembly` in `@interchange/inference`, the canonical composition of the standard reactor wiring (audit collector, authz extension, before-tool extensions, size-cap transform default, blob reader, audit-flush lifecycle hooks).
- Migrate `createHarness` onto the helper. Reactor wiring collapses from ~90 inline lines into one call. Behavior, the public `Harness` type, and the existing harness tests are unchanged.
- Unblocks INTR-51 (in-process agent package), which will reuse the helper without depending on mail transport.

## Changes

- `packages/inference/src/assembly.ts` (new): `createReactorAssembly`, `ReactorAssemblyConfig`, `ReactorAssembly`. Composes a size-cap tool-result transform (prepended, default 10_000 chars), an authz before-tool extension when `authorize` is supplied, an audit collector when `auditStore` is supplied, chained `afterCheckpoint`/`onShutdown` hooks that flush audit before the caller's hook runs, and a `BlobReader` over the supplied context store. Does NOT wrap the context store — that concern belongs to the caller.
- `packages/inference/src/assembly.test.ts` (new): 12 unit tests covering composition order, audit-flush ordering, blob reader wiring, the absent-audit and absent-authz paths, and the `composedOnEvent` interception that feeds the audit collector.
- `packages/inference/src/index.ts`: re-export the helper and its types.
- `packages/harness/src/harness.ts`: replace the inline reactor-assembly wiring with one `createReactorAssembly` call. Rename the local connector-state-wrapped store from `contextStore` to `wrappedStore` to make the layering explicit. Remove the now-redundant `auditCollector.onEvent(event)` feed in `handleEvent` (the helper composes that path). Rework `setProviderConfig` to mutate a locally-cloned `providerConfig` object in place since the helper now owns the `reactorConfig` object reference; the reactor's lazy read of `config.providerConfig` per inference call observes the mutations.

## Why context-store wrapping stays in harness

The wrapper at `packages/harness/src/harness.ts:163-217` is glue between harness-owned mutable mail state (`connectorThreadRoot`, `connectorLastMessageId`, `connectorReplyTo`, `connectorSubject`) and the store's per-cycle `writeMetadata` rhythm. Moving it into the helper means the helper owns the mail state, at which point it stops being reactor-assembly. INTR-51 will produce a real second consumer; that's the right moment to factor a shared decorator against two real shapes, not one and a guess.

## Test plan

- [x] `make all` green on the branch (lint, `tsc -b`, 1302 main + 9 sidecar/inference integration tests).
- [x] `packages/harness/src/harness.test.ts` and `packages/harness/src/deploy-tree.test.ts` byte-identical to `origin/main` (hard gate).
- [x] 12 new tests in `packages/inference/src/assembly.test.ts` cover the composition contract end-to-end.
- [x] No drive-by changes outside the four expected files.

Closes INTR-49