### PR TITLE
Add @interchange/agent and coding-agent example

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -29,8 +29,11 @@ This is a bun monorepo. When developing new TypeScript code:
 
 - **Applications** go in `apps/`
 - **Shared libraries** go in `packages/`
+- **Reference consumers** go in `examples/`
 
 Do not create standalone TypeScript files in the repository root.
+
+`examples/` is for runnable reference consumers that demonstrate how to use a package's public API. Examples are first-class workspace members: they have their own `package.json`, are listed in the root `tsconfig.json` `references` array, and are gated by `make all` (lint, type-check, test) just like packages and apps. They are not throwaway scratch code.
 
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -73,6 +73,17 @@
         "vite": "^6.3.5",
       },
     },
+    "packages/agent": {
+      "name": "@interchange/agent",
+      "version": "0.0.0",
+      "dependencies": {
+        "@interchange/inference": "workspace:*",
+        "@interchange/mime": "workspace:*",
+        "@interchange/storage-isogit": "workspace:*",
+        "@interchange/types": "workspace:*",
+        "arktype": "catalog:",
+      },
+    },
     "packages/authz": {
       "name": "@interchange/authz",
       "version": "0.0.0",
@@ -424,6 +435,8 @@
     "@inquirer/figures": ["@inquirer/figures@1.0.15", "", {}, "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g=="],
 
     "@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
+
+    "@interchange/agent": ["@interchange/agent@workspace:packages/agent"],
 
     "@interchange/authz": ["@interchange/authz@workspace:packages/authz"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -73,6 +73,16 @@
         "vite": "^6.3.5",
       },
     },
+    "examples/coding-agent": {
+      "name": "@interchange/example-coding-agent",
+      "version": "0.0.0",
+      "dependencies": {
+        "@interchange/agent": "workspace:*",
+        "@interchange/tools-lsp": "workspace:*",
+        "@interchange/tools-posix": "workspace:*",
+        "@interchange/types": "workspace:*",
+      },
+    },
     "packages/agent": {
       "name": "@interchange/agent",
       "version": "0.0.0",
@@ -444,6 +454,8 @@
     "@interchange/crypto-node": ["@interchange/crypto-node@workspace:packages/crypto-node"],
 
     "@interchange/db": ["@interchange/db@workspace:packages/db"],
+
+    "@interchange/example-coding-agent": ["@interchange/example-coding-agent@workspace:examples/coding-agent"],
 
     "@interchange/harness": ["@interchange/harness@workspace:packages/harness"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -77,6 +77,7 @@
       "name": "@interchange/agent",
       "version": "0.0.0",
       "dependencies": {
+        "@interchange/harness": "workspace:*",
         "@interchange/inference": "workspace:*",
         "@interchange/mime": "workspace:*",
         "@interchange/storage-isogit": "workspace:*",

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -54,6 +54,7 @@ export default defineConfig(
             "tests/sidecar/*.ts",
             "tests/inference-testing/*.ts",
             "tests/inference/transform-cutover.test.ts",
+            "tests/agent/*.ts",
           ],
           maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 16,
         },

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -55,6 +55,7 @@ export default defineConfig(
             "tests/inference-testing/*.ts",
             "tests/inference/transform-cutover.test.ts",
             "tests/agent/*.ts",
+            "tests/coding-agent/*.ts",
           ],
           maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 16,
         },

--- a/examples/coding-agent/README.md
+++ b/examples/coding-agent/README.md
@@ -1,0 +1,46 @@
+# coding-agent example
+
+A reference consumer of `@interchange/agent`. Wires the agent against
+`@interchange/tools-posix` (read/write/edit files, run shell, grep, search)
+and `@interchange/tools-lsp` (language-server diagnostics) so the model can
+read files, write files, and reason about the codebase it is operating on.
+
+This example exists to demonstrate the public surface of `@interchange/agent`
+end-to-end. Treat it as documentation that compiles.
+
+## What it shows
+
+- Constructing an agent via `createAgent` with a real `contextDir`.
+- Bridging an existing `ToolRunner` (the bundle returned by
+  `createPosixTools` with the LSP plugin attached) into the agent via
+  `fromToolRunner`.
+- A single-shot `send()` that returns the model's reply.
+- Persistent history: re-running the example against the same `contextDir`
+  picks up where the previous run left off — this is the resume-from-crash
+  story. There is nothing to opt into; the agent commits each cycle to git
+  via `@interchange/storage-isogit` and `history()` projects from there.
+
+## Running
+
+```bash
+export ANTHROPIC_API_KEY=sk-...
+bun run start "list the markdown files in the repo root"
+```
+
+By default the example stores conversation state under
+`<repo-root>/tmp/coding-agent/context/`. The directory is gitignored by the
+repository-wide `tmp/` rule. Delete it to start a fresh conversation:
+
+```bash
+rm -rf ../../tmp/coding-agent
+```
+
+The default working directory for tool calls is the repository root; pass
+`--cwd <path>` to change it.
+
+## Provider
+
+The example targets Anthropic out of the box. To use a different provider,
+construct the agent yourself with the appropriate `ProviderConfig` and call
+`createCodingAgent` from `./src/agent.ts` directly — `createCodingAgent`
+accepts a `providerOverride` that bypasses the Anthropic default.

--- a/examples/coding-agent/package.json
+++ b/examples/coding-agent/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@interchange/example-coding-agent",
+  "version": "0.0.0",
+  "license": "GPL-3.0-only",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "start": "bun run src/cli.ts"
+  },
+  "dependencies": {
+    "@interchange/agent": "workspace:*",
+    "@interchange/tools-lsp": "workspace:*",
+    "@interchange/tools-posix": "workspace:*",
+    "@interchange/types": "workspace:*"
+  }
+}

--- a/examples/coding-agent/src/agent.ts
+++ b/examples/coding-agent/src/agent.ts
@@ -1,0 +1,106 @@
+// Factory for the coding-agent reference consumer.
+//
+// `createCodingAgent` builds an `@interchange/agent` Agent wired against
+// the posix tools (with the LSP plugin attached) and a real
+// `contextDir`-backed isogit store. The factory is separated from the
+// CLI entry so tests can construct the same agent with a stubbed
+// provider.
+
+import { mkdirSync } from "node:fs";
+
+import { createAgent, fromToolRunner, type Agent } from "@interchange/agent";
+import { createLSPPlugin } from "@interchange/tools-lsp";
+import { createPosixTools, type PosixTools } from "@interchange/tools-posix";
+import type { ProviderConfig } from "@interchange/types/runtime";
+
+import { CODING_AGENT_SYSTEM_PROMPT } from "./prompt";
+
+export const DEFAULT_MODEL = "claude-3-5-sonnet-20241022";
+export const DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com";
+
+export type CodingAgentOptions = {
+  /** Where to persist conversation history and audit records. */
+  contextDir: string;
+  /** Working directory for tool calls (read/write/grep are scoped here). */
+  cwd: string;
+  /**
+   * Anthropic API key. Required unless `providerOverride` is set, in
+   * which case it is ignored.
+   */
+  apiKey?: string;
+  /** Override the default Anthropic Claude model. */
+  model?: string;
+  /**
+   * Inject a fully-formed provider config (typically used by tests that
+   * stub the inference layer). When provided, `apiKey` and `model` are
+   * ignored.
+   */
+  providerOverride?: ProviderConfig;
+};
+
+export type CodingAgent = {
+  agent: Agent;
+  posixTools: PosixTools;
+  /**
+   * Close the agent and dispose of the tool runner. Idempotent enough to
+   * be called from a `finally` block.
+   */
+  close(): Promise<void>;
+};
+
+export async function createCodingAgent(
+  opts: CodingAgentOptions,
+): Promise<CodingAgent> {
+  mkdirSync(opts.contextDir, { recursive: true });
+
+  const posixTools = createPosixTools({
+    cwd: opts.cwd,
+    plugins: [createLSPPlugin({ cwd: opts.cwd })],
+  });
+
+  let provider: ProviderConfig;
+  if (opts.providerOverride !== undefined) {
+    provider = opts.providerOverride;
+  } else {
+    if (opts.apiKey === undefined) {
+      await posixTools.dispose();
+      throw new Error(
+        "createCodingAgent: either apiKey or providerOverride is required",
+      );
+    }
+    provider = {
+      provider: "anthropic",
+      baseURL: DEFAULT_ANTHROPIC_BASE_URL,
+      apiKey: opts.apiKey,
+      model: opts.model ?? DEFAULT_MODEL,
+    };
+  }
+
+  if (provider.model === undefined) {
+    await posixTools.dispose();
+    throw new Error("createCodingAgent: provider must have model defined");
+  }
+
+  let agent: Agent;
+  try {
+    agent = await createAgent({
+      contextDir: opts.contextDir,
+      providers: [provider],
+      defaultModel: provider.model,
+      systemPrompt: CODING_AGENT_SYSTEM_PROMPT,
+      tools: fromToolRunner(posixTools),
+    });
+  } catch (cause) {
+    await posixTools.dispose();
+    throw cause;
+  }
+
+  return {
+    agent,
+    posixTools,
+    async close() {
+      await agent.close();
+      await posixTools.dispose();
+    },
+  };
+}

--- a/examples/coding-agent/src/agent.ts
+++ b/examples/coding-agent/src/agent.ts
@@ -9,6 +9,7 @@
 import { mkdirSync } from "node:fs";
 
 import { createAgent, fromToolRunner, type Agent } from "@interchange/agent";
+import type { Dependencies } from "@interchange/inference";
 import { createLSPPlugin } from "@interchange/tools-lsp";
 import { createPosixTools, type PosixTools } from "@interchange/tools-posix";
 import type { ProviderConfig } from "@interchange/types/runtime";
