### PR TITLE
Add mail-builder helpers in @interchange/mime

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -106,6 +106,9 @@
         "@interchange/types": "workspace:*",
         "arktype": "catalog:",
       },
+      "devDependencies": {
+        "@interchange/mime": "workspace:*",
+      },
     },
     "packages/hub": {
       "name": "@interchange/hub",
@@ -141,6 +144,9 @@
         "@interchange/log": "workspace:*",
         "@interchange/types": "workspace:*",
         "arktype": "catalog:",
+      },
+      "devDependencies": {
+        "@interchange/mime": "workspace:*",
       },
     },
     "packages/inference-testing": {

--- a/bun.lock
+++ b/bun.lock
@@ -181,6 +181,7 @@
       "dependencies": {
         "@interchange/crypto-node": "workspace:*",
         "@interchange/types": "workspace:*",
+        "arktype": "catalog:",
       },
     },
     "packages/pack-transport": {

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -14,5 +14,8 @@
     "@interchange/log": "workspace:*",
     "@interchange/types": "workspace:*",
     "arktype": "catalog:"
+  },
+  "devDependencies": {
+    "@interchange/mime": "workspace:*"
   }
 }

--- a/packages/harness/src/harness.test.ts
+++ b/packages/harness/src/harness.test.ts
@@ -32,6 +32,7 @@ import type {
 } from "@interchange/types/runtime";
 import type { AuditRecord, ErrorRecord } from "@interchange/types/audit";
 import type { AuthzCallResult } from "@interchange/inference";
+import { createInboundMessage } from "@interchange/mime";
 import type {
   ReactorInboundEvent,
   ReactorDirector,
@@ -348,19 +349,12 @@ function makeMockTransport(): MockTransport {
 }
 
 function makeInboundMessage(from = "user@test"): InboundMessage {
-  return {
-    ref: { uid: 1, mailbox: "INBOX" },
-    headers: {
-      from,
-      to: ["agent@local.interchange"],
-      date: new Date().toISOString(),
-      messageId: `<${Math.random()}@test>`,
-      subject: "Test conversation",
-    },
-    flags: [],
+  return createInboundMessage({
+    from,
+    to: "agent@local.interchange",
+    subject: "Test conversation",
     content: "Hello, agent!",
-    signatureStatus: "missing",
-  };
+  });
 }
 
 function makeConfig(

--- a/packages/harness/src/tools.ts
+++ b/packages/harness/src/tools.ts
@@ -16,34 +16,13 @@ import type {
   OutboundMessage,
   SearchQuery,
 } from "@interchange/types/runtime";
+import { InterchangeType } from "@interchange/types/runtime";
 
 type ToolHandler = (call: ToolCall, signal: AbortSignal) => Promise<ToolResult>;
 
 // ---------------------------------------------------------------------------
 // Argument schemas
 // ---------------------------------------------------------------------------
-
-const InterchangeType = type.enumerated(
-  "conversation.message",
-  "conversation.join",
-  "conversation.leave",
-  "offering.request",
-  "offering.response",
-  "offering.error",
-  "offering.discover",
-  "offering.catalog",
-  "payment.required",
-  "payment.receipt",
-  "payment.verified",
-  "approval.request",
-  "approval.granted",
-  "approval.denied",
-  "system.health",
-  "system.register",
-  "system.deregister",
-  "system.credential.refresh",
-);
-type InterchangeType = typeof InterchangeType.infer;
 
 const SendArgs = type({
   to: "string | string[]",

--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -13,5 +13,8 @@
     "@interchange/log": "workspace:*",
     "@interchange/types": "workspace:*",
     "arktype": "catalog:"
+  },
+  "devDependencies": {
+    "@interchange/mime": "workspace:*"
   }
 }

--- a/packages/inference/src/assembly.test.ts
+++ b/packages/inference/src/assembly.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "bun:test";
 
 import { createReactorAssembly } from "./assembly";
+import { createInboundMessage } from "@interchange/mime";
 import type { AuthzCallResult } from "./authz-extension";
 import type { ReactorEmittedEvent } from "./reactor";
 
@@ -110,18 +111,11 @@ function makeToolRunner(content: string | Record<string, unknown>): ToolRunner {
 }
 
 function makeInboundMessage(): InboundMessage {
-  return {
-    ref: { uid: 1, mailbox: "INBOX" },
-    headers: {
-      from: "test@example.com",
-      to: ["agent@example.com"],
-      date: new Date().toISOString(),
-      messageId: `msg-${Math.random()}`,
-    },
-    flags: [],
+  return createInboundMessage({
+    from: "test@example.com",
+    to: "agent@example.com",
     content: "hello",
-    signatureStatus: "missing",
-  };
+  });
 }
 
 // Director that executes a single tool call on message.received and ends on

--- a/packages/inference/src/reactor.test.ts
+++ b/packages/inference/src/reactor.test.ts
@@ -5,6 +5,7 @@ import { createGateManager } from "./gates";
 import { createCorrelationRegistry } from "./correlation";
 import { createReactor } from "./reactor";
 import { createDefaultDependencies } from "./harness";
+import { createInboundMessage } from "@interchange/mime";
 
 import type {
   ReactorDirector,
@@ -157,23 +158,16 @@ function waitForEvent(
   });
 }
 
-// Simple inbound message factory.
+// Simple inbound message factory. Delegates to the mail-builder so the
+// reactor tests exercise the same shape consumers of @interchange/mime
+// produce in production code.
 function makeInboundMessage(correlationId?: string): InboundMessage {
-  return {
-    ref: { uid: 1, mailbox: "INBOX" },
-    headers: {
-      from: "test@example.com",
-      to: ["agent@example.com"],
-      date: new Date().toISOString(),
-      messageId: `msg-${Math.random()}`,
-      ...(correlationId !== undefined
-        ? { interchangeCorrelationId: correlationId }
-        : {}),
-    },
-    flags: [],
+  return createInboundMessage({
+    from: "test@example.com",
+    to: "agent@example.com",
     content: "hello",
-    signatureStatus: "missing",
-  };
+    ...(correlationId !== undefined ? { correlationId } : {}),
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/mail-memory/src/fetch.ts
+++ b/packages/mail-memory/src/fetch.ts
@@ -9,6 +9,7 @@ import type {
   CryptoProvider,
   MessageRef,
 } from "@interchange/types/runtime";
+import { InterchangeType } from "@interchange/types/runtime";
 import type { MailboxStore } from "./mailbox";
 import { requireMessage } from "./mailbox";
 import {
@@ -22,26 +23,7 @@ import { buildMessageHeaders } from "./headers";
 import { verifyDetachedSignature } from "@interchange/crypto-node";
 
 const MessagePayload = type({
-  type: type.enumerated(
-    "conversation.message",
-    "conversation.join",
-    "conversation.leave",
-    "offering.request",
-    "offering.response",
-    "offering.error",
-    "offering.discover",
-    "offering.catalog",
-    "payment.required",
-    "payment.receipt",
-    "payment.verified",
-    "approval.request",
-    "approval.granted",
-    "approval.denied",
-    "system.health",
-    "system.register",
-    "system.deregister",
-    "system.credential.refresh",
-  ),
+  type: InterchangeType,
   version: "string",
   body: "Record<string, unknown>",
 });

--- a/packages/mail-memory/src/headers.ts
+++ b/packages/mail-memory/src/headers.ts
@@ -1,31 +1,9 @@
-import type {
-  MessageHeaders,
-  InterchangeType,
-} from "@interchange/types/runtime";
-
-const INTERCHANGE_TYPES = new Set<string>([
-  "conversation.message",
-  "conversation.join",
-  "conversation.leave",
-  "offering.request",
-  "offering.response",
-  "offering.error",
-  "offering.discover",
-  "offering.catalog",
-  "payment.required",
-  "payment.receipt",
-  "payment.verified",
-  "approval.request",
-  "approval.granted",
-  "approval.denied",
-  "system.health",
-  "system.register",
-  "system.deregister",
-  "system.credential.refresh",
-]);
+import { type } from "arktype";
+import type { MessageHeaders } from "@interchange/types/runtime";
+import { InterchangeType } from "@interchange/types/runtime";
 
 function isInterchangeType(s: string): s is InterchangeType {
-  return INTERCHANGE_TYPES.has(s);
+  return !(InterchangeType(s) instanceof type.errors);
 }
 
 /**

--- a/packages/mime/package.json
+++ b/packages/mime/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@interchange/crypto-node": "workspace:*",
-    "@interchange/types": "workspace:*"
+    "@interchange/types": "workspace:*",
+    "arktype": "catalog:"
   }
 }

--- a/packages/mime/src/index.ts
+++ b/packages/mime/src/index.ts
@@ -26,3 +26,11 @@ export type {
 } from "./mime";
 
 export { createDetachedSignatureFromProvider } from "./pgp-sign";
+
+export { createInboundMessage, createOutboundMessage } from "./mail-builder";
+
+export type {
+  CreateInboundMessageOpts,
+  CreateOutboundMessageOpts,
+  InboundPayloadInput,
+} from "./mail-builder";

--- a/packages/mime/src/mail-builder.test.ts
+++ b/packages/mime/src/mail-builder.test.ts
@@ -1,0 +1,740 @@
+import { describe, test, expect } from "bun:test";
+import type {
+  InboundMessage,
+  MessageAttachment,
+  OutboundMessage,
+} from "@interchange/types/runtime";
+
+import { createInboundMessage, createOutboundMessage } from "./mail-builder";
+import type {
+  CreateInboundMessageOpts,
+  CreateOutboundMessageOpts,
+} from "./mail-builder";
+
+const FROM = "alice@example.com";
+const TO = "agent@example.com";
+
+// Test-only escape hatches. The builders' types reject obviously invalid
+// inputs at compile time, but the defensive validation also has to surface
+// errors when callers bypass the type system (e.g. data deserialised from
+// unknown JSON). These helpers route around the type checker so the
+// runtime guards can be exercised directly.
+function callInboundUnsafe(opts: unknown): unknown {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- exercise runtime validation against type-violating input
+  return createInboundMessage(opts as CreateInboundMessageOpts);
+}
+function callOutboundUnsafe(opts: unknown): unknown {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- exercise runtime validation against type-violating input
+  return createOutboundMessage(opts as CreateOutboundMessageOpts);
+}
+
+describe("createInboundMessage", () => {
+  test("conversation content with default ref/flags/signatureStatus", () => {
+    const msg = createInboundMessage({ from: FROM, to: TO, content: "hi" });
+
+    expect(msg.ref).toEqual({ uid: 1, mailbox: "INBOX" });
+    expect(msg.flags).toEqual([]);
+    expect(msg.signatureStatus).toBe("missing");
+    expect(msg.content).toBe("hi");
+    expect(msg.payload).toBeUndefined();
+    expect(msg.attachments).toBeUndefined();
+    expect(msg.headers.from).toBe(FROM);
+    expect(msg.headers.to).toEqual([TO]);
+    expect(msg.headers.interchangeType).toBeUndefined();
+  });
+
+  test("auto-generated messageId derives domain from `from`", () => {
+    const msg = createInboundMessage({ from: FROM, to: TO, content: "hi" });
+    expect(msg.headers.messageId).toMatch(/^<[^<>\s]+@example\.com>$/);
+  });
+
+  test("auto-generated date is a parseable ISO string", () => {
+    const msg = createInboundMessage({ from: FROM, to: TO, content: "hi" });
+    const parsed = new Date(msg.headers.date);
+    expect(Number.isNaN(parsed.getTime())).toBe(false);
+    expect(msg.headers.date).toBe(parsed.toISOString());
+  });
+
+  test("structured payload sets interchangeType header automatically", () => {
+    const msg = createInboundMessage({
+      from: FROM,
+      to: TO,
+      payload: {
+        type: "offering.request",
+        body: { offeringId: "code-review", parameters: {} },
+      },
+    });
+
+    expect(msg.payload).toEqual({
+      type: "offering.request",
+      version: "1",
+      body: { offeringId: "code-review", parameters: {} },
+    });
+    expect(msg.headers.interchangeType).toBe("offering.request");
+    expect(msg.content).toBeUndefined();
+  });
+
+  test("payload.version override is preserved", () => {
+    const msg = createInboundMessage({
+      from: FROM,
+      to: TO,
+      payload: {
+        type: "payment.required",
+        version: "2",
+        body: { amount: "0.50" },
+      },
+    });
+    expect(msg.payload?.version).toBe("2");
+  });
+
+  test("attachments are passed through when non-empty", () => {
+    const attachments: MessageAttachment[] = [
+      {
+        name: "report.pdf",
+        contentType: "application/pdf",
+        data: new Uint8Array([1, 2, 3]),
+      },
+    ];
+    const msg = createInboundMessage({
+      from: FROM,
+      to: TO,
+      content: "see attached",
+      attachments,
+    });
+    expect(msg.attachments).toEqual(attachments);
+  });
+
+  test("threading headers are wired through", () => {
+    const msg = createInboundMessage({
+      from: FROM,
+      to: TO,
+      content: "reply",
+      inReplyTo: "<original@example.com>",
+      references: ["<one@example.com>", "<two@example.com>"],
+      correlationId: "corr-123",
+    });
+
+    expect(msg.headers.inReplyTo).toBe("<original@example.com>");
+    expect(msg.headers.references).toEqual([
+      "<one@example.com>",
+      "<two@example.com>",
+    ]);
+    expect(msg.headers.interchangeCorrelationId).toBe("corr-123");
+  });
+
+  test("all interchange identity headers map through", () => {
+    const msg = createInboundMessage({
+      from: FROM,
+      to: TO,
+      content: "hi",
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      sessionId: "session-1",
+      offeringId: "offering-1",
+      schemaVersion: "1",
+      traceparent: "00-trace-span-01",
+      tracestate: "vendor=foo",
+      listId: "list-1",
+    });
+
+    expect(msg.headers.interchangeTenantId).toBe("tenant-1");
+    expect(msg.headers.interchangeAgentId).toBe("agent-1");
+    expect(msg.headers.interchangeSessionId).toBe("session-1");
+    expect(msg.headers.interchangeOfferingId).toBe("offering-1");
+    expect(msg.headers.interchangeSchemaVersion).toBe("1");
+    expect(msg.headers.traceparent).toBe("00-trace-span-01");
+    expect(msg.headers.tracestate).toBe("vendor=foo");
+    expect(msg.headers.listId).toBe("list-1");
+  });
+
+  test("ref override merges with synthetic defaults", () => {
+    const a = createInboundMessage({
+      from: FROM,
+      to: TO,
+      content: "x",
+      ref: { uid: 42 },
+    });
+    expect(a.ref).toEqual({ uid: 42, mailbox: "INBOX" });
+
+    const b = createInboundMessage({
+      from: FROM,
+      to: TO,
+      content: "x",
+      ref: { mailbox: "Trash" },
+    });
+    expect(b.ref).toEqual({ uid: 1, mailbox: "Trash" });
+  });
+
+  test("Date input is normalised to an ISO string", () => {
+    const fixed = new Date("2026-01-02T03:04:05.000Z");
+    const msg = createInboundMessage({
+      from: FROM,
+      to: TO,
+      content: "x",
+      date: fixed,
+    });
+    expect(msg.headers.date).toBe("2026-01-02T03:04:05.000Z");
+  });
+
+  test("flags and signatureStatus overrides are respected", () => {
+    const msg = createInboundMessage({
+      from: FROM,
+      to: TO,
+      content: "x",
+      flags: ["\\Seen"],
+      signatureStatus: "valid",
+    });
+    expect(msg.flags).toEqual(["\\Seen"]);
+    expect(msg.signatureStatus).toBe("valid");
+  });
+
+  test("cc accepts a string and normalises to an array", () => {
+    const msg = createInboundMessage({
+      from: FROM,
+      to: TO,
+      content: "x",
+      cc: "watcher@example.com",
+    });
+    expect(msg.headers.cc).toEqual(["watcher@example.com"]);
+  });
+
+  test("control-frame (no content, no payload) is allowed", () => {
+    const msg = createInboundMessage({ from: FROM, to: TO });
+    expect(msg.content).toBeUndefined();
+    expect(msg.payload).toBeUndefined();
+    expect(msg.flags).toEqual([]);
+  });
+
+  test("explicit interchangeType is allowed for content-only messages", () => {
+    const msg = createInboundMessage({
+      from: FROM,
+      to: TO,
+      content: "join",
+      interchangeType: "conversation.join",
+    });
+    expect(msg.headers.interchangeType).toBe("conversation.join");
+  });
+
+  describe("validation", () => {
+    test("throws when both content and payload are set", () => {
+      expect(() =>
+        createInboundMessage({
+          from: FROM,
+          to: TO,
+          content: "x",
+          payload: { type: "offering.request", body: {} },
+        }),
+      ).toThrow(/`content` and `payload` are mutually exclusive/);
+    });
+
+    test("throws when from is empty", () => {
+      expect(() =>
+        createInboundMessage({ from: "", to: TO, content: "x" }),
+      ).toThrow(/`from` must be a non-empty string/);
+    });
+
+    test("throws when to is an empty array", () => {
+      expect(() =>
+        createInboundMessage({ from: FROM, to: [], content: "x" }),
+      ).toThrow(/`to` must contain at least one recipient address/);
+    });
+
+    test("throws when to contains an empty string", () => {
+      expect(() =>
+        createInboundMessage({ from: FROM, to: [""], content: "x" }),
+      ).toThrow(/`to\[0\]` must be a non-empty string/);
+    });
+
+    test("throws when payload.type is not a known InterchangeType", () => {
+      expect(() =>
+        callInboundUnsafe({
+          from: FROM,
+          to: TO,
+          payload: {
+            type: "not.a.real.type",
+            body: {},
+          },
+        }),
+      ).toThrow(/`payload.type` is not a valid InterchangeType/);
+    });
+
+    test("throws when interchangeType conflicts with payload.type", () => {
+      expect(() =>
+        createInboundMessage({
+          from: FROM,
+          to: TO,
+          payload: { type: "offering.request", body: {} },
+          interchangeType: "payment.required",
+        }),
+      ).toThrow(
+        /`interchangeType` \(payment\.required\) conflicts with `payload\.type` \(offering\.request\)/,
+      );
+    });
+
+    test("throws when messageId lacks angle brackets", () => {
+      expect(() =>
+        createInboundMessage({
+          from: FROM,
+          to: TO,
+          content: "x",
+          messageId: "missing-brackets@example.com",
+        }),
+      ).toThrow(/`messageId` must be an RFC 2822 message identifier/);
+    });
+
+    test("throws when inReplyTo lacks angle brackets", () => {
+      expect(() =>
+        createInboundMessage({
+          from: FROM,
+          to: TO,
+          content: "x",
+          inReplyTo: "bare",
+        }),
+      ).toThrow(/`inReplyTo` must be an RFC 2822 message identifier/);
+    });
+
+    test("throws when references contains a malformed entry", () => {
+      expect(() =>
+        createInboundMessage({
+          from: FROM,
+          to: TO,
+          content: "x",
+          references: ["<one@example.com>", "bad"],
+        }),
+      ).toThrow(/`references\[1\]` must be an RFC 2822 message identifier/);
+    });
+
+    test("throws when references is an empty array", () => {
+      expect(() =>
+        createInboundMessage({
+          from: FROM,
+          to: TO,
+          content: "x",
+          references: [],
+        }),
+      ).toThrow(/`references`, when provided, must contain at least one entry/);
+    });
+
+    test("throws when date string is not parseable", () => {
+      expect(() =>
+        createInboundMessage({
+          from: FROM,
+          to: TO,
+          content: "x",
+          date: "not-a-date",
+        }),
+      ).toThrow(/`date` is not a parseable date string/);
+    });
+
+    test("throws when date is an Invalid Date instance", () => {
+      expect(() =>
+        createInboundMessage({
+          from: FROM,
+          to: TO,
+          content: "x",
+          date: new Date("nope"),
+        }),
+      ).toThrow(/`date` is an Invalid Date/);
+    });
+
+    test("throws when optional string fields are empty", () => {
+      expect(() =>
+        createInboundMessage({
+          from: FROM,
+          to: TO,
+          content: "x",
+          correlationId: "",
+        }),
+      ).toThrow(/`correlationId`, when provided, must be a non-empty string/);
+    });
+
+    test("throws when flags contains an empty string", () => {
+      expect(() =>
+        createInboundMessage({
+          from: FROM,
+          to: TO,
+          content: "x",
+          flags: ["\\Seen", ""],
+        }),
+      ).toThrow(/`flags\[1\]` must be a non-empty string/);
+    });
+
+    test("throws when ref.mailbox is empty", () => {
+      expect(() =>
+        createInboundMessage({
+          from: FROM,
+          to: TO,
+          content: "x",
+          ref: { mailbox: "" },
+        }),
+      ).toThrow(/`ref\.mailbox`.*must be a non-empty string/);
+    });
+
+    test("throws when from lacks an @ domain", () => {
+      expect(() =>
+        createInboundMessage({
+          from: "alice",
+          to: TO,
+          content: "x",
+        }),
+      ).toThrow(/`from` must be an RFC 5322 address/);
+    });
+
+    test("throws when a `to` entry lacks an @ domain", () => {
+      expect(() =>
+        createInboundMessage({
+          from: FROM,
+          to: ["agent@example.com", "loose-string"],
+          content: "x",
+        }),
+      ).toThrow(/`to\[1\]` must be an RFC 5322 address/);
+    });
+
+    test("throws when messageId has angle brackets but no @ host", () => {
+      expect(() =>
+        createInboundMessage({
+          from: FROM,
+          to: TO,
+          content: "x",
+          messageId: "<no-at-sign>",
+        }),
+      ).toThrow(/`messageId` must be an RFC 2822 message identifier/);
+    });
+
+    test("throws when payload.type is a conversation type", () => {
+      expect(() =>
+        createInboundMessage({
+          from: FROM,
+          to: TO,
+          payload: { type: "conversation.message", body: {} },
+        }),
+      ).toThrow(/conversation types must use `content` instead of `payload`/);
+    });
+
+    test("throws when payload.body is null", () => {
+      expect(() =>
+        callInboundUnsafe({
+          from: FROM,
+          to: TO,
+          payload: { type: "offering.request", body: null },
+        }),
+      ).toThrow(/`payload\.body` must be a plain object/);
+    });
+
+    test("throws when payload.body is an array", () => {
+      expect(() =>
+        callInboundUnsafe({
+          from: FROM,
+          to: TO,
+          payload: { type: "offering.request", body: [] },
+        }),
+      ).toThrow(/`payload\.body` must be a plain object/);
+    });
+
+    test("throws when payload.version is not a string", () => {
+      expect(() =>
+        callInboundUnsafe({
+          from: FROM,
+          to: TO,
+          payload: { type: "offering.request", body: {}, version: 7 },
+        }),
+      ).toThrow(/`payload\.version`.*must be a non-empty string/);
+    });
+
+    test("throws when ref.uid is not an integer", () => {
+      expect(() =>
+        callInboundUnsafe({
+          from: FROM,
+          to: TO,
+          content: "x",
+          ref: { uid: "not-a-number" },
+        }),
+      ).toThrow(/`ref\.uid`.*must be a positive integer/);
+    });
+
+    test("throws when content is the empty string", () => {
+      expect(() =>
+        createInboundMessage({ from: FROM, to: TO, content: "" }),
+      ).toThrow(/`content`, when provided, must be a non-empty string/);
+    });
+
+    test("throws when signatureStatus is not a recognised value", () => {
+      expect(() =>
+        callInboundUnsafe({
+          from: FROM,
+          to: TO,
+          content: "x",
+          signatureStatus: "bogus",
+        }),
+      ).toThrow(/`signatureStatus` is not a recognised SignatureStatus/);
+    });
+
+    test("throws when ref.uid is zero", () => {
+      expect(() =>
+        createInboundMessage({
+          from: FROM,
+          to: TO,
+          content: "x",
+          ref: { uid: 0 },
+        }),
+      ).toThrow(/`ref\.uid`.*must be a positive integer/);
+    });
+  });
+});
+
+describe("createOutboundMessage", () => {
+  test("conversation content with required fields", () => {
+    const msg = createOutboundMessage({
+      to: TO,
+      type: "conversation.message",
+      content: "hi",
+    });
+    expect(msg).toEqual({
+      to: TO,
+      type: "conversation.message",
+      content: "hi",
+    });
+  });
+
+  test("structured payload with summary and attachments", () => {
+    const attachments: MessageAttachment[] = [
+      {
+        name: "x.bin",
+        contentType: "application/octet-stream",
+        data: new Uint8Array([0]),
+      },
+    ];
+    const msg = createOutboundMessage({
+      to: TO,
+      type: "offering.request",
+      payload: { offeringId: "code-review", parameters: {} },
+      summary: "Code review request",
+      attachments,
+    });
+    expect(msg.type).toBe("offering.request");
+    expect(msg.payload).toEqual({ offeringId: "code-review", parameters: {} });
+    expect(msg.summary).toBe("Code review request");
+    expect(msg.attachments).toEqual(attachments);
+    expect(msg.content).toBeUndefined();
+  });
+
+  test("to/cc are passed through without normalisation", () => {
+    const single = createOutboundMessage({
+      to: "single@example.com",
+      type: "conversation.message",
+      content: "hi",
+      cc: "watcher@example.com",
+    });
+    expect(single.to).toBe("single@example.com");
+    expect(single.cc).toBe("watcher@example.com");
+
+    const many = createOutboundMessage({
+      to: ["a@example.com", "b@example.com"],
+      type: "conversation.message",
+      content: "hi",
+      cc: ["c@example.com"],
+    });
+    expect(many.to).toEqual(["a@example.com", "b@example.com"]);
+    expect(many.cc).toEqual(["c@example.com"]);
+  });
+
+  test("threading fields are wired through", () => {
+    const msg = createOutboundMessage({
+      to: TO,
+      type: "approval.granted",
+      payload: { decision: "approved" },
+      inReplyTo: "<request@example.com>",
+      correlationId: "corr-abc",
+      sessionId: "session-1",
+      tenantId: "tenant-1",
+    });
+    expect(msg.inReplyTo).toBe("<request@example.com>");
+    expect(msg.correlationId).toBe("corr-abc");
+    expect(msg.sessionId).toBe("session-1");
+    expect(msg.tenantId).toBe("tenant-1");
+  });
+
+  describe("validation", () => {
+    test("throws when type is invalid", () => {
+      expect(() =>
+        callOutboundUnsafe({
+          to: TO,
+          type: "not.real",
+          content: "x",
+        }),
+      ).toThrow(/`type` is not a valid InterchangeType/);
+    });
+
+    test("throws when content and payload are both set", () => {
+      expect(() =>
+        createOutboundMessage({
+          to: TO,
+          type: "offering.request",
+          content: "x",
+          payload: { offeringId: "x" },
+        }),
+      ).toThrow(/`content` and `payload` are mutually exclusive/);
+    });
+
+    test("throws when to is empty string", () => {
+      expect(() =>
+        createOutboundMessage({
+          to: "",
+          type: "conversation.message",
+          content: "x",
+        }),
+      ).toThrow(/`to` must be a non-empty string/);
+    });
+
+    test("throws when to is empty array", () => {
+      expect(() =>
+        createOutboundMessage({
+          to: [],
+          type: "conversation.message",
+          content: "x",
+        }),
+      ).toThrow(/`to` must contain at least one recipient address/);
+    });
+
+    test("throws when to array has empty entry", () => {
+      expect(() =>
+        createOutboundMessage({
+          to: ["valid@example.com", ""],
+          type: "conversation.message",
+          content: "x",
+        }),
+      ).toThrow(/`to\[1\]` must be a non-empty string/);
+    });
+
+    test("throws when cc array has empty entry", () => {
+      expect(() =>
+        createOutboundMessage({
+          to: TO,
+          type: "conversation.message",
+          content: "x",
+          cc: [""],
+        }),
+      ).toThrow(/`cc\[0\]` must be a non-empty string/);
+    });
+
+    test("throws when inReplyTo lacks angle brackets", () => {
+      expect(() =>
+        createOutboundMessage({
+          to: TO,
+          type: "conversation.message",
+          content: "x",
+          inReplyTo: "bare-id",
+        }),
+      ).toThrow(/`inReplyTo` must be an RFC 2822 message identifier/);
+    });
+
+    test("throws when summary is empty", () => {
+      expect(() =>
+        createOutboundMessage({
+          to: TO,
+          type: "offering.request",
+          payload: { x: 1 },
+          summary: "",
+        }),
+      ).toThrow(/`summary`, when provided, must be a non-empty string/);
+    });
+
+    test("throws when type is conversation.* with payload", () => {
+      expect(() =>
+        createOutboundMessage({
+          to: TO,
+          type: "conversation.message",
+          payload: { x: 1 },
+        }),
+      ).toThrow(
+        /conversation `type` conversation\.message must use `content` instead of `payload`/,
+      );
+    });
+
+    test("throws when type is non-conversation with content", () => {
+      expect(() =>
+        createOutboundMessage({
+          to: TO,
+          type: "offering.request",
+          content: "hi",
+        }),
+      ).toThrow(
+        /non-conversation `type` offering\.request must use `payload` instead of `content`/,
+      );
+    });
+
+    test("throws when payload is null", () => {
+      expect(() =>
+        callOutboundUnsafe({
+          to: TO,
+          type: "offering.request",
+          payload: null,
+        }),
+      ).toThrow(/`payload` must be a plain object/);
+    });
+
+    test("throws when payload is an array", () => {
+      expect(() =>
+        callOutboundUnsafe({
+          to: TO,
+          type: "offering.request",
+          payload: [1, 2, 3],
+        }),
+      ).toThrow(/`payload` must be a plain object/);
+    });
+
+    test("throws when content is the empty string", () => {
+      expect(() =>
+        createOutboundMessage({
+          to: TO,
+          type: "conversation.message",
+          content: "",
+        }),
+      ).toThrow(/`content`, when provided, must be a non-empty string/);
+    });
+
+    test("throws when conversation type is missing content", () => {
+      expect(() =>
+        createOutboundMessage({
+          to: TO,
+          type: "conversation.message",
+        }),
+      ).toThrow(/conversation `type` conversation\.message requires `content`/);
+    });
+
+    test("throws when non-conversation type is missing payload", () => {
+      expect(() =>
+        createOutboundMessage({
+          to: TO,
+          type: "offering.request",
+        }),
+      ).toThrow(/non-conversation `type` offering\.request requires `payload`/);
+    });
+
+    test("throws when a to entry lacks an @ domain", () => {
+      expect(() =>
+        createOutboundMessage({
+          to: ["agent@example.com", "loose-string"],
+          type: "conversation.message",
+          content: "x",
+        }),
+      ).toThrow(/`to\[1\]` must be an RFC 5322 address/);
+    });
+  });
+});
+
+// Compile-time guards: the public return types of the builders match
+// InboundMessage / OutboundMessage exactly. Variables are unused at runtime;
+// referenced via the `_` prefix to satisfy lint.
+const _inbound: InboundMessage = createInboundMessage({
+  from: FROM,
+  to: TO,
+  content: "x",
+});
+const _outbound: OutboundMessage = createOutboundMessage({
+  to: TO,
+  type: "conversation.message",
+  content: "x",
+});
+void _inbound;
+void _outbound;

--- a/packages/mime/src/mail-builder.ts
+++ b/packages/mime/src/mail-builder.ts
@@ -1,0 +1,492 @@
+/**
+ * Builders for InboundMessage and OutboundMessage shapes.
+ *
+ * Constructing these by hand requires assembling MessageRef, MessageHeaders,
+ * payload envelopes, signature status, and other mail-shaped fields that the
+ * transport normally produces after parsing wire bytes. These builders
+ * collapse that boilerplate behind two factories with sensible defaults.
+ *
+ * The builders use the parsed-shape MessageHeaders from
+ * @interchange/types/runtime (where date is an ISO string), NOT the
+ * wire-shape MessageHeaders local to this package (where date is a Date
+ * object and headers are serialised to RFC 2822 bytes via assembleMessage).
+ *
+ * Consumers import the message types from @interchange/types directly; the
+ * @interchange/mime barrel does not re-export them.
+ */
+
+import { type } from "arktype";
+import type {
+  InboundMessage,
+  MessageAttachment,
+  MessageHeaders,
+  MessageRef,
+  OutboundMessage,
+} from "@interchange/types/runtime";
+import { InterchangeType, SignatureStatus } from "@interchange/types/runtime";
+import { generateMessageId } from "./mime";
+
+/**
+ * Default schema version for structured payloads. Matches
+ * docs/MESSAGE.md § Payload Structure, which specifies "version": "1" as
+ * the current schema version for every Interchange payload type. Audit
+ * this default whenever the documented schema version increments.
+ */
+const DEFAULT_PAYLOAD_VERSION = "1";
+
+const MESSAGE_ID_RE = /^<[^<>\s@]+@[^<>\s@]+>$/;
+const ADDRESS_RE = /^[^@\s]+@[^@\s]+$/;
+
+const CONVERSATION_TYPE_PREFIX = "conversation.";
+
+// ---------------------------------------------------------------------------
+// InboundMessage builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Structured payload envelope for an inbound message. `version` defaults to
+ * the current schema version per docs/MESSAGE.md.
+ */
+export type InboundPayloadInput = {
+  type: InterchangeType;
+  body: Record<string, unknown>;
+  version?: string;
+};
+
+export type CreateInboundMessageOpts = {
+  from: string;
+  to: string | string[];
+
+  /** Plain-text body. Mutually exclusive with `payload`. */
+  content?: string;
+
+  /** Structured JSON envelope. Mutually exclusive with `content`. */
+  payload?: InboundPayloadInput;
+
+  cc?: string | string[];
+  subject?: string;
+
+  /**
+   * Defaults to `new Date().toISOString()`. Accepts Date or any string
+   * parseable by `new Date(...)`; stored as an ISO 8601 string.
+   */
+  date?: Date | string;
+
+  /** Defaults to `generateMessageId(from)`. Must be of the form `<id@host>`. */
+  messageId?: string;
+
+  inReplyTo?: string;
+  references?: string[];
+  listId?: string;
+
+  /**
+   * Interchange-Type header value. Auto-derived from `payload.type` when a
+   * payload is supplied; throws if explicitly set to a value that conflicts
+   * with `payload.type`.
+   */
+  interchangeType?: InterchangeType;
+
+  correlationId?: string;
+  tenantId?: string;
+  agentId?: string;
+  sessionId?: string;
+  offeringId?: string;
+  schemaVersion?: string;
+  traceparent?: string;
+  tracestate?: string;
+
+  attachments?: MessageAttachment[];
+
+  /** Merged with `{ uid: 1, mailbox: "INBOX" }`. */
+  ref?: Partial<MessageRef>;
+
+  flags?: string[];
+
+  /** Defaults to `"missing"`. */
+  signatureStatus?: SignatureStatus;
+};
+
+export function createInboundMessage(
+  opts: CreateInboundMessageOpts,
+): InboundMessage {
+  const fn = "createInboundMessage";
+
+  requireAddress(opts.from, "from", fn);
+  const to = normalizeAndValidateAddressArray(opts.to, "to", fn);
+
+  validateBodyExclusivity(opts.content, opts.payload, fn);
+
+  if (opts.payload !== undefined) {
+    validateInterchangeType(opts.payload.type, "payload.type", fn);
+    if (isConversationType(opts.payload.type)) {
+      throw new Error(
+        `${fn}: conversation types must use \`content\` instead of \`payload\`; got \`payload.type\`: ${opts.payload.type}`,
+      );
+    }
+    validatePayloadBody(opts.payload.body, "payload.body", fn);
+    if (opts.payload.version !== undefined) {
+      if (
+        typeof opts.payload.version !== "string" ||
+        opts.payload.version.length === 0
+      ) {
+        throw new Error(
+          `${fn}: \`payload.version\`, when provided, must be a non-empty string`,
+        );
+      }
+    }
+  }
+
+  if (opts.interchangeType !== undefined) {
+    validateInterchangeType(opts.interchangeType, "interchangeType", fn);
+    if (
+      opts.payload !== undefined &&
+      opts.interchangeType !== opts.payload.type
+    ) {
+      throw new Error(
+        `${fn}: \`interchangeType\` (${opts.interchangeType}) conflicts with \`payload.type\` (${opts.payload.type})`,
+      );
+    }
+  }
+
+  if (opts.messageId !== undefined) {
+    validateMessageId(opts.messageId, "messageId", fn);
+  }
+  if (opts.inReplyTo !== undefined) {
+    validateMessageId(opts.inReplyTo, "inReplyTo", fn);
+  }
+  if (opts.references !== undefined) {
+    if (opts.references.length === 0) {
+      throw new Error(
+        `${fn}: \`references\`, when provided, must contain at least one entry`,
+      );
+    }
+    opts.references.forEach((ref, i) => {
+      validateMessageId(ref, `references[${i}]`, fn);
+    });
+  }
+
+  const cc =
+    opts.cc === undefined
+      ? undefined
+      : normalizeAndValidateAddressArray(opts.cc, "cc", fn);
+
+  rejectEmptyStringIfPresent(opts.content, "content", fn);
+  rejectEmptyStringIfPresent(opts.subject, "subject", fn);
+  rejectEmptyStringIfPresent(opts.listId, "listId", fn);
+  rejectEmptyStringIfPresent(opts.correlationId, "correlationId", fn);
+  rejectEmptyStringIfPresent(opts.tenantId, "tenantId", fn);
+  rejectEmptyStringIfPresent(opts.agentId, "agentId", fn);
+  rejectEmptyStringIfPresent(opts.sessionId, "sessionId", fn);
+  rejectEmptyStringIfPresent(opts.offeringId, "offeringId", fn);
+  rejectEmptyStringIfPresent(opts.schemaVersion, "schemaVersion", fn);
+  rejectEmptyStringIfPresent(opts.traceparent, "traceparent", fn);
+  rejectEmptyStringIfPresent(opts.tracestate, "tracestate", fn);
+
+  if (opts.flags !== undefined) {
+    opts.flags.forEach((flag, i) => {
+      if (typeof flag !== "string" || flag.length === 0) {
+        throw new Error(`${fn}: \`flags[${i}]\` must be a non-empty string`);
+      }
+    });
+  }
+
+  const signatureStatus = opts.signatureStatus ?? "missing";
+  const validatedStatus = SignatureStatus(signatureStatus);
+  if (validatedStatus instanceof type.errors) {
+    throw new Error(
+      `${fn}: \`signatureStatus\` is not a recognised SignatureStatus: ${validatedStatus.summary}`,
+    );
+  }
+
+  const date = normalizeDate(opts.date, "date", fn);
+  const messageId = opts.messageId ?? generateMessageId(opts.from);
+  const derivedInterchangeType = opts.interchangeType ?? opts.payload?.type;
+
+  const headers: MessageHeaders = { from: opts.from, to, date, messageId };
+  if (cc !== undefined) headers.cc = cc;
+  if (opts.subject !== undefined) headers.subject = opts.subject;
+  if (opts.inReplyTo !== undefined) headers.inReplyTo = opts.inReplyTo;
+  if (opts.references !== undefined) headers.references = opts.references;
+  if (opts.listId !== undefined) headers.listId = opts.listId;
+  if (derivedInterchangeType !== undefined) {
+    headers.interchangeType = derivedInterchangeType;
+  }
+  if (opts.correlationId !== undefined) {
+    headers.interchangeCorrelationId = opts.correlationId;
+  }
+  if (opts.tenantId !== undefined) headers.interchangeTenantId = opts.tenantId;
+  if (opts.agentId !== undefined) headers.interchangeAgentId = opts.agentId;
+  if (opts.sessionId !== undefined) {
+    headers.interchangeSessionId = opts.sessionId;
+  }
+  if (opts.offeringId !== undefined) {
+    headers.interchangeOfferingId = opts.offeringId;
+  }
+  if (opts.schemaVersion !== undefined) {
+    headers.interchangeSchemaVersion = opts.schemaVersion;
+  }
+  if (opts.traceparent !== undefined) headers.traceparent = opts.traceparent;
+  if (opts.tracestate !== undefined) headers.tracestate = opts.tracestate;
+
+  if (opts.ref?.uid !== undefined) {
+    if (
+      typeof opts.ref.uid !== "number" ||
+      !Number.isInteger(opts.ref.uid) ||
+      !Number.isFinite(opts.ref.uid) ||
+      opts.ref.uid < 1
+    ) {
+      throw new Error(
+        `${fn}: \`ref.uid\`, when provided, must be a positive integer (IMAP UID)`,
+      );
+    }
+  }
+  const ref: MessageRef = {
+    uid: opts.ref?.uid ?? 1,
+    mailbox: opts.ref?.mailbox ?? "INBOX",
+  };
+  if (typeof ref.mailbox !== "string" || ref.mailbox.length === 0) {
+    throw new Error(
+      `${fn}: \`ref.mailbox\`, when provided, must be a non-empty string`,
+    );
+  }
+
+  const result: InboundMessage = {
+    ref,
+    headers,
+    flags: opts.flags ?? [],
+    signatureStatus,
+  };
+  if (opts.content !== undefined) result.content = opts.content;
+  if (opts.payload !== undefined) {
+    result.payload = {
+      type: opts.payload.type,
+      version: opts.payload.version ?? DEFAULT_PAYLOAD_VERSION,
+      body: opts.payload.body,
+    };
+  }
+  if (opts.attachments !== undefined && opts.attachments.length > 0) {
+    result.attachments = opts.attachments;
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// OutboundMessage builder
+// ---------------------------------------------------------------------------
+
+export type CreateOutboundMessageOpts = {
+  to: string | string[];
+
+  /** Interchange payload type. Determines content vs payload semantics. */
+  type: InterchangeType;
+
+  /** Plain-text body. Mutually exclusive with `payload`. */
+  content?: string;
+
+  /** Structured JSON envelope body. Mutually exclusive with `content`. */
+  payload?: Record<string, unknown>;
+
+  cc?: string | string[];
+  subject?: string;
+
+  /** Human-readable summary used as the text/plain part for structured types. */
+  summary?: string;
+
+  inReplyTo?: string;
+  correlationId?: string;
+  sessionId?: string;
+  tenantId?: string;
+
+  attachments?: MessageAttachment[];
+};
+
+export function createOutboundMessage(
+  opts: CreateOutboundMessageOpts,
+): OutboundMessage {
+  const fn = "createOutboundMessage";
+
+  validateInterchangeType(opts.type, "type", fn);
+  // Validate addresses without mutating the source shape; the OutboundMessage
+  // type preserves `string | string[]` and downstream consumers handle both.
+  normalizeAndValidateAddressArray(opts.to, "to", fn);
+  if (opts.cc !== undefined) {
+    normalizeAndValidateAddressArray(opts.cc, "cc", fn);
+  }
+
+  validateBodyExclusivity(opts.content, opts.payload, fn);
+
+  if (isConversationType(opts.type)) {
+    if (opts.payload !== undefined) {
+      throw new Error(
+        `${fn}: conversation \`type\` ${opts.type} must use \`content\` instead of \`payload\``,
+      );
+    }
+    if (opts.content === undefined) {
+      throw new Error(
+        `${fn}: conversation \`type\` ${opts.type} requires \`content\``,
+      );
+    }
+  } else {
+    if (opts.content !== undefined) {
+      throw new Error(
+        `${fn}: non-conversation \`type\` ${opts.type} must use \`payload\` instead of \`content\``,
+      );
+    }
+    if (opts.payload === undefined) {
+      throw new Error(
+        `${fn}: non-conversation \`type\` ${opts.type} requires \`payload\``,
+      );
+    }
+  }
+  if (opts.payload !== undefined) {
+    validatePayloadBody(opts.payload, "payload", fn);
+  }
+
+  if (opts.inReplyTo !== undefined) {
+    validateMessageId(opts.inReplyTo, "inReplyTo", fn);
+  }
+  rejectEmptyStringIfPresent(opts.content, "content", fn);
+  rejectEmptyStringIfPresent(opts.subject, "subject", fn);
+  rejectEmptyStringIfPresent(opts.summary, "summary", fn);
+  rejectEmptyStringIfPresent(opts.correlationId, "correlationId", fn);
+  rejectEmptyStringIfPresent(opts.sessionId, "sessionId", fn);
+  rejectEmptyStringIfPresent(opts.tenantId, "tenantId", fn);
+
+  const result: OutboundMessage = { to: opts.to, type: opts.type };
+  if (opts.cc !== undefined) result.cc = opts.cc;
+  if (opts.subject !== undefined) result.subject = opts.subject;
+  if (opts.content !== undefined) result.content = opts.content;
+  if (opts.payload !== undefined) result.payload = opts.payload;
+  if (opts.summary !== undefined) result.summary = opts.summary;
+  if (opts.attachments !== undefined && opts.attachments.length > 0) {
+    result.attachments = opts.attachments;
+  }
+  if (opts.inReplyTo !== undefined) result.inReplyTo = opts.inReplyTo;
+  if (opts.correlationId !== undefined) {
+    result.correlationId = opts.correlationId;
+  }
+  if (opts.sessionId !== undefined) result.sessionId = opts.sessionId;
+  if (opts.tenantId !== undefined) result.tenantId = opts.tenantId;
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+function rejectEmptyStringIfPresent(
+  value: string | undefined,
+  field: string,
+  fn: string,
+): void {
+  if (value !== undefined && value.length === 0) {
+    throw new Error(
+      `${fn}: \`${field}\`, when provided, must be a non-empty string`,
+    );
+  }
+}
+
+function requireAddress(value: unknown, field: string, fn: string): void {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${fn}: \`${field}\` must be a non-empty string`);
+  }
+  if (!ADDRESS_RE.test(value)) {
+    throw new Error(
+      `${fn}: \`${field}\` must be an RFC 5322 address of the form \`local@domain\`; got: ${value}`,
+    );
+  }
+}
+
+function normalizeAndValidateAddressArray(
+  input: string | string[],
+  field: string,
+  fn: string,
+): string[] {
+  if (typeof input === "string") {
+    requireAddress(input, field, fn);
+    return [input];
+  }
+  if (!Array.isArray(input) || input.length === 0) {
+    throw new Error(
+      `${fn}: \`${field}\` must contain at least one recipient address`,
+    );
+  }
+  input.forEach((entry, i) => {
+    requireAddress(entry, `${field}[${i}]`, fn);
+  });
+  return input;
+}
+
+function validatePayloadBody(value: unknown, field: string, fn: string): void {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(
+      `${fn}: \`${field}\` must be a plain object (got ${
+        value === null ? "null" : Array.isArray(value) ? "array" : typeof value
+      })`,
+    );
+  }
+}
+
+function isConversationType(t: InterchangeType): boolean {
+  return t.startsWith(CONVERSATION_TYPE_PREFIX);
+}
+
+function validateInterchangeType(
+  value: unknown,
+  field: string,
+  fn: string,
+): void {
+  const validated = InterchangeType(value);
+  if (validated instanceof type.errors) {
+    throw new Error(
+      `${fn}: \`${field}\` is not a valid InterchangeType: ${validated.summary}`,
+    );
+  }
+}
+
+function validateMessageId(value: string, field: string, fn: string): void {
+  if (!MESSAGE_ID_RE.test(value)) {
+    throw new Error(
+      `${fn}: \`${field}\` must be an RFC 2822 message identifier of the form \`<id@host>\`; got: ${value}`,
+    );
+  }
+}
+
+function normalizeDate(
+  input: Date | string | undefined,
+  field: string,
+  fn: string,
+): string {
+  if (input === undefined) return new Date().toISOString();
+  if (input instanceof Date) {
+    if (Number.isNaN(input.getTime())) {
+      throw new Error(`${fn}: \`${field}\` is an Invalid Date`);
+    }
+    return input.toISOString();
+  }
+  if (typeof input !== "string" || input.length === 0) {
+    throw new Error(
+      `${fn}: \`${field}\`, when provided, must be a Date or a non-empty string`,
+    );
+  }
+  const parsed = new Date(input);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(
+      `${fn}: \`${field}\` is not a parseable date string: ${input}`,
+    );
+  }
+  return parsed.toISOString();
+}
+
+function validateBodyExclusivity(
+  content: unknown,
+  payload: unknown,
+  fn: string,
+): void {
+  if (content !== undefined && payload !== undefined) {
+    throw new Error(
+      `${fn}: \`content\` and \`payload\` are mutually exclusive; provide at most one`,
+    );
+  }
+}

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -91,26 +91,31 @@ export type MessageRef = {
 /**
  * Interchange payload types as defined in MESSAGE.md § Payload Types.
  * The type field in structured messages matches the Interchange-Type header.
+ *
+ * Exposed as both an arktype validator (for runtime validation at parse
+ * boundaries and tool-argument schemas) and a derived TypeScript union.
  */
-export type InterchangeType =
-  | "conversation.message"
-  | "conversation.join"
-  | "conversation.leave"
-  | "offering.request"
-  | "offering.response"
-  | "offering.error"
-  | "offering.discover"
-  | "offering.catalog"
-  | "payment.required"
-  | "payment.receipt"
-  | "payment.verified"
-  | "approval.request"
-  | "approval.granted"
-  | "approval.denied"
-  | "system.health"
-  | "system.register"
-  | "system.deregister"
-  | "system.credential.refresh";
+export const InterchangeType = type.enumerated(
+  "conversation.message",
+  "conversation.join",
+  "conversation.leave",
+  "offering.request",
+  "offering.response",
+  "offering.error",
+  "offering.discover",
+  "offering.catalog",
+  "payment.required",
+  "payment.receipt",
+  "payment.verified",
+  "approval.request",
+  "approval.granted",
+  "approval.denied",
+  "system.health",
+  "system.register",
+  "system.deregister",
+  "system.credential.refresh",
+);
+export type InterchangeType = typeof InterchangeType.infer;
 
 /**
  * Attachment for an outbound message. Content is raw bytes; the transport
@@ -213,7 +218,13 @@ export type MessageHeaders = {
  *
  * (MESSAGE.md § Transport Interface › fetchFull)
  */
-export type SignatureStatus = "valid" | "invalid" | "unknown" | "missing";
+export const SignatureStatus = type.enumerated(
+  "valid",
+  "invalid",
+  "unknown",
+  "missing",
+);
+export type SignatureStatus = typeof SignatureStatus.infer;
 
 /**
  * A parsed MIME part returned by `fetchPart()`.


### PR DESCRIPTION
## Summary

- New `createInboundMessage` / `createOutboundMessage` factories in `@interchange/mime` that produce parsed-shape `InboundMessage` / `OutboundMessage` values from `@interchange/types/runtime` with sensible defaults. Callers no longer assemble `MessageRef`, `MessageHeaders`, payload envelopes, or signature status by hand to deliver `InterchangeType` payloads to a reactor or to set up synthetic test fixtures.
- `InterchangeType` is promoted from a TypeScript union to a shared arktype validator in `@interchange/types/runtime`. The literal list (18 entries) previously lived in four sites; it now lives in one, and the consumers reuse the shared validator.
- The three test-suite `makeInboundMessage` helpers (in `harness.test.ts`, `reactor.test.ts`, `assembly.test.ts`) delegate to `createInboundMessage`. Their signatures are preserved so ~108 existing call sites are unchanged.

## Changes

- `packages/types/src/runtime.ts`: `InterchangeType` is now an arktype `type.enumerated(...)` with the TS union derived from `.infer`.
- `packages/mime/src/mail-builder.ts`: new builders with defensive validation — RFC 5322 addresses, RFC 2822 Message-IDs, content/payload mutual exclusivity, conversation-vs-structured type coherence, plain-object payload bodies, parseable dates, valid `InterchangeType` literals, non-empty optional string fields, positive-integer `ref.uid`.
- `packages/mime/src/mail-builder.test.ts`: 57 unit tests covering all builder shapes (plain content, structured payload, attachments, threading, defaults, overrides) plus the validation paths via two `unknown`-typed escape-hatch helpers that exercise the runtime guards.
- `packages/mime/src/index.ts`: barrel exports the two factories and their input types. Runtime message types stay imported from `@interchange/types` directly per the issue.
- `packages/mime/package.json`: adds `arktype` (runtime validation).
- `packages/mail-memory/src/{fetch,headers}.ts` and `packages/harness/src/tools.ts`: reuse the shared `InterchangeType` validator instead of inline enums.
- `packages/{harness,inference}/package.json`: add `@interchange/mime` as a `devDependencies` workspace dep for the test-helper migration.

## Notes

- The new builders use the parsed-shape `MessageHeaders` from `@interchange/types/runtime` (where `date` is an ISO string). The wire-shape `MessageHeaders` local to `mime.ts` (where `date` is a `Date` and headers are serialised to RFC 2822 bytes via `assembleMessage`) is untouched. The two coexist intentionally; unifying them is out of scope.
- `payload.version` defaults to \`"1"\` per \`docs/MESSAGE.md § Payload Structure\`. Audit this default if the schema version increments.
- The synthetic \`ref\` default of \`{ uid: 1, mailbox: "INBOX" }\` matches the prior ad-hoc fixtures so the call sites work unchanged.

## Testing

- \`make all\`: lint + tsc + 1359 bun tests + 9 sidecar/inference integration tests, all green.
- Test coverage for every builder shape, every validation path, and every error message in \`mail-builder.test.ts\`.

Closes INTR-50