### PR TITLE
Lift hub foundation helpers and decouple session middleware from better-auth

### DIFF
--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -1,5 +1,9 @@
 import { eq, and, isNull } from "drizzle-orm";
-import { createDB, createGrantStore } from "@interchange/db";
+import {
+  createDB,
+  createGrantStore,
+  resolveInstanceProviders,
+} from "@interchange/db";
 import { agentInstance, sessionMail } from "@interchange/db/schema";
 import {
   createAgentRepoStore,
@@ -9,7 +13,6 @@ import {
   createSessionService,
   createSidecarRouter,
   generateId,
-  resolveInstanceProviders,
 } from "@interchange/hub";
 import { generateKeyPair } from "@interchange/crypto-node";
 import { parseMailToEmail } from "@interchange/mime";

--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -331,7 +331,11 @@ const sessionService = createSessionService({
 });
 
 const app = createApp({
-  auth,
+  getSession: async (headers) => {
+    const result = await auth.api.getSession({ headers });
+    return result ? { user: result.user, session: result.session } : null;
+  },
+  authHandler: (c) => auth.handler(c.req.raw),
   db,
   sidecarRouter,
   sessionService,

--- a/bin/gen-api-docs.ts
+++ b/bin/gen-api-docs.ts
@@ -143,20 +143,17 @@ function formatTypeName(schema: JsonSchema, tagHint?: string): string {
 // 3. Load the Hono app and fetch the OpenAPI spec
 // ---------------------------------------------------------------------------
 
-const mockAuth = {
-  api: { getSession: async () => null },
-  handler: async () => new Response("", { status: 404 }),
-};
-
 const app = createApp({
   // Stub dependencies — this script only calls /openapi.json which uses
   // route metadata, not runtime services. These stubs are never called.
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- stub; only /openapi.json is called
-  auth: mockAuth as never,
+  getSession: async () => null,
+  authHandler: () => new Response("", { status: 404 }),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- stub; only /openapi.json is called
   db: {} as never,
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- stub; only /openapi.json is called
   sidecarRouter: {} as never,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- stub; only /openapi.json is called
+  sessionService: {} as never,
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- stub; only /openapi.json is called
   eventCollectors: {} as never,
 });

--- a/bun.lock
+++ b/bun.lock
@@ -207,6 +207,7 @@
       "name": "@interchange/db",
       "version": "0.0.0",
       "dependencies": {
+        "@interchange/log": "workspace:*",
         "@interchange/types": "workspace:*",
         "arktype": "catalog:",
         "drizzle-orm": "^0.45.1",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -18,6 +18,7 @@
     "db:migrate": "drizzle-kit migrate --config=drizzle.config.ts"
   },
   "dependencies": {
+    "@interchange/log": "workspace:*",
     "@interchange/types": "workspace:*",
     "arktype": "catalog:",
     "drizzle-orm": "^0.45.1",

--- a/packages/db/src/credential-resolution.ts
+++ b/packages/db/src/credential-resolution.ts
@@ -1,10 +1,23 @@
 import { eq, and, isNull } from "drizzle-orm";
+import { type } from "arktype";
+
+import { getLogger } from "@interchange/log";
+import { CredentialRequirement as CredentialRequirementType } from "@interchange/types";
+import type { ProviderConfig } from "@interchange/types/runtime";
 
 import type { DB } from "./client";
+import { agent } from "./schema/agents";
+import { agentSession } from "./schema/sessions";
 import { credential } from "./schema/credentials";
 import { oauthClient } from "./schema/oauth-clients";
 import { provider } from "./schema/providers";
 import { getAncestorChain } from "./tenant-hierarchy";
+
+const log = getLogger(["db", "credentials"]);
+
+const CredentialRequirements = CredentialRequirementType.array();
+
+export const ProviderMetadata = type({ baseURL: "string" });
 
 /**
  * Resolves a provider by name, walking up the tenant hierarchy.
@@ -166,4 +179,85 @@ export async function resolveCredentialRequirement(
   }
 
   return null;
+}
+
+/**
+ * Resolve the full ProviderConfig[] for a single running instance by
+ * re-resolving each credential requirement from the agent definition.
+ *
+ * Returns an empty array if no requirements are defined or none could
+ * be resolved.
+ */
+export async function resolveInstanceProviders(
+  db: DB["db"],
+  tenantId: string,
+  instance: { agentId: string; sessionId: string | null },
+): Promise<ProviderConfig[]> {
+  const agentRow = await db.query.agent.findFirst({
+    where: eq(agent.id, instance.agentId),
+  });
+  if (!agentRow) return [];
+
+  const requirements = CredentialRequirements(
+    agentRow.credentialRequirements ?? [],
+  );
+  if (requirements instanceof type.errors) {
+    log.warn`Invalid credential requirements for agent ${agentRow.id}: ${requirements.summary}`;
+    return [];
+  }
+
+  let invokerPrincipalId: string | null = null;
+  if (instance.sessionId) {
+    const session = await db.query.agentSession.findFirst({
+      where: eq(agentSession.id, instance.sessionId),
+    });
+    if (session) {
+      invokerPrincipalId = session.principalId;
+    }
+  }
+
+  const providers: ProviderConfig[] = [];
+  for (const req of requirements) {
+    if (req.source === "creator" && !agentRow.creatorPrincipalId) {
+      continue;
+    }
+    if (req.source === "invoker" && !invokerPrincipalId) {
+      continue;
+    }
+
+    let resolved;
+    try {
+      resolved = await resolveCredentialRequirement(
+        db,
+        tenantId,
+        req,
+        agentRow.creatorPrincipalId ?? "",
+        invokerPrincipalId,
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn`Failed to resolve credential for provider ${req.providerName}: ${msg}`;
+      continue;
+    }
+    if (!resolved) continue;
+
+    const providerRow = await db.query.provider.findFirst({
+      where: eq(provider.id, resolved.providerId),
+    });
+    if (!providerRow) continue;
+
+    const metadata = ProviderMetadata(providerRow.metadata ?? {});
+    if (metadata instanceof type.errors) {
+      log.warn`Invalid provider metadata for provider ${providerRow.id}: ${metadata.summary}`;
+      continue;
+    }
+
+    providers.push({
+      provider: providerRow.plugin,
+      baseURL: metadata.baseURL,
+      apiKey: resolved.secret,
+    });
+  }
+
+  return providers;
 }

--- a/packages/db/src/credential-resolution.ts
+++ b/packages/db/src/credential-resolution.ts
@@ -121,7 +121,7 @@ export async function resolveCredentialRequirement(
   db: DB["db"],
   tenantId: string,
   requirement: CredentialRequirement,
-  creatorPrincipalId: string,
+  creatorPrincipalId: string | null,
   invokerPrincipalId: string | null,
 ) {
   const resolvedProvider = await resolveProviderByName(
@@ -231,7 +231,7 @@ export async function resolveInstanceProviders(
         db,
         tenantId,
         req,
-        agentRow.creatorPrincipalId ?? "",
+        agentRow.creatorPrincipalId,
         invokerPrincipalId,
       );
     } catch (err: unknown) {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -8,6 +8,8 @@ export {
   resolveCredentialByName,
   resolveCredentialById,
   resolveCredentialRequirement,
+  resolveInstanceProviders,
+  ProviderMetadata,
 } from "./credential-resolution";
 export {
   parseAgentRow,

--- a/packages/hub-client/src/transforms.ts
+++ b/packages/hub-client/src/transforms.ts
@@ -1,6 +1,9 @@
+import { parseAgentAddress } from "@interchange/types";
 import type { InferenceTurnResponse, MailResponse } from "@interchange/types";
 
 import type { InstanceEvent, MailAddress, ToolCallEvent } from "./types";
+
+export { isAgentAddress } from "@interchange/types";
 
 export function parseFromHeader(from: string): string {
   const match = from.match(/^"(.+)"\s+<.+>$/);
@@ -34,11 +37,6 @@ export function formatAddress(addr: {
   return addr.name ?? addr.email;
 }
 
-export function isAgentAddress(email: string): boolean {
-  const local = email.split("@")[0];
-  return !!local && local.startsWith("ins_");
-}
-
 // Inbound mail is always shown. Outbound mail is shown unless it is a
 // connector thread reply (interchange-type: conversation.message), which is
 // already represented as streaming text → committed turn in the timeline.
@@ -55,9 +53,9 @@ export function shouldShowMail(data: {
 export function resolveAgentAddress(
   addr: MailAddress,
 ): { instanceId: string; label: string } | null {
-  const local = addr.email.split("@")[0];
-  if (!local || !local.startsWith("ins_")) return null;
-  return { instanceId: local, label: formatAddress(addr) };
+  const parsed = parseAgentAddress(addr.email);
+  if (!parsed) return null;
+  return { instanceId: parsed.instanceId, label: formatAddress(addr) };
 }
 
 export function resolveAgentRecipient(

--- a/packages/hub/src/app.test.ts
+++ b/packages/hub/src/app.test.ts
@@ -2,7 +2,6 @@ import { describe, test, expect } from "bun:test";
 import { type } from "arktype";
 import type { DB } from "@interchange/db";
 import { createApp } from "./app";
-import type { Auth } from "./auth";
 import { createEventCollectorRegistry } from "./event-collector-registry";
 import type { SessionService } from "./session-service";
 import { createSidecarRouter } from "./ws/sidecar-handler";
@@ -11,14 +10,6 @@ const OpenAPISpec = type({
   info: { title: "string", version: "string" },
   paths: "Record<string, Record<string, unknown>>",
 });
-
-// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- betterAuth type cannot be structurally satisfied in tests
-const mockAuth = {
-  api: {
-    getSession: async () => null,
-  },
-  handler: async () => new Response("", { status: 404 }),
-} as unknown as Auth;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- drizzle PgDatabase type cannot be structurally satisfied in tests
 const mockDb = {} as unknown as DB["db"];
@@ -37,7 +28,8 @@ const sessionService: SessionService = {
 const eventCollectors = createEventCollectorRegistry({ db: mockDb });
 
 const app = createApp({
-  auth: mockAuth,
+  getSession: async () => null,
+  authHandler: () => new Response("", { status: 404 }),
   db: mockDb,
   sidecarRouter,
   sessionService,

--- a/packages/hub/src/app.ts
+++ b/packages/hub/src/app.ts
@@ -3,9 +3,10 @@ import { Hono } from "hono";
 import { openAPIRouteHandler } from "hono-openapi";
 
 import { honoLogger, type HonoContext } from "@interchange/log/hono";
-import type { Auth } from "./auth";
 import type { AppEnv } from "./context";
+import { createSessionMiddleware } from "./middleware/session";
 import { requireAuth, resolveTenant } from "./middleware/tenant";
+import type { GetSession } from "./session";
 import { meRoutes } from "./routes/me";
 import { tenantRoutes } from "./routes/tenants";
 import { tenantFederationRoutes } from "./routes/tenant-federation";
@@ -33,7 +34,8 @@ import type { SidecarRouter } from "./ws/sidecar-handler";
 import type { EventCollectorRegistry } from "./event-collector-registry";
 
 export type CreateAppOpts = {
-  auth: Auth;
+  getSession: GetSession;
+  authHandler: Handler<AppEnv>;
   db: DB["db"];
   sidecarRouter: SidecarRouter;
   sessionService: SessionService;
@@ -43,7 +45,8 @@ export type CreateAppOpts = {
 };
 
 export function createApp({
-  auth,
+  getSession,
+  authHandler,
   db,
   sidecarRouter,
   sessionService,
@@ -71,17 +74,12 @@ export function createApp({
     c.set("sidecarRouter", sidecarRouter);
     c.set("sessionService", sessionService);
     c.set("eventCollectors", eventCollectors);
-    const result = await auth.api.getSession({
-      headers: c.req.raw.headers,
-    });
-    c.set("user", result?.user ?? null);
-    c.set("session", result?.session ?? null);
     await next();
   });
 
-  app.all("/api/auth/*", (c) => {
-    return auth.handler(c.req.raw);
-  });
+  app.use(createSessionMiddleware(getSession));
+
+  app.all("/api/auth/*", authHandler);
 
   app.get("/status", (c) => c.json({ status: "ok" }));
 

--- a/packages/hub/src/context.ts
+++ b/packages/hub/src/context.ts
@@ -2,8 +2,8 @@ import type { DB } from "@interchange/db";
 import type { ConditionRegistry, GrantStore } from "@interchange/types/authz";
 import type { Env } from "hono";
 
-import type { Auth } from "./auth";
 import type { EventCollectorRegistry } from "./event-collector-registry";
+import type { SessionInfo, SessionUser } from "./session";
 import type { SessionService } from "./session-service";
 import type { SidecarRouter } from "./ws/sidecar-handler";
 
@@ -36,8 +36,8 @@ export type AppEnv = Env & {
     sidecarRouter: SidecarRouter;
     sessionService: SessionService;
     eventCollectors: EventCollectorRegistry;
-    user: Auth["$Infer"]["Session"]["user"] | null;
-    session: Auth["$Infer"]["Session"]["session"] | null;
+    user: SessionUser | null;
+    session: SessionInfo | null;
   };
 };
 

--- a/packages/hub/src/credential-push.ts
+++ b/packages/hub/src/credential-push.ts
@@ -1,115 +1,17 @@
-// Shared logic for resolving and pushing provider credentials to sidecars.
+// Shared logic for pushing provider credentials to sidecars.
 //
-// Used by the credentials PATCH route (tenant-wide push after secret rotation)
-// and by the reconnect handler (per-instance refresh after sidecar reconnect).
+// Used by the credentials PATCH route to broadcast updates to every running
+// instance in the tenant after a credential secret is rotated.
 
 import { eq, and } from "drizzle-orm";
-import { type } from "arktype";
 import { getLogger } from "@interchange/log";
-import {
-  agent,
-  agentInstance,
-  agentSession,
-  provider,
-} from "@interchange/db/schema";
-import { resolveCredentialRequirement } from "@interchange/db";
-import type { ProviderConfig } from "@interchange/types/runtime";
+import { agentInstance } from "@interchange/db/schema";
+import { resolveInstanceProviders } from "@interchange/db";
 import type { DB } from "@interchange/db";
 
 import type { SidecarRouter } from "./ws/sidecar-handler";
 
 const log = getLogger(["hub", "credentials"]);
-
-const CredentialRequirement = type({
-  providerName: "string",
-  "scopes?": "string[]",
-  source: "'tenant' | 'creator' | 'invoker'",
-  "name?": "string",
-});
-const CredentialRequirements = CredentialRequirement.array();
-
-const ProviderMetadata = type({ baseURL: "string" });
-
-/**
- * Resolve the full ProviderConfig[] for a single running instance by
- * re-resolving each credential requirement from the agent definition.
- *
- * Returns an empty array if no requirements are defined or none could
- * be resolved.
- */
-export async function resolveInstanceProviders(
-  db: DB["db"],
-  tenantId: string,
-  instance: { agentId: string; sessionId: string | null },
-): Promise<ProviderConfig[]> {
-  const agentRow = await db.query.agent.findFirst({
-    where: eq(agent.id, instance.agentId),
-  });
-  if (!agentRow) return [];
-
-  const requirements = CredentialRequirements(
-    agentRow.credentialRequirements ?? [],
-  );
-  if (requirements instanceof type.errors) {
-    log.warn`Invalid credential requirements for agent ${agentRow.id}: ${requirements.summary}`;
-    return [];
-  }
-
-  let invokerPrincipalId: string | null = null;
-  if (instance.sessionId) {
-    const session = await db.query.agentSession.findFirst({
-      where: eq(agentSession.id, instance.sessionId),
-    });
-    if (session) {
-      invokerPrincipalId = session.principalId;
-    }
-  }
-
-  const providers: ProviderConfig[] = [];
-  for (const req of requirements) {
-    if (req.source === "creator" && !agentRow.creatorPrincipalId) {
-      continue;
-    }
-    if (req.source === "invoker" && !invokerPrincipalId) {
-      continue;
-    }
-
-    let resolved;
-    try {
-      resolved = await resolveCredentialRequirement(
-        db,
-        tenantId,
-        req,
-        agentRow.creatorPrincipalId ?? "",
-        invokerPrincipalId,
-      );
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.warn`Failed to resolve credential for provider ${req.providerName}: ${msg}`;
-      continue;
-    }
-    if (!resolved) continue;
-
-    const providerRow = await db.query.provider.findFirst({
-      where: eq(provider.id, resolved.providerId),
-    });
-    if (!providerRow) continue;
-
-    const metadata = ProviderMetadata(providerRow.metadata ?? {});
-    if (metadata instanceof type.errors) {
-      log.warn`Invalid provider metadata for provider ${providerRow.id}: ${metadata.summary}`;
-      continue;
-    }
-
-    providers.push({
-      provider: providerRow.plugin,
-      baseURL: metadata.baseURL,
-      apiKey: resolved.secret,
-    });
-  }
-
-  return providers;
-}
 
 /**
  * After a credential secret is rotated, find all running instances in the

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -11,6 +11,7 @@ export {
 } from "./session-service";
 export { createApp, type App, type CreateAppOpts } from "./app";
 export type { AppEnv, TenantEnv, TenantRow, PrincipalRow } from "./context";
+export type { GetSession, SessionInfo, SessionUser } from "./session";
 export {
   createEventCollectorRegistry,
   type EventCollectorRegistry,

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -22,7 +22,4 @@ export {
   type WsHandle,
 } from "./ws";
 export { generateId } from "./ids";
-export {
-  resolveInstanceProviders,
-  pushProviderUpdates,
-} from "./credential-push";
+export { pushProviderUpdates } from "./credential-push";

--- a/packages/hub/src/middleware/session.ts
+++ b/packages/hub/src/middleware/session.ts
@@ -1,0 +1,13 @@
+import type { Context, Next } from "hono";
+
+import type { AppEnv } from "../context";
+import type { GetSession } from "../session";
+
+export function createSessionMiddleware(getSession: GetSession) {
+  return async function sessionMiddleware(c: Context<AppEnv>, next: Next) {
+    const result = await getSession(c.req.raw.headers);
+    c.set("user", result?.user ?? null);
+    c.set("session", result?.session ?? null);
+    await next();
+  };
+}

--- a/packages/hub/src/routes/instances.test.ts
+++ b/packages/hub/src/routes/instances.test.ts
@@ -5,8 +5,8 @@ import type { GrantRule } from "@interchange/types/authz";
 import type { SessionStatus } from "@interchange/types";
 
 import { createApp } from "../app";
-import type { Auth } from "../auth";
 import type { EventCollectorRegistry } from "../event-collector-registry";
+import type { GetSession } from "../session";
 import type { SessionService } from "../session-service";
 import type { SidecarRouter } from "../ws/sidecar-handler";
 
@@ -150,17 +150,26 @@ function createMockDB(opts: MockDBOpts) {
   } as unknown as Parameters<typeof createApp>[0]["db"];
 }
 
-function createMockAuth(userId: string) {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- betterAuth type cannot be structurally satisfied in tests
-  return {
-    api: {
-      getSession: async () => ({
-        user: { id: userId, email: "test@example.com", name: "Test User" },
-        session: { id: "session_test" },
-      }),
+function createMockGetSession(userId: string): GetSession {
+  const now = new Date("2025-01-01");
+  return async () => ({
+    user: {
+      id: userId,
+      email: "test@example.com",
+      emailVerified: true,
+      name: "Test User",
+      createdAt: now,
+      updatedAt: now,
     },
-    handler: async () => new Response("", { status: 404 }),
-  } as unknown as Auth;
+    session: {
+      id: "session_test",
+      userId,
+      token: "tok_test",
+      expiresAt: new Date("2999-01-01"),
+      createdAt: now,
+      updatedAt: now,
+    },
+  });
 }
 
 function createMockSidecarRouter(
@@ -267,7 +276,8 @@ function createTestApp(opts: TestAppOpts = {}) {
   );
 
   return createApp({
-    auth: createMockAuth(USER_ID),
+    getSession: createMockGetSession(USER_ID),
+    authHandler: () => new Response("", { status: 404 }),
     db,
     grantStore: createInMemoryGrantStore(opts.grants ?? [makeGrant()]),
     sidecarRouter: createMockSidecarRouter(opts.routableAddresses),

--- a/packages/hub/src/routes/instances.ts
+++ b/packages/hub/src/routes/instances.ts
@@ -21,6 +21,7 @@ import {
 import {
   resolveCredentialRequirement,
   parseAgentSkills,
+  ProviderMetadata,
 } from "@interchange/db";
 import { evaluateGrants, authorize } from "@interchange/authz";
 import { parseMailToEmail, extractPartByPath } from "@interchange/mime";
@@ -30,12 +31,14 @@ import {
   CreateAgentInstance,
   AgentInstanceResponse,
   AgentHealth,
+  CredentialRequirement,
   OfferingDetail,
   GrantRequirement,
   SendMessage,
   MailResponse,
   InferenceTurnResponse,
   ErrorResponse,
+  formatAgentAddress,
   paginatedSchema,
 } from "@interchange/types";
 import type { GrantEffect, GrantOrigin } from "@interchange/types";
@@ -58,19 +61,8 @@ import {
   pageParameters,
 } from "../pagination";
 
-const CredentialRequirement = type({
-  providerName: "string",
-  "scopes?": "string[]",
-  source: "'tenant' | 'creator' | 'invoker'",
-  "name?": "string",
-});
-
 const CredentialRequirements = CredentialRequirement.array();
 const GrantRequirements = GrantRequirement.array();
-
-const ProviderMetadata = type({
-  baseURL: "string",
-});
 
 const ModelConfig = type({
   defaultModel: "string",
@@ -183,7 +175,7 @@ app.post(
     }
 
     const instanceId = generateId("instance");
-    const agentAddress = `${instanceId}@${tenant.domain}`;
+    const agentAddress = formatAgentAddress(instanceId, tenant.domain);
 
     // --- Credential resolution ---
 

--- a/packages/hub/src/session.ts
+++ b/packages/hub/src/session.ts
@@ -1,0 +1,44 @@
+// Hub-owned session contract.
+//
+// SessionUser and SessionInfo mirror the structural shape that better-auth
+// currently returns (see @better-auth/core/dist/db/schema/{user,session}),
+// but the hub does not reference Auth["$Infer"]. This breaks the type-level
+// dependency on better-auth so a third-party identity provider can be
+// plugged in by satisfying the GetSession contract.
+//
+// The shapes are kept intentionally hand-written: deriving with Pick<>
+// against the better-auth types would re-introduce the type dependency.
+// The trade-off is that a field added upstream in better-auth would not
+// surface here automatically.
+//
+// The optional `?: T | null | undefined` shape (rather than `?: T | null`)
+// is deliberate. Under exactOptionalPropertyTypes, the latter rejects an
+// explicit `undefined` assignment, but the inferred return of
+// z.string().nullish() in better-auth's user/session schemas is
+// `string | null | undefined`. Without the trailing `| undefined`, the
+// adapter in apps/hub cannot pass the result through structurally.
+
+export type SessionUser = {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  email: string;
+  emailVerified: boolean;
+  name: string;
+  image?: string | null | undefined;
+};
+
+export type SessionInfo = {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  userId: string;
+  expiresAt: Date;
+  token: string;
+  ipAddress?: string | null | undefined;
+  userAgent?: string | null | undefined;
+};
+
+export type GetSession = (
+  headers: Headers,
+) => Promise<{ user: SessionUser; session: SessionInfo } | null>;

--- a/packages/hub/src/ws/sidecar-handler.test.ts
+++ b/packages/hub/src/ws/sidecar-handler.test.ts
@@ -4,6 +4,7 @@ import {
   generateKeyPair,
   importPrivateKeyBytes,
 } from "@interchange/crypto-node";
+import { parseAgentAddress } from "@interchange/types";
 import { createSidecarRouter, type WsHandle } from "./sidecar-handler";
 
 function hexEncode(bytes: Uint8Array): string {
@@ -304,7 +305,8 @@ describe("SidecarRouter", () => {
             {
               id: "mail_outbound",
               direction: "outbound",
-              instanceId: senderAddress.split("@")[0] ?? senderAddress,
+              instanceId:
+                parseAgentAddress(senderAddress)?.instanceId ?? senderAddress,
               address: senderAddress,
               createdAt: new Date(),
             },
@@ -314,7 +316,7 @@ describe("SidecarRouter", () => {
               results.push({
                 id: `mail_in_${addr}`,
                 direction: "inbound",
-                instanceId: addr.split("@")[0] ?? addr,
+                instanceId: parseAgentAddress(addr)?.instanceId ?? addr,
                 address: addr,
                 createdAt: new Date(),
               });
@@ -369,14 +371,15 @@ describe("SidecarRouter", () => {
             {
               id: "mail_out",
               direction: "outbound" as const,
-              instanceId: senderAddress.split("@")[0] ?? senderAddress,
+              instanceId:
+                parseAgentAddress(senderAddress)?.instanceId ?? senderAddress,
               address: senderAddress,
               createdAt: new Date(),
             },
             ...recipients.map((addr) => ({
               id: `mail_in_${addr}`,
               direction: "inbound" as const,
-              instanceId: addr.split("@")[0] ?? addr,
+              instanceId: parseAgentAddress(addr)?.instanceId ?? addr,
               address: addr,
               createdAt: new Date(),
             })),

--- a/packages/types/src/agent-address.test.ts
+++ b/packages/types/src/agent-address.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from "bun:test";
+
+import {
+  formatAgentAddress,
+  isAgentAddress,
+  parseAgentAddress,
+} from "./agent-address";
+
+describe("formatAgentAddress", () => {
+  test("joins instanceId and domain with @", () => {
+    expect(formatAgentAddress("ins_abc123", "tenant.example")).toBe(
+      "ins_abc123@tenant.example",
+    );
+  });
+});
+
+describe("parseAgentAddress", () => {
+  test("splits a well-formed address", () => {
+    expect(parseAgentAddress("ins_abc123@tenant.example")).toEqual({
+      instanceId: "ins_abc123",
+      domain: "tenant.example",
+    });
+  });
+
+  test("returns null when instance prefix is missing", () => {
+    expect(parseAgentAddress("usr_alice@tenant.example")).toBeNull();
+  });
+
+  test("returns null when the @ is missing", () => {
+    expect(parseAgentAddress("ins_abc123")).toBeNull();
+  });
+
+  test("returns null when the local part is empty", () => {
+    expect(parseAgentAddress("@tenant.example")).toBeNull();
+  });
+
+  test("returns null when the domain part is empty", () => {
+    expect(parseAgentAddress("ins_abc123@")).toBeNull();
+  });
+
+  test("does not validate the shape of the domain", () => {
+    expect(parseAgentAddress("ins_abc123@not a real domain")).toEqual({
+      instanceId: "ins_abc123",
+      domain: "not a real domain",
+    });
+  });
+
+  test("splits on the first @ and treats the rest as the domain", () => {
+    expect(parseAgentAddress("ins_abc123@foo@bar")).toEqual({
+      instanceId: "ins_abc123",
+      domain: "foo@bar",
+    });
+  });
+});
+
+describe("isAgentAddress", () => {
+  test("true for ins_-prefixed addresses with a domain", () => {
+    expect(isAgentAddress("ins_abc123@tenant.example")).toBe(true);
+  });
+
+  test("false for non-agent local parts", () => {
+    expect(isAgentAddress("usr_alice@tenant.example")).toBe(false);
+  });
+
+  test("false for bare instance IDs without a domain", () => {
+    expect(isAgentAddress("ins_abc123")).toBe(false);
+  });
+});

--- a/packages/types/src/agent-address.ts
+++ b/packages/types/src/agent-address.ts
@@ -1,0 +1,34 @@
+// Agent instance addresses are "<instanceId>@<domain>" where instanceId is
+// the `ins_`-prefixed identifier produced by generateId("instance"). These
+// helpers are the single source of truth for that format.
+//
+// The shape of the right-hand side of the "@" is not validated beyond the
+// requirement that it be non-empty: tightening the contract (DNS-ish
+// validation, normalisation, etc.) is a separate follow-up. The parser
+// IS stricter than the previous hub-client implementation in one respect
+// — it rejects a bare local part with no "@" and an empty domain, where
+// the previous `split("@")[0]` extraction would have accepted them. All
+// observed callers feed full "<local>@<domain>" addresses or fall back
+// to the raw input.
+
+const INSTANCE_PREFIX = "ins_";
+
+export function formatAgentAddress(instanceId: string, domain: string): string {
+  return `${instanceId}@${domain}`;
+}
+
+export function parseAgentAddress(
+  address: string,
+): { instanceId: string; domain: string } | null {
+  const atIdx = address.indexOf("@");
+  if (atIdx <= 0) return null;
+  const instanceId = address.slice(0, atIdx);
+  const domain = address.slice(atIdx + 1);
+  if (!instanceId.startsWith(INSTANCE_PREFIX)) return null;
+  if (domain.length === 0) return null;
+  return { instanceId, domain };
+}
+
+export function isAgentAddress(address: string): boolean {
+  return parseAgentAddress(address) !== null;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -14,6 +14,7 @@ export * from "./credentials";
 export * from "./offerings";
 export * from "./models";
 export * from "./observability";
+export * from "./agent-address";
 export * from "./agent-data";
 export * from "./audit";
 export * from "./sidecars";


### PR DESCRIPTION
## Summary

- Consolidate three helpers that were duplicated or misplaced inside the hub package, preparing for the hub split. The `CredentialRequirement` arktype validator is now imported from `@interchange/types`; agent address formatting and parsing moves into a new `@interchange/types/agent-address` module; and `resolveInstanceProviders` (with its `ProviderMetadata` helper) moves into `@interchange/db` alongside `resolveCredentialRequirement`.
- Break the type-level dependency on better-auth. The request context, the inline session middleware, and `CreateAppOpts` no longer reference `Auth["$Infer"]`. A new `packages/hub/src/session.ts` defines hand-written `SessionUser`, `SessionInfo`, and `GetSession` types that mirror what better-auth returns today. `createApp` now takes `getSession` and `authHandler` callbacks; the first-party `apps/hub` builds the better-auth `Auth` and passes an adapter through.
- `packages/hub/src/ids.ts` was on the original plan but is deferred until the hub package is actually split — placement is easier to decide once we know who needs to mint IDs.

## Changes

- `packages/types/src/agent-address.ts`: new module owning `formatAgentAddress` / `parseAgentAddress` / `isAgentAddress`. Stricter than the previous `split("@")[0]` implementation in that it requires a non-empty domain.
- `packages/db/src/credential-resolution.ts`: gains `resolveInstanceProviders` and exports `ProviderMetadata`. `packages/db/package.json` picks up an `@interchange/log` dep for the resolver's warnings.
- `packages/hub/src/credential-push.ts`: shrinks to `pushProviderUpdates` only.
- `packages/hub/src/routes/instances.ts`: switches to the canonical `CredentialRequirement`, `formatAgentAddress`, and the lifted `ProviderMetadata`.
- `packages/hub-client/src/transforms.ts`: `isAgentAddress` is re-exported from `@interchange/types`; `resolveAgentAddress` now delegates to `parseAgentAddress`. Public surface unchanged.
- `packages/hub/src/session.ts` + `packages/hub/src/middleware/session.ts`: hub-owned session contract and the extracted middleware factory.
- `packages/hub/src/app.ts` and `packages/hub/src/context.ts`: `Auth`-typed surface replaced with `GetSession` / `SessionUser` / `SessionInfo`.
- `apps/hub/src/index.ts`: adapter that projects `auth.api.getSession()` into the hub-owned shape.
- `bin/gen-api-docs.ts`: drops the `mockAuth` shim and its eslint-disable.
- Hub test mocks (`app.test.ts`, `routes/instances.test.ts`) and the four `.split("@")[0]` sites in `ws/sidecar-handler.test.ts` move to the new contracts.

## Testing

- `make all` passes locally (lint + tsc -b + bun test, including the two-pass test split).
- New unit tests for the agent-address module (`packages/types/src/agent-address.test.ts`).
- Existing hub-client transform tests still pass against the re-pointed `isAgentAddress` / `resolveAgentAddress`.

Closes INTR-64