@@ -36,6 +37,12 @@ export type CodingAgentOptions = {
    * ignored.
    */
   providerOverride?: ProviderConfig;
+  /**
+   * Inference dependencies for the underlying agent. Production callers
+   * leave this undefined; tests pass `setupHarness().deps` from
+   * `@interchange/inference-testing` to swap the fetch implementation.
+   */
+  deps?: Dependencies;
 };
 
 export type CodingAgent = {
@@ -89,6 +96,7 @@ export async function createCodingAgent(
       defaultModel: provider.model,
       systemPrompt: CODING_AGENT_SYSTEM_PROMPT,
       tools: fromToolRunner(posixTools),
+      ...(opts.deps !== undefined ? { deps: opts.deps } : {}),
     });
   } catch (cause) {
     await posixTools.dispose();

--- a/examples/coding-agent/src/cli.ts
+++ b/examples/coding-agent/src/cli.ts
@@ -1,0 +1,102 @@
+// CLI entrypoint for the coding-agent example.
+//
+//   bun run start "list the markdown files in the repo root"
+//
+// Reads ANTHROPIC_API_KEY from the environment, instantiates an agent
+// pointed at the example's default context directory, sends a single
+// prompt, and prints the model's reply. History is committed to the
+// context directory; running the script again resumes the same
+// conversation.
+//
+// The reply is written to stdout. Reactor events (inference deltas,
+// tool calls, checkpoints) are streamed to stderr as they happen so the
+// example exercises `agent.stream()` alongside `agent.send()`.
+
+import { parseArgs } from "node:util";
+
+import type { ReactorEmittedEvent } from "@interchange/inference";
+
+import { createCodingAgent } from "./agent";
+import { defaultContextDir, defaultRepoRoot } from "./paths";
+
+type CliArgs = {
+  prompt: string;
+  cwd: string;
+  contextDir: string;
+  model: string | undefined;
+};
+
+function parseCliArgs(argv: string[]): CliArgs {
+  const { values, positionals } = parseArgs({
+    args: argv,
+    allowPositionals: true,
+    options: {
+      cwd: { type: "string" },
+      "context-dir": { type: "string" },
+      model: { type: "string" },
+    },
+  });
+  const prompt = positionals.join(" ").trim();
+  if (prompt === "") {
+    throw new Error(
+      "usage: bun run start [--cwd <dir>] [--context-dir <dir>] [--model <name>] <prompt>",
+    );
+  }
+  return {
+    prompt,
+    cwd: values.cwd ?? defaultRepoRoot(),
+    contextDir: values["context-dir"] ?? defaultContextDir(),
+    model: values.model,
+  };
+}
+
+async function main(argv: string[]): Promise<void> {
+  const apiKey = process.env["ANTHROPIC_API_KEY"];
+  if (apiKey === undefined || apiKey === "") {
+    process.stderr.write("ANTHROPIC_API_KEY is required\n");
+    process.exit(1);
+  }
+
+  let args: CliArgs;
+  try {
+    args = parseCliArgs(argv);
+  } catch (err) {
+    process.stderr.write(
+      (err instanceof Error ? err.message : String(err)) + "\n",
+    );
+    process.exit(1);
+  }
+
+  const { agent, close } = await createCodingAgent({
+    contextDir: args.contextDir,
+    cwd: args.cwd,
+    apiKey,
+    ...(args.model !== undefined ? { model: args.model } : {}),
+  });
+
+  // Mirror the reactor's event stream to stderr so the user can watch
+  // tool calls, inference deltas, and checkpoints land in real time
+  // while the send() resolves on stdout. The pump runs concurrently
+  // with the send and terminates when agent.close() is called.
+  const streamPump = pumpStreamToStderr(agent.stream());
+
+  try {
+    const { reply } = await agent.send(args.prompt);
+    process.stdout.write(reply + "\n");
+  } finally {
+    await close();
+    await streamPump;
+  }
+}
+
+async function pumpStreamToStderr(
+  events: AsyncIterable<ReactorEmittedEvent>,
+): Promise<void> {
+  for await (const event of events) {
+    // Format one event per line; keep the payload compact so the
+    // example output is readable.
+    process.stderr.write(`[${event.type}] seq=${String(event.seq)}\n`);
+  }
+}
+
+await main(process.argv.slice(2));

--- a/examples/coding-agent/src/cli.ts
+++ b/examples/coding-agent/src/cli.ts
@@ -14,7 +14,8 @@
 
 import { parseArgs } from "node:util";
 
-import type { ReactorEmittedEvent } from "@interchange/inference";
+import type { Dependencies, ReactorEmittedEvent } from "@interchange/inference";
+import type { ProviderConfig } from "@interchange/types/runtime";
 
 import { createCodingAgent } from "./agent";
 import { defaultContextDir, defaultRepoRoot } from "./paths";
@@ -26,7 +27,18 @@ type CliArgs = {
   model: string | undefined;
 };
 
-function parseCliArgs(argv: string[]): CliArgs {
+export type MainOptions = {
+  /** Replace stdout (defaults to `process.stdout.write`). */
+  stdout?: (chunk: string) => void;
+  /** Replace stderr (defaults to `process.stderr.write`). */
+  stderr?: (chunk: string) => void;
+  /** Inject inference deps (for tests using `@interchange/inference-testing`). */
+  deps?: Dependencies;
+  /** Skip credential parsing and use this provider directly. */
+  providerOverride?: ProviderConfig;
+};
+
+export function parseCliArgs(argv: string[]): CliArgs {
   const { values, positionals } = parseArgs({
     args: argv,
     allowPositionals: true,
@@ -50,53 +62,75 @@ function parseCliArgs(argv: string[]): CliArgs {
   };
 }
 
-async function main(argv: string[]): Promise<void> {
-  const apiKey = process.env["ANTHROPIC_API_KEY"];
-  if (apiKey === undefined || apiKey === "") {
-    process.stderr.write("ANTHROPIC_API_KEY is required\n");
-    process.exit(1);
+async function pumpStreamToStderr(
+  events: AsyncIterable<ReactorEmittedEvent>,
+  stderr: (chunk: string) => void,
+): Promise<void> {
+  for await (const event of events) {
+    stderr(`[${event.type}] seq=${String(event.seq)}\n`);
+  }
+}
+
+/**
+ * Execute one CLI run. Returns an exit code (0 success, non-zero failure).
+ * Pure with respect to globals when callers supply `stdout`/`stderr`/
+ * `providerOverride`/`deps` — that's the seam tests use.
+ */
+export async function main(
+  argv: string[],
+  env: NodeJS.ProcessEnv,
+  opts: MainOptions = {},
+): Promise<number> {
+  const stdout = opts.stdout ?? ((s) => void process.stdout.write(s));
+  const stderr = opts.stderr ?? ((s) => void process.stderr.write(s));
+
+  const apiKey = env["ANTHROPIC_API_KEY"];
+  if (
+    opts.providerOverride === undefined &&
+    (apiKey === undefined || apiKey === "")
+  ) {
+    stderr("ANTHROPIC_API_KEY is required\n");
+    return 1;
   }
 
   let args: CliArgs;
   try {
     args = parseCliArgs(argv);
   } catch (err) {
-    process.stderr.write(
-      (err instanceof Error ? err.message : String(err)) + "\n",
-    );
-    process.exit(1);
+    stderr((err instanceof Error ? err.message : String(err)) + "\n");
+    return 1;
   }
 
   const { agent, close } = await createCodingAgent({
     contextDir: args.contextDir,
     cwd: args.cwd,
-    apiKey,
+    ...(apiKey !== undefined ? { apiKey } : {}),
     ...(args.model !== undefined ? { model: args.model } : {}),
+    ...(opts.providerOverride !== undefined
+      ? { providerOverride: opts.providerOverride }
+      : {}),
+    ...(opts.deps !== undefined ? { deps: opts.deps } : {}),
   });
 
   // Mirror the reactor's event stream to stderr so the user can watch
   // tool calls, inference deltas, and checkpoints land in real time
   // while the send() resolves on stdout. The pump runs concurrently
   // with the send and terminates when agent.close() is called.
-  const streamPump = pumpStreamToStderr(agent.stream());
+  const streamPump = pumpStreamToStderr(agent.stream(), stderr);
 
   try {
     const { reply } = await agent.send(args.prompt);
-    process.stdout.write(reply + "\n");
+    stdout(reply + "\n");
+    return 0;
   } finally {
     await close();
     await streamPump;
   }
 }
 
-async function pumpStreamToStderr(
-  events: AsyncIterable<ReactorEmittedEvent>,
-): Promise<void> {
-  for await (const event of events) {
-    // Format one event per line; keep the payload compact so the
-    // example output is readable.
-    process.stderr.write(`[${event.type}] seq=${String(event.seq)}\n`);
-  }
+// Top-level invocation when run directly (not when imported by tests).
+// Bun sets `import.meta.main` true for the entry module.
+if (import.meta.main) {
+  const code = await main(process.argv.slice(2), process.env);
+  if (code !== 0) process.exit(code);
 }
-
-await main(process.argv.slice(2));

--- a/examples/coding-agent/src/index.ts
+++ b/examples/coding-agent/src/index.ts
@@ -1,0 +1,15 @@
+// Public surface of the coding-agent example.
+//
+// The example is primarily run from `src/cli.ts`, but `createCodingAgent`
+// and the path helpers are exported so other consumers (including tests)
+// can construct the same agent shape.
+
+export {
+  createCodingAgent,
+  DEFAULT_ANTHROPIC_BASE_URL,
+  DEFAULT_MODEL,
+  type CodingAgent,
+  type CodingAgentOptions,
+} from "./agent";
+export { CODING_AGENT_SYSTEM_PROMPT } from "./prompt";
+export { defaultContextDir, defaultRepoRoot } from "./paths";

--- a/examples/coding-agent/src/index.ts
+++ b/examples/coding-agent/src/index.ts
@@ -13,3 +13,4 @@ export {
 } from "./agent";
 export { CODING_AGENT_SYSTEM_PROMPT } from "./prompt";
 export { defaultContextDir, defaultRepoRoot } from "./paths";
+export { main, parseCliArgs, type MainOptions } from "./cli";

--- a/examples/coding-agent/src/paths.ts
+++ b/examples/coding-agent/src/paths.ts
@@ -1,0 +1,22 @@
+// Default context directory location.
+//
+// The example persists conversation state under `<repo-root>/tmp/coding-
+// agent/context/`. The top-level `tmp/` is gitignored by repository
+// convention (`.gitignore`), and the `coding-agent/` subdirectory is left
+// without a leading dot so it is visible in casual directory listings.
+
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function defaultRepoRoot(): string {
+  // This file lives at <repo>/examples/coding-agent/src/paths.ts.
+  // The repo root is three levels up.
+  const here = fileURLToPath(new URL(".", import.meta.url));
+  return resolve(here, "..", "..", "..");
+}
+
+export function defaultContextDir(
+  repoRoot: string = defaultRepoRoot(),
+): string {
+  return resolve(repoRoot, "tmp", "coding-agent", "context");
+}

--- a/examples/coding-agent/src/prompt.ts
+++ b/examples/coding-agent/src/prompt.ts
@@ -1,0 +1,19 @@
+// System prompt for the coding-agent example.
+//
+// Intentionally short and operational rather than aspirational — the
+// prompt's job here is to demonstrate the agent surface, not to compete
+// with production coding agents.
+
+export const CODING_AGENT_SYSTEM_PROMPT = `\
+You are a coding assistant operating inside a repository. You have access
+to filesystem tools (read_file, write_file, edit_file, search_files, grep)
+and a shell (run_shell), plus language-server diagnostics via the
+lsp_diagnostics tool.
+
+Use the tools to investigate the codebase before answering. Prefer reading
+a file over guessing at its contents. When the user asks you to change
+code, propose the change first, then apply it with edit_file or
+write_file.
+
+Keep replies concise. When you have nothing more to do, end the turn.
+`;

--- a/examples/coding-agent/tsconfig.json
+++ b/examples/coding-agent/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "workspaces": [
     "packages/*",
-    "apps/*"
+    "apps/*",
+    "examples/*"
   ],
   "catalog": {
     "arktype": "^2.1.29"

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -10,6 +10,7 @@
     }
   },
   "dependencies": {
+    "@interchange/harness": "workspace:*",
     "@interchange/inference": "workspace:*",
     "@interchange/mime": "workspace:*",
     "@interchange/storage-isogit": "workspace:*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@interchange/agent",
+  "version": "0.0.0",
+  "license": "GPL-3.0-only",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "dependencies": {
+    "@interchange/inference": "workspace:*",
+    "@interchange/mime": "workspace:*",
+    "@interchange/storage-isogit": "workspace:*",
+    "@interchange/types": "workspace:*",
+    "arktype": "catalog:"
+  }
+}

--- a/packages/agent/src/agent.test.ts
+++ b/packages/agent/src/agent.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "bun:test";
+
+import type { ContextStore, ProviderConfig } from "@interchange/types/runtime";
+
+import { AgentConfigError, createAgent } from "./agent";
+
+const PROVIDER: ProviderConfig = {
+  provider: "anthropic",
+  baseURL: "https://api.anthropic.com",
+  apiKey: "sk-test",
+  model: "claude-3-5-sonnet",
+};
+
+function stubContextStore(): ContextStore {
+  // Storage-validation tests reject before touching the store; the stub
+  // never has any of its methods called.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub, never invoked
+  return {} as ContextStore;
+}
+
+describe("createAgent storage configuration", () => {
+  test("rejects when both contextStore and contextDir are given", async () => {
+    await expect(
+      createAgent({
+        contextStore: stubContextStore(),
+        contextDir: "/tmp/agent-config-1",
+        providers: [PROVIDER],
+        defaultModel: "claude-3-5-sonnet",
+        systemPrompt: "test",
+        tools: [],
+      }),
+    ).rejects.toBeInstanceOf(AgentConfigError);
+  });
+
+  test("rejects when neither contextStore nor contextDir is given", async () => {
+    await expect(
+      createAgent({
+        providers: [PROVIDER],
+        defaultModel: "claude-3-5-sonnet",
+        systemPrompt: "test",
+        tools: [],
+      }),
+    ).rejects.toBeInstanceOf(AgentConfigError);
+  });
+});

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -15,6 +15,7 @@ import { createDefaultDirector } from "@interchange/harness";
 import {
   createReactorAssembly,
   type AuthzExtensionOptions,
+  type Dependencies,
   type ReactorEmittedEvent,
 } from "@interchange/inference";
 import { createInboundMessage } from "@interchange/mime";
@@ -94,6 +95,16 @@ export type AgentConfig = {
    * consumers are unaffected. Defaults to 1024.
    */
   streamBufferMax?: number;
+
+  /**
+   * Inference dependencies (notably `fetch`) for the reactor's underlying
+   * `runInference` call. Production callers should leave this undefined —
+   * the assembly falls back to `createDefaultDependencies()` which binds
+   * `globalThis.fetch`. Pass `setupHarness().deps` from
+   * `@interchange/inference-testing` in tests to swap the fetch
+   * implementation for a deterministic stub.
+   */
+  deps?: Dependencies;
 };
 
 export type SendOptions = {
@@ -283,6 +294,7 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
     ...(config.sizeCapMaxChars !== undefined
       ? { sizeCapMaxChars: config.sizeCapMaxChars }
       : {}),
+    ...(config.deps !== undefined ? { deps: config.deps } : {}),
   });
 
   sendQueue = createSendQueue<InboundMessage, SendResult>({
@@ -320,7 +332,13 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
     content: string | InboundMessage,
     opts?: SendOptions,
   ): Promise<SendResult> {
-    ensureOpen();
+    // Closed-agent errors come back as rejections so callers can handle
+    // them with `.catch()` instead of having to defensively wrap every
+    // `agent.send(...)` in a try/catch. `SendQueueFullError` from
+    // `sendQueue.enqueue` is left as a synchronous throw — it signals a
+    // programmer error (the caller exceeded the configured queue cap)
+    // and per the design must fail loud.
+    if (closed) return Promise.reject(new AgentClosedError());
     const message = buildInboundMessage(content, opts);
     return sendQueue.enqueue(message, opts?.signal);
   }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -20,16 +20,16 @@
 //     the singleton-per-`contextDir` lock so another agent can open the
 //     same directory.
 //
-// `setProvider` caveat: the default director captures `model` at
-// construction time and passes it into `capabilities.infer(model, ...)`
-// on every cycle. `ReactorDirector.decide` is not handed
-// `providerConfig`, so a model swap via `setProvider` rotates only the
-// fields the reactor reads lazily off the shared `providerConfig`
-// object — `provider`, `baseURL`, `apiKey`. To change the model
-// mid-conversation, close the agent and reopen it with a different
-// `defaultModel`, or supply a custom `director` that closes over the
-// agent's provider registry itself and substitutes the live model in
-// its own `infer` action.
+// `setProvider` covers all of `provider`/`baseURL`/`apiKey`/`model`.
+// Credentials rotate via the shared `providerConfig` object the reactor
+// reads lazily at the start of each inference call. The model rotates
+// via a thin wrapper the agent puts around the director's
+// `capabilities`: every `capabilities.infer(model, ...)` call the
+// director makes is rewritten to use the active provider's current
+// model, regardless of which model the director itself captured. This
+// makes the rotation invisible to both the default director and any
+// caller-supplied director that just relays the model it was
+// constructed with.
 
 import { createDefaultDirector } from "@interchange/harness";
 import {
@@ -49,6 +49,7 @@ import type {
   ConversationTurn,
   InboundMessage,
   ProviderConfig,
+  ReactorCapabilities,
   ReactorDirector,
 } from "@interchange/types/runtime";
 
@@ -172,14 +173,29 @@ export type Agent = {
   close(): Promise<void>;
   /**
    * Replace the active provider's fields in place. Picked up at the
-   * start of the next inference call. Note: the default director
-   * captures `model` at construction; mutating model via setProvider has
-   * no effect unless a custom director is supplied. See the file
-   * header for details.
+   * start of the next inference call. `model` is rotated alongside
+   * `provider`/`baseURL`/`apiKey`: the agent wraps the director so
+   * every `capabilities.infer(model, ...)` call uses the active
+   * provider's current model.
    */
   setProvider(config: ProviderConfig): void;
+  /**
+   * Project conversation history from the underlying context store.
+   * Remains callable after `close()` — reads do not need the reactor
+   * and the store is not destroyed by close. Returns the full-fidelity
+   * `ConversationTurn[]` from the store's latest committed state.
+   */
   history(): Promise<ConversationTurn[]>;
+  /**
+   * List recent checkpoints from the context store. Remains callable
+   * after `close()` for the same reason as `history()`.
+   */
   checkpoints(limit?: number): Promise<ContextCommit[]>;
+  /**
+   * Read the conversation turns recorded at a specific commit hash.
+   * Remains callable after `close()` for the same reason as
+   * `history()`.
+   */
   readAt(hash: string): Promise<ConversationTurn[]>;
   readonly blobReader: BlobReader;
 };
@@ -241,23 +257,46 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
     throw cause;
   }
 
-  let director: ReactorDirector;
+  // Capture the initial model so the capabilities wrapper has a safe
+  // fallback if a setProvider call ever leaves active.model undefined.
+  if (providerRegistry.active.model === undefined) {
+    if (lock !== undefined) lock.release();
+    throw new AgentConfigError("active provider must have model defined");
+  }
+  const initialModel = providerRegistry.active.model;
+
+  let baseDirector: ReactorDirector;
   if (config.director !== undefined) {
-    director = config.director;
+    baseDirector = config.director;
   } else {
-    if (providerRegistry.active.model === undefined) {
-      if (lock !== undefined) lock.release();
-      throw new AgentConfigError(
-        "active provider must have model defined when using the default director",
-      );
-    }
-    director = createDefaultDirector(
-      providerRegistry.active.model,
+    baseDirector = createDefaultDirector(
+      initialModel,
       config.systemPrompt,
       [...toolRunner.definitions],
       {},
     );
   }
+
+  // Wrap the director's `capabilities` so every `infer(model, ...)` call
+  // uses the live model from providerRegistry.active. This lets
+  // setProvider rotate `model` (alongside provider/baseURL/apiKey)
+  // without requiring the inner director to know about it. The default
+  // director captures `model` at construction; this wrapper substitutes
+  // the live value at action-build time.
+  const director: ReactorDirector = {
+    async decide(event, state, capabilities) {
+      const wrappedCapabilities: ReactorCapabilities = {
+        ...capabilities,
+        infer: (_requestedModel, options) => {
+          const liveModel = providerRegistry.active.model ?? initialModel;
+          return options === undefined
+            ? capabilities.infer(liveModel)
+            : capabilities.infer(liveModel, options);
+        },
+      };
+      return baseDirector.decide(event, state, wrappedCapabilities);
+    },
+  };
 
   const sessionId = config.sessionId ?? crypto.randomUUID();
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -34,11 +34,13 @@ import type {
 import { acquireContextDirLock, type ContextDirLock } from "./lock";
 import { createProviderRegistry, type ProviderRegistry } from "./provider";
 import { createSendQueue, type SendQueue } from "./send-queue";
+import { createStreamConsumer, type StreamConsumer } from "./stream";
 import { createToolRunner, type AgentTool, type AgentToolRunner } from "./tool";
 
 const DEFAULT_SEND_FROM = "user@local";
 const DEFAULT_SEND_TO = "agent@local";
 const DEFAULT_SEND_QUEUE_MAX = 16;
+const DEFAULT_STREAM_BUFFER_MAX = 1024;
 
 export type AgentConfig = {
   /**
@@ -84,6 +86,14 @@ export type AgentConfig = {
    * Defaults to 16.
    */
   sendQueueMax?: number;
+
+  /**
+   * Maximum events any single `stream()` consumer may buffer. When a
+   * consumer falls more than this many events behind the next read on
+   * that consumer's iterator throws `StreamBackpressureError`; other
+   * consumers are unaffected. Defaults to 1024.
+   */
+  streamBufferMax?: number;
 };
 
 export type SendOptions = {
@@ -203,10 +213,8 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
 
   const sessionId = config.sessionId ?? crypto.randomUUID();
 
-  // Stream fan-out. Commit 8 replaces this naive callback set with a
-  // bounded per-consumer buffer.
-  type EventListener = (event: ReactorEmittedEvent) => void;
-  const streamConsumers = new Set<EventListener>();
+  const streamBufferMax = config.streamBufferMax ?? DEFAULT_STREAM_BUFFER_MAX;
+  const streamConsumers = new Set<StreamConsumer>();
 
   // Per-active-cycle bookkeeping for send(). The reactor produces one or
   // more inference.done events during a cycle; we keep the most recent
@@ -256,7 +264,10 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
     }
 
     for (const consumer of streamConsumers) {
-      consumer(event);
+      consumer.push(event);
+      if (consumer.closed) {
+        streamConsumers.delete(consumer);
+      }
     }
   }
 
@@ -314,13 +325,11 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
     return sendQueue.enqueue(message, opts?.signal);
   }
 
-  // eslint-disable-next-line require-yield -- placeholder iterator; commit 8 replaces with bounded fan-out
-  async function* stream(): AsyncIterable<ReactorEmittedEvent> {
+  function stream(): AsyncIterable<ReactorEmittedEvent> {
     ensureOpen();
-    // Placeholder until commit 8 wires the bounded per-consumer buffer.
-    // Returning an immediately-finishing iterator keeps the type honest
-    // without yielding events.
-    return;
+    const consumer = createStreamConsumer(streamBufferMax);
+    streamConsumers.add(consumer);
+    return consumer.iterator();
   }
 
   function deliver(message: InboundMessage): void {
@@ -352,6 +361,7 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
     reactor.abort("user_disconnect");
     sendQueue.drain(new AgentClosedError());
     activeCycle = null;
+    for (const consumer of streamConsumers) consumer.close();
     streamConsumers.clear();
     if (lock !== undefined) lock.release();
   }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -33,10 +33,12 @@ import type {
 
 import { acquireContextDirLock, type ContextDirLock } from "./lock";
 import { createProviderRegistry, type ProviderRegistry } from "./provider";
+import { createSendQueue, type SendQueue } from "./send-queue";
 import { createToolRunner, type AgentTool, type AgentToolRunner } from "./tool";
 
 const DEFAULT_SEND_FROM = "user@local";
 const DEFAULT_SEND_TO = "agent@local";
+const DEFAULT_SEND_QUEUE_MAX = 16;
 
 export type AgentConfig = {
   /**
@@ -75,9 +77,25 @@ export type AgentConfig = {
 
   /** Override the auto-generated session ID. */
   sessionId?: string;
+
+  /**
+   * Maximum number of pending sends (active + queued). Once reached,
+   * additional `send()` calls throw `SendQueueFullError` synchronously.
+   * Defaults to 16.
+   */
+  sendQueueMax?: number;
 };
 
 export type SendOptions = {
+  /**
+   * Abort signal for this send. When the signal fires before processing
+   * the call is dropped from the queue and the promise rejects with the
+   * signal's reason. When it fires mid-cycle the promise rejects
+   * immediately, but the underlying reactor cycle keeps running because
+   * the reactor does not expose per-cycle cancellation — the next queued
+   * send waits for that cycle to finish before starting. The reply (if
+   * any) is still visible via `stream()` and `history()`.
+   */
   signal?: AbortSignal;
   /** Override the default "from" header on the synthetic inbound message. */
   from?: string;
@@ -119,13 +137,6 @@ export class AgentClosedError extends Error {
   constructor() {
     super("agent is closed");
     this.name = "AgentClosedError";
-  }
-}
-
-export class ConcurrentSendError extends Error {
-  constructor() {
-    super("send() is already in flight; queueing lands in a later change");
-    this.name = "ConcurrentSendError";
   }
 }
 
@@ -192,16 +203,58 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
 
   const sessionId = config.sessionId ?? crypto.randomUUID();
 
-  // Event listeners. Commits 7 and 8 replace these naive callback sets with
-  // a FIFO send queue and a bounded per-consumer stream buffer.
+  // Stream fan-out. Commit 8 replaces this naive callback set with a
+  // bounded per-consumer buffer.
   type EventListener = (event: ReactorEmittedEvent) => void;
   const streamConsumers = new Set<EventListener>();
-  let activeSendListener: EventListener | undefined;
+
+  // Per-active-cycle bookkeeping for send(). The reactor produces one or
+  // more inference.done events during a cycle; we keep the most recent
+  // assistant turn so the final connector.reply can be paired with the
+  // full-fidelity turn (rather than a synthesized text-only fallback).
+  type ActiveCycle = { lastAssistantTurn: AssistantTurn | undefined };
+  let activeCycle: ActiveCycle | null = null;
+
+  // sendQueue is built after the reactor (since its `start` callback
+  // delivers into the reactor), but handleEvent — which is wired into the
+  // reactor's assembly — needs to see sendQueue. Assigned exactly once
+  // after the reactor exists and before reactor.start(); no event can
+  // reach handleEvent before the queue is wired.
+  // eslint-disable-next-line prefer-const -- forward declaration; const cannot express this ordering
+  let sendQueue: SendQueue<InboundMessage, SendResult>;
+
+  function buildSyntheticTurn(text: string): ConversationTurn {
+    return {
+      role: "assistant",
+      content: [{ type: "text", text }],
+      ...(providerRegistry.active.model !== undefined
+        ? { model: providerRegistry.active.model }
+        : {}),
+      timestamp: Date.now(),
+    };
+  }
 
   function handleEvent(event: ReactorEmittedEvent): void {
-    if (activeSendListener !== undefined) {
-      activeSendListener(event);
+    if (activeCycle !== null && event.type === "inference.done") {
+      activeCycle.lastAssistantTurn = event.data.turn;
     }
+
+    if (activeCycle !== null) {
+      if (event.type === "connector.reply") {
+        const turn: ConversationTurn =
+          activeCycle.lastAssistantTurn ??
+          buildSyntheticTurn(event.data.content);
+        activeCycle = null;
+        sendQueue.resolveActive({ reply: event.data.content, turn });
+      } else if (event.type === "reactor.error") {
+        activeCycle = null;
+        sendQueue.rejectActive(new Error(`reactor error: ${event.data.error}`));
+      } else if (event.type === "reactor.done") {
+        activeCycle = null;
+        sendQueue.rejectActive(new AgentClosedError());
+      }
+    }
+
     for (const consumer of streamConsumers) {
       consumer(event);
     }
@@ -221,10 +274,17 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
       : {}),
   });
 
+  sendQueue = createSendQueue<InboundMessage, SendResult>({
+    maxDepth: config.sendQueueMax ?? DEFAULT_SEND_QUEUE_MAX,
+    start: (message) => {
+      activeCycle = { lastAssistantTurn: undefined };
+      reactor.deliver(message);
+    },
+  });
+
   reactor.start();
 
   let closed = false;
-  let sendInFlight = false;
 
   function ensureOpen(): void {
     if (closed) throw new AgentClosedError();
@@ -250,51 +310,8 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
     opts?: SendOptions,
   ): Promise<SendResult> {
     ensureOpen();
-    if (sendInFlight) {
-      return Promise.reject(new ConcurrentSendError());
-    }
-    sendInFlight = true;
-
     const message = buildInboundMessage(content, opts);
-
-    return new Promise<SendResult>((resolve, reject) => {
-      let lastAssistantTurn: AssistantTurn | undefined;
-
-      activeSendListener = (event) => {
-        if (event.type === "inference.done") {
-          lastAssistantTurn = event.data.turn;
-          return;
-        }
-        if (event.type === "connector.reply") {
-          activeSendListener = undefined;
-          sendInFlight = false;
-          const turn: ConversationTurn = lastAssistantTurn ?? {
-            role: "assistant",
-            content: [{ type: "text", text: event.data.content }],
-            ...(providerRegistry.active.model !== undefined
-              ? { model: providerRegistry.active.model }
-              : {}),
-            timestamp: Date.now(),
-          };
-          resolve({ reply: event.data.content, turn });
-          return;
-        }
-        if (event.type === "reactor.error") {
-          activeSendListener = undefined;
-          sendInFlight = false;
-          reject(new Error(`reactor error: ${event.data.error}`));
-          return;
-        }
-        if (event.type === "reactor.done") {
-          activeSendListener = undefined;
-          sendInFlight = false;
-          reject(new AgentClosedError());
-          return;
-        }
-      };
-
-      reactor.deliver(message);
-    });
+    return sendQueue.enqueue(message, opts?.signal);
   }
 
   // eslint-disable-next-line require-yield -- placeholder iterator; commit 8 replaces with bounded fan-out
@@ -333,8 +350,9 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
     if (closed) return;
     closed = true;
     reactor.abort("user_disconnect");
+    sendQueue.drain(new AgentClosedError());
+    activeCycle = null;
     streamConsumers.clear();
-    activeSendListener = undefined;
     if (lock !== undefined) lock.release();
   }
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -4,12 +4,32 @@
 // dispatcher, wires `createReactorAssembly`, and exposes the public Agent
 // surface. The agent owns the active provider config object so
 // `setProvider` can mutate it in place and the reactor's lazy read at the
-// start of each inference call picks up the swap.
+// start of each inference call picks up the new credentials.
 //
-// This module implements the baseline shape: `deliver`, `setProvider`,
-// `history`, `checkpoints`, `readAt`, `blobReader`, and a single-in-flight
-// `send`. The FIFO queue + AbortSignal on `send`, the bounded fan-out for
-// `stream`, and the full `close` lifecycle land in subsequent commits.
+// Composition:
+//   - `send()` enqueues into a FIFO `SendQueue` capped at `sendQueueMax`.
+//     Per-send `AbortSignal` removes queued items or rejects in-flight
+//     callers while letting the reactor cycle finish in the background.
+//   - `stream()` returns a bounded `StreamConsumer` iterator; consumers
+//     buffer independently and noisy backpressure poisons only the
+//     affected iterator.
+//   - `close()` aborts the reactor, drains the send queue with
+//     `AgentClosedError`, terminates every active stream iterator, waits
+//     up to `closeTimeoutMs` for the reactor's shutdown sequence to
+//     complete (audit flush, in-flight commits), and finally releases
+//     the singleton-per-`contextDir` lock so another agent can open the
+//     same directory.
+//
+// `setProvider` caveat: the default director captures `model` at
+// construction time and passes it into `capabilities.infer(model, ...)`
+// on every cycle. `ReactorDirector.decide` is not handed
+// `providerConfig`, so a model swap via `setProvider` rotates only the
+// fields the reactor reads lazily off the shared `providerConfig`
+// object — `provider`, `baseURL`, `apiKey`. To change the model
+// mid-conversation, close the agent and reopen it with a different
+// `defaultModel`, or supply a custom `director` that closes over the
+// agent's provider registry itself and substitutes the live model in
+// its own `infer` action.
 
 import { createDefaultDirector } from "@interchange/harness";
 import {
@@ -42,6 +62,7 @@ const DEFAULT_SEND_FROM = "user@local";
 const DEFAULT_SEND_TO = "agent@local";
 const DEFAULT_SEND_QUEUE_MAX = 16;
 const DEFAULT_STREAM_BUFFER_MAX = 1024;
+const DEFAULT_CLOSE_TIMEOUT_MS = 5000;
 
 export type AgentConfig = {
   /**
@@ -105,6 +126,15 @@ export type AgentConfig = {
    * implementation for a deterministic stub.
    */
   deps?: Dependencies;
+
+  /**
+   * Maximum milliseconds `close()` waits for the reactor's shutdown
+   * sequence (which flushes audit and any pending commits) before
+   * releasing the singleton `contextDir` lock and returning. Defaults
+   * to 5000ms. Set to 0 to release immediately without waiting (useful
+   * for tests where the reactor's shutdown is intentionally blocked).
+   */
+  closeTimeoutMs?: number;
 };
 
 export type SendOptions = {
@@ -140,6 +170,13 @@ export type Agent = {
   stream(): AsyncIterable<ReactorEmittedEvent>;
   deliver(message: InboundMessage): void;
   close(): Promise<void>;
+  /**
+   * Replace the active provider's fields in place. Picked up at the
+   * start of the next inference call. Note: the default director
+   * captures `model` at construction; mutating model via setProvider has
+   * no effect unless a custom director is supplied. See the file
+   * header for details.
+   */
   setProvider(config: ProviderConfig): void;
   history(): Promise<ConversationTurn[]>;
   checkpoints(limit?: number): Promise<ContextCommit[]>;
@@ -242,6 +279,22 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
   // eslint-disable-next-line prefer-const -- forward declaration; const cannot express this ordering
   let sendQueue: SendQueue<InboundMessage, SendResult>;
 
+  // shutdownComplete resolves from the assembly's onShutdown hook
+  // (composed after audit flush by the assembly) or, as a fallback, from
+  // handleEvent observing the reactor's terminal `reactor.done` event.
+  // close() awaits this (with a timeout) before releasing the
+  // contextDir lock so a subsequent createAgent on the same directory
+  // sees a quiesced store.
+  let resolveShutdown: () => void = () => {
+    // Reassigned by the Promise constructor below; seed a no-op so the
+    // forward-referenced call in handleEvent is safe even if the
+    // Promise constructor has not yet run (it does, synchronously, on
+    // the next line).
+  };
+  const shutdownComplete = new Promise<void>((resolve) => {
+    resolveShutdown = resolve;
+  });
+
   function buildSyntheticTurn(text: string): ConversationTurn {
     return {
       role: "assistant",
@@ -265,7 +318,12 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
           buildSyntheticTurn(event.data.content);
         activeCycle = null;
         sendQueue.resolveActive({ reply: event.data.content, turn });
-      } else if (event.type === "reactor.error") {
+      } else if (event.type === "reactor.error" && event.data.fatal) {
+        // Only fatal reactor errors terminate the active send. Non-fatal
+        // errors (e.g. transient write/commit failures the reactor is
+        // recovering from) are surfaced via stream() but must not
+        // resolve send() — the cycle is still running and may yet
+        // produce connector.reply or a fatal error.
         activeCycle = null;
         sendQueue.rejectActive(new Error(`reactor error: ${event.data.error}`));
       } else if (event.type === "reactor.done") {
@@ -274,7 +332,19 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
       }
     }
 
-    for (const consumer of streamConsumers) {
+    // reactor.done is the reactor's terminal event. Resolve
+    // shutdownComplete here in addition to the onShutdown hook so close()
+    // does not hang for the full closeTimeoutMs on paths where the hook
+    // never fires (e.g. the reactor's context-store load fails during
+    // start, or the composed onShutdown wrapper throws during audit
+    // flush). resolveShutdown is idempotent.
+    if (event.type === "reactor.done") {
+      resolveShutdown();
+    }
+
+    // Iterate a snapshot so removing closed consumers mid-iteration is
+    // not just relying on Set's iteration tolerance.
+    for (const consumer of Array.from(streamConsumers)) {
       consumer.push(event);
       if (consumer.closed) {
         streamConsumers.delete(consumer);
@@ -289,6 +359,9 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
     toolRunner,
     contextStore,
     onEvent: handleEvent,
+    onShutdown: async () => {
+      resolveShutdown();
+    },
     ...(auditStore !== undefined ? { auditStore } : {}),
     ...(config.authorize !== undefined ? { authorize: config.authorize } : {}),
     ...(config.sizeCapMaxChars !== undefined
@@ -381,6 +454,26 @@ export async function createAgent(config: AgentConfig): Promise<Agent> {
     activeCycle = null;
     for (const consumer of streamConsumers) consumer.close();
     streamConsumers.clear();
+
+    // Wait for the reactor's shutdown sequence (audit flush, in-flight
+    // commits) before releasing the lock so a subsequent createAgent on
+    // the same contextDir does not race with background writers against
+    // the same .git directory. The timeout is a backstop: if the
+    // reactor's shutdown is genuinely stuck (e.g. a parked test fetch
+    // that never resolves) we release the lock anyway rather than
+    // deadlock the caller. `closeTimeoutMs: 0` disables the wait.
+    const timeoutMs = config.closeTimeoutMs ?? DEFAULT_CLOSE_TIMEOUT_MS;
+    if (timeoutMs > 0) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, timeoutMs);
+      });
+      try {
+        await Promise.race([shutdownComplete, timeout]);
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
+      }
+    }
     if (lock !== undefined) lock.release();
   }
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1,0 +1,352 @@
+// In-process agent runtime.
+//
+// `createAgent` resolves storage, builds the provider registry and tool
+// dispatcher, wires `createReactorAssembly`, and exposes the public Agent
+// surface. The agent owns the active provider config object so
+// `setProvider` can mutate it in place and the reactor's lazy read at the
+// start of each inference call picks up the swap.
+//
+// This module implements the baseline shape: `deliver`, `setProvider`,
+// `history`, `checkpoints`, `readAt`, `blobReader`, and a single-in-flight
+// `send`. The FIFO queue + AbortSignal on `send`, the bounded fan-out for
+// `stream`, and the full `close` lifecycle land in subsequent commits.
+
+import { createDefaultDirector } from "@interchange/harness";
+import {
+  createReactorAssembly,
+  type AuthzExtensionOptions,
+  type ReactorEmittedEvent,
+} from "@interchange/inference";
+import { createInboundMessage } from "@interchange/mime";
+import { createIsogitStore } from "@interchange/storage-isogit";
+import type {
+  AssistantTurn,
+  AuditStore,
+  BlobReader,
+  ContextCommit,
+  ContextStore,
+  ConversationTurn,
+  InboundMessage,
+  ProviderConfig,
+  ReactorDirector,
+} from "@interchange/types/runtime";
+
+import { acquireContextDirLock, type ContextDirLock } from "./lock";
+import { createProviderRegistry, type ProviderRegistry } from "./provider";
+import { createToolRunner, type AgentTool, type AgentToolRunner } from "./tool";
+
+const DEFAULT_SEND_FROM = "user@local";
+const DEFAULT_SEND_TO = "agent@local";
+
+export type AgentConfig = {
+  /**
+   * The conversation/history store. Exactly one of `contextStore` or
+   * `contextDir` must be supplied. When `contextStore` is given the caller
+   * owns the store's lifetime; the singleton-per-directory lock is not
+   * acquired.
+   */
+  contextStore?: ContextStore;
+
+  /**
+   * Path to a directory the agent will manage as an isogit-backed
+   * `ContextStore & AuditStore`. The singleton-per-directory lock is
+   * acquired when this form is used.
+   */
+  contextDir?: string;
+
+  /** Pre-configured providers. Must be non-empty. Each entry must have model. */
+  providers: ProviderConfig[];
+  /** Must match the `model` field of one of `providers`. */
+  defaultModel: string;
+
+  /** System prompt for the default director. */
+  systemPrompt: string;
+  /** Tools registered via `tool()` / `stringTool()`. */
+  tools: AgentTool[];
+  /** Director override. Defaults to `createDefaultDirector`. */
+  director?: ReactorDirector;
+
+  /** Audit store. When omitted with `contextDir`, the isogit store is used. */
+  auditStore?: AuditStore;
+  /** Authz extension hook. */
+  authorize?: AuthzExtensionOptions["authorize"];
+  /** Override the default 10k tool-result size cap. */
+  sizeCapMaxChars?: number;
+
+  /** Override the auto-generated session ID. */
+  sessionId?: string;
+};
+
+export type SendOptions = {
+  signal?: AbortSignal;
+  /** Override the default "from" header on the synthetic inbound message. */
+  from?: string;
+};
+
+export type SendResult = {
+  /** Reply text emitted by the director's `reply` action. */
+  reply: string;
+  /**
+   * Full-fidelity assistant turn that produced the reply. Captured from
+   * the reactor's `inference.done` event preceding `connector.reply`.
+   */
+  turn: ConversationTurn;
+};
+
+export type Agent = {
+  send(
+    content: string | InboundMessage,
+    opts?: SendOptions,
+  ): Promise<SendResult>;
+  stream(): AsyncIterable<ReactorEmittedEvent>;
+  deliver(message: InboundMessage): void;
+  close(): Promise<void>;
+  setProvider(config: ProviderConfig): void;
+  history(): Promise<ConversationTurn[]>;
+  checkpoints(limit?: number): Promise<ContextCommit[]>;
+  readAt(hash: string): Promise<ConversationTurn[]>;
+  readonly blobReader: BlobReader;
+};
+
+export class AgentConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentConfigError";
+  }
+}
+
+export class AgentClosedError extends Error {
+  constructor() {
+    super("agent is closed");
+    this.name = "AgentClosedError";
+  }
+}
+
+export class ConcurrentSendError extends Error {
+  constructor() {
+    super("send() is already in flight; queueing lands in a later change");
+    this.name = "ConcurrentSendError";
+  }
+}
+
+export async function createAgent(config: AgentConfig): Promise<Agent> {
+  const hasStore = config.contextStore !== undefined;
+  const hasDir = config.contextDir !== undefined;
+  if (hasStore === hasDir) {
+    throw new AgentConfigError(
+      "exactly one of contextStore or contextDir is required",
+    );
+  }
+
+  let contextStore: ContextStore;
+  let auditStore: AuditStore | undefined;
+  let lock: ContextDirLock | undefined;
+
+  if (config.contextDir !== undefined) {
+    lock = acquireContextDirLock(config.contextDir);
+    try {
+      const store = await createIsogitStore(config.contextDir);
+      contextStore = store;
+      auditStore = config.auditStore ?? store;
+    } catch (cause) {
+      lock.release();
+      throw cause;
+    }
+  } else if (config.contextStore !== undefined) {
+    contextStore = config.contextStore;
+    auditStore = config.auditStore;
+  } else {
+    throw new AgentConfigError("unreachable: storage form validated above");
+  }
+
+  let providerRegistry: ProviderRegistry;
+  let toolRunner: AgentToolRunner;
+  try {
+    providerRegistry = createProviderRegistry({
+      providers: config.providers,
+      defaultModel: config.defaultModel,
+    });
+    toolRunner = createToolRunner(config.tools);
+  } catch (cause) {
+    if (lock !== undefined) lock.release();
+    throw cause;
+  }
+
+  let director: ReactorDirector;
+  if (config.director !== undefined) {
+    director = config.director;
+  } else {
+    if (providerRegistry.active.model === undefined) {
+      if (lock !== undefined) lock.release();
+      throw new AgentConfigError(
+        "active provider must have model defined when using the default director",
+      );
+    }
+    director = createDefaultDirector(
+      providerRegistry.active.model,
+      config.systemPrompt,
+      [...toolRunner.definitions],
+      {},
+    );
+  }
+
+  const sessionId = config.sessionId ?? crypto.randomUUID();
+
+  // Event listeners. Commits 7 and 8 replace these naive callback sets with
+  // a FIFO send queue and a bounded per-consumer stream buffer.
+  type EventListener = (event: ReactorEmittedEvent) => void;
+  const streamConsumers = new Set<EventListener>();
+  let activeSendListener: EventListener | undefined;
+
+  function handleEvent(event: ReactorEmittedEvent): void {
+    if (activeSendListener !== undefined) {
+      activeSendListener(event);
+    }
+    for (const consumer of streamConsumers) {
+      consumer(event);
+    }
+  }
+
+  const { reactor, blobReader } = createReactorAssembly({
+    sessionId,
+    director,
+    providerConfig: providerRegistry.active,
+    toolRunner,
+    contextStore,
+    onEvent: handleEvent,
+    ...(auditStore !== undefined ? { auditStore } : {}),
+    ...(config.authorize !== undefined ? { authorize: config.authorize } : {}),
+    ...(config.sizeCapMaxChars !== undefined
+      ? { sizeCapMaxChars: config.sizeCapMaxChars }
+      : {}),
+  });
+
+  reactor.start();
+
+  let closed = false;
+  let sendInFlight = false;
+
+  function ensureOpen(): void {
+    if (closed) throw new AgentClosedError();
+  }
+
+  function buildInboundMessage(
+    content: string | InboundMessage,
+    opts?: SendOptions,
+  ): InboundMessage {
+    if (typeof content !== "string") return content;
+    // Conversation messages use `content` (a string); the mail-builder
+    // rejects passing `payload` for conversation types.
+    return createInboundMessage({
+      from: opts?.from ?? DEFAULT_SEND_FROM,
+      to: DEFAULT_SEND_TO,
+      content,
+      interchangeType: "conversation.message",
+    });
+  }
+
+  function send(
+    content: string | InboundMessage,
+    opts?: SendOptions,
+  ): Promise<SendResult> {
+    ensureOpen();
+    if (sendInFlight) {
+      return Promise.reject(new ConcurrentSendError());
+    }
+    sendInFlight = true;
+
+    const message = buildInboundMessage(content, opts);
+
+    return new Promise<SendResult>((resolve, reject) => {
+      let lastAssistantTurn: AssistantTurn | undefined;
+
+      activeSendListener = (event) => {
+        if (event.type === "inference.done") {
+          lastAssistantTurn = event.data.turn;
+          return;
+        }
+        if (event.type === "connector.reply") {
+          activeSendListener = undefined;
+          sendInFlight = false;
+          const turn: ConversationTurn = lastAssistantTurn ?? {
+            role: "assistant",
+            content: [{ type: "text", text: event.data.content }],
+            ...(providerRegistry.active.model !== undefined
+              ? { model: providerRegistry.active.model }
+              : {}),
+            timestamp: Date.now(),
+          };
+          resolve({ reply: event.data.content, turn });
+          return;
+        }
+        if (event.type === "reactor.error") {
+          activeSendListener = undefined;
+          sendInFlight = false;
+          reject(new Error(`reactor error: ${event.data.error}`));
+          return;
+        }
+        if (event.type === "reactor.done") {
+          activeSendListener = undefined;
+          sendInFlight = false;
+          reject(new AgentClosedError());
+          return;
+        }
+      };
+
+      reactor.deliver(message);
+    });
+  }
+
+  // eslint-disable-next-line require-yield -- placeholder iterator; commit 8 replaces with bounded fan-out
+  async function* stream(): AsyncIterable<ReactorEmittedEvent> {
+    ensureOpen();
+    // Placeholder until commit 8 wires the bounded per-consumer buffer.
+    // Returning an immediately-finishing iterator keeps the type honest
+    // without yielding events.
+    return;
+  }
+
+  function deliver(message: InboundMessage): void {
+    ensureOpen();
+    reactor.deliver(message);
+  }
+
+  function setProvider(cfg: ProviderConfig): void {
+    ensureOpen();
+    providerRegistry.setProvider(cfg);
+  }
+
+  async function history(): Promise<ConversationTurn[]> {
+    const loaded = await contextStore.load();
+    return loaded.turns;
+  }
+
+  async function checkpoints(limit?: number): Promise<ContextCommit[]> {
+    return contextStore.log(limit);
+  }
+
+  async function readAt(hash: string): Promise<ConversationTurn[]> {
+    return contextStore.readAt(hash);
+  }
+
+  async function close(): Promise<void> {
+    if (closed) return;
+    closed = true;
+    reactor.abort("user_disconnect");
+    streamConsumers.clear();
+    activeSendListener = undefined;
+    if (lock !== undefined) lock.release();
+  }
+
+  return {
+    send,
+    stream,
+    deliver,
+    close,
+    setProvider,
+    history,
+    checkpoints,
+    readAt,
+    blobReader,
+  };
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,0 +1,8 @@
+// @interchange/agent — in-process agent runtime.
+//
+// Sits on top of `createReactorAssembly` from `@interchange/inference` to
+// provide a code-driven agent surface: send a message, stream events, project
+// history, hot-swap providers. Peer to `@interchange/harness`; the harness
+// drives the reactor from a mail transport (INBOX watch, connector threads,
+// outbound replies via MessageTransport) while the agent drives it from
+// in-process calls.

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -8,3 +8,13 @@
 // in-process calls.
 
 export { AgentInUseError } from "./lock";
+export {
+  type AgentTool,
+  type AgentToolRunner,
+  type StringToolHandler,
+  type ToolHandler,
+  DuplicateToolError,
+  createToolRunner,
+  stringTool,
+  tool,
+} from "./tool";

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6,3 +6,5 @@
 // drives the reactor from a mail transport (INBOX watch, connector threads,
 // outbound replies via MessageTransport) while the agent drives it from
 // in-process calls.
+
+export { AgentInUseError } from "./lock";

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -15,6 +15,7 @@ export {
   type ToolHandler,
   DuplicateToolError,
   createToolRunner,
+  fromToolRunner,
   stringTool,
   tool,
 } from "./tool";

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -24,3 +24,13 @@ export {
   ProviderNotFoundError,
   createProviderRegistry,
 } from "./provider";
+export {
+  type Agent,
+  type AgentConfig,
+  type SendOptions,
+  type SendResult,
+  AgentClosedError,
+  AgentConfigError,
+  ConcurrentSendError,
+  createAgent,
+} from "./agent";

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -18,3 +18,9 @@ export {
   stringTool,
   tool,
 } from "./tool";
+export {
+  type ProviderRegistry,
+  InvalidProviderConfigError,
+  ProviderNotFoundError,
+  createProviderRegistry,
+} from "./provider";

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -34,3 +34,4 @@ export {
   createAgent,
 } from "./agent";
 export { SendQueueFullError } from "./send-queue";
+export { StreamBackpressureError } from "./stream";

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -31,6 +31,6 @@ export {
   type SendResult,
   AgentClosedError,
   AgentConfigError,
-  ConcurrentSendError,
   createAgent,
 } from "./agent";
+export { SendQueueFullError } from "./send-queue";

--- a/packages/agent/src/lock.test.ts
+++ b/packages/agent/src/lock.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect } from "bun:test";
+import { resolve } from "node:path";
+
+import { acquireContextDirLock, AgentInUseError } from "./lock";
+
+describe("acquireContextDirLock", () => {
+  test("returns a lock whose path is the resolved absolute path", () => {
+    const lock = acquireContextDirLock("/tmp/agent-lock-1");
+    try {
+      expect(lock.path).toBe(resolve("/tmp/agent-lock-1"));
+    } finally {
+      lock.release();
+    }
+  });
+
+  test("rejects a second acquisition of the same directory", () => {
+    const lock = acquireContextDirLock("/tmp/agent-lock-2");
+    try {
+      expect(() => acquireContextDirLock("/tmp/agent-lock-2")).toThrow(
+        AgentInUseError,
+      );
+    } finally {
+      lock.release();
+    }
+  });
+
+  test("re-acquires the same directory after release", () => {
+    const lock1 = acquireContextDirLock("/tmp/agent-lock-3");
+    lock1.release();
+    const lock2 = acquireContextDirLock("/tmp/agent-lock-3");
+    try {
+      expect(lock2.path).toBe(resolve("/tmp/agent-lock-3"));
+    } finally {
+      lock2.release();
+    }
+  });
+
+  test("collides on lexically distinct but equivalent paths", () => {
+    const lock = acquireContextDirLock("/tmp/agent-lock-4/../agent-lock-4/foo");
+    try {
+      expect(() => acquireContextDirLock("/tmp/agent-lock-4/foo")).toThrow(
+        AgentInUseError,
+      );
+    } finally {
+      lock.release();
+    }
+  });
+
+  test("collides on a relative path that resolves to the same absolute path", () => {
+    const absolute = resolve("relative-lock-test-dir");
+    const lock = acquireContextDirLock("relative-lock-test-dir");
+    try {
+      expect(lock.path).toBe(absolute);
+      expect(() => acquireContextDirLock(absolute)).toThrow(AgentInUseError);
+    } finally {
+      lock.release();
+    }
+  });
+
+  test("does not collide between distinct directories", () => {
+    const lock1 = acquireContextDirLock("/tmp/agent-lock-5a");
+    const lock2 = acquireContextDirLock("/tmp/agent-lock-5b");
+    try {
+      expect(lock1.path).not.toBe(lock2.path);
+    } finally {
+      lock1.release();
+      lock2.release();
+    }
+  });
+
+  test("release is idempotent", () => {
+    const lock = acquireContextDirLock("/tmp/agent-lock-6");
+    lock.release();
+    lock.release();
+    const reacquired = acquireContextDirLock("/tmp/agent-lock-6");
+    reacquired.release();
+  });
+
+  test("AgentInUseError exposes contextDir as the resolved path", () => {
+    const lock = acquireContextDirLock("/tmp/agent-lock-7");
+    try {
+      acquireContextDirLock("/tmp/agent-lock-7");
+      throw new Error("should have thrown AgentInUseError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AgentInUseError);
+      if (err instanceof AgentInUseError) {
+        expect(err.contextDir).toBe(resolve("/tmp/agent-lock-7"));
+      }
+    } finally {
+      lock.release();
+    }
+  });
+});

--- a/packages/agent/src/lock.ts
+++ b/packages/agent/src/lock.ts
@@ -1,0 +1,57 @@
+// Process-wide registry of held context-directory locks.
+//
+// The agent enforces a runtime singleton-per-contextDir invariant: at most one
+// in-process agent may own a given context directory at a time. Holding two
+// agents against the same directory simultaneously corrupts both the git
+// state and the audit collector's bookkeeping.
+//
+// This is a best-effort in-process check. It does not coordinate across OS
+// processes, and it compares lexically-resolved absolute paths — two paths
+// that point to the same directory through symlinks or `..`/`/./` segments
+// are normalized by `path.resolve`, but a hard link or a separately mounted
+// bind to the same inode will not be detected. Callers passing their own
+// `contextStore` (rather than a `contextDir` string) bypass the lock; they
+// are responsible for their store's lifetime.
+
+import { resolve } from "node:path";
+
+const heldLocks = new Set<string>();
+
+export class AgentInUseError extends Error {
+  readonly contextDir: string;
+
+  constructor(contextDir: string) {
+    super(`an agent is already open for context directory: ${contextDir}`);
+    this.name = "AgentInUseError";
+    this.contextDir = contextDir;
+  }
+}
+
+export type ContextDirLock = {
+  /** Absolute, resolved path of the locked directory. */
+  readonly path: string;
+  /** Release the lock. Idempotent. */
+  release(): void;
+};
+
+/**
+ * Acquire the process-wide lock for `contextDir`. Throws `AgentInUseError`
+ * if another agent already holds it. The returned `release` is idempotent.
+ */
+export function acquireContextDirLock(contextDir: string): ContextDirLock {
+  const path = resolve(contextDir);
+  if (heldLocks.has(path)) {
+    throw new AgentInUseError(path);
+  }
+  heldLocks.add(path);
+
+  let released = false;
+  return {
+    path,
+    release() {
+      if (released) return;
+      released = true;
+      heldLocks.delete(path);
+    },
+  };
+}

--- a/packages/agent/src/provider.test.ts
+++ b/packages/agent/src/provider.test.ts
@@ -1,0 +1,148 @@
+import { describe, test, expect } from "bun:test";
+
+import type { ProviderConfig } from "@interchange/types/runtime";
+
+import {
+  createProviderRegistry,
+  InvalidProviderConfigError,
+  ProviderNotFoundError,
+} from "./provider";
+
+const P_ANTHROPIC: ProviderConfig = {
+  provider: "anthropic",
+  baseURL: "https://api.anthropic.com",
+  apiKey: "sk-anthropic-1",
+  model: "claude-3-5-sonnet",
+};
+
+const P_OPENAI: ProviderConfig = {
+  provider: "openai",
+  baseURL: "https://api.openai.com",
+  apiKey: "sk-openai-1",
+  model: "gpt-4o",
+};
+
+/**
+ * Test helper: produce an intentionally-invalid `ProviderConfig` value so
+ * we can verify that runtime validation rejects it. The whole point is to
+ * exercise the arktype check, which requires bypassing the static type.
+ */
+function invalidConfig(value: unknown): ProviderConfig {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- intentional invalid input for arktype validation test
+  return value as ProviderConfig;
+}
+
+describe("createProviderRegistry", () => {
+  test("selects the provider whose model matches defaultModel", () => {
+    const reg = createProviderRegistry({
+      providers: [P_ANTHROPIC, P_OPENAI],
+      defaultModel: "gpt-4o",
+    });
+    expect(reg.active.provider).toBe("openai");
+    expect(reg.active.model).toBe("gpt-4o");
+    expect(reg.active.apiKey).toBe("sk-openai-1");
+  });
+
+  test("rejects an empty providers[] array", () => {
+    expect(() =>
+      createProviderRegistry({ providers: [], defaultModel: "anything" }),
+    ).toThrow(InvalidProviderConfigError);
+  });
+
+  test("rejects providers that fail ProviderConfig arktype validation", () => {
+    expect(() =>
+      createProviderRegistry({
+        providers: [invalidConfig({ provider: "x", apiKey: "k" })],
+        defaultModel: "anything",
+      }),
+    ).toThrow(InvalidProviderConfigError);
+  });
+
+  test("rejects a provider entry missing model", () => {
+    const noModel: ProviderConfig = {
+      provider: "anthropic",
+      baseURL: "u",
+      apiKey: "k",
+    };
+    expect(() =>
+      createProviderRegistry({
+        providers: [noModel],
+        defaultModel: "anything",
+      }),
+    ).toThrow(InvalidProviderConfigError);
+  });
+
+  test("throws ProviderNotFoundError when defaultModel matches no provider", () => {
+    expect(() =>
+      createProviderRegistry({
+        providers: [P_ANTHROPIC],
+        defaultModel: "gpt-4o",
+      }),
+    ).toThrow(ProviderNotFoundError);
+  });
+
+  test("active is a mutable holder; setProvider mutates fields in place", () => {
+    const reg = createProviderRegistry({
+      providers: [P_ANTHROPIC],
+      defaultModel: "claude-3-5-sonnet",
+    });
+    const reference = reg.active;
+
+    reg.setProvider({
+      provider: "anthropic",
+      baseURL: "https://proxy.example.com",
+      apiKey: "sk-new",
+      model: "claude-3-5-haiku",
+    });
+
+    expect(reg.active).toBe(reference);
+    expect(reg.active.provider).toBe("anthropic");
+    expect(reg.active.baseURL).toBe("https://proxy.example.com");
+    expect(reg.active.apiKey).toBe("sk-new");
+    expect(reg.active.model).toBe("claude-3-5-haiku");
+  });
+
+  test("setProvider deletes model when the new config has none", () => {
+    const reg = createProviderRegistry({
+      providers: [P_ANTHROPIC],
+      defaultModel: "claude-3-5-sonnet",
+    });
+
+    reg.setProvider({
+      provider: "anthropic",
+      baseURL: "https://api.anthropic.com",
+      apiKey: "sk-anthropic-1",
+    });
+
+    expect(reg.active.model).toBeUndefined();
+  });
+
+  test("setProvider throws InvalidProviderConfigError on invalid input", () => {
+    const reg = createProviderRegistry({
+      providers: [P_ANTHROPIC],
+      defaultModel: "claude-3-5-sonnet",
+    });
+
+    expect(() => reg.setProvider(invalidConfig({ provider: "x" }))).toThrow(
+      InvalidProviderConfigError,
+    );
+  });
+
+  test("does not mutate the caller's providers[] entries", () => {
+    const inputs: ProviderConfig[] = [{ ...P_ANTHROPIC }];
+    const reg = createProviderRegistry({
+      providers: inputs,
+      defaultModel: "claude-3-5-sonnet",
+    });
+
+    reg.setProvider({
+      provider: "anthropic",
+      baseURL: "https://other.example.com",
+      apiKey: "sk-other",
+      model: "claude-3-5-sonnet",
+    });
+
+    expect(inputs[0]?.apiKey).toBe("sk-anthropic-1");
+    expect(inputs[0]?.baseURL).toBe("https://api.anthropic.com");
+  });
+});

--- a/packages/agent/src/provider.ts
+++ b/packages/agent/src/provider.ts
@@ -1,0 +1,95 @@
+// Provider registry.
+//
+// The agent accepts an array of pre-configured providers and a defaultModel
+// at construction. The provider whose `model` field matches `defaultModel`
+// becomes the active config — the same object reference is what the
+// reactor's assembly holds and reads lazily at each inference call.
+//
+// `setProvider` mutates that shared object in place so the next inference
+// call observes the new credentials and model. In-flight calls keep using
+// the values they read at start-of-call (the reactor does not refetch
+// mid-stream); the swap is therefore safe with respect to torn state.
+
+import { type } from "arktype";
+
+import {
+  ProviderConfig as ProviderConfigValidator,
+  type ProviderConfig,
+} from "@interchange/types/runtime";
+
+export class InvalidProviderConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidProviderConfigError";
+  }
+}
+
+export class ProviderNotFoundError extends Error {
+  readonly model: string;
+
+  constructor(model: string) {
+    super(`no provider in providers[] has model ${model}`);
+    this.name = "ProviderNotFoundError";
+    this.model = model;
+  }
+}
+
+export type ProviderRegistry = {
+  /**
+   * The mutable active provider config. The same object reference is held
+   * by the reactor; mutating it through `setProvider` is what swaps the
+   * provider for subsequent inference calls.
+   */
+  readonly active: ProviderConfig;
+  /** Replace the active provider's fields in place. */
+  setProvider(config: ProviderConfig): void;
+};
+
+export function createProviderRegistry(opts: {
+  providers: ProviderConfig[];
+  defaultModel: string;
+}): ProviderRegistry {
+  if (opts.providers.length === 0) {
+    throw new InvalidProviderConfigError("providers[] must be non-empty");
+  }
+
+  const validated: ProviderConfig[] = [];
+  for (const [i, raw] of opts.providers.entries()) {
+    const parsed = ProviderConfigValidator(raw);
+    if (parsed instanceof type.errors) {
+      throw new InvalidProviderConfigError(
+        `providers[${String(i)}]: ${parsed.summary}`,
+      );
+    }
+    if (parsed.model === undefined) {
+      throw new InvalidProviderConfigError(
+        `providers[${String(i)}]: model is required when used in agent providers[]`,
+      );
+    }
+    validated.push(parsed);
+  }
+
+  const initial = validated.find((p) => p.model === opts.defaultModel);
+  if (initial === undefined) {
+    throw new ProviderNotFoundError(opts.defaultModel);
+  }
+
+  const active: ProviderConfig = { ...initial };
+
+  function setProvider(config: ProviderConfig): void {
+    const parsed = ProviderConfigValidator(config);
+    if (parsed instanceof type.errors) {
+      throw new InvalidProviderConfigError(parsed.summary);
+    }
+    active.provider = parsed.provider;
+    active.baseURL = parsed.baseURL;
+    active.apiKey = parsed.apiKey;
+    if (parsed.model !== undefined) {
+      active.model = parsed.model;
+    } else {
+      delete active.model;
+    }
+  }
+
+  return { active, setProvider };
+}

--- a/packages/agent/src/send-queue.test.ts
+++ b/packages/agent/src/send-queue.test.ts
@@ -1,0 +1,207 @@
+import { describe, test, expect } from "bun:test";
+
+import { createSendQueue, SendQueueFullError } from "./send-queue";
+
+/**
+ * Tests use `string` as the result type so the queue's generic R parameter
+ * holds a real value (it cannot be `void` under
+ * `@typescript-eslint/no-invalid-void-type`). The actual values are
+ * arbitrary; tests assert ordering and lifecycle, not result content.
+ */
+
+describe("createSendQueue", () => {
+  test("starts the first enqueued item immediately", () => {
+    const started: string[] = [];
+    const q = createSendQueue<string, string>({
+      maxDepth: 4,
+      start: (item) => {
+        started.push(item);
+      },
+    });
+
+    void q.enqueue("a");
+    expect(started).toEqual(["a"]);
+  });
+
+  test("queues subsequent items and starts each on resolveActive", async () => {
+    const started: string[] = [];
+    const q = createSendQueue<string, string>({
+      maxDepth: 4,
+      start: (item) => {
+        started.push(item);
+      },
+    });
+
+    const p1 = q.enqueue("a");
+    const p2 = q.enqueue("b");
+    expect(started).toEqual(["a"]);
+
+    q.resolveActive("r1");
+    expect(await p1).toBe("r1");
+    expect(started).toEqual(["a", "b"]);
+
+    q.resolveActive("r2");
+    expect(await p2).toBe("r2");
+  });
+
+  test("throws SendQueueFullError synchronously at capacity", () => {
+    const started: number[] = [];
+    const q = createSendQueue<number, string>({
+      maxDepth: 2,
+      start: (item) => {
+        started.push(item);
+      },
+    });
+
+    void q.enqueue(1);
+    void q.enqueue(2);
+    expect(() => q.enqueue(3)).toThrow(SendQueueFullError);
+  });
+
+  test("rejects pre-aborted signal without enqueuing", async () => {
+    const ctl = new AbortController();
+    ctl.abort();
+
+    const started: number[] = [];
+    const q = createSendQueue<number, string>({
+      maxDepth: 4,
+      start: (item) => {
+        started.push(item);
+      },
+    });
+
+    await expect(q.enqueue(1, ctl.signal)).rejects.toBeDefined();
+    expect(started).toEqual([]);
+    expect(q.depth).toBe(0);
+  });
+
+  test("removes a queued item whose signal fires before processing", async () => {
+    const started: number[] = [];
+    const ctl = new AbortController();
+    const q = createSendQueue<number, string>({
+      maxDepth: 4,
+      start: (item) => {
+        started.push(item);
+      },
+    });
+
+    const p1 = q.enqueue(1);
+    const p2 = q.enqueue(2, ctl.signal);
+    const p3 = q.enqueue(3);
+
+    expect(started).toEqual([1]);
+    ctl.abort();
+    await expect(p2).rejects.toBeDefined();
+
+    q.resolveActive("r1");
+    expect(await p1).toBe("r1");
+    expect(started).toEqual([1, 3]);
+
+    q.resolveActive("r3");
+    expect(await p3).toBe("r3");
+  });
+
+  test("settles caller on in-flight abort but waits for consumer to advance", async () => {
+    const started: number[] = [];
+    const ctl = new AbortController();
+    const q = createSendQueue<number, string>({
+      maxDepth: 4,
+      start: (item) => {
+        started.push(item);
+      },
+    });
+
+    const p1 = q.enqueue(1, ctl.signal);
+    const p2 = q.enqueue(2);
+    expect(started).toEqual([1]);
+
+    ctl.abort();
+    await expect(p1).rejects.toBeDefined();
+    // Active slot is still held until the consumer reports the cycle done.
+    expect(started).toEqual([1]);
+
+    q.resolveActive("late-r1");
+    expect(started).toEqual([1, 2]);
+
+    q.resolveActive("r2");
+    expect(await p2).toBe("r2");
+  });
+
+  test("late resolveActive after abort is a no-op for the caller", async () => {
+    const ctl = new AbortController();
+    const started: number[] = [];
+    const q = createSendQueue<number, string>({
+      maxDepth: 4,
+      start: (item) => {
+        started.push(item);
+      },
+    });
+
+    const p = q.enqueue(1, ctl.signal);
+    ctl.abort();
+    await expect(p).rejects.toBeDefined();
+
+    q.resolveActive("late");
+    expect(q.depth).toBe(0);
+  });
+
+  test("drain rejects active and pending jobs with the given reason", async () => {
+    const started: number[] = [];
+    const q = createSendQueue<number, string>({
+      maxDepth: 4,
+      start: (item) => {
+        started.push(item);
+      },
+    });
+
+    const p1 = q.enqueue(1);
+    const p2 = q.enqueue(2);
+    const reason = new Error("closed");
+
+    q.drain(reason);
+    await expect(p1).rejects.toBe(reason);
+    await expect(p2).rejects.toBe(reason);
+    expect(q.depth).toBe(0);
+  });
+
+  test("depth reflects active + pending", () => {
+    const started: number[] = [];
+    const q = createSendQueue<number, string>({
+      maxDepth: 4,
+      start: (item) => {
+        started.push(item);
+      },
+    });
+
+    expect(q.depth).toBe(0);
+    void q.enqueue(1);
+    expect(q.depth).toBe(1);
+    void q.enqueue(2);
+    expect(q.depth).toBe(2);
+
+    q.resolveActive("r1");
+    expect(q.depth).toBe(1);
+    q.resolveActive("r2");
+    expect(q.depth).toBe(0);
+  });
+
+  test("capacity check counts the abandoned active slot", async () => {
+    const ctl = new AbortController();
+    const started: number[] = [];
+    const q = createSendQueue<number, string>({
+      maxDepth: 2,
+      start: (item) => {
+        started.push(item);
+      },
+    });
+
+    const p1 = q.enqueue(1, ctl.signal);
+    void q.enqueue(2);
+    ctl.abort();
+    await expect(p1).rejects.toBeDefined();
+
+    // Active slot still occupied (consumer has not advanced). Adding a
+    // third would exceed maxDepth=2.
+    expect(() => q.enqueue(3)).toThrow(SendQueueFullError);
+  });
+});

--- a/packages/agent/src/send-queue.ts
+++ b/packages/agent/src/send-queue.ts
@@ -1,0 +1,200 @@
+// FIFO queue for serializing send() calls against a single reactor.
+//
+// The agent processes one reactor cycle at a time, so concurrent send()
+// callers are queued. Each queued item carries the caller's resolve/reject
+// hooks and an optional AbortSignal:
+//
+//   - If the signal is already aborted when enqueue() is called the queue
+//     rejects synchronously without enqueueing.
+//   - If the signal fires while the item is still queued the item is
+//     removed and rejected.
+//   - If the signal fires while the item is active the caller-facing
+//     promise rejects immediately, but the reactor cycle continues in the
+//     background. The queue does not start the next item until the consumer
+//     reports the cycle done via resolveActive/rejectActive. This keeps the
+//     queue ordered against actual reactor cycles — two send() promises
+//     cannot interleave at the reactor level.
+//
+// Queue depth (active + pending) is bounded by `maxDepth`; exceeding it
+// throws `SendQueueFullError` synchronously from enqueue() so a buggy
+// caller flooding sends fails loud instead of silently buffering.
+
+export class SendQueueFullError extends Error {
+  readonly maxDepth: number;
+
+  constructor(maxDepth: number) {
+    super(`send queue is full (max depth ${String(maxDepth)})`);
+    this.name = "SendQueueFullError";
+    this.maxDepth = maxDepth;
+  }
+}
+
+type Job<T, R> = {
+  item: T;
+  signal?: AbortSignal;
+  abortHandler?: () => void;
+  resolve: (value: R) => void;
+  reject: (reason: unknown) => void;
+  /**
+   * True once the caller-facing promise has been settled (resolve or
+   * reject). Subsequent settles are no-ops. The active slot may remain
+   * occupied after a settle when the caller aborted mid-cycle — the queue
+   * waits for the consumer's resolveActive/rejectActive before pumping the
+   * next item.
+   */
+  settled: boolean;
+};
+
+export type SendQueueOptions<T> = {
+  maxDepth: number;
+  /**
+   * Called when a job moves from pending to active. The consumer drives
+   * the underlying work and must eventually call `resolveActive` or
+   * `rejectActive` exactly once.
+   */
+  start: (item: T) => void;
+};
+
+export type SendQueue<T, R> = {
+  enqueue(item: T, signal?: AbortSignal): Promise<R>;
+  /** Mark the active job complete with success and pump the next. */
+  resolveActive(value: R): void;
+  /** Mark the active job complete with failure and pump the next. */
+  rejectActive(reason: unknown): void;
+  /** Reject the active job (if any) and every pending job with `reason`. */
+  drain(reason: unknown): void;
+  /** Current pending count (queued + active). */
+  readonly depth: number;
+};
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("aborted", "AbortError");
+}
+
+export function createSendQueue<T, R>(
+  opts: SendQueueOptions<T>,
+): SendQueue<T, R> {
+  const pending: Job<T, R>[] = [];
+  let active: Job<T, R> | null = null;
+
+  function settle(
+    job: Job<T, R>,
+    kind: "resolve" | "reject",
+    value: unknown,
+  ): void {
+    if (job.settled) return;
+    job.settled = true;
+    if (job.abortHandler !== undefined && job.signal !== undefined) {
+      job.signal.removeEventListener("abort", job.abortHandler);
+    }
+    if (kind === "resolve") {
+      // The queue's value type is checked at enqueue / resolveActive; the
+      // generic narrowing here is safe by construction.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- generic resolve value
+      job.resolve(value as R);
+    } else {
+      job.reject(value);
+    }
+  }
+
+  function pump(): void {
+    while (active === null && pending.length > 0) {
+      const next = pending.shift();
+      if (next === undefined) return;
+      if (next.signal?.aborted === true) {
+        settle(next, "reject", abortReason(next.signal));
+        continue;
+      }
+      active = next;
+      opts.start(next.item);
+      return;
+    }
+  }
+
+  function enqueue(item: T, signal?: AbortSignal): Promise<R> {
+    if (signal?.aborted === true) {
+      return Promise.reject(abortReason(signal));
+    }
+
+    const depth = pending.length + (active !== null ? 1 : 0);
+    if (depth >= opts.maxDepth) {
+      throw new SendQueueFullError(opts.maxDepth);
+    }
+
+    let resolve!: (value: R) => void;
+    let reject!: (reason: unknown) => void;
+    const promise = new Promise<R>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    const job: Job<T, R> = {
+      item,
+      ...(signal !== undefined ? { signal } : {}),
+      resolve,
+      reject,
+      settled: false,
+    };
+
+    if (signal !== undefined) {
+      const handler = (): void => {
+        const reason = abortReason(signal);
+        if (active === job) {
+          // In flight: settle the caller now; the consumer will eventually
+          // call resolveActive/rejectActive which becomes a no-op and
+          // advances the queue.
+          settle(job, "reject", reason);
+        } else {
+          const idx = pending.indexOf(job);
+          if (idx >= 0) pending.splice(idx, 1);
+          settle(job, "reject", reason);
+        }
+      };
+      signal.addEventListener("abort", handler, { once: true });
+      job.abortHandler = handler;
+    }
+
+    pending.push(job);
+    pump();
+    return promise;
+  }
+
+  function resolveActive(value: R): void {
+    if (active === null) return;
+    const job = active;
+    active = null;
+    settle(job, "resolve", value);
+    pump();
+  }
+
+  function rejectActive(reason: unknown): void {
+    if (active === null) return;
+    const job = active;
+    active = null;
+    settle(job, "reject", reason);
+    pump();
+  }
+
+  function drain(reason: unknown): void {
+    const drained: Job<T, R>[] = [];
+    if (active !== null) {
+      drained.push(active);
+      active = null;
+    }
+    drained.push(...pending);
+    pending.length = 0;
+    for (const job of drained) {
+      settle(job, "reject", reason);
+    }
+  }
+
+  return {
+    enqueue,
+    resolveActive,
+    rejectActive,
+    drain,
+    get depth() {
+      return pending.length + (active !== null ? 1 : 0);
+    },
+  };
+}

--- a/packages/agent/src/stream.test.ts
+++ b/packages/agent/src/stream.test.ts
@@ -1,0 +1,167 @@
+import { describe, test, expect } from "bun:test";
+
+import type { ReactorEmittedEvent } from "@interchange/inference";
+
+import { createStreamConsumer, StreamBackpressureError } from "./stream";
+
+/**
+ * Build a minimal ReactorEmittedEvent suitable for fan-out testing. The
+ * event's structural details do not matter — the stream consumer treats
+ * events opaquely — so we use `reactor.done`, which has an empty `data`.
+ */
+function makeEvent(seq: number): ReactorEmittedEvent {
+  return { type: "reactor.done", seq, data: {} };
+}
+
+async function collect(
+  it: AsyncIterableIterator<ReactorEmittedEvent>,
+  n: number,
+): Promise<ReactorEmittedEvent[]> {
+  const out: ReactorEmittedEvent[] = [];
+  for (let i = 0; i < n; i++) {
+    const r = await it.next();
+    if (r.done === true) break;
+    out.push(r.value);
+  }
+  return out;
+}
+
+describe("createStreamConsumer", () => {
+  test("delivers buffered events to a later iterator read", async () => {
+    const c = createStreamConsumer(8);
+    const it = c.iterator();
+    c.push(makeEvent(1));
+    c.push(makeEvent(2));
+    const got = await collect(it, 2);
+    expect(got.map((e) => e.seq)).toEqual([1, 2]);
+  });
+
+  test("delivers events directly to a waiting iterator", async () => {
+    const c = createStreamConsumer(8);
+    const it = c.iterator();
+    const pending = it.next();
+    c.push(makeEvent(42));
+    const r = await pending;
+    expect(r.done).toBe(false);
+    if (r.done !== true) expect(r.value.seq).toBe(42);
+  });
+
+  test("close terminates pending and subsequent reads with done", async () => {
+    const c = createStreamConsumer(8);
+    const it = c.iterator();
+    const pending = it.next();
+    c.close();
+    const r1 = await pending;
+    expect(r1.done).toBe(true);
+    const r2 = await it.next();
+    expect(r2.done).toBe(true);
+  });
+
+  test("close after buffered events still drains them before done", async () => {
+    const c = createStreamConsumer(8);
+    const it = c.iterator();
+    c.push(makeEvent(1));
+    c.push(makeEvent(2));
+    c.close();
+    const r1 = await it.next();
+    expect(r1.done).toBe(false);
+    const r2 = await it.next();
+    expect(r2.done).toBe(false);
+    const r3 = await it.next();
+    expect(r3.done).toBe(true);
+  });
+
+  test("overflow throws StreamBackpressureError on next read", async () => {
+    const c = createStreamConsumer(3);
+    const it = c.iterator();
+    c.push(makeEvent(1));
+    c.push(makeEvent(2));
+    c.push(makeEvent(3));
+    c.push(makeEvent(4));
+
+    // Buffered events drain first.
+    const r1 = await it.next();
+    expect(r1.done).toBe(false);
+    const r2 = await it.next();
+    expect(r2.done).toBe(false);
+    const r3 = await it.next();
+    expect(r3.done).toBe(false);
+
+    // Next read sees the overflow.
+    await expect(it.next()).rejects.toBeInstanceOf(StreamBackpressureError);
+  });
+
+  test("overflow rejects a pending waiter", async () => {
+    const c = createStreamConsumer(2);
+    const it = c.iterator();
+    const pending = it.next();
+    // Direct delivery to the waiter does NOT increase the buffer.
+    c.push(makeEvent(1));
+    const r1 = await pending;
+    expect(r1.done).toBe(false);
+
+    // Now buffer 2 events (capacity), then a 3rd while another waiter is
+    // pending — wait, an immediate waiter would consume the 3rd directly.
+    // Instead saturate the buffer first.
+    c.push(makeEvent(2));
+    c.push(makeEvent(3));
+    // Saturated. A pending waiter at this point will be served from the
+    // buffer; the overflow only fires on a push that has no waiter and a
+    // full buffer.
+    c.push(makeEvent(4));
+
+    // Drain.
+    const r2 = await it.next();
+    expect(r2.done).toBe(false);
+    const r3 = await it.next();
+    expect(r3.done).toBe(false);
+
+    await expect(it.next()).rejects.toBeInstanceOf(StreamBackpressureError);
+  });
+
+  test("multiple consumers buffer independently", async () => {
+    const a = createStreamConsumer(8);
+    const b = createStreamConsumer(8);
+    const ai = a.iterator();
+    const bi = b.iterator();
+
+    a.push(makeEvent(1));
+    b.push(makeEvent(1));
+    a.push(makeEvent(2));
+    b.push(makeEvent(2));
+
+    const aGot = await collect(ai, 2);
+    const bGot = await collect(bi, 2);
+    expect(aGot.map((e) => e.seq)).toEqual([1, 2]);
+    expect(bGot.map((e) => e.seq)).toEqual([1, 2]);
+  });
+
+  test("iterator.return() closes the consumer", async () => {
+    const c = createStreamConsumer(8);
+    const it = c.iterator();
+    expect(c.closed).toBe(false);
+    await it.return?.();
+    expect(c.closed).toBe(true);
+    const r = await it.next();
+    expect(r.done).toBe(true);
+  });
+
+  test("push after close is ignored", async () => {
+    const c = createStreamConsumer(8);
+    const it = c.iterator();
+    c.close();
+    c.push(makeEvent(1));
+    const r = await it.next();
+    expect(r.done).toBe(true);
+  });
+
+  test("Symbol.asyncIterator returns the iterator itself", async () => {
+    const c = createStreamConsumer(8);
+    const it = c.iterator();
+    expect(it[Symbol.asyncIterator]()).toBe(it);
+  });
+
+  test("rejects maxBuffer < 1", () => {
+    expect(() => createStreamConsumer(0)).toThrow();
+  });
+});

--- a/packages/agent/src/stream.ts
+++ b/packages/agent/src/stream.ts
@@ -1,0 +1,142 @@
+// Bounded per-consumer fan-out for the agent's reactor event stream.
+//
+// Each call to `agent.stream()` creates a fresh `StreamConsumer`. The
+// agent feeds every reactor event to every consumer; consumers buffer
+// independently. If a consumer falls more than `maxBuffer` events behind
+// it is poisoned with `StreamBackpressureError` and its iterator throws
+// on the next read — the consumer is removed but other consumers keep
+// running.
+//
+// Loud failure matches the defensive-coding rule: silently dropping
+// events would hide consumer bugs, and unbounded buffering would let a
+// stalled consumer balloon the agent's memory. The cap is configurable
+// via `streamBufferMax` on `AgentConfig`.
+
+import type { ReactorEmittedEvent } from "@interchange/inference";
+
+export class StreamBackpressureError extends Error {
+  readonly maxBuffer: number;
+
+  constructor(maxBuffer: number) {
+    super(`stream consumer fell more than ${String(maxBuffer)} events behind`);
+    this.name = "StreamBackpressureError";
+    this.maxBuffer = maxBuffer;
+  }
+}
+
+type Waiter = {
+  resolve: (value: IteratorResult<ReactorEmittedEvent>) => void;
+  reject: (reason: unknown) => void;
+};
+
+export type StreamConsumer = {
+  /** Deliver an event to this consumer's buffer. */
+  push(event: ReactorEmittedEvent): void;
+  /** Cleanly terminate the iterator with `done: true`. */
+  close(): void;
+  /** True once close() or an overflow has poisoned the consumer. */
+  readonly closed: boolean;
+  /** Iterator handed back to the caller of `stream()`. */
+  iterator(): AsyncIterableIterator<ReactorEmittedEvent>;
+};
+
+export function createStreamConsumer(maxBuffer: number): StreamConsumer {
+  if (maxBuffer < 1) {
+    throw new Error(`streamBufferMax must be >= 1, got ${String(maxBuffer)}`);
+  }
+
+  const buffer: ReactorEmittedEvent[] = [];
+  const waiters: Waiter[] = [];
+  let overflow: StreamBackpressureError | undefined;
+  let done = false;
+
+  function settleOverflowedWaiters(err: StreamBackpressureError): void {
+    while (waiters.length > 0) {
+      const w = waiters.shift();
+      if (w === undefined) return;
+      w.reject(err);
+    }
+  }
+
+  function settleDoneWaiters(): void {
+    while (waiters.length > 0) {
+      const w = waiters.shift();
+      if (w === undefined) return;
+      w.resolve({ value: undefined, done: true });
+    }
+  }
+
+  function push(event: ReactorEmittedEvent): void {
+    if (done || overflow !== undefined) return;
+
+    if (waiters.length > 0) {
+      const w = waiters.shift();
+      if (w === undefined) return;
+      w.resolve({ value: event, done: false });
+      return;
+    }
+
+    if (buffer.length >= maxBuffer) {
+      overflow = new StreamBackpressureError(maxBuffer);
+      settleOverflowedWaiters(overflow);
+      return;
+    }
+
+    buffer.push(event);
+  }
+
+  function close(): void {
+    if (done) return;
+    done = true;
+    settleDoneWaiters();
+  }
+
+  function nextResult(): Promise<IteratorResult<ReactorEmittedEvent>> {
+    if (overflow !== undefined) {
+      // Drain any buffered events before throwing so the caller sees
+      // every event up to the overflow point.
+      if (buffer.length > 0) {
+        const ev = buffer.shift();
+        if (ev !== undefined) {
+          return Promise.resolve({ value: ev, done: false });
+        }
+      }
+      return Promise.reject(overflow);
+    }
+    if (buffer.length > 0) {
+      const ev = buffer.shift();
+      if (ev !== undefined) {
+        return Promise.resolve({ value: ev, done: false });
+      }
+    }
+    if (done) {
+      return Promise.resolve({ value: undefined, done: true });
+    }
+    return new Promise((resolve, reject) => {
+      waiters.push({ resolve, reject });
+    });
+  }
+
+  function iterator(): AsyncIterableIterator<ReactorEmittedEvent> {
+    const it: AsyncIterableIterator<ReactorEmittedEvent> = {
+      next: nextResult,
+      async return() {
+        close();
+        return { value: undefined, done: true };
+      },
+      [Symbol.asyncIterator]() {
+        return it;
+      },
+    };
+    return it;
+  }
+
+  return {
+    push,
+    close,
+    get closed() {
+      return done || overflow !== undefined;
+    },
+    iterator,
+  };
+}

--- a/packages/agent/src/tool.test.ts
+++ b/packages/agent/src/tool.test.ts
@@ -1,0 +1,174 @@
+import { describe, test, expect } from "bun:test";
+
+import type { ToolDefinition } from "@interchange/types/runtime";
+
+import { createToolRunner, DuplicateToolError, stringTool, tool } from "./tool";
+
+const DEF_A: ToolDefinition = {
+  name: "a",
+  description: "tool a",
+  inputSchema: { type: "object" },
+};
+
+const DEF_B: ToolDefinition = {
+  name: "b",
+  description: "tool b",
+  inputSchema: { type: "object" },
+};
+
+describe("createToolRunner", () => {
+  test("dispatches to a full handler by tool name", async () => {
+    const runner = createToolRunner([
+      tool({
+        definition: DEF_A,
+        handler: async (call) => ({
+          callId: call.id,
+          content: `got ${String(call.arguments.x)}`,
+        }),
+      }),
+    ]);
+
+    const result = await runner.run(
+      { id: "c1", name: "a", arguments: { x: 5 } },
+      new AbortController().signal,
+    );
+
+    expect(result).toEqual({ callId: "c1", content: "got 5" });
+  });
+
+  test("lifts the string handler return into a ToolResult", async () => {
+    const runner = createToolRunner([
+      stringTool({
+        definition: DEF_A,
+        handler: async (args) => `hello ${String(args.name)}`,
+      }),
+    ]);
+
+    const result = await runner.run(
+      { id: "c2", name: "a", arguments: { name: "world" } },
+      new AbortController().signal,
+    );
+
+    expect(result).toEqual({ callId: "c2", content: "hello world" });
+  });
+
+  test("returns an error ToolResult for an unknown tool name", async () => {
+    const runner = createToolRunner([
+      tool({
+        definition: DEF_A,
+        handler: async (call) => ({ callId: call.id, content: "" }),
+      }),
+    ]);
+
+    const result = await runner.run(
+      { id: "c3", name: "nope", arguments: {} },
+      new AbortController().signal,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.callId).toBe("c3");
+    expect(result.content).toBe("unknown tool: nope");
+  });
+
+  test("wraps a thrown error from a full handler into an error ToolResult", async () => {
+    const runner = createToolRunner([
+      tool({
+        definition: DEF_A,
+        handler: async () => {
+          throw new Error("boom");
+        },
+      }),
+    ]);
+
+    const result = await runner.run(
+      { id: "c4", name: "a", arguments: {} },
+      new AbortController().signal,
+    );
+
+    expect(result).toEqual({ callId: "c4", content: "boom", isError: true });
+  });
+
+  test("wraps a thrown error from a string handler into an error ToolResult", async () => {
+    const runner = createToolRunner([
+      stringTool({
+        definition: DEF_A,
+        handler: async () => {
+          throw new Error("bad input");
+        },
+      }),
+    ]);
+
+    const result = await runner.run(
+      { id: "c5", name: "a", arguments: {} },
+      new AbortController().signal,
+    );
+
+    expect(result).toEqual({
+      callId: "c5",
+      content: "bad input",
+      isError: true,
+    });
+  });
+
+  test("exposes definitions in registration order", () => {
+    const runner = createToolRunner([
+      tool({
+        definition: DEF_A,
+        handler: async (call) => ({ callId: call.id, content: "" }),
+      }),
+      stringTool({ definition: DEF_B, handler: async () => "x" }),
+    ]);
+
+    expect(runner.definitions.map((d) => d.name)).toEqual(["a", "b"]);
+  });
+
+  test("throws DuplicateToolError at construction on duplicate names", () => {
+    expect(() =>
+      createToolRunner([
+        tool({
+          definition: DEF_A,
+          handler: async (call) => ({ callId: call.id, content: "" }),
+        }),
+        stringTool({ definition: DEF_A, handler: async () => "x" }),
+      ]),
+    ).toThrow(DuplicateToolError);
+  });
+
+  test("propagates the AbortSignal to the handler", async () => {
+    let received: AbortSignal | undefined;
+    const runner = createToolRunner([
+      tool({
+        definition: DEF_A,
+        handler: async (call, signal) => {
+          received = signal;
+          return { callId: call.id, content: "ok" };
+        },
+      }),
+    ]);
+
+    const ctl = new AbortController();
+    await runner.run({ id: "c6", name: "a", arguments: {} }, ctl.signal);
+
+    expect(received).toBe(ctl.signal);
+  });
+
+  test("string handler receives the parsed arguments object", async () => {
+    let received: Record<string, unknown> | undefined;
+    const runner = createToolRunner([
+      stringTool({
+        definition: DEF_A,
+        handler: async (args) => {
+          received = args;
+          return "ok";
+        },
+      }),
+    ]);
+
+    await runner.run(
+      { id: "c7", name: "a", arguments: { foo: 1, bar: "x" } },
+      new AbortController().signal,
+    );
+
+    expect(received).toEqual({ foo: 1, bar: "x" });
+  });
+});

--- a/packages/agent/src/tool.test.ts
+++ b/packages/agent/src/tool.test.ts
@@ -2,7 +2,13 @@ import { describe, test, expect } from "bun:test";
 
 import type { ToolDefinition } from "@interchange/types/runtime";
 
-import { createToolRunner, DuplicateToolError, stringTool, tool } from "./tool";
+import {
+  createToolRunner,
+  DuplicateToolError,
+  fromToolRunner,
+  stringTool,
+  tool,
+} from "./tool";
 
 const DEF_A: ToolDefinition = {
   name: "a",
@@ -150,6 +156,43 @@ describe("createToolRunner", () => {
     await runner.run({ id: "c6", name: "a", arguments: {} }, ctl.signal);
 
     expect(received).toBe(ctl.signal);
+  });
+
+  test("fromToolRunner wraps each definition as a full-handler AgentTool", async () => {
+    const calls: string[] = [];
+    const stubRunner = {
+      definitions: [DEF_A, DEF_B] as const,
+      run: async (call: {
+        id: string;
+        name: string;
+        arguments: Record<string, unknown>;
+      }) => {
+        calls.push(call.name);
+        return Promise.resolve({
+          callId: call.id,
+          content: `ran ${call.name}`,
+        });
+      },
+    };
+
+    const tools = fromToolRunner(stubRunner);
+    const runner = createToolRunner(tools);
+
+    expect(runner.definitions.map((d) => d.name)).toEqual(["a", "b"]);
+
+    const ra = await runner.run(
+      { id: "c8", name: "a", arguments: {} },
+      new AbortController().signal,
+    );
+    expect(ra).toEqual({ callId: "c8", content: "ran a" });
+
+    const rb = await runner.run(
+      { id: "c9", name: "b", arguments: {} },
+      new AbortController().signal,
+    );
+    expect(rb).toEqual({ callId: "c9", content: "ran b" });
+
+    expect(calls).toEqual(["a", "b"]);
   });
 
   test("string handler receives the parsed arguments object", async () => {

--- a/packages/agent/src/tool.ts
+++ b/packages/agent/src/tool.ts
@@ -1,0 +1,128 @@
+// Tool registration and dispatch.
+//
+// Two registration shapes are supported:
+//
+//   `tool({ definition, handler })`        — handler receives the full
+//                                            ToolCall and returns the full
+//                                            ToolResult. Use when the
+//                                            handler needs the callId or
+//                                            wants to set isError/detail/
+//                                            pendingMarker.
+//
+//   `stringTool({ definition, handler })`  — sugar for the common case of
+//                                            "compute a string from the
+//                                            parsed arguments." The callId
+//                                            is filled in from the
+//                                            surrounding ToolCall, and
+//                                            isError is false unless the
+//                                            handler throws.
+//
+// `createToolRunner(tools)` builds a `ToolRunner` that dispatches by tool
+// name. Per the ToolRunner contract (packages/types/src/runtime.ts), `run`
+// must not throw — unknown tool names and handler exceptions are surfaced
+// as `ToolResult` with `isError: true` so the model sees them and can
+// recover.
+
+import type {
+  ToolCall,
+  ToolDefinition,
+  ToolResult,
+  ToolRunner,
+} from "@interchange/types/runtime";
+
+export type ToolHandler = (
+  call: ToolCall,
+  signal: AbortSignal,
+) => Promise<ToolResult>;
+
+export type StringToolHandler = (
+  args: Record<string, unknown>,
+  signal: AbortSignal,
+) => Promise<string>;
+
+export type AgentTool =
+  | { kind: "full"; definition: ToolDefinition; handler: ToolHandler }
+  | {
+      kind: "string";
+      definition: ToolDefinition;
+      handler: StringToolHandler;
+    };
+
+export function tool(args: {
+  definition: ToolDefinition;
+  handler: ToolHandler;
+}): AgentTool {
+  return { kind: "full", definition: args.definition, handler: args.handler };
+}
+
+export function stringTool(args: {
+  definition: ToolDefinition;
+  handler: StringToolHandler;
+}): AgentTool {
+  return {
+    kind: "string",
+    definition: args.definition,
+    handler: args.handler,
+  };
+}
+
+export class DuplicateToolError extends Error {
+  readonly toolName: string;
+
+  constructor(toolName: string) {
+    super(`duplicate tool name: ${toolName}`);
+    this.name = "DuplicateToolError";
+    this.toolName = toolName;
+  }
+}
+
+export type AgentToolRunner = ToolRunner & {
+  readonly definitions: readonly ToolDefinition[];
+};
+
+/**
+ * Build a `ToolRunner` that dispatches by tool name. Throws
+ * `DuplicateToolError` at construction if any two tools share a name.
+ *
+ * At call time, unknown tool names and exceptions from handlers are
+ * converted to `ToolResult { isError: true }` so the contract on
+ * `ToolRunner.run` ("must not throw") is upheld.
+ */
+export function createToolRunner(tools: AgentTool[]): AgentToolRunner {
+  const byName = new Map<string, AgentTool>();
+  for (const t of tools) {
+    if (byName.has(t.definition.name)) {
+      throw new DuplicateToolError(t.definition.name);
+    }
+    byName.set(t.definition.name, t);
+  }
+
+  const definitions: readonly ToolDefinition[] = tools.map((t) => t.definition);
+
+  return {
+    definitions,
+    async run(call, signal): Promise<ToolResult> {
+      const found = byName.get(call.name);
+      if (found === undefined) {
+        return {
+          callId: call.id,
+          content: `unknown tool: ${call.name}`,
+          isError: true,
+        };
+      }
+      try {
+        if (found.kind === "full") {
+          return await found.handler(call, signal);
+        }
+        const text = await found.handler(call.arguments, signal);
+        return { callId: call.id, content: text };
+      } catch (err) {
+        return {
+          callId: call.id,
+          content: err instanceof Error ? err.message : String(err),
+          isError: true,
+        };
+      }
+    },
+  };
+}

--- a/packages/agent/src/tool.ts
+++ b/packages/agent/src/tool.ts
@@ -66,6 +66,26 @@ export function stringTool(args: {
   };
 }
 
+/**
+ * Adapt a pre-built ToolRunner (e.g. the one returned by
+ * `createPosixTools`) into a list of AgentTools that can be passed to
+ * `createAgent({ tools })`. Each definition becomes a full-handler
+ * AgentTool that delegates to the runner's `run`.
+ *
+ * Use this when integrating tool packages whose public surface is a
+ * single ToolRunner rather than individual handlers.
+ */
+export function fromToolRunner(runner: {
+  readonly definitions: readonly ToolDefinition[];
+  run: ToolRunner["run"];
+}): AgentTool[] {
+  return runner.definitions.map((definition) => ({
+    kind: "full",
+    definition,
+    handler: (call, signal) => runner.run(call, signal),
+  }));
+}
+
 export class DuplicateToolError extends Error {
   readonly toolName: string;
 

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/inference-testing/src/harness.ts
+++ b/packages/inference-testing/src/harness.ts
@@ -22,12 +22,14 @@ import {
   captureMatcherSource,
   createMatcherTable,
   scanWaitingSet,
+  type ReplyOnceOpts,
   type RequestPredicate,
   type Scenario,
   type WaitingFetch,
   type WhenRequestMatchesOpts,
   type WireEventPredicate,
 } from "./scenario";
+import { completeResponse, type Provider } from "./wire/agnostic";
 import {
   createSimulatedStream,
   toStreamId,
@@ -216,6 +218,15 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     return handle.stream;
   };
 
+  // Most-recently matched request, cloned so the test can consume its
+  // body without affecting the original. See `scenario.lastRequest`.
+  // Type widened to satisfy the gap between Bun's global Request and
+  // the undici Request the fetch stub builds; both have the methods
+  // the public surface needs (clone, json, text, headers).
+  let lastMatchedRequest:
+    | ReturnType<WaitingFetch["request"]["clone"]>
+    | undefined;
+
   const routeWaitingFetch = (
     wf: WaitingFetch,
     stream: SimulatedStream,
@@ -224,6 +235,7 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     wf.settled = true;
     const idx = waiting.indexOf(wf);
     if (idx >= 0) waiting.splice(idx, 1);
+    lastMatchedRequest = wf.request.clone();
     // Per-call abort isolation on the matched stream: once a fetch has
     // been bound to a stream, an abort on its signal must error ONLY
     // that stream's controller. We attach the listener here (the
@@ -396,12 +408,44 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     });
   };
 
+  const lastRequest = (): Request | undefined =>
+    // The clone is produced by the (undici-typed) WaitingFetch.request,
+    // but the public Scenario type uses the platform's global Request.
+    // The shape is identical; the cast bridges the type-only gap.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- type-only bridge between undici Request and Bun's global Request
+    lastMatchedRequest as Request | undefined;
+
+  const replyOnce = (
+    provider: Provider,
+    opts: ReplyOnceOpts,
+  ): SimulatedStream => {
+    const stream = createStream();
+    const chunks = completeResponse(provider, {
+      ...(opts.text !== undefined ? { text: opts.text } : {}),
+      ...(opts.toolCalls !== undefined ? { toolCalls: opts.toolCalls } : {}),
+      ...(opts.headUsage !== undefined ? { headUsage: opts.headUsage } : {}),
+      ...(opts.tailUsage !== undefined ? { tailUsage: opts.tailUsage } : {}),
+    });
+    // Schedule at the next safe virtual time so callers do not have to
+    // compute `clock.now() + N` themselves and so multiple replyOnce
+    // calls in the same test never schedule into the past.
+    stream.enqueueAll(chunks, { startAt: clock.now() + 1 });
+    whenRequestMatches(
+      opts.predicate ?? (() => true),
+      stream,
+      opts.responseOpts,
+    );
+    return stream;
+  };
+
   const scenario: Scenario = {
     createStream,
     whenRequestMatches,
     onTool,
     invokeTool,
     lastToolDispatch,
+    lastRequest,
+    replyOnce,
     abortAt,
     abortAfter,
   };

--- a/packages/inference-testing/src/index.ts
+++ b/packages/inference-testing/src/index.ts
@@ -20,6 +20,7 @@ export type {
 
 export type {
   Scenario,
+  ReplyOnceOpts,
   RequestPredicate,
   WhenRequestMatchesOpts,
   WireEventPredicate,

--- a/packages/inference-testing/src/scenario.ts
+++ b/packages/inference-testing/src/scenario.ts
@@ -1,6 +1,7 @@
 import { AmbiguousRequestError, type AmbiguousFetchInfo } from "./errors";
 import type { ChunkFiredEvent, SimulatedStream } from "./simulated-stream";
 import type { DispatchToolResult, ToolHandler } from "./tool-handler";
+import type { Provider } from "./wire/agnostic";
 
 /**
  * Predicate evaluated against wire-event chunks the harness sees being
@@ -20,6 +21,38 @@ export type WireEventPredicate = (event: ChunkFiredEvent) => boolean;
  * cannot enforce purity.
  */
 export type RequestPredicate = (req: Request) => boolean;
+
+/**
+ * Options for `scenario.replyOnce`. `text` and `toolCalls` are the response
+ * payload (passed through to `wire.completeResponse`); `headUsage` and
+ * `tailUsage` are optional usage frames. `predicate` narrows which fetch
+ * the matcher routes to (defaults to match-any). `responseOpts` shapes
+ * the HTTP envelope of the `Response` the matcher produces.
+ */
+export type ReplyOnceOpts = {
+  readonly text?: string;
+  readonly toolCalls?: {
+    callId: string;
+    name: string;
+    argsJSON: string;
+  }[];
+  readonly headUsage?: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    thinking: number;
+  };
+  readonly tailUsage?: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    thinking: number;
+  };
+  readonly predicate?: RequestPredicate;
+  readonly responseOpts?: WhenRequestMatchesOpts;
+};
 
 /**
  * Optional response shape for `whenRequestMatches`. The default behavior is
@@ -128,6 +161,37 @@ export type Scenario = {
    * tool result without instrumenting the handler closure directly.
    */
   lastToolDispatch(name: string): unknown;
+  /**
+   * Returns a clone of the most-recently matched `Request`, or `undefined`
+   * if no fetch has been routed by a matcher yet. The harness records
+   * every routed request so tests can `await req.json()` after the fact
+   * to assert on the body shape — the matcher predicate itself is
+   * synchronous on purpose (it runs on every scan pass) and so cannot
+   * read the body, but `lastRequest` is the post-match seam.
+   *
+   * The returned `Request` is a clone so the test can consume its body
+   * without affecting the original (the production reactor will still
+   * read the body via the `Response` returned through the stream).
+   */
+  lastRequest(): Request | undefined;
+  /**
+   * Convenience wrapper that creates a stream, builds a complete
+   * single-turn response for `provider`, enqueues it at the next safe
+   * virtual time (`clock.now() + 1`), and registers a single-use
+   * match-any matcher routing the next fetch to it. Returns the stream
+   * so tests that need to enqueue additional chunks or capture the
+   * handle can still do so.
+   *
+   * The optional `predicate` narrows the match (defaults to `() => true`).
+   * The optional `responseOpts` shapes the `Response` envelope (status,
+   * headers) just like `whenRequestMatches`. The optional `whenOpts`
+   * passes through to `whenRequestMatches`.
+   *
+   * Use this for the common "drive one round-trip with this reply" test
+   * shape. For richer scenarios (multiple turns, custom chunk timing,
+   * tool calls), use `createStream` + `whenRequestMatches` directly.
+   */
+  replyOnce(provider: Provider, opts: ReplyOnceOpts): SimulatedStream;
   /**
    * Schedules `controller.abort()` to fire at the supplied virtual time.
    * The caller supplies the `AbortController` they want aborted —

--- a/tests/agent/lifecycle.test.ts
+++ b/tests/agent/lifecycle.test.ts
@@ -1,0 +1,132 @@
+// Integration tests for @interchange/agent lifecycle that exercise the
+// real isogit-backed context store but do not require driving inference.
+//
+// These tests cover the singleton-per-`contextDir` lock, the
+// close-and-reopen contract that backs the resume-from-crash story, and
+// the storage-validation surface of `createAgent`. Tests that drive real
+// inference live alongside this file in `send-flow.test.ts`.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  AgentInUseError,
+  createAgent,
+  type Agent,
+  type AgentConfig,
+} from "@interchange/agent";
+import type {
+  ContextStore,
+  InboundMessage,
+  ProviderConfig,
+} from "@interchange/types/runtime";
+
+/**
+ * Test helper: build an `InboundMessage` shaped just enough to exercise
+ * the `closed` guard on `agent.deliver`. The agent rejects before
+ * inspecting the message contents.
+ */
+function stubInboundMessage(): InboundMessage {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub never inspected
+  return {} as InboundMessage;
+}
+
+/**
+ * Test helper: produce a stub ContextStore reference for tests that
+ * verify createAgent rejects before touching the store. Bypasses the
+ * static type via `unknown` because constructing a full ContextStore for
+ * a never-invoked path would be busywork.
+ */
+function stubContextStore(): ContextStore {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub never invoked
+  return {} as ContextStore;
+}
+
+const PROVIDER: ProviderConfig = {
+  provider: "anthropic",
+  baseURL: "https://api.anthropic.com",
+  apiKey: "sk-test-lifecycle",
+  model: "claude-3-5-sonnet",
+};
+
+function baseConfig(contextDir: string): AgentConfig {
+  return {
+    contextDir,
+    providers: [PROVIDER],
+    defaultModel: PROVIDER.model ?? "claude-3-5-sonnet",
+    systemPrompt: "lifecycle test agent",
+    tools: [],
+  };
+}
+
+describe("@interchange/agent lifecycle", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "agent-lifecycle-"));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("acquires the singleton lock; second concurrent agent rejects", async () => {
+    const dir = join(workDir, "ctx");
+    const first = await createAgent(baseConfig(dir));
+    try {
+      await expect(createAgent(baseConfig(dir))).rejects.toBeInstanceOf(
+        AgentInUseError,
+      );
+    } finally {
+      await first.close();
+    }
+  });
+
+  test("close releases the lock so a fresh agent can reopen the same dir", async () => {
+    const dir = join(workDir, "ctx");
+
+    const first = await createAgent(baseConfig(dir));
+    await first.close();
+
+    const second = await createAgent(baseConfig(dir));
+    try {
+      // Fresh agent on the same context dir starts with empty history.
+      const turns = await second.history();
+      expect(turns).toEqual([]);
+    } finally {
+      await second.close();
+    }
+  });
+
+  test("close is idempotent", async () => {
+    const dir = join(workDir, "ctx");
+    const agent = await createAgent(baseConfig(dir));
+    await agent.close();
+    await agent.close();
+    // A subsequent open on the same dir should still succeed.
+    const reopened = await createAgent(baseConfig(dir));
+    await reopened.close();
+  });
+
+  test("methods after close throw AgentClosedError", async () => {
+    const dir = join(workDir, "ctx");
+    const agent: Agent = await createAgent(baseConfig(dir));
+    await agent.close();
+
+    expect(() => agent.deliver(stubInboundMessage())).toThrow();
+    expect(() => agent.setProvider(PROVIDER)).toThrow();
+    await expect(agent.send("hi")).rejects.toBeDefined();
+  });
+
+  test("rejects configurations that supply both contextStore and contextDir", async () => {
+    const dir = join(workDir, "ctx");
+    await expect(
+      createAgent({
+        ...baseConfig(dir),
+        contextStore: stubContextStore(),
+      }),
+    ).rejects.toBeDefined();
+  });
+});

--- a/tests/agent/send-flow.test.ts
+++ b/tests/agent/send-flow.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  AgentClosedError,
   createAgent,
   SendQueueFullError,
   type Agent,
@@ -208,8 +209,8 @@ describe("@interchange/agent send-flow integration", () => {
     await first;
     await second;
 
-    expect(firstReason).toBeDefined();
-    expect(secondReason).toBeDefined();
+    expect(firstReason).toBeInstanceOf(AgentClosedError);
+    expect(secondReason).toBeInstanceOf(AgentClosedError);
   });
 
   test("setProvider hot-swaps credentials before the next inference", async () => {

--- a/tests/agent/send-flow.test.ts
+++ b/tests/agent/send-flow.test.ts
@@ -18,11 +18,7 @@ import {
   SendQueueFullError,
   type Agent,
 } from "@interchange/agent";
-import {
-  setupHarness,
-  wire,
-  type Harness,
-} from "@interchange/inference-testing";
+import { setupHarness, type Harness } from "@interchange/inference-testing";
 import type {
   ConversationTurn,
   ProviderConfig,
@@ -34,36 +30,6 @@ const PROVIDER: ProviderConfig = {
   apiKey: "sk-test-send-flow",
   model: "claude-3-5-sonnet",
 };
-
-const USAGE_HEAD = {
-  input: 10,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  thinking: 0,
-};
-
-const USAGE_TAIL = {
-  input: 0,
-  output: 5,
-  cacheRead: 0,
-  cacheWrite: 0,
-  thinking: 0,
-};
-
-function wireSingleReply(harness: Harness, text: string): void {
-  const stream = harness.scenario.createStream();
-  const chunks = wire.completeResponse("anthropic", {
-    text,
-    headUsage: USAGE_HEAD,
-    tailUsage: USAGE_TAIL,
-  });
-  // Schedule the chunks relative to the harness's current virtual time
-  // so multiple wireSingleReply calls in the same test never schedule
-  // into the past after an earlier round-trip has advanced the clock.
-  stream.enqueueAll(chunks, { startAt: harness.clock.now() + 10 });
-  harness.scenario.whenRequestMatches(() => true, stream);
-}
 
 describe("@interchange/agent send-flow integration", () => {
   let workDir: string;
@@ -80,7 +46,7 @@ describe("@interchange/agent send-flow integration", () => {
   });
 
   test("end-to-end send round-trips to a connector.reply", async () => {
-    wireSingleReply(harness, "Hi there!");
+    harness.scenario.replyOnce("anthropic", { text: "Hi there!" });
 
     const agent = await createAgent({
       contextDir: join(workDir, "ctx"),
@@ -103,7 +69,7 @@ describe("@interchange/agent send-flow integration", () => {
   });
 
   test("persists the assistant turn so history() and reopened agents see it", async () => {
-    wireSingleReply(harness, "Persisted reply");
+    harness.scenario.replyOnce("anthropic", { text: "Persisted reply" });
 
     const dir = join(workDir, "ctx");
     const agent = await createAgent({
@@ -150,7 +116,7 @@ describe("@interchange/agent send-flow integration", () => {
   });
 
   test("readAt returns the conversation at the recorded commit hash", async () => {
-    wireSingleReply(harness, "Checkpoint reply");
+    harness.scenario.replyOnce("anthropic", { text: "Checkpoint reply" });
 
     const agent = await createAgent({
       contextDir: join(workDir, "ctx"),
@@ -180,7 +146,7 @@ describe("@interchange/agent send-flow integration", () => {
   });
 
   test("close-while-pending rejects queued sends with AgentClosedError", async () => {
-    wireSingleReply(harness, "should never observe");
+    harness.scenario.replyOnce("anthropic", { text: "should never observe" });
 
     const agent: Agent = await createAgent({
       contextDir: join(workDir, "ctx"),
@@ -214,7 +180,7 @@ describe("@interchange/agent send-flow integration", () => {
   });
 
   test("setProvider hot-swaps credentials before the next inference", async () => {
-    wireSingleReply(harness, "first-provider reply");
+    harness.scenario.replyOnce("anthropic", { text: "first-provider reply" });
 
     const agent = await createAgent({
       contextDir: join(workDir, "ctx"),
@@ -239,31 +205,25 @@ describe("@interchange/agent send-flow integration", () => {
         model: PROVIDER.model ?? "claude-3-5-sonnet",
       });
 
-      let observedKey: string | undefined;
-      const stream = harness.scenario.createStream();
-      const chunks = wire.completeResponse("anthropic", {
-        text: "rotated reply",
-        headUsage: USAGE_HEAD,
-        tailUsage: USAGE_TAIL,
-      });
-      stream.enqueueAll(chunks, { startAt: harness.clock.now() + 10 });
-      harness.scenario.whenRequestMatches((req) => {
-        observedKey = req.headers.get("x-api-key") ?? undefined;
-        return true;
-      }, stream);
+      harness.scenario.replyOnce("anthropic", { text: "rotated reply" });
 
       const second = agent.send("Hello again");
       await harness.run();
       const r = await second;
       expect(r.reply).toBe("rotated reply");
-      expect(observedKey).toBe("sk-rotated");
+
+      const matched = harness.scenario.lastRequest();
+      if (matched === undefined) {
+        throw new Error("expected a matched request after setProvider swap");
+      }
+      expect(matched.headers.get("x-api-key")).toBe("sk-rotated");
     } finally {
       await agent.close();
     }
   });
 
   test("setProvider rotates the model in the next inference request", async () => {
-    wireSingleReply(harness, "first-model reply");
+    harness.scenario.replyOnce("anthropic", { text: "first-model reply" });
 
     const agent = await createAgent({
       contextDir: join(workDir, "ctx"),
@@ -290,30 +250,20 @@ describe("@interchange/agent send-flow integration", () => {
         model: NEW_MODEL,
       });
 
-      let observedRequest: Request | undefined;
-      const stream = harness.scenario.createStream();
-      const chunks = wire.completeResponse("anthropic", {
+      harness.scenario.replyOnce("anthropic", {
         text: "second-model reply",
-        headUsage: USAGE_HEAD,
-        tailUsage: USAGE_TAIL,
       });
-      stream.enqueueAll(chunks, { startAt: harness.clock.now() + 10 });
-      // The matcher predicate must be synchronous, so clone the request
-      // and read its body after the round-trip completes.
-      harness.scenario.whenRequestMatches((req) => {
-        observedRequest = req.clone();
-        return true;
-      }, stream);
 
       const second = agent.send("Hello again");
       await harness.run();
       const r = await second;
       expect(r.reply).toBe("second-model reply");
 
-      if (observedRequest === undefined) {
-        throw new Error("matcher did not capture a request");
+      const matched = harness.scenario.lastRequest();
+      if (matched === undefined) {
+        throw new Error("expected a matched request after model swap");
       }
-      const body: unknown = await observedRequest.json();
+      const body: unknown = await matched.json();
       if (typeof body !== "object" || body === null || !("model" in body)) {
         throw new Error("expected inference request body to include `model`");
       }
@@ -324,7 +274,7 @@ describe("@interchange/agent send-flow integration", () => {
   });
 
   test("abort signal on in-flight send rejects without blocking the agent", async () => {
-    wireSingleReply(harness, "abandoned reply");
+    harness.scenario.replyOnce("anthropic", { text: "abandoned reply" });
 
     const agent = await createAgent({
       contextDir: join(workDir, "ctx"),
@@ -355,7 +305,7 @@ describe("@interchange/agent send-flow integration", () => {
       await harness.run();
 
       // Wire a fresh reply for the next send.
-      wireSingleReply(harness, "post-abort reply");
+      harness.scenario.replyOnce("anthropic", { text: "post-abort reply" });
       const next = agent.send("Round two");
       await harness.run();
       const result = await next;
@@ -366,7 +316,7 @@ describe("@interchange/agent send-flow integration", () => {
   });
 
   test("synchronously throws SendQueueFullError past the configured cap", async () => {
-    wireSingleReply(harness, "stalled response");
+    harness.scenario.replyOnce("anthropic", { text: "stalled response" });
 
     const agent = await createAgent({
       contextDir: join(workDir, "ctx"),

--- a/tests/agent/send-flow.test.ts
+++ b/tests/agent/send-flow.test.ts
@@ -1,0 +1,332 @@
+// Integration tests for @interchange/agent send/close flow driven by the
+// @interchange/inference-testing harness.
+//
+// Each test wires a deterministic Anthropic SSE response, constructs an
+// agent backed by a real isogit context store and the harness's stubbed
+// fetch, and drives the reactor through a real send cycle. These tests
+// are what prove the agent's wiring actually carries inference events
+// through to `connector.reply` and persists turns.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createAgent,
+  SendQueueFullError,
+  type Agent,
+} from "@interchange/agent";
+import {
+  setupHarness,
+  wire,
+  type Harness,
+} from "@interchange/inference-testing";
+import type {
+  ConversationTurn,
+  ProviderConfig,
+} from "@interchange/types/runtime";
+
+const PROVIDER: ProviderConfig = {
+  provider: "anthropic",
+  baseURL: "https://api.anthropic.com",
+  apiKey: "sk-test-send-flow",
+  model: "claude-3-5-sonnet",
+};
+
+const USAGE_HEAD = {
+  input: 10,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  thinking: 0,
+};
+
+const USAGE_TAIL = {
+  input: 0,
+  output: 5,
+  cacheRead: 0,
+  cacheWrite: 0,
+  thinking: 0,
+};
+
+function wireSingleReply(harness: Harness, text: string): void {
+  const stream = harness.scenario.createStream();
+  const chunks = wire.completeResponse("anthropic", {
+    text,
+    headUsage: USAGE_HEAD,
+    tailUsage: USAGE_TAIL,
+  });
+  // Schedule the chunks relative to the harness's current virtual time
+  // so multiple wireSingleReply calls in the same test never schedule
+  // into the past after an earlier round-trip has advanced the clock.
+  stream.enqueueAll(chunks, { startAt: harness.clock.now() + 10 });
+  harness.scenario.whenRequestMatches(() => true, stream);
+}
+
+describe("@interchange/agent send-flow integration", () => {
+  let workDir: string;
+  let harness: Harness;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "agent-send-flow-"));
+    harness = setupHarness();
+  });
+
+  afterEach(() => {
+    harness.dispose();
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("end-to-end send round-trips to a connector.reply", async () => {
+    wireSingleReply(harness, "Hi there!");
+
+    const agent = await createAgent({
+      contextDir: join(workDir, "ctx"),
+      providers: [PROVIDER],
+      defaultModel: PROVIDER.model ?? "claude-3-5-sonnet",
+      systemPrompt: "send-flow test",
+      tools: [],
+      deps: harness.deps,
+    });
+
+    try {
+      const sendPromise = agent.send("Hello");
+      await harness.run();
+      const result = await sendPromise;
+      expect(result.reply).toBe("Hi there!");
+      expect(result.turn.role).toBe("assistant");
+    } finally {
+      await agent.close();
+    }
+  });
+
+  test("persists the assistant turn so history() and reopened agents see it", async () => {
+    wireSingleReply(harness, "Persisted reply");
+
+    const dir = join(workDir, "ctx");
+    const agent = await createAgent({
+      contextDir: dir,
+      providers: [PROVIDER],
+      defaultModel: PROVIDER.model ?? "claude-3-5-sonnet",
+      systemPrompt: "send-flow test",
+      tools: [],
+      deps: harness.deps,
+    });
+
+    let firstHistory: ConversationTurn[] = [];
+    try {
+      const sendPromise = agent.send("Hello");
+      await harness.run();
+      await sendPromise;
+      firstHistory = await agent.history();
+    } finally {
+      await agent.close();
+    }
+
+    expect(firstHistory.length).toBeGreaterThan(0);
+    expect(firstHistory.some((t) => t.role === "assistant")).toBe(true);
+
+    // Reopen on the same directory and verify the projection survives.
+    // The reopened agent does not need a working provider; we only
+    // exercise history(), which reads from the store directly.
+    const reopened = await createAgent({
+      contextDir: dir,
+      providers: [PROVIDER],
+      defaultModel: PROVIDER.model ?? "claude-3-5-sonnet",
+      systemPrompt: "send-flow test",
+      tools: [],
+      deps: harness.deps,
+    });
+
+    try {
+      const turns = await reopened.history();
+      expect(turns.length).toBe(firstHistory.length);
+      expect(turns.some((t) => t.role === "assistant")).toBe(true);
+    } finally {
+      await reopened.close();
+    }
+  });
+
+  test("readAt returns the conversation at the recorded commit hash", async () => {
+    wireSingleReply(harness, "Checkpoint reply");
+
+    const agent = await createAgent({
+      contextDir: join(workDir, "ctx"),
+      providers: [PROVIDER],
+      defaultModel: PROVIDER.model ?? "claude-3-5-sonnet",
+      systemPrompt: "send-flow test",
+      tools: [],
+      deps: harness.deps,
+    });
+
+    try {
+      const sendPromise = agent.send("Hello");
+      await harness.run();
+      await sendPromise;
+
+      const checkpoints = await agent.checkpoints(10);
+      expect(checkpoints.length).toBeGreaterThan(0);
+      const latest = checkpoints[0];
+      if (latest === undefined)
+        throw new Error("expected at least one checkpoint");
+
+      const turns = await agent.readAt(latest.hash);
+      expect(turns.length).toBeGreaterThan(0);
+    } finally {
+      await agent.close();
+    }
+  });
+
+  test("close-while-pending rejects queued sends with AgentClosedError", async () => {
+    wireSingleReply(harness, "should never observe");
+
+    const agent: Agent = await createAgent({
+      contextDir: join(workDir, "ctx"),
+      providers: [PROVIDER],
+      defaultModel: PROVIDER.model ?? "claude-3-5-sonnet",
+      systemPrompt: "send-flow test",
+      tools: [],
+      deps: harness.deps,
+    });
+
+    // Kick off an in-flight send, then a queued second one.
+    let firstReason: unknown;
+    let secondReason: unknown;
+    const first = agent.send("first").catch((err: unknown) => {
+      firstReason = err;
+    });
+    const second = agent.send("second").catch((err: unknown) => {
+      secondReason = err;
+    });
+
+    // Close without advancing the clock — the in-flight inference is
+    // parked on a matcher, so the active send hasn't completed yet.
+    await agent.close();
+
+    // Let any settle-microtasks complete.
+    await first;
+    await second;
+
+    expect(firstReason).toBeDefined();
+    expect(secondReason).toBeDefined();
+  });
+
+  test("setProvider hot-swaps credentials before the next inference", async () => {
+    wireSingleReply(harness, "first-provider reply");
+
+    const agent = await createAgent({
+      contextDir: join(workDir, "ctx"),
+      providers: [PROVIDER],
+      defaultModel: PROVIDER.model ?? "claude-3-5-sonnet",
+      systemPrompt: "send-flow test",
+      tools: [],
+      deps: harness.deps,
+    });
+
+    try {
+      const first = agent.send("Hello");
+      await harness.run();
+      await first;
+
+      // Swap to a new credential. The next send picks up the new apiKey
+      // when the reactor reads providerConfig at start-of-inference.
+      agent.setProvider({
+        provider: "anthropic",
+        baseURL: "https://api.anthropic.com",
+        apiKey: "sk-rotated",
+        model: PROVIDER.model ?? "claude-3-5-sonnet",
+      });
+
+      let observedKey: string | undefined;
+      const stream = harness.scenario.createStream();
+      const chunks = wire.completeResponse("anthropic", {
+        text: "rotated reply",
+        headUsage: USAGE_HEAD,
+        tailUsage: USAGE_TAIL,
+      });
+      stream.enqueueAll(chunks, { startAt: harness.clock.now() + 10 });
+      harness.scenario.whenRequestMatches((req) => {
+        observedKey = req.headers.get("x-api-key") ?? undefined;
+        return true;
+      }, stream);
+
+      const second = agent.send("Hello again");
+      await harness.run();
+      const r = await second;
+      expect(r.reply).toBe("rotated reply");
+      expect(observedKey).toBe("sk-rotated");
+    } finally {
+      await agent.close();
+    }
+  });
+
+  test("abort signal on in-flight send rejects without blocking the agent", async () => {
+    wireSingleReply(harness, "abandoned reply");
+
+    const agent = await createAgent({
+      contextDir: join(workDir, "ctx"),
+      providers: [PROVIDER],
+      defaultModel: PROVIDER.model ?? "claude-3-5-sonnet",
+      systemPrompt: "send-flow test",
+      tools: [],
+      deps: harness.deps,
+    });
+
+    try {
+      const ctl = new AbortController();
+      let abortedReason: unknown;
+      const sendPromise = agent
+        .send("Hello", { signal: ctl.signal })
+        .catch((err: unknown) => {
+          abortedReason = err;
+        });
+
+      // Abort while the inference is parked on the matcher.
+      ctl.abort();
+      await sendPromise;
+      expect(abortedReason).toBeDefined();
+
+      // Even though the previous cycle is still draining in the
+      // background, advancing the clock allows it to complete so the
+      // next send can run cleanly on the same agent.
+      await harness.run();
+
+      // Wire a fresh reply for the next send.
+      wireSingleReply(harness, "post-abort reply");
+      const next = agent.send("Round two");
+      await harness.run();
+      const result = await next;
+      expect(result.reply).toBe("post-abort reply");
+    } finally {
+      await agent.close();
+    }
+  });
+
+  test("synchronously throws SendQueueFullError past the configured cap", async () => {
+    wireSingleReply(harness, "stalled response");
+
+    const agent = await createAgent({
+      contextDir: join(workDir, "ctx"),
+      providers: [PROVIDER],
+      defaultModel: PROVIDER.model ?? "claude-3-5-sonnet",
+      systemPrompt: "send-flow test",
+      tools: [],
+      deps: harness.deps,
+      sendQueueMax: 2,
+    });
+
+    try {
+      // Two sends saturate the queue; the inference is parked on the
+      // matcher with no clock advance, so none complete.
+      const p1 = agent.send("a");
+      const p2 = agent.send("b");
+      expect(() => agent.send("c")).toThrow(SendQueueFullError);
+      // Avoid unhandled-rejection warnings on the parked sends.
+      p1.catch(() => undefined);
+      p2.catch(() => undefined);
+    } finally {
+      await agent.close();
+    }
+  });
+});

--- a/tests/agent/send-flow.test.ts
+++ b/tests/agent/send-flow.test.ts
@@ -262,6 +262,67 @@ describe("@interchange/agent send-flow integration", () => {
     }
   });
 
+  test("setProvider rotates the model in the next inference request", async () => {
+    wireSingleReply(harness, "first-model reply");
+
+    const agent = await createAgent({
+      contextDir: join(workDir, "ctx"),
+      providers: [PROVIDER],
+      defaultModel: PROVIDER.model ?? "claude-3-5-sonnet",
+      systemPrompt: "send-flow test",
+      tools: [],
+      deps: harness.deps,
+    });
+
+    try {
+      const first = agent.send("Hello");
+      await harness.run();
+      await first;
+
+      // Swap to a completely different model. The wrapped director's
+      // capabilities.infer substitutes the live model on each call, so
+      // the next request body should carry the new model name.
+      const NEW_MODEL = "claude-3-5-haiku";
+      agent.setProvider({
+        provider: "anthropic",
+        baseURL: "https://api.anthropic.com",
+        apiKey: PROVIDER.apiKey,
+        model: NEW_MODEL,
+      });
+
+      let observedRequest: Request | undefined;
+      const stream = harness.scenario.createStream();
+      const chunks = wire.completeResponse("anthropic", {
+        text: "second-model reply",
+        headUsage: USAGE_HEAD,
+        tailUsage: USAGE_TAIL,
+      });
+      stream.enqueueAll(chunks, { startAt: harness.clock.now() + 10 });
+      // The matcher predicate must be synchronous, so clone the request
+      // and read its body after the round-trip completes.
+      harness.scenario.whenRequestMatches((req) => {
+        observedRequest = req.clone();
+        return true;
+      }, stream);
+
+      const second = agent.send("Hello again");
+      await harness.run();
+      const r = await second;
+      expect(r.reply).toBe("second-model reply");
+
+      if (observedRequest === undefined) {
+        throw new Error("matcher did not capture a request");
+      }
+      const body: unknown = await observedRequest.json();
+      if (typeof body !== "object" || body === null || !("model" in body)) {
+        throw new Error("expected inference request body to include `model`");
+      }
+      expect(body.model).toBe(NEW_MODEL);
+    } finally {
+      await agent.close();
+    }
+  });
+
   test("abort signal on in-flight send rejects without blocking the agent", async () => {
     wireSingleReply(harness, "abandoned reply");
 

--- a/tests/coding-agent/cli.test.ts
+++ b/tests/coding-agent/cli.test.ts
@@ -10,11 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { main } from "@interchange/example-coding-agent";
-import {
-  setupHarness,
-  wire,
-  type Harness,
-} from "@interchange/inference-testing";
+import { setupHarness, type Harness } from "@interchange/inference-testing";
 import type { ProviderConfig } from "@interchange/types/runtime";
 
 const PROVIDER: ProviderConfig = {
@@ -23,33 +19,6 @@ const PROVIDER: ProviderConfig = {
   apiKey: "sk-test-cli",
   model: "claude-3-5-sonnet",
 };
-
-const USAGE_HEAD = {
-  input: 10,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  thinking: 0,
-};
-
-const USAGE_TAIL = {
-  input: 0,
-  output: 5,
-  cacheRead: 0,
-  cacheWrite: 0,
-  thinking: 0,
-};
-
-function wireReply(harness: Harness, text: string): void {
-  const stream = harness.scenario.createStream();
-  const chunks = wire.completeResponse("anthropic", {
-    text,
-    headUsage: USAGE_HEAD,
-    tailUsage: USAGE_TAIL,
-  });
-  stream.enqueueAll(chunks, { startAt: harness.clock.now() + 10 });
-  harness.scenario.whenRequestMatches(() => true, stream);
-}
 
 describe("coding-agent CLI", () => {
   let workDir: string;
@@ -70,7 +39,7 @@ describe("coding-agent CLI", () => {
   });
 
   test("runs end-to-end: parses argv, drives reactor, prints reply, exits 0", async () => {
-    wireReply(harness, "Hello from the model");
+    harness.scenario.replyOnce("anthropic", { text: "Hello from the model" });
 
     const contextDir = join(workDir, "ctx");
     const argv = [
@@ -150,7 +119,7 @@ describe("coding-agent CLI", () => {
     const argv = ["--cwd", workDir, "--context-dir", contextDir];
 
     // First run.
-    wireReply(harness, "first reply");
+    harness.scenario.replyOnce("anthropic", { text: "first reply" });
     const firstRun = main(
       [...argv, "first prompt"],
       { ANTHROPIC_API_KEY: "x" },
@@ -175,7 +144,7 @@ describe("coding-agent CLI", () => {
     // the example's persistence really does survive process death.
     harness.dispose();
     harness = setupHarness();
-    wireReply(harness, "second reply");
+    harness.scenario.replyOnce("anthropic", { text: "second reply" });
 
     const secondRun = main(
       [...argv, "second prompt"],

--- a/tests/coding-agent/cli.test.ts
+++ b/tests/coding-agent/cli.test.ts
@@ -1,0 +1,208 @@
+// End-to-end test for the coding-agent example's CLI. Drives the actual
+// `main()` entry through @interchange/inference-testing so we exercise
+// every real path the binary takes — argument parsing, agent
+// construction, send, stream pump, close, exit code — without making a
+// network call.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { main } from "@interchange/example-coding-agent";
+import {
+  setupHarness,
+  wire,
+  type Harness,
+} from "@interchange/inference-testing";
+import type { ProviderConfig } from "@interchange/types/runtime";
+
+const PROVIDER: ProviderConfig = {
+  provider: "anthropic",
+  baseURL: "https://api.anthropic.com",
+  apiKey: "sk-test-cli",
+  model: "claude-3-5-sonnet",
+};
+
+const USAGE_HEAD = {
+  input: 10,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  thinking: 0,
+};
+
+const USAGE_TAIL = {
+  input: 0,
+  output: 5,
+  cacheRead: 0,
+  cacheWrite: 0,
+  thinking: 0,
+};
+
+function wireReply(harness: Harness, text: string): void {
+  const stream = harness.scenario.createStream();
+  const chunks = wire.completeResponse("anthropic", {
+    text,
+    headUsage: USAGE_HEAD,
+    tailUsage: USAGE_TAIL,
+  });
+  stream.enqueueAll(chunks, { startAt: harness.clock.now() + 10 });
+  harness.scenario.whenRequestMatches(() => true, stream);
+}
+
+describe("coding-agent CLI", () => {
+  let workDir: string;
+  let harness: Harness;
+  let stdoutBuf: string;
+  let stderrBuf: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "coding-agent-cli-"));
+    harness = setupHarness();
+    stdoutBuf = "";
+    stderrBuf = "";
+  });
+
+  afterEach(() => {
+    harness.dispose();
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("runs end-to-end: parses argv, drives reactor, prints reply, exits 0", async () => {
+    wireReply(harness, "Hello from the model");
+
+    const contextDir = join(workDir, "ctx");
+    const argv = [
+      "--cwd",
+      workDir,
+      "--context-dir",
+      contextDir,
+      "hello",
+      "agent",
+    ];
+
+    const runPromise = main(
+      argv,
+      { ANTHROPIC_API_KEY: "irrelevant" },
+      {
+        stdout: (s) => {
+          stdoutBuf += s;
+        },
+        stderr: (s) => {
+          stderrBuf += s;
+        },
+        providerOverride: PROVIDER,
+        deps: harness.deps,
+      },
+    );
+
+    await harness.run();
+    const code = await runPromise;
+
+    expect(code).toBe(0);
+    expect(stdoutBuf).toBe("Hello from the model\n");
+    // The stream pump emits one line per reactor event; we should see
+    // at least one event (`message.received`) before the cycle completes.
+    expect(stderrBuf).toMatch(/\[message\.received\]/);
+  });
+
+  test("missing ANTHROPIC_API_KEY (and no providerOverride) returns exit code 1", async () => {
+    const code = await main(
+      ["any prompt"],
+      {},
+      {
+        stdout: (s) => {
+          stdoutBuf += s;
+        },
+        stderr: (s) => {
+          stderrBuf += s;
+        },
+      },
+    );
+
+    expect(code).toBe(1);
+    expect(stderrBuf).toContain("ANTHROPIC_API_KEY is required");
+    expect(stdoutBuf).toBe("");
+  });
+
+  test("empty prompt returns exit code 1 with a usage message", async () => {
+    const code = await main(
+      [],
+      { ANTHROPIC_API_KEY: "x" },
+      {
+        stdout: (s) => {
+          stdoutBuf += s;
+        },
+        stderr: (s) => {
+          stderrBuf += s;
+        },
+      },
+    );
+
+    expect(code).toBe(1);
+    expect(stderrBuf).toContain("usage:");
+    expect(stdoutBuf).toBe("");
+  });
+
+  test("resume from crash: second run on same contextDir sees prior history", async () => {
+    const contextDir = join(workDir, "ctx");
+    const argv = ["--cwd", workDir, "--context-dir", contextDir];
+
+    // First run.
+    wireReply(harness, "first reply");
+    const firstRun = main(
+      [...argv, "first prompt"],
+      { ANTHROPIC_API_KEY: "x" },
+      {
+        stdout: (s) => {
+          stdoutBuf += s;
+        },
+        stderr: () => undefined,
+        providerOverride: PROVIDER,
+        deps: harness.deps,
+      },
+    );
+    await harness.run();
+    expect(await firstRun).toBe(0);
+    expect(stdoutBuf).toBe("first reply\n");
+
+    // Reset stdout buffer for the second run.
+    stdoutBuf = "";
+
+    // Second run on the same contextDir. A fresh harness for a clean
+    // matcher state but the same context dir on disk — proving that
+    // the example's persistence really does survive process death.
+    harness.dispose();
+    harness = setupHarness();
+    wireReply(harness, "second reply");
+
+    const secondRun = main(
+      [...argv, "second prompt"],
+      { ANTHROPIC_API_KEY: "x" },
+      {
+        stdout: (s) => {
+          stdoutBuf += s;
+        },
+        stderr: () => undefined,
+        providerOverride: PROVIDER,
+        deps: harness.deps,
+      },
+    );
+    await harness.run();
+    expect(await secondRun).toBe(0);
+    expect(stdoutBuf).toBe("second reply\n");
+
+    // Verify the on-disk history projection survived both runs by
+    // opening the context store directly — the issue's acceptance gate
+    // for resume-from-crash.
+    const { createIsogitStore } = await import("@interchange/storage-isogit");
+    const store = await createIsogitStore(contextDir);
+    const loaded = await store.load();
+    // Each round-trip produces a user turn and an assistant turn, so we
+    // expect at least 4 turns total across both runs.
+    expect(loaded.turns.length).toBeGreaterThanOrEqual(4);
+    const assistantTurns = loaded.turns.filter((t) => t.role === "assistant");
+    expect(assistantTurns.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     { "path": "apps/hub" },
     { "path": "apps/ui" },
     { "path": "apps/sidecar" },
-    { "path": "packages/inference-testing" }
+    { "path": "packages/inference-testing" },
+    { "path": "examples/coding-agent" }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     { "path": "packages/pack-transport" },
     { "path": "packages/hub-client" },
     { "path": "packages/harness" },
+    { "path": "packages/agent" },
     { "path": "apps/hub" },
     { "path": "apps/ui" },
     { "path": "apps/sidecar" },


### PR DESCRIPTION
## Summary

- New `@interchange/agent` package: in-process agent runtime sitting on `createReactorAssembly` from `@interchange/inference`. Peer to `@interchange/harness` (the mail-transport-bound consumer); the agent is the code-driven `send`/`stream`/`history` consumer.
- New `examples/coding-agent/`: reference consumer wiring `createAgent` with `@interchange/tools-posix` + `@interchange/tools-lsp`, persisting to `tmp/coding-agent/context/` so re-running resumes prior conversations. CLI is verified end-to-end through `@interchange/inference-testing` (parses argv, drives the reactor, prints reply, exit code; resume-from-crash by reopening the same `contextDir`).
- `examples/` established as a first-class workspace alongside `apps/` and `packages/` (gated by `make all`, listed in root `tsconfig.json` references, documented in `CONVENTIONS.md`).
- Two small ergonomic additions to `@interchange/inference-testing` driven by writing the integration tests: `scenario.replyOnce(provider, opts)` collapses the create-stream + build-chunks + enqueue + register-matcher ritual into one call, and `scenario.lastRequest()` returns a clone of the most-recently matched `Request` so tests can assert on the body shape without instrumenting a capture closure inside the (sync-only) matcher predicate.

Public agent surface: `createAgent`, `send`, `stream`, `deliver`, `close`, `setProvider`, `history`, `checkpoints`, `readAt`, `blobReader`, plus tool sugar (`tool`, `stringTool`, `fromToolRunner`).

Notable design points:
- **Singleton-per-contextDir**: runtime check via `AgentInUseError` (path-resolved lock; same `contextStore` instance passed by the caller bypasses the lock).
- **FIFO send queue** with configurable `sendQueueMax` (default 16); per-send `AbortSignal` removes queued items or rejects in-flight callers; overflow throws `SendQueueFullError` synchronously.
- **Bounded `stream()` fan-out** per consumer with `streamBufferMax` (default 1024); overflow throws `StreamBackpressureError` into the affected iterator only.
- **`setProvider` rotates everything**, including `model`. The agent wraps the director's `capabilities.infer(model, ...)` so the live model is substituted on every call — works with the default director and any caller-supplied director that simply relays its captured model.
- **`close()` waits for shutdown** (audit flush + in-flight commits) before releasing the contextDir lock, bounded by `closeTimeoutMs` (default 5s) as a backstop. Fallback resolution on `reactor.done` for paths where `onShutdown` never fires.
- Non-fatal `reactor.error` events do not terminate the active send — the cycle may still produce a `connector.reply`.

## Test plan

- [x] `make all` clean: **1429 tests** passing across 77 files, no regressions in existing 1300+ tests.
- [x] Per-commit `tsc -b` clean for all 17 commits.
- [x] Per-commit `bun test packages/agent tests/agent` passes for every commit; test count grows monotonically.
- [x] Lifecycle tests against real isogit store: singleton lock, close+reopen on same dir, idempotent close, post-close error contract.
- [x] Send-flow integration via `@interchange/inference-testing`: round-trip send/reply, history persistence across reopen, `readAt` against recorded checkpoint, close-while-pending drainage with `AgentClosedError`, `setProvider` credential rotation, `setProvider` model rotation (asserts on-wire model name via `lastRequest()`), abort-mid-flight, `SendQueueFullError` past cap.
- [x] **CLI end-to-end** via the harness: argv parsing, agent construction, send, stream pump, close, exit codes; missing-API-key and empty-prompt failure paths; resume-from-crash (two invocations on the same `contextDir` produce ≥4 history turns the second run can see).

Closes INTR-51