### PR TITLE
Make the session plane composable via an event-emitter API

### DIFF
--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -10,6 +10,7 @@ import {
   createSidecarRouter,
 } from "@interchange/hub";
 import { generateKeyPair } from "@interchange/crypto-node";
+import { hexEncode } from "@interchange/types";
 import { upgradeWebSocket, websocket } from "hono/bun";
 import { setup, getLogger } from "@interchange/log";
 
@@ -35,12 +36,6 @@ if (!hubDataDir) {
 
 const hubSigningKey = await generateKeyPair();
 log.info("Generated hub deploy signing key");
-
-function hexEncode(bytes: Uint8Array): string {
-  return Array.from(bytes)
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
 
 const agentRepoStore = createAgentRepoStore({
   dataDir: hubDataDir,

--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -1,25 +1,17 @@
-import { eq, and, isNull } from "drizzle-orm";
-import {
-  createDB,
-  createGrantStore,
-  resolveInstanceProviders,
-} from "@interchange/db";
-import { agentInstance, sessionMail } from "@interchange/db/schema";
+import { createDB, createGrantStore } from "@interchange/db";
 import {
   createAgentRepoStore,
   createApp,
   createAuth,
   createEventCollectorRegistry,
+  createHubSessionLookups,
+  createHubSessionOrchestrator,
   createSessionService,
   createSidecarRouter,
-  generateId,
 } from "@interchange/hub";
 import { generateKeyPair } from "@interchange/crypto-node";
-import { parseMailToEmail } from "@interchange/mime";
-import { parseInferenceEvent } from "@interchange/types/runtime";
 import { upgradeWebSocket, websocket } from "hono/bun";
 import { setup, getLogger } from "@interchange/log";
-import { type } from "arktype";
 
 await setup();
 
@@ -34,24 +26,6 @@ const { db } = createDB({
 });
 
 const auth = createAuth(db);
-const eventCollectors = createEventCollectorRegistry({
-  db,
-  onTurnFinalized(agentAddress, turn) {
-    sidecarRouter.dispatchAgentEvent(agentAddress, {
-      type: "turn.committed",
-      data: {
-        turnId: turn.turnId,
-        status: turn.status,
-        text: turn.text,
-        hadReply: turn.hadReply,
-        hadError: turn.hadError,
-        errors: turn.errors,
-        toolCalls: turn.toolCalls,
-        toolErrors: turn.toolErrors,
-      },
-    });
-  },
-});
 const grantStore = createGrantStore(db);
 
 const hubDataDir = process.env["HUB_DATA_DIR"];
@@ -73,256 +47,39 @@ const agentRepoStore = createAgentRepoStore({
   signingKey: hubSigningKey,
 });
 
-function parseAgentId(agentAddress: string): string {
-  const atIdx = agentAddress.indexOf("@");
-  if (atIdx === -1) {
-    throw new Error(`Invalid agent address: "${agentAddress}"`);
-  }
-  return agentAddress.substring(0, atIdx);
-}
-
-async function requireInstance(agentAddress: string) {
-  const row = await db.query.agentInstance.findFirst({
-    where: and(
-      eq(agentInstance.address, agentAddress),
-      isNull(agentInstance.endedAt),
-    ),
-  });
-  if (!row) {
-    throw new Error(`No active instance found for address "${agentAddress}"`);
-  }
-  return row;
-}
+const lookups = createHubSessionLookups({ db, agentRepoStore });
 
 const sidecarRouter = createSidecarRouter({
   hubPublicKey: hexEncode(hubSigningKey.publicKey),
-  onAgentEvent(agentAddress, _sessionId, event) {
-    const validated = parseInferenceEvent(event);
-    if (validated instanceof type.errors) {
-      log.warn("Received invalid agent event for {agentAddress}: {summary}", {
-        agentAddress,
-        summary: validated.summary,
-      });
-      return;
-    }
-    eventCollectors.dispatch(agentAddress, validated);
-  },
-  onSidecarDisconnect(agentAddresses) {
-    for (const addr of agentAddresses) {
-      eventCollectors.abandon(addr);
-    }
-  },
-  async onAgentDeployAck(agentAddress, publicKey) {
-    const instance = await requireInstance(agentAddress);
+  lookups,
+});
 
-    await db
-      .update(agentInstance)
-      .set({ publicKey })
-      .where(eq(agentInstance.id, instance.id));
-  },
-  async onAgentReconnected(agentAddress) {
-    const instance = await requireInstance(agentAddress);
-
-    if (!instance.sessionId) {
-      throw new Error(
-        `Agent "${agentAddress}" reconnected but has no active session`,
-      );
-    }
-    const sessionId = instance.sessionId;
-
-    // Refresh grants before creating any local state. If this fails,
-    // the address is rejected and nothing needs cleanup.
-    const grants = await grantStore.collectGrants(
-      instance.principalId,
-      instance.tenantId,
-    );
-    await sidecarRouter.sendGrantsUpdate(agentAddress, grants);
-
-    // Re-resolve and push credentials so the agent picks up any
-    // rotations that happened while the sidecar was disconnected.
-    // Fail-open: a stale credential causes runtime 401s, not a
-    // security escalation, so we log rather than reject the reconnect.
-    try {
-      const providers = await resolveInstanceProviders(
-        db,
-        instance.tenantId,
-        instance,
-      );
-      if (providers.length > 0) {
-        await sidecarRouter.sendProvidersUpdate(agentAddress, providers);
-      }
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.warn(
-        "Failed to push credentials on reconnect for {agentAddress}: {msg}",
-        { agentAddress, msg },
-      );
-    }
-
-    const now = new Date();
-    if (instance.status !== "running") {
-      await db
-        .update(agentInstance)
-        .set({ status: "running", updatedAt: now })
-        .where(eq(agentInstance.id, instance.id));
-    }
-    if (!eventCollectors.has(agentAddress)) {
-      eventCollectors.create(
-        agentAddress,
-        instance.tenantId,
-        sessionId,
-        instance.id,
-      );
-      log.info(
-        "Restored event collector for reconnected agent {agentAddress}",
-        { agentAddress },
-      );
-    }
-  },
-  async onStatePackReceived(agentAddress, pack, ref, commitSha) {
-    const agentId = parseAgentId(agentAddress);
-    try {
-      await agentRepoStore.receiveStatePack(agentId, pack, ref, commitSha);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.startsWith("path_violation")) {
-        log.warn("State pack rejected for {agentAddress}: {msg}", {
-          agentAddress,
-          msg,
-        });
-        return { accepted: false, reason: "path_violation" as const };
-      }
-      throw err;
-    }
-    return { accepted: true };
-  },
-  async lookupDeployRef(agentAddress) {
-    const agentId = parseAgentId(agentAddress);
-    return agentRepoStore.getDeployRef(agentId);
-  },
-  async onDeployRefStale(agentAddress) {
-    const agentId = parseAgentId(agentAddress);
-    const { pack, commitSha, ref } =
-      await agentRepoStore.createDeployPack(agentId);
-    await sidecarRouter.sendPack(agentAddress, pack, ref, commitSha);
-    log.info("Re-deployed stale agent {agentAddress}", { agentAddress });
-  },
-  async lookupPublicKey(agentAddress) {
-    const row = await db
-      .select({ publicKey: agentInstance.publicKey })
-      .from(agentInstance)
-      .where(
-        and(
-          eq(agentInstance.address, agentAddress),
-          isNull(agentInstance.endedAt),
-        ),
-      )
-      .limit(1)
-      .then((rows) => rows[0]);
-    if (!row) {
-      return null;
-    }
-    return row.publicKey;
-  },
-  async onMailPersist({ senderAddress, recipients, raw }) {
-    const senderInstance = await requireInstance(senderAddress);
-    if (!senderInstance.sessionId) {
-      throw new Error(
-        `Instance ${senderInstance.id} has no session for address "${senderAddress}"`,
-      );
-    }
-    const createdAt = new Date();
-
-    // Outbound record on the sender's session.
-    const outboundId = generateId("sessionMail");
-    const outboundRecord = {
-      id: outboundId,
-      sessionId: senderInstance.sessionId,
-      instanceId: senderInstance.id,
-      tenantId: senderInstance.tenantId,
-      direction: "outbound" as const,
-      status: "delivered" as const,
-      raw,
-      createdAt,
-    };
-
-    // Inbound records for each recipient that has an active agent instance.
-    // Recipients that are not agent instances (e.g. human user addresses)
-    // are skipped.
-    const recipientResults = await Promise.all(
-      recipients.map(async (addr) => {
-        const row = await db.query.agentInstance.findFirst({
-          where: and(
-            eq(agentInstance.address, addr),
-            isNull(agentInstance.endedAt),
-          ),
-        });
-        if (row === undefined) {
-          return null;
-        }
-        if (row.sessionId === null) {
-          log.warn`Active instance ${row.id} for "${addr}" has no session; skipping inbound record`;
-          return null;
-        }
-        return { addr, instance: row, sessionId: row.sessionId };
-      }),
-    );
-    const recipientInstances = recipientResults.filter(
-      (r): r is NonNullable<typeof r> => r !== null,
-    );
-
-    const inboundEntries = recipientInstances.map(
-      ({ addr, instance, sessionId }) => {
-        const id = generateId("sessionMail");
-        return {
-          record: {
-            id,
-            sessionId,
-            instanceId: instance.id,
-            tenantId: instance.tenantId,
-            direction: "inbound" as const,
-            status: "delivered" as const,
-            raw,
-            createdAt,
-          },
-          result: {
-            id,
-            direction: "inbound" as const,
-            instanceId: instance.id,
-            address: addr,
-            createdAt,
-          },
-        };
-      },
-    );
-
-    await db
-      .insert(sessionMail)
-      .values([outboundRecord, ...inboundEntries.map((e) => e.record)]);
-
-    return [
-      {
-        id: outboundId,
-        direction: "outbound" as const,
-        instanceId: senderInstance.id,
-        address: senderInstance.address,
-        createdAt,
-      },
-      ...inboundEntries.map((e) => e.result),
-    ];
-  },
-  onMailPersisted(row) {
-    const parsed = parseMailToEmail(row.raw, row.id);
-    sidecarRouter.dispatchAgentEvent(row.address, {
-      type: "mail.delivered",
+const eventCollectors = createEventCollectorRegistry({
+  db,
+  onTurnFinalized(agentAddress, turn) {
+    sidecarRouter.dispatchAgentEvent(agentAddress, {
+      type: "turn.committed",
       data: {
-        ...parsed,
-        id: row.id,
-        direction: row.direction,
-        receivedAt: row.createdAt.toISOString(),
+        turnId: turn.turnId,
+        status: turn.status,
+        text: turn.text,
+        hadReply: turn.hadReply,
+        hadError: turn.hadError,
+        errors: turn.errors,
+        toolCalls: turn.toolCalls,
+        toolErrors: turn.toolErrors,
       },
     });
   },
+});
+
+createHubSessionOrchestrator({
+  events: sidecarRouter.events,
+  router: sidecarRouter,
+  db,
+  eventCollectors,
+  grantStore,
+  agentRepoStore,
 });
 
 const sessionService = createSessionService({

--- a/apps/sidecar/src/key-store.ts
+++ b/apps/sidecar/src/key-store.ts
@@ -219,12 +219,6 @@ export async function scanExistingAgents(
   return results;
 }
 
-export function hexEncode(bytes: Uint8Array): string {
-  return Array.from(bytes)
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-
 async function fileExists(filePath: string): Promise<boolean> {
   try {
     await fs.access(filePath);

--- a/apps/sidecar/src/session-manager.ts
+++ b/apps/sidecar/src/session-manager.ts
@@ -47,9 +47,10 @@ import type {
 } from "@interchange/types/runtime";
 import { createBlobReader } from "@interchange/types/runtime";
 
+import { hexEncode } from "@interchange/types";
+
 import {
   loadOrGenerateKeyPair,
-  hexEncode,
   persistAgentConfig,
   scanExistingAgents,
   type AgentKeyEntry,

--- a/apps/sidecar/src/ws-client.test.ts
+++ b/apps/sidecar/src/ws-client.test.ts
@@ -8,6 +8,7 @@ import {
   type WsHandle,
 } from "@interchange/hub";
 import { createInMemoryTransport } from "@interchange/mail-memory";
+import { hexEncode } from "@interchange/types";
 import type {
   HarnessConfig,
   InboundMessage,
@@ -825,12 +826,6 @@ describe("sidecar↔hub integration", () => {
     // deploy commit signatures. Distinct from the agent keypair.
     const hubKp = await generateKeyPair();
     const fakeAddress = "restored@test.interchange";
-
-    function hexEncode(bytes: Uint8Array): string {
-      return Array.from(bytes)
-        .map((b) => b.toString(16).padStart(2, "0"))
-        .join("");
-    }
 
     const agentPublicKeyHex = hexEncode(agentKp.publicKey);
     const hubPublicKeyHex = hexEncode(hubKp.publicKey);

--- a/apps/sidecar/src/ws-client.test.ts
+++ b/apps/sidecar/src/ws-client.test.ts
@@ -191,13 +191,16 @@ function startTestServer(): TestEnv {
   const router = createSidecarRouter({
     requestTimeoutMs: 5000,
     hubPublicKey: "a".repeat(64),
-    onAgentEvent(addr, sid, event) {
-      agentEvents.push({ addr, sid, event });
-    },
-    onMailOutbound(rawMessage, recipients) {
+  });
+  router.events.on("agent.event", ({ agentAddress, sessionId, event }) => {
+    agentEvents.push({ addr: agentAddress, sid: sessionId, event });
+  });
+  router.events.on(
+    "mail.outbound.undelivered",
+    ({ rawMessage, recipients }) => {
       outboundMail.push({ rawMessage, recipients });
     },
-  });
+  );
 
   const app = new Hono();
   app.get(
@@ -750,8 +753,6 @@ describe("sidecar↔hub integration", () => {
     const badRouter = createSidecarRouter({
       requestTimeoutMs: 5000,
       hubPublicKey: "abc", // odd length — hexDecode should throw
-      onAgentEvent: () => undefined,
-      onMailOutbound: () => undefined,
     });
 
     const badApp = new Hono();
@@ -839,10 +840,10 @@ describe("sidecar↔hub integration", () => {
       requestTimeoutMs: 5000,
       challengeTimeoutMs: 5000,
       hubPublicKey: hubPublicKeyHex,
-      onAgentEvent: () => undefined,
-      onMailOutbound: () => undefined,
-      lookupPublicKey: async (addr) =>
-        addr === fakeAddress ? agentPublicKeyHex : null,
+      lookups: {
+        lookupPublicKey: async (addr) =>
+          addr === fakeAddress ? agentPublicKeyHex : null,
+      },
     });
 
     const reconnectApp = new Hono();

--- a/apps/sidecar/src/ws-client.ts
+++ b/apps/sidecar/src/ws-client.ts
@@ -33,7 +33,7 @@ import type { KeyPair } from "@interchange/types/runtime";
 
 import type { SessionManager, SessionEventSink } from "./session-manager";
 import { createPackReceiver, chunkPack } from "@interchange/pack-transport";
-import { hexEncode } from "./key-store";
+import { hexDecode, hexEncode } from "@interchange/types";
 
 const logger = getLogger(["interchange", "sidecar", "ws"]);
 
@@ -678,20 +678,6 @@ function base64ToUint8Array(base64: string): Uint8Array {
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) {
     bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
-
-function hexDecode(hex: string): Uint8Array {
-  if (hex.length % 2 !== 0) {
-    throw new Error(`hexDecode: odd-length input (${hex.length} chars)`);
-  }
-  if (!/^[0-9a-fA-F]*$/.test(hex)) {
-    throw new Error("hexDecode: input contains non-hex characters");
-  }
-  const bytes = new Uint8Array(hex.length / 2);
-  for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
   }
   return bytes;
 }

--- a/packages/hub/src/event-collector-registry.ts
+++ b/packages/hub/src/event-collector-registry.ts
@@ -1,8 +1,9 @@
 // Registry of active event collectors, keyed by agent address.
 //
 // The hub creates a collector when an instance starts and removes it when the
-// instance ends or the sidecar disconnects. The onAgentEvent callback looks
-// up the collector by agent address and dispatches the event.
+// instance ends or the sidecar disconnects. The hub session orchestrator's
+// `agent.event` listener looks up the collector by agent address and
+// dispatches the event.
 
 import type { DB } from "@interchange/db";
 import type { InferenceEvent } from "@interchange/types/runtime";

--- a/packages/hub/src/hub-session-lookups.ts
+++ b/packages/hub/src/hub-session-lookups.ts
@@ -1,0 +1,183 @@
+// Lookups that the sidecar wire layer issues against host state. These
+// are queries (one answer per question) rather than events (broadcast
+// notifications), so they live separately from the event emitter.
+//
+// Each lookup is a stateless DB or repo call. They are gathered into a
+// single struct that the hub app passes to `createSidecarRouter` as
+// `lookups`.
+
+import { eq, and, isNull } from "drizzle-orm";
+import type { DB } from "@interchange/db";
+import { agentInstance, sessionMail } from "@interchange/db/schema";
+import { getLogger } from "@interchange/log";
+
+import type { AgentRepoStore } from "./agent-repo";
+import { generateId } from "./ids";
+import type { SidecarLookups } from "./ws/sidecar-events";
+
+const logger = getLogger(["hub", "lookups"]);
+
+export type HubSessionLookupsDeps = {
+  db: DB["db"];
+  agentRepoStore: AgentRepoStore;
+};
+
+export function createHubSessionLookups(
+  deps: HubSessionLookupsDeps,
+): Required<SidecarLookups> {
+  const { db, agentRepoStore } = deps;
+
+  return {
+    async lookupPublicKey(agentAddress) {
+      const row = await db
+        .select({ publicKey: agentInstance.publicKey })
+        .from(agentInstance)
+        .where(
+          and(
+            eq(agentInstance.address, agentAddress),
+            isNull(agentInstance.endedAt),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0]);
+      if (!row) {
+        return null;
+      }
+      return row.publicKey;
+    },
+
+    async lookupDeployRef(agentAddress) {
+      const agentId = parseAgentId(agentAddress);
+      return agentRepoStore.getDeployRef(agentId);
+    },
+
+    async persistMail({ senderAddress, recipients, raw }) {
+      const senderInstance = await requireInstance(db, senderAddress);
+      if (!senderInstance.sessionId) {
+        throw new Error(
+          `Instance ${senderInstance.id} has no session for address "${senderAddress}"`,
+        );
+      }
+      const createdAt = new Date();
+
+      // Outbound record on the sender's session.
+      const outboundId = generateId("sessionMail");
+      const outboundRecord = {
+        id: outboundId,
+        sessionId: senderInstance.sessionId,
+        instanceId: senderInstance.id,
+        tenantId: senderInstance.tenantId,
+        direction: "outbound" as const,
+        status: "delivered" as const,
+        raw,
+        createdAt,
+      };
+
+      // Inbound records for each recipient that has an active agent
+      // instance. Recipients that are not agent instances (e.g. human
+      // user addresses) are skipped.
+      const recipientResults = await Promise.all(
+        recipients.map(async (addr) => {
+          const row = await db.query.agentInstance.findFirst({
+            where: and(
+              eq(agentInstance.address, addr),
+              isNull(agentInstance.endedAt),
+            ),
+          });
+          if (row === undefined) {
+            return null;
+          }
+          if (row.sessionId === null) {
+            logger.warn`Active instance ${row.id} for "${addr}" has no session; skipping inbound record`;
+            return null;
+          }
+          return { addr, instance: row, sessionId: row.sessionId };
+        }),
+      );
+      const recipientInstances = recipientResults.filter(
+        (r): r is NonNullable<typeof r> => r !== null,
+      );
+
+      const inboundEntries = recipientInstances.map(
+        ({ addr, instance, sessionId }) => {
+          const id = generateId("sessionMail");
+          return {
+            record: {
+              id,
+              sessionId,
+              instanceId: instance.id,
+              tenantId: instance.tenantId,
+              direction: "inbound" as const,
+              status: "delivered" as const,
+              raw,
+              createdAt,
+            },
+            result: {
+              id,
+              direction: "inbound" as const,
+              instanceId: instance.id,
+              address: addr,
+              createdAt,
+            },
+          };
+        },
+      );
+
+      await db
+        .insert(sessionMail)
+        .values([outboundRecord, ...inboundEntries.map((e) => e.record)]);
+
+      return [
+        {
+          id: outboundId,
+          direction: "outbound" as const,
+          instanceId: senderInstance.id,
+          address: senderInstance.address,
+          createdAt,
+        },
+        ...inboundEntries.map((e) => e.result),
+      ];
+    },
+
+    async receiveStatePack(agentAddress, pack, ref, commitSha) {
+      const agentId = parseAgentId(agentAddress);
+      try {
+        await agentRepoStore.receiveStatePack(agentId, pack, ref, commitSha);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.startsWith("path_violation")) {
+          logger.warn`State pack rejected for ${agentAddress}: ${msg}`;
+          return { accepted: false, reason: "path_violation" as const };
+        }
+        throw err;
+      }
+      return { accepted: true };
+    },
+  };
+}
+
+export function parseAgentId(agentAddress: string): string {
+  const atIdx = agentAddress.indexOf("@");
+  if (atIdx === -1) {
+    throw new Error(`Invalid agent address: "${agentAddress}"`);
+  }
+  return agentAddress.substring(0, atIdx);
+}
+
+export async function requireInstance(
+  db: DB["db"],
+  agentAddress: string,
+): Promise<
+  NonNullable<Awaited<ReturnType<typeof db.query.agentInstance.findFirst>>>
+> {
+  const row = await db.query.agentInstance.findFirst({
+    where: and(
+      eq(agentInstance.address, agentAddress),
+      isNull(agentInstance.endedAt),
+    ),
+  });
+  if (!row) {
+    throw new Error(`No active instance found for address "${agentAddress}"`);
+  }
+  return row;
+}

--- a/packages/hub/src/hub-session-orchestrator.test.ts
+++ b/packages/hub/src/hub-session-orchestrator.test.ts
@@ -1,0 +1,486 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+
+import type { DB } from "@interchange/db";
+import type { GrantRule, GrantStore } from "@interchange/types/authz";
+import type {
+  InferenceEvent,
+  ProviderConfig,
+} from "@interchange/types/runtime";
+
+import type { AgentRepoStore, DeployContent } from "./agent-repo";
+import type { EventCollectorRegistry } from "./event-collector-registry";
+import { createHubSessionOrchestrator } from "./hub-session-orchestrator";
+import {
+  createSidecarEmitter,
+  type SidecarEventEmitter,
+} from "./ws/sidecar-events";
+
+// ---------------------------------------------------------------------------
+// Fixtures and mocks
+// ---------------------------------------------------------------------------
+
+const TENANT_ID = "tnt_1";
+const PRINCIPAL_ID = "prn_1";
+const INSTANCE_ID = "ins_1";
+const AGENT_ID = "agt_1";
+const AGENT_ADDRESS = "ins_1@tenant.local";
+const SESSION_ID = "ses_1";
+
+type InstanceStatus = "deployed" | "running" | "updating" | "error" | "stopped";
+
+type InstanceRow = {
+  id: string;
+  agentId: string;
+  tenantId: string;
+  principalId: string;
+  address: string;
+  status: InstanceStatus;
+  sessionId: string | null;
+  publicKey: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  endedAt: Date | null;
+};
+
+function makeInstance(overrides: Partial<InstanceRow> = {}): InstanceRow {
+  return {
+    id: INSTANCE_ID,
+    agentId: AGENT_ID,
+    tenantId: TENANT_ID,
+    principalId: PRINCIPAL_ID,
+    address: AGENT_ADDRESS,
+    status: "running",
+    sessionId: SESSION_ID,
+    publicKey: null,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-01"),
+    endedAt: null,
+    ...overrides,
+  };
+}
+
+type UpdateCall = { table: string; set: Record<string, unknown> };
+
+type MockDBOpts = {
+  instance?: InstanceRow | undefined;
+  recordUpdates?: UpdateCall[];
+  /** When set, `resolveInstanceProviders` queries fan out into these
+   * tables; the helper returns empty arrays so the orchestrator's
+   * credential push is a no-op. */
+  emptyProviderTables?: boolean;
+};
+
+function createMockDB(opts: MockDBOpts) {
+  const updates = opts.recordUpdates ?? [];
+
+  function tableName(t: unknown): string {
+    if (t && typeof t === "object" && "name" in t && typeof t.name === "string")
+      return t.name;
+    return "<unknown>";
+  }
+
+  /* eslint-disable @typescript-eslint/no-unsafe-type-assertion --
+   * drizzle PgDatabase type cannot be structurally satisfied in tests */
+  return {
+    query: {
+      agentInstance: {
+        findFirst: async () => opts.instance,
+      },
+      agent: { findFirst: async () => undefined },
+      agentSession: { findFirst: async () => undefined },
+      provider: { findFirst: async () => undefined, findMany: async () => [] },
+      credential: {
+        findFirst: async () => undefined,
+        findMany: async () => [],
+      },
+      oauthClient: { findFirst: async () => undefined },
+      tenant: { findFirst: async () => undefined },
+    },
+    update(t: unknown) {
+      return {
+        set(values: Record<string, unknown>) {
+          return {
+            where: async () => {
+              updates.push({ table: tableName(t), set: values });
+            },
+          };
+        },
+      };
+    },
+    select() {
+      return {
+        from: () => ({
+          where: () => ({
+            limit: () => Promise.resolve([]),
+            orderBy: () => ({ limit: () => Promise.resolve([]) }),
+          }),
+          innerJoin: () => ({
+            where: () => ({ limit: () => Promise.resolve([]) }),
+          }),
+        }),
+      };
+    },
+  } as unknown as DB["db"];
+  /* eslint-enable @typescript-eslint/no-unsafe-type-assertion */
+}
+
+type RouterCall =
+  | { kind: "sendGrantsUpdate"; addr: string; grants: GrantRule[] }
+  | { kind: "sendProvidersUpdate"; addr: string; providers: ProviderConfig[] }
+  | {
+      kind: "sendPack";
+      addr: string;
+      pack: Uint8Array;
+      ref: string;
+      sha: string;
+    }
+  | { kind: "dispatchAgentEvent"; addr: string; event: unknown };
+
+function createRouterFacade(): {
+  facade: Parameters<typeof createHubSessionOrchestrator>[0]["router"];
+  calls: RouterCall[];
+} {
+  const calls: RouterCall[] = [];
+  return {
+    calls,
+    facade: {
+      async sendGrantsUpdate(addr, grants) {
+        calls.push({ kind: "sendGrantsUpdate", addr, grants });
+      },
+      async sendProvidersUpdate(addr, providers) {
+        calls.push({ kind: "sendProvidersUpdate", addr, providers });
+      },
+      async sendPack(addr, pack, ref, sha) {
+        calls.push({ kind: "sendPack", addr, pack, ref, sha });
+      },
+      dispatchAgentEvent(addr, event) {
+        calls.push({ kind: "dispatchAgentEvent", addr, event });
+      },
+    },
+  };
+}
+
+type CollectorCall =
+  | { kind: "create"; addr: string; sessionId: string }
+  | { kind: "dispatch"; addr: string; event: InferenceEvent }
+  | { kind: "abandon"; addr: string };
+
+function createCollectorRegistry(
+  initiallyHas: Set<string> = new Set<string>(),
+): {
+  registry: EventCollectorRegistry;
+  calls: CollectorCall[];
+  has: Set<string>;
+} {
+  const calls: CollectorCall[] = [];
+  const has = new Set(initiallyHas);
+  return {
+    calls,
+    has,
+    registry: {
+      create(addr, _tenantId, sessionId, _instanceId) {
+        has.add(addr);
+        calls.push({ kind: "create", addr, sessionId });
+      },
+      dispatch(addr, event) {
+        calls.push({ kind: "dispatch", addr, event });
+      },
+      abandon(addr) {
+        has.delete(addr);
+        calls.push({ kind: "abandon", addr });
+      },
+      has: (addr) => has.has(addr),
+      getStatus: () => undefined,
+      getAccumulatedText: () => undefined,
+      getCurrentTurnId: () => undefined,
+      getLastTurnId: () => undefined,
+    },
+  };
+}
+
+function createGrantStoreStub(grants: GrantRule[] = []): GrantStore {
+  return {
+    collectGrants: async () => grants,
+  };
+}
+
+type RepoCall = { kind: "createDeployPack"; agentId: string };
+
+function createRepoStoreStub(): {
+  store: AgentRepoStore;
+  calls: RepoCall[];
+} {
+  const calls: RepoCall[] = [];
+  return {
+    calls,
+    store: {
+      async writeDeployTree(_agentId: string, _content: DeployContent) {
+        throw new Error("mock: writeDeployTree not implemented");
+      },
+      async createDeployPack(agentId: string) {
+        calls.push({ kind: "createDeployPack", agentId });
+        return {
+          pack: new Uint8Array([1, 2, 3]),
+          commitSha: "c".repeat(40),
+          ref: "refs/heads/deploy",
+        };
+      },
+      async receiveStatePack() {
+        throw new Error("mock: receiveStatePack not implemented");
+      },
+      getSigningPublicKey() {
+        return new Uint8Array(32);
+      },
+      async getDeployRef() {
+        return null;
+      },
+    },
+  };
+}
+
+type Harness = {
+  events: SidecarEventEmitter;
+  router: ReturnType<typeof createRouterFacade>;
+  collectors: ReturnType<typeof createCollectorRegistry>;
+  repo: ReturnType<typeof createRepoStoreStub>;
+  updates: UpdateCall[];
+  dispose: () => void;
+};
+
+function setup(opts: MockDBOpts & { grants?: GrantRule[] } = {}): Harness {
+  const updates: UpdateCall[] = [];
+  const db = createMockDB({ ...opts, recordUpdates: updates });
+  const events = createSidecarEmitter();
+  const router = createRouterFacade();
+  const collectors = createCollectorRegistry();
+  const repo = createRepoStoreStub();
+  const grantStore = createGrantStoreStub(opts.grants);
+
+  const orchestrator = createHubSessionOrchestrator({
+    events,
+    router: router.facade,
+    db,
+    eventCollectors: collectors.registry,
+    grantStore,
+    agentRepoStore: repo.store,
+  });
+
+  return {
+    events,
+    router,
+    collectors,
+    repo,
+    updates,
+    dispose: orchestrator.dispose,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createHubSessionOrchestrator", () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    harness = setup({ instance: makeInstance() });
+  });
+
+  describe("agent.event", () => {
+    test("valid event is dispatched to the collector registry", () => {
+      // reactor.start is a valid InferenceEvent that arktype's
+      // parseInferenceEvent will accept; the orchestrator dispatches
+      // it to the collector unchanged.
+      harness.events.emit("agent.event", {
+        agentAddress: AGENT_ADDRESS,
+        sessionId: SESSION_ID,
+        event: { type: "reactor.start", seq: 1, data: { tools: [] } },
+      });
+      const dispatched = harness.collectors.calls.find(
+        (c) => c.kind === "dispatch",
+      );
+      expect(dispatched).toBeDefined();
+    });
+
+    test("invalid event is dropped (no dispatch call)", () => {
+      harness.events.emit("agent.event", {
+        agentAddress: AGENT_ADDRESS,
+        sessionId: SESSION_ID,
+        event: { not_a_real_event: true },
+      });
+      const dispatched = harness.collectors.calls.find(
+        (c) => c.kind === "dispatch",
+      );
+      expect(dispatched).toBeUndefined();
+    });
+  });
+
+  describe("sidecar.disconnect", () => {
+    test("abandons every collector for the closed connection", () => {
+      harness.events.emit("sidecar.disconnect", {
+        agentAddresses: ["a@x", "b@x", "c@x"],
+      });
+      const abandonedAddrs = harness.collectors.calls
+        .filter((c) => c.kind === "abandon")
+        .map((c) => (c.kind === "abandon" ? c.addr : null));
+      expect(abandonedAddrs).toEqual(["a@x", "b@x", "c@x"]);
+    });
+  });
+
+  describe("agent.deploy.ack", () => {
+    test("stores the public key on the active instance", async () => {
+      await harness.events.emitAndAwait("agent.deploy.ack", {
+        agentAddress: AGENT_ADDRESS,
+        publicKey: "deadbeef",
+      });
+      expect(harness.updates).toHaveLength(1);
+      expect(harness.updates[0]?.set).toEqual({ publicKey: "deadbeef" });
+    });
+  });
+
+  describe("agent.reconnected", () => {
+    test("refreshes grants and skips status update when already running", async () => {
+      const grant: GrantRule = {
+        id: "grant-1",
+        resource: "x:y",
+        action: "read",
+        effect: "allow",
+        origin: "system",
+        conditions: null,
+        expiresAt: null,
+        roleId: null,
+        principalId: PRINCIPAL_ID,
+      };
+      harness = setup({ instance: makeInstance(), grants: [grant] });
+
+      await harness.events.emitAndAwait("agent.reconnected", {
+        agentAddress: AGENT_ADDRESS,
+      });
+
+      const grantsCall = harness.router.calls.find(
+        (c) => c.kind === "sendGrantsUpdate",
+      );
+      expect(grantsCall).toBeDefined();
+      if (grantsCall?.kind === "sendGrantsUpdate") {
+        expect(grantsCall.grants).toEqual([grant]);
+      }
+
+      // status was already "running", no update should fire
+      expect(harness.updates).toHaveLength(0);
+    });
+
+    test("flips status to running and restores collector when missing", async () => {
+      harness = setup({ instance: makeInstance({ status: "deployed" }) });
+
+      await harness.events.emitAndAwait("agent.reconnected", {
+        agentAddress: AGENT_ADDRESS,
+      });
+
+      const statusUpdate = harness.updates.find(
+        (u) => u.set["status"] === "running",
+      );
+      expect(statusUpdate).toBeDefined();
+
+      const created = harness.collectors.calls.find((c) => c.kind === "create");
+      expect(created).toBeDefined();
+      if (created?.kind === "create") {
+        expect(created.addr).toBe(AGENT_ADDRESS);
+        expect(created.sessionId).toBe(SESSION_ID);
+      }
+    });
+
+    test("throws when the instance has no active session", async () => {
+      harness = setup({ instance: makeInstance({ sessionId: null }) });
+
+      await expect(
+        harness.events.emitAndAwait("agent.reconnected", {
+          agentAddress: AGENT_ADDRESS,
+        }),
+      ).rejects.toThrow(/no active session/);
+    });
+
+    test("throws when no active instance exists", async () => {
+      harness = setup({ instance: undefined });
+
+      await expect(
+        harness.events.emitAndAwait("agent.reconnected", {
+          agentAddress: AGENT_ADDRESS,
+        }),
+      ).rejects.toThrow(/No active instance/);
+    });
+  });
+
+  describe("deploy.ref.stale", () => {
+    test("creates a deploy pack and pushes it via the router", async () => {
+      await harness.events.emitAndAwait("deploy.ref.stale", {
+        agentAddress: AGENT_ADDRESS,
+      });
+
+      expect(harness.repo.calls).toEqual([
+        { kind: "createDeployPack", agentId: "ins_1" },
+      ]);
+
+      const sendPack = harness.router.calls.find((c) => c.kind === "sendPack");
+      expect(sendPack).toBeDefined();
+      if (sendPack?.kind === "sendPack") {
+        expect(sendPack.addr).toBe(AGENT_ADDRESS);
+        expect(sendPack.ref).toBe("refs/heads/deploy");
+      }
+    });
+  });
+
+  describe("mail.persisted", () => {
+    test("dispatches a mail.delivered agent event for the recipient", () => {
+      const raw = new TextEncoder().encode(
+        [
+          "From: sender@x",
+          "To: recipient@x",
+          "Subject: hello",
+          "",
+          "body",
+          "",
+        ].join("\r\n"),
+      );
+      const createdAt = new Date("2026-01-01T00:00:00.000Z");
+
+      harness.events.emit("mail.persisted", {
+        id: "mail_1",
+        raw,
+        createdAt,
+        direction: "inbound",
+        instanceId: INSTANCE_ID,
+        address: AGENT_ADDRESS,
+      });
+
+      const dispatched = harness.router.calls.find(
+        (c) => c.kind === "dispatchAgentEvent",
+      );
+      expect(dispatched).toBeDefined();
+      if (dispatched?.kind !== "dispatchAgentEvent") return;
+      expect(dispatched.addr).toBe(AGENT_ADDRESS);
+
+      const evt = dispatched.event;
+      expect(evt).toMatchObject({
+        type: "mail.delivered",
+        data: {
+          id: "mail_1",
+          direction: "inbound",
+          receivedAt: "2026-01-01T00:00:00.000Z",
+        },
+      });
+    });
+  });
+
+  describe("dispose", () => {
+    test("removes all subscriptions so later emits are inert", () => {
+      harness.dispose();
+      harness.events.emit("sidecar.disconnect", {
+        agentAddresses: [AGENT_ADDRESS],
+      });
+      const abandoned = harness.collectors.calls.find(
+        (c) => c.kind === "abandon",
+      );
+      expect(abandoned).toBeUndefined();
+    });
+  });
+});

--- a/packages/hub/src/hub-session-orchestrator.ts
+++ b/packages/hub/src/hub-session-orchestrator.ts
@@ -1,0 +1,198 @@
+// Hub-side orchestrator for the sidecar event emitter.
+//
+// Subscribes to the sidecar router's events and runs the host-side
+// reactions: dispatching inference events to the event collector,
+// refreshing grants and credentials on reconnect, ingesting state
+// packs, re-deploying stale agents, persisting mail, and forwarding
+// mail.delivered notifications back to subscribers.
+//
+// The orchestrator depends on a narrow `HubSessionRouterFacade` rather
+// than the full SidecarRouter, so tests can drive subscriber behavior
+// with a small stub and an isolated emitter.
+
+import { eq } from "drizzle-orm";
+import { type } from "arktype";
+import type { DB } from "@interchange/db";
+import { agentInstance } from "@interchange/db/schema";
+import { resolveInstanceProviders } from "@interchange/db";
+import { parseMailToEmail } from "@interchange/mime";
+import { parseInferenceEvent } from "@interchange/types/runtime";
+import type { GrantRule, GrantStore } from "@interchange/types/authz";
+import type { ProviderConfig } from "@interchange/types/runtime";
+import { getLogger } from "@interchange/log";
+
+import type { AgentRepoStore } from "./agent-repo";
+import type { EventCollectorRegistry } from "./event-collector-registry";
+import type { SidecarEventEmitter } from "./ws/sidecar-events";
+import { parseAgentId, requireInstance } from "./hub-session-lookups";
+
+const log = getLogger(["hub", "orchestrator"]);
+
+/** Subset of `SidecarRouter` the orchestrator drives outbound. The
+ * narrow surface keeps tests honest and decouples the orchestrator
+ * from the rest of the router API. */
+export type HubSessionRouterFacade = {
+  sendGrantsUpdate(agentAddress: string, grants: GrantRule[]): Promise<void>;
+  sendProvidersUpdate(
+    agentAddress: string,
+    providers: ProviderConfig[],
+  ): Promise<void>;
+  sendPack(
+    agentAddress: string,
+    pack: Uint8Array,
+    ref: string,
+    commitSha: string,
+  ): Promise<void>;
+  dispatchAgentEvent(agentAddress: string, event: unknown): void;
+};
+
+export type HubSessionOrchestratorDeps = {
+  events: SidecarEventEmitter;
+  router: HubSessionRouterFacade;
+  db: DB["db"];
+  eventCollectors: EventCollectorRegistry;
+  grantStore: GrantStore;
+  agentRepoStore: AgentRepoStore;
+};
+
+export type HubSessionOrchestrator = {
+  /** Unsubscribe all listeners. Tests use this between cases; the hub
+   * application doesn't need to dispose because the orchestrator's
+   * lifetime matches the process. */
+  dispose(): void;
+};
+
+export function createHubSessionOrchestrator(
+  deps: HubSessionOrchestratorDeps,
+): HubSessionOrchestrator {
+  const { events, router, db, eventCollectors, grantStore, agentRepoStore } =
+    deps;
+
+  const unsubscribers: (() => void)[] = [];
+
+  unsubscribers.push(
+    events.on("agent.event", ({ agentAddress, event }) => {
+      const validated = parseInferenceEvent(event);
+      if (validated instanceof type.errors) {
+        log.warn("Received invalid agent event for {agentAddress}: {summary}", {
+          agentAddress,
+          summary: validated.summary,
+        });
+        return;
+      }
+      eventCollectors.dispatch(agentAddress, validated);
+    }),
+  );
+
+  unsubscribers.push(
+    events.on("sidecar.disconnect", ({ agentAddresses }) => {
+      for (const addr of agentAddresses) {
+        eventCollectors.abandon(addr);
+      }
+    }),
+  );
+
+  unsubscribers.push(
+    events.on("agent.deploy.ack", async ({ agentAddress, publicKey }) => {
+      const instance = await requireInstance(db, agentAddress);
+      await db
+        .update(agentInstance)
+        .set({ publicKey })
+        .where(eq(agentInstance.id, instance.id));
+    }),
+  );
+
+  unsubscribers.push(
+    events.on("agent.reconnected", async ({ agentAddress }) => {
+      const instance = await requireInstance(db, agentAddress);
+
+      if (!instance.sessionId) {
+        throw new Error(
+          `Agent "${agentAddress}" reconnected but has no active session`,
+        );
+      }
+      const sessionId = instance.sessionId;
+
+      // Refresh grants before creating any local state. If this
+      // fails, the address is rejected and nothing needs cleanup.
+      const grants = await grantStore.collectGrants(
+        instance.principalId,
+        instance.tenantId,
+      );
+      await router.sendGrantsUpdate(agentAddress, grants);
+
+      // Re-resolve and push credentials so the agent picks up any
+      // rotations that happened while the sidecar was disconnected.
+      // Fail-open: a stale credential causes runtime 401s, not a
+      // security escalation, so we log rather than reject the
+      // reconnect.
+      try {
+        const providers = await resolveInstanceProviders(
+          db,
+          instance.tenantId,
+          instance,
+        );
+        if (providers.length > 0) {
+          await router.sendProvidersUpdate(agentAddress, providers);
+        }
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.warn(
+          "Failed to push credentials on reconnect for {agentAddress}: {msg}",
+          { agentAddress, msg },
+        );
+      }
+
+      const now = new Date();
+      if (instance.status !== "running") {
+        await db
+          .update(agentInstance)
+          .set({ status: "running", updatedAt: now })
+          .where(eq(agentInstance.id, instance.id));
+      }
+      if (!eventCollectors.has(agentAddress)) {
+        eventCollectors.create(
+          agentAddress,
+          instance.tenantId,
+          sessionId,
+          instance.id,
+        );
+        log.info(
+          "Restored event collector for reconnected agent {agentAddress}",
+          { agentAddress },
+        );
+      }
+    }),
+  );
+
+  unsubscribers.push(
+    events.on("deploy.ref.stale", async ({ agentAddress }) => {
+      const agentId = parseAgentId(agentAddress);
+      const { pack, commitSha, ref } =
+        await agentRepoStore.createDeployPack(agentId);
+      await router.sendPack(agentAddress, pack, ref, commitSha);
+      log.info("Re-deployed stale agent {agentAddress}", { agentAddress });
+    }),
+  );
+
+  unsubscribers.push(
+    events.on("mail.persisted", (row) => {
+      const parsed = parseMailToEmail(row.raw, row.id);
+      router.dispatchAgentEvent(row.address, {
+        type: "mail.delivered",
+        data: {
+          ...parsed,
+          id: row.id,
+          direction: row.direction,
+          receivedAt: row.createdAt.toISOString(),
+        },
+      });
+    }),
+  );
+
+  return {
+    dispose() {
+      for (const off of unsubscribers) off();
+    },
+  };
+}

--- a/packages/hub/src/hub-session-orchestrator.ts
+++ b/packages/hub/src/hub-session-orchestrator.ts
@@ -93,6 +93,17 @@ export function createHubSessionOrchestrator(
   );
 
   unsubscribers.push(
+    events.on("mail.outbound.undelivered", ({ recipients }) => {
+      // The hub has no external mail transport today. Anything that
+      // could not be delivered locally or queued for a disconnected
+      // agent is dropped; log so operators can see it.
+      log.warn("Dropping mail with no local recipient: {recipients}", {
+        recipients: recipients.join(", "),
+      });
+    }),
+  );
+
+  unsubscribers.push(
     events.on("agent.deploy.ack", async ({ agentAddress, publicKey }) => {
       const instance = await requireInstance(db, agentAddress);
       await db

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -28,6 +28,7 @@ export {
   type SidecarEventListener,
   type SidecarLookups,
   type SidecarMailPersistedPayload,
+  type SidecarMailPersistedRow,
 } from "./ws";
 export {
   createHubSessionLookups,

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -21,6 +21,23 @@ export {
   type SidecarRouter,
   type SidecarRouterConfig,
   type WsHandle,
+  createSidecarEmitter,
+  type SidecarEventEmitter,
+  type SidecarEventMap,
+  type SidecarEventType,
+  type SidecarEventListener,
+  type SidecarLookups,
+  type SidecarMailPersistedPayload,
 } from "./ws";
+export {
+  createHubSessionLookups,
+  type HubSessionLookupsDeps,
+} from "./hub-session-lookups";
+export {
+  createHubSessionOrchestrator,
+  type HubSessionOrchestrator,
+  type HubSessionOrchestratorDeps,
+  type HubSessionRouterFacade,
+} from "./hub-session-orchestrator";
 export { generateId } from "./ids";
 export { pushProviderUpdates } from "./credential-push";

--- a/packages/hub/src/routes/instances.test.ts
+++ b/packages/hub/src/routes/instances.test.ts
@@ -9,6 +9,7 @@ import type { EventCollectorRegistry } from "../event-collector-registry";
 import type { GetSession } from "../session";
 import type { SessionService } from "../session-service";
 import type { SidecarRouter } from "../ws/sidecar-handler";
+import { createSidecarEmitter } from "../ws/sidecar-events";
 
 // ---------------------------------------------------------------------------
 // Test data constants
@@ -223,6 +224,7 @@ function createMockSidecarRouter(
     },
     getConnectedSidecars: () => [],
     getRoutableAddresses: () => routableAddresses,
+    events: createSidecarEmitter(),
   };
 }
 

--- a/packages/hub/src/session-service.test.ts
+++ b/packages/hub/src/session-service.test.ts
@@ -7,6 +7,7 @@ import {
   type UserMessageParams,
 } from "./session-service";
 import type { SidecarRouter } from "./ws/sidecar-handler";
+import { createSidecarEmitter } from "./ws/sidecar-events";
 
 type Call = { method: string; args: unknown[] };
 
@@ -61,6 +62,7 @@ function createMockRouter(): SidecarRouter & {
     dispatchAgentEvent: () => undefined,
     getConnectedSidecars: () => [],
     getRoutableAddresses: () => [],
+    events: createSidecarEmitter(),
   };
   return mock;
 }

--- a/packages/hub/src/ws/index.ts
+++ b/packages/hub/src/ws/index.ts
@@ -5,3 +5,13 @@ export {
   type SidecarConnection,
   type WsHandle,
 } from "./sidecar-handler";
+export {
+  createSidecarEmitter,
+  type SidecarEventEmitter,
+  type SidecarEventMap,
+  type SidecarEventType,
+  type SidecarEventListener,
+  type SidecarLookups,
+  type SidecarMailPersistedRow,
+  type SidecarMailPersistedPayload,
+} from "./sidecar-events";

--- a/packages/hub/src/ws/sidecar-events.test.ts
+++ b/packages/hub/src/ws/sidecar-events.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect } from "bun:test";
+import { createSidecarEmitter } from "./sidecar-events";
+
+describe("createSidecarEmitter", () => {
+  test("delivers events to subscribed listeners", () => {
+    const emitter = createSidecarEmitter();
+    const seen: { addr: string; sid: string }[] = [];
+    emitter.on("agent.event", ({ agentAddress, sessionId }) => {
+      seen.push({ addr: agentAddress, sid: sessionId });
+    });
+
+    emitter.emit("agent.event", {
+      agentAddress: "a@x",
+      sessionId: "s-1",
+      event: { type: "x" },
+    });
+
+    expect(seen).toEqual([{ addr: "a@x", sid: "s-1" }]);
+  });
+
+  test("supports multiple listeners on the same event", () => {
+    const emitter = createSidecarEmitter();
+    const order: string[] = [];
+    emitter.on("sidecar.disconnect", () => {
+      order.push("a");
+    });
+    emitter.on("sidecar.disconnect", () => {
+      order.push("b");
+    });
+
+    emitter.emit("sidecar.disconnect", { agentAddresses: [] });
+
+    expect(order).toEqual(["a", "b"]);
+  });
+
+  test("unsubscribe removes the listener", () => {
+    const emitter = createSidecarEmitter();
+    let count = 0;
+    const unsubscribe = emitter.on("sidecar.disconnect", () => {
+      count++;
+    });
+
+    emitter.emit("sidecar.disconnect", { agentAddresses: [] });
+    unsubscribe();
+    emitter.emit("sidecar.disconnect", { agentAddresses: [] });
+
+    expect(count).toBe(1);
+  });
+
+  test("emit swallows listener errors and continues", () => {
+    const emitter = createSidecarEmitter();
+    const seen: string[] = [];
+    emitter.on("sidecar.disconnect", () => {
+      throw new Error("boom");
+    });
+    emitter.on("sidecar.disconnect", () => {
+      seen.push("ran");
+    });
+
+    emitter.emit("sidecar.disconnect", { agentAddresses: [] });
+
+    expect(seen).toEqual(["ran"]);
+  });
+
+  test("emitAndAwait runs listeners sequentially and rethrows the first failure", async () => {
+    const emitter = createSidecarEmitter();
+    const seen: string[] = [];
+    emitter.on("agent.reconnected", async () => {
+      seen.push("a");
+    });
+    emitter.on("agent.reconnected", async () => {
+      seen.push("b");
+      throw new Error("listener b failed");
+    });
+    emitter.on("agent.reconnected", async () => {
+      seen.push("c");
+    });
+
+    await expect(
+      emitter.emitAndAwait("agent.reconnected", { agentAddress: "a@x" }),
+    ).rejects.toThrow(/listener b failed/);
+
+    expect(seen).toEqual(["a", "b"]);
+  });
+
+  test("listenerCount reflects current subscriptions", () => {
+    const emitter = createSidecarEmitter();
+    expect(emitter.listenerCount("agent.reconnected")).toBe(0);
+
+    const off = emitter.on("agent.reconnected", () => undefined);
+    expect(emitter.listenerCount("agent.reconnected")).toBe(1);
+
+    off();
+    expect(emitter.listenerCount("agent.reconnected")).toBe(0);
+  });
+});

--- a/packages/hub/src/ws/sidecar-events.ts
+++ b/packages/hub/src/ws/sidecar-events.ts
@@ -1,0 +1,216 @@
+// Typed event emitter for the sidecar router.
+//
+// The router emits events at the points where wire-layer frame handling
+// completes and a host-side decision or side effect is required. Two
+// emission shapes are exposed:
+//
+// - `emit(type, payload)` — notification semantics. Each listener runs
+//   inside its own try/catch; a thrown error is logged and does not
+//   affect other listeners or the wire layer. Used for events whose
+//   outcome does not feed back into protocol behavior.
+//
+// - `emitAndAwait(type, payload)` — sequential await semantics.
+//   Listeners run in registration order; the first rejection propagates
+//   to the caller and stops the chain. Used for events whose outcome
+//   affects subsequent wire-layer state (e.g. reconnect rollback).
+//
+// The TSDoc on each entry in `SidecarEventMap` records which semantic
+// applies. Mixing the two on a single event is intentional: today's
+// wire layer already has both behaviors, and pretending otherwise
+// would silently change failure handling.
+
+import type { PackRejectReason } from "@interchange/types/sidecar";
+import { getLogger } from "@interchange/log";
+
+const logger = getLogger(["hub", "ws", "sidecar", "events"]);
+
+export type SidecarMailPersistedRow = {
+  id: string;
+  createdAt: Date;
+  direction: "inbound" | "outbound";
+  instanceId: string | null;
+  address: string;
+};
+
+export type SidecarMailPersistedPayload = SidecarMailPersistedRow & {
+  raw: Uint8Array;
+};
+
+export type SidecarEventMap = {
+  /** Notification. Emitted for every agent.event frame the wire layer
+   * decodes. The wire layer also forwards the event to in-process agent
+   * subscribers registered via `router.subscribeAgent`; this event is
+   * the host-side observation point. */
+  "agent.event": {
+    agentAddress: string;
+    sessionId: string;
+    event: unknown;
+  };
+
+  /** Notification. Emitted once when a sidecar's connection closes,
+   * carrying the set of agent addresses that were registered on that
+   * connection. */
+  "sidecar.disconnect": {
+    agentAddresses: string[];
+  };
+
+  /** Notification. Emitted when a mail.outbound frame from a sidecar
+   * names recipients that the wire layer could not deliver locally and
+   * could not enqueue for a disconnected agent. The host is free to
+   * relay it onto an external transport or drop it. */
+  "mail.outbound.undelivered": {
+    rawMessage: string;
+    recipients: string[];
+  };
+
+  /** Notification. Emitted once per row produced by the host's
+   * `persistMail` lookup. The wire layer calls `persistMail` to obtain
+   * the rows; this event fires for each so subscribers can react
+   * per-row (e.g. dispatch a delivered event). */
+  "mail.persisted": SidecarMailPersistedPayload;
+
+  /** Awaited. Emitted when an agent.deploy.ack frame arrives. Rejection
+   * fails the pending deploy with the listener's error. */
+  "agent.deploy.ack": {
+    agentAddress: string;
+    publicKey: string;
+  };
+
+  /** Awaited. Emitted per address after challenge verification
+   * succeeds and before the disconnect queue is flushed. Rejection
+   * rolls that address back from the routing table; earlier listeners
+   * in registration order have already executed and their side effects
+   * are not undone. A subsequent reconnect arriving mid-flight may
+   * supersede this one, so listeners must be idempotent. */
+  "agent.reconnected": {
+    agentAddress: string;
+  };
+
+  /** Awaited. Emitted per address after the wire layer has confirmed
+   * the sidecar's deploy ref is stale relative to the hub's current
+   * ref. The listener's job is to push a fresh deploy pack. The wire
+   * layer fires this only when staleness is confirmed; subscribing
+   * without a `lookupDeployRef` configured on the router will never
+   * deliver. */
+  "deploy.ref.stale": {
+    agentAddress: string;
+  };
+};
+
+export type SidecarEventType = keyof SidecarEventMap;
+
+export type SidecarEventListener<T extends SidecarEventType> = (
+  payload: SidecarEventMap[T],
+) => void | Promise<void>;
+
+export type SidecarEventEmitter = {
+  on<T extends SidecarEventType>(
+    type: T,
+    listener: SidecarEventListener<T>,
+  ): () => void;
+  emit<T extends SidecarEventType>(type: T, payload: SidecarEventMap[T]): void;
+  emitAndAwait<T extends SidecarEventType>(
+    type: T,
+    payload: SidecarEventMap[T],
+  ): Promise<void>;
+  /** Number of listeners registered for `type`. Wire-layer callers use
+   * this to skip an `await` when nothing is listening, preserving the
+   * synchronous scheduling of unconfigured-handler paths. */
+  listenerCount(type: SidecarEventType): number;
+};
+
+export function createSidecarEmitter(): SidecarEventEmitter {
+  const listeners: { [K in SidecarEventType]: Set<SidecarEventListener<K>> } = {
+    "agent.event": new Set(),
+    "sidecar.disconnect": new Set(),
+    "mail.outbound.undelivered": new Set(),
+    "mail.persisted": new Set(),
+    "agent.deploy.ack": new Set(),
+    "agent.reconnected": new Set(),
+    "deploy.ref.stale": new Set(),
+  };
+
+  function on<T extends SidecarEventType>(
+    type: T,
+    listener: SidecarEventListener<T>,
+  ): () => void {
+    listeners[type].add(listener);
+    return () => {
+      listeners[type].delete(listener);
+    };
+  }
+
+  function emit<T extends SidecarEventType>(
+    type: T,
+    payload: SidecarEventMap[T],
+  ): void {
+    const set = listeners[type];
+    if (set.size === 0) return;
+    for (const listener of [...set]) {
+      try {
+        const result = listener(payload);
+        if (result instanceof Promise) {
+          result.catch((err: unknown) => {
+            logger.warn`Listener for ${type} threw: ${
+              err instanceof Error ? err.message : String(err)
+            }`;
+          });
+        }
+      } catch (err) {
+        logger.warn`Listener for ${type} threw: ${
+          err instanceof Error ? err.message : String(err)
+        }`;
+      }
+    }
+  }
+
+  async function emitAndAwait<T extends SidecarEventType>(
+    type: T,
+    payload: SidecarEventMap[T],
+  ): Promise<void> {
+    const set = listeners[type];
+    if (set.size === 0) return;
+    for (const listener of [...set]) {
+      await listener(payload);
+    }
+  }
+
+  function listenerCount(type: SidecarEventType): number {
+    return listeners[type].size;
+  }
+
+  return { on, emit, emitAndAwait, listenerCount };
+}
+
+export type SidecarLookups = {
+  /** Returns the hex-encoded Ed25519 public key stored for the address,
+   * or `null` if the address is unknown. Used during the reconnect
+   * challenge to verify the sidecar's signature. */
+  lookupPublicKey?: (agentAddress: string) => Promise<string | null>;
+
+  /** Returns the hub's current deploy ref for the address, or `null` if
+   * no deploy state is tracked. The wire layer compares this against
+   * the sidecar's reported ref during reconnect and emits
+   * `deploy.ref.stale` only on mismatch. */
+  lookupDeployRef?: (agentAddress: string) => Promise<string | null>;
+
+  /** Persists a delivered outbound mail frame. Returns one row per
+   * persisted record; the wire layer attaches `raw` to each row and
+   * emits a `mail.persisted` event. */
+  persistMail?: (args: {
+    senderAddress: string;
+    recipients: string[];
+    raw: Uint8Array;
+  }) => Promise<SidecarMailPersistedRow[]>;
+
+  /** Ingests a received state pack and returns whether the wire layer
+   * should ack or reject the pack to the sidecar. */
+  receiveStatePack?: (
+    agentAddress: string,
+    pack: Uint8Array,
+    ref: string,
+    commitSha: string,
+  ) => Promise<
+    { accepted: true } | { accepted: false; reason: PackRejectReason }
+  >;
+};

--- a/packages/hub/src/ws/sidecar-handler.test.ts
+++ b/packages/hub/src/ws/sidecar-handler.test.ts
@@ -4,22 +4,8 @@ import {
   generateKeyPair,
   importPrivateKeyBytes,
 } from "@interchange/crypto-node";
-import { parseAgentAddress } from "@interchange/types";
+import { hexDecode, hexEncode, parseAgentAddress } from "@interchange/types";
 import { createSidecarRouter, type WsHandle } from "./sidecar-handler";
-
-function hexEncode(bytes: Uint8Array): string {
-  return Array.from(bytes)
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-
-function hexDecode(hex: string): Uint8Array {
-  const bytes = new Uint8Array(hex.length / 2);
-  for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
-  }
-  return bytes;
-}
 
 function signChallenge(
   nonce: string,

--- a/packages/hub/src/ws/sidecar-handler.test.ts
+++ b/packages/hub/src/ws/sidecar-handler.test.ts
@@ -251,12 +251,14 @@ describe("SidecarRouter", () => {
       expect(delivered.type).toBe("mail.inbound");
     });
 
-    test("unroutable mail goes to onMailOutbound callback", () => {
+    test("unroutable mail emits mail.outbound.undelivered", () => {
       const outbound: { rawMessage: string; recipients: string[] }[] = [];
-      const router = createSidecarRouter({
-        onMailOutbound(rawMessage, recipients) {
-          outbound.push({ rawMessage, recipients });
-        },
+      const router = createSidecarRouter({});
+      router.events.on("mail.outbound.undelivered", (event) => {
+        outbound.push({
+          rawMessage: event.rawMessage,
+          recipients: event.recipients,
+        });
       });
 
       const ws = createMockWs();
@@ -291,42 +293,45 @@ describe("SidecarRouter", () => {
       // mail.delivered SSE event is dispatched.
       const persisted: { id: string; address: string }[] = [];
       const router = createSidecarRouter({
-        onMailPersist: async ({ senderAddress, recipients }) => {
-          // Mirrors the fixed onMailPersist: always create the outbound
-          // record for the sender, and only create inbound records for
-          // recipients that are agent instances (ins_ prefix).
-          const results: {
-            id: string;
-            direction: "inbound" | "outbound";
-            instanceId: string | null;
-            address: string;
-            createdAt: Date;
-          }[] = [
-            {
-              id: "mail_outbound",
-              direction: "outbound",
-              instanceId:
-                parseAgentAddress(senderAddress)?.instanceId ?? senderAddress,
-              address: senderAddress,
-              createdAt: new Date(),
-            },
-          ];
-          for (const addr of recipients) {
-            if (addr.startsWith("ins_")) {
-              results.push({
-                id: `mail_in_${addr}`,
-                direction: "inbound",
-                instanceId: parseAgentAddress(addr)?.instanceId ?? addr,
-                address: addr,
+        lookups: {
+          persistMail: async ({ senderAddress, recipients }) => {
+            // Mirrors the fixed persistMail: always create the
+            // outbound record for the sender, and only create
+            // inbound records for recipients that are agent
+            // instances (ins_ prefix).
+            const results: {
+              id: string;
+              direction: "inbound" | "outbound";
+              instanceId: string | null;
+              address: string;
+              createdAt: Date;
+            }[] = [
+              {
+                id: "mail_outbound",
+                direction: "outbound",
+                instanceId:
+                  parseAgentAddress(senderAddress)?.instanceId ?? senderAddress,
+                address: senderAddress,
                 createdAt: new Date(),
-              });
+              },
+            ];
+            for (const addr of recipients) {
+              if (addr.startsWith("ins_")) {
+                results.push({
+                  id: `mail_in_${addr}`,
+                  direction: "inbound",
+                  instanceId: parseAgentAddress(addr)?.instanceId ?? addr,
+                  address: addr,
+                  createdAt: new Date(),
+                });
+              }
             }
-          }
-          return results;
+            return results;
+          },
         },
-        onMailPersisted(row) {
-          persisted.push({ id: row.id, address: row.address });
-        },
+      });
+      router.events.on("mail.persisted", (row) => {
+        persisted.push({ id: row.id, address: row.address });
       });
 
       const ws = createMockWs();
@@ -363,31 +368,33 @@ describe("SidecarRouter", () => {
       expect(persisted[0]?.address).toBe("ins_sender@tenant.example");
     });
 
-    test("onMailPersist success calls onMailPersisted for each result", async () => {
+    test("persistMail lookup result fans out as mail.persisted events", async () => {
       const persisted: { id: string; address: string }[] = [];
       const router = createSidecarRouter({
-        onMailPersist: async ({ senderAddress, recipients }) => {
-          return [
-            {
-              id: "mail_out",
-              direction: "outbound" as const,
-              instanceId:
-                parseAgentAddress(senderAddress)?.instanceId ?? senderAddress,
-              address: senderAddress,
-              createdAt: new Date(),
-            },
-            ...recipients.map((addr) => ({
-              id: `mail_in_${addr}`,
-              direction: "inbound" as const,
-              instanceId: parseAgentAddress(addr)?.instanceId ?? addr,
-              address: addr,
-              createdAt: new Date(),
-            })),
-          ];
+        lookups: {
+          persistMail: async ({ senderAddress, recipients }) => {
+            return [
+              {
+                id: "mail_out",
+                direction: "outbound" as const,
+                instanceId:
+                  parseAgentAddress(senderAddress)?.instanceId ?? senderAddress,
+                address: senderAddress,
+                createdAt: new Date(),
+              },
+              ...recipients.map((addr) => ({
+                id: `mail_in_${addr}`,
+                direction: "inbound" as const,
+                instanceId: parseAgentAddress(addr)?.instanceId ?? addr,
+                address: addr,
+                createdAt: new Date(),
+              })),
+            ];
+          },
         },
-        onMailPersisted(row) {
-          persisted.push({ id: row.id, address: row.address });
-        },
+      });
+      router.events.on("mail.persisted", (row) => {
+        persisted.push({ id: row.id, address: row.address });
       });
 
       const ws = createMockWs();
@@ -475,14 +482,14 @@ describe("SidecarRouter", () => {
       expect(router.getRoutableAddresses()).toContain("new-agent@local");
     });
 
-    test("agent.deploy.ack calls onAgentDeployAck before resolving", async () => {
+    test("agent.deploy.ack invokes subscribers before resolving", async () => {
       const ackCalls: { address: string; publicKey: string }[] = [];
       const router = createSidecarRouter({
         requestTimeoutMs: 500,
         hubPublicKey: TEST_HUB_KEY,
-        async onAgentDeployAck(address, publicKey) {
-          ackCalls.push({ address, publicKey });
-        },
+      });
+      router.events.on("agent.deploy.ack", ({ agentAddress, publicKey }) => {
+        ackCalls.push({ address: agentAddress, publicKey });
       });
 
       const ws = createMockWs();
@@ -533,13 +540,13 @@ describe("SidecarRouter", () => {
       ]);
     });
 
-    test("agent.deploy rejects when onAgentDeployAck fails", async () => {
+    test("agent.deploy rejects when agent.deploy.ack subscriber throws", async () => {
       const router = createSidecarRouter({
         requestTimeoutMs: 500,
         hubPublicKey: TEST_HUB_KEY,
-        async onAgentDeployAck() {
-          throw new Error("DB write failed");
-        },
+      });
+      router.events.on("agent.deploy.ack", () => {
+        throw new Error("DB write failed");
       });
 
       const ws = createMockWs();
@@ -851,12 +858,11 @@ describe("SidecarRouter", () => {
   });
 
   describe("agent events", () => {
-    test("agent.event frames are forwarded to callback", () => {
+    test("agent.event frames are forwarded to subscribers", () => {
       const events: { addr: string; sid: string; event: unknown }[] = [];
-      const router = createSidecarRouter({
-        onAgentEvent(addr, sid, event) {
-          events.push({ addr, sid, event });
-        },
+      const router = createSidecarRouter({});
+      router.events.on("agent.event", ({ agentAddress, sessionId, event }) => {
+        events.push({ addr: agentAddress, sid: sessionId, event });
       });
 
       const ws = createMockWs();
@@ -1159,8 +1165,10 @@ describe("SidecarRouter", () => {
 
       const router = createSidecarRouter({
         requestTimeoutMs: 5000,
-        lookupPublicKey: async (addr) =>
-          addr === "agent@local" ? publicKeyHex : null,
+        lookups: {
+          lookupPublicKey: async (addr) =>
+            addr === "agent@local" ? publicKeyHex : null,
+        },
       });
 
       const ws = createMockWs();
@@ -1208,8 +1216,10 @@ describe("SidecarRouter", () => {
 
       const router = createSidecarRouter({
         requestTimeoutMs: 5000,
-        lookupPublicKey: async (addr) =>
-          addr === "agent@local" ? publicKeyHex : null,
+        lookups: {
+          lookupPublicKey: async (addr) =>
+            addr === "agent@local" ? publicKeyHex : null,
+        },
       });
 
       const ws = createMockWs();
@@ -1254,7 +1264,9 @@ describe("SidecarRouter", () => {
     test("reconnect sends challenge.failed for unknown address", async () => {
       const router = createSidecarRouter({
         requestTimeoutMs: 5000,
-        lookupPublicKey: async () => null,
+        lookups: {
+          lookupPublicKey: async () => null,
+        },
       });
 
       const ws = createMockWs();
@@ -1291,7 +1303,9 @@ describe("SidecarRouter", () => {
 
       const router = createSidecarRouter({
         requestTimeoutMs: 5000,
-        lookupPublicKey: async (addr) => keys.get(addr) ?? null,
+        lookups: {
+          lookupPublicKey: async (addr) => keys.get(addr) ?? null,
+        },
       });
 
       const ws = createMockWs();
@@ -1333,19 +1347,21 @@ describe("SidecarRouter", () => {
       expect(router.getRoutableAddresses()).not.toContain("agent-b@local");
     });
 
-    test("reconnect with stale deployRef triggers onDeployRefStale", async () => {
+    test("reconnect with stale deployRef emits deploy.ref.stale", async () => {
       const kp = await generateKeyPair();
       const publicKeyHex = hexEncode(kp.publicKey);
       const staleAddresses: string[] = [];
 
       const router = createSidecarRouter({
         requestTimeoutMs: 5000,
-        lookupPublicKey: async (addr) =>
-          addr === "agent@local" ? publicKeyHex : null,
-        lookupDeployRef: async () => "aaaa",
-        onDeployRefStale: async (addr) => {
-          staleAddresses.push(addr);
+        lookups: {
+          lookupPublicKey: async (addr) =>
+            addr === "agent@local" ? publicKeyHex : null,
+          lookupDeployRef: async () => "aaaa",
         },
+      });
+      router.events.on("deploy.ref.stale", ({ agentAddress }) => {
+        staleAddresses.push(agentAddress);
       });
 
       const ws = createMockWs();
@@ -1384,19 +1400,21 @@ describe("SidecarRouter", () => {
       expect(staleAddresses).toContain("agent@local");
     });
 
-    test("reconnect with matching deployRef skips onDeployRefStale", async () => {
+    test("reconnect with matching deployRef skips deploy.ref.stale", async () => {
       const kp = await generateKeyPair();
       const publicKeyHex = hexEncode(kp.publicKey);
       const staleAddresses: string[] = [];
 
       const router = createSidecarRouter({
         requestTimeoutMs: 5000,
-        lookupPublicKey: async (addr) =>
-          addr === "agent@local" ? publicKeyHex : null,
-        lookupDeployRef: async () => "aaaa",
-        onDeployRefStale: async (addr) => {
-          staleAddresses.push(addr);
+        lookups: {
+          lookupPublicKey: async (addr) =>
+            addr === "agent@local" ? publicKeyHex : null,
+          lookupDeployRef: async () => "aaaa",
         },
+      });
+      router.events.on("deploy.ref.stale", ({ agentAddress }) => {
+        staleAddresses.push(agentAddress);
       });
 
       const ws = createMockWs();
@@ -1435,19 +1453,21 @@ describe("SidecarRouter", () => {
       expect(staleAddresses).toEqual([]);
     });
 
-    test("reconnect with absent deployRef triggers onDeployRefStale", async () => {
+    test("reconnect with absent deployRef emits deploy.ref.stale", async () => {
       const kp = await generateKeyPair();
       const publicKeyHex = hexEncode(kp.publicKey);
       const staleAddresses: string[] = [];
 
       const router = createSidecarRouter({
         requestTimeoutMs: 5000,
-        lookupPublicKey: async (addr) =>
-          addr === "agent@local" ? publicKeyHex : null,
-        lookupDeployRef: async () => "aaaa",
-        onDeployRefStale: async (addr) => {
-          staleAddresses.push(addr);
+        lookups: {
+          lookupPublicKey: async (addr) =>
+            addr === "agent@local" ? publicKeyHex : null,
+          lookupDeployRef: async () => "aaaa",
         },
+      });
+      router.events.on("deploy.ref.stale", ({ agentAddress }) => {
+        staleAddresses.push(agentAddress);
       });
 
       const ws = createMockWs();
@@ -1492,11 +1512,10 @@ describe("SidecarRouter", () => {
 
       const router = createSidecarRouter({
         requestTimeoutMs: 5000,
-        lookupPublicKey: async (addr) =>
-          addr === "agent@local" ? publicKeyHex : null,
-        lookupDeployRef: async () => null,
-        onDeployRefStale: async (addr) => {
-          staleAddresses.push(addr);
+        lookups: {
+          lookupPublicKey: async (addr) =>
+            addr === "agent@local" ? publicKeyHex : null,
+          lookupDeployRef: async () => null,
         },
       });
 
@@ -1541,8 +1560,10 @@ describe("SidecarRouter", () => {
 
       const router = createSidecarRouter({
         requestTimeoutMs: 5000,
-        lookupPublicKey: async (addr) =>
-          addr === "agent@local" ? hexEncode(kp.publicKey) : null,
+        lookups: {
+          lookupPublicKey: async (addr) =>
+            addr === "agent@local" ? hexEncode(kp.publicKey) : null,
+        },
       });
 
       const ws = createMockWs();
@@ -1572,8 +1593,10 @@ describe("SidecarRouter", () => {
       const kp = await generateKeyPair();
       const router = createSidecarRouter({
         requestTimeoutMs: 500,
-        async lookupPublicKey() {
-          return hexEncode(kp.publicKey);
+        lookups: {
+          async lookupPublicKey() {
+            return hexEncode(kp.publicKey);
+          },
         },
       });
 
@@ -1645,8 +1668,10 @@ describe("SidecarRouter", () => {
       const router = createSidecarRouter({
         requestTimeoutMs: 500,
         disconnectQueueMaxSize: 2,
-        async lookupPublicKey() {
-          return hexEncode(kp.publicKey);
+        lookups: {
+          async lookupPublicKey() {
+            return hexEncode(kp.publicKey);
+          },
         },
       });
 
@@ -1804,7 +1829,7 @@ describe("SidecarRouter", () => {
     });
   });
 
-  describe("onAgentReconnected callback", () => {
+  describe("agent.reconnected event", () => {
     test("fires for each verified address on reconnect", async () => {
       const kp = await generateKeyPair();
       const publicKeyHex = hexEncode(kp.publicKey);
@@ -1812,11 +1837,13 @@ describe("SidecarRouter", () => {
 
       const router = createSidecarRouter({
         requestTimeoutMs: 5000,
-        lookupPublicKey: async (addr) =>
-          addr === "agent@local" ? publicKeyHex : null,
-        onAgentReconnected: async (addr) => {
-          reconnected.push(addr);
+        lookups: {
+          lookupPublicKey: async (addr) =>
+            addr === "agent@local" ? publicKeyHex : null,
         },
+      });
+      router.events.on("agent.reconnected", ({ agentAddress }) => {
+        reconnected.push(agentAddress);
       });
 
       const ws = createMockWs();
@@ -1861,11 +1888,13 @@ describe("SidecarRouter", () => {
 
       const router = createSidecarRouter({
         requestTimeoutMs: 5000,
-        lookupPublicKey: async (addr) =>
-          addr === "agent@local" ? publicKeyHex : null,
-        onAgentReconnected: async (addr) => {
-          reconnected.push(addr);
+        lookups: {
+          lookupPublicKey: async (addr) =>
+            addr === "agent@local" ? publicKeyHex : null,
         },
+      });
+      router.events.on("agent.reconnected", ({ agentAddress }) => {
+        reconnected.push(agentAddress);
       });
 
       const ws = createMockWs();
@@ -1901,22 +1930,24 @@ describe("SidecarRouter", () => {
       expect(reconnected).toEqual([]);
     });
 
-    test("callback error does not prevent other addresses from reconnecting", async () => {
+    test("listener error does not prevent other addresses from reconnecting", async () => {
       const kp1 = await generateKeyPair();
       const kp2 = await generateKeyPair();
       const reconnected: string[] = [];
 
       const router = createSidecarRouter({
         requestTimeoutMs: 5000,
-        lookupPublicKey: async (addr) => {
-          if (addr === "agent1@local") return hexEncode(kp1.publicKey);
-          if (addr === "agent2@local") return hexEncode(kp2.publicKey);
-          return null;
+        lookups: {
+          lookupPublicKey: async (addr) => {
+            if (addr === "agent1@local") return hexEncode(kp1.publicKey);
+            if (addr === "agent2@local") return hexEncode(kp2.publicKey);
+            return null;
+          },
         },
-        onAgentReconnected: async (addr) => {
-          if (addr === "agent1@local") throw new Error("DB failure");
-          reconnected.push(addr);
-        },
+      });
+      router.events.on("agent.reconnected", ({ agentAddress }) => {
+        if (agentAddress === "agent1@local") throw new Error("DB failure");
+        reconnected.push(agentAddress);
       });
 
       const ws = createMockWs();
@@ -2008,25 +2039,6 @@ describe("SidecarRouter", () => {
       ).rejects.toThrow("Hub signing key is required");
 
       expect(router.getRoutableAddresses()).not.toContain("new-agent@local");
-    });
-
-    test("throws when only lookupDeployRef is provided without onDeployRefStale", () => {
-      expect(() =>
-        createSidecarRouter({
-          requestTimeoutMs: 500,
-          lookupDeployRef: async () => null,
-        }),
-      ).toThrow("lookupDeployRef and onDeployRefStale must both be provided");
-    });
-
-    test("throws when only onDeployRefStale is provided without lookupDeployRef", () => {
-      expect(() =>
-        createSidecarRouter({
-          requestTimeoutMs: 500,
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          onDeployRefStale: async () => {},
-        }),
-      ).toThrow("lookupDeployRef and onDeployRefStale must both be provided");
     });
   });
 });

--- a/packages/hub/src/ws/sidecar-handler.test.ts
+++ b/packages/hub/src/ws/sidecar-handler.test.ts
@@ -889,6 +889,60 @@ describe("SidecarRouter", () => {
         data: {},
       });
     });
+
+    test("agent.event frames are emitted on router.events", () => {
+      const seen: { addr: string; sid: string }[] = [];
+      const router = createSidecarRouter({});
+      router.events.on("agent.event", ({ agentAddress, sessionId }) => {
+        seen.push({ addr: agentAddress, sid: sessionId });
+      });
+
+      const ws = createMockWs();
+      router.handleOpen(ws);
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "register",
+          sidecarId: "sc-1",
+          token: "tok",
+          agentAddresses: [],
+        }),
+      );
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "agent.event",
+          agentAddress: "agent@local",
+          sessionId: "sess-1",
+          event: { type: "reactor.start", seq: 0, data: {} },
+        }),
+      );
+
+      expect(seen).toEqual([{ addr: "agent@local", sid: "sess-1" }]);
+    });
+
+    test("sidecar.disconnect is emitted on router.events", () => {
+      const router = createSidecarRouter({});
+      const seen: string[][] = [];
+      router.events.on("sidecar.disconnect", ({ agentAddresses }) => {
+        seen.push(agentAddresses);
+      });
+
+      const ws = createMockWs();
+      router.handleOpen(ws);
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "register",
+          sidecarId: "sc-1",
+          token: "tok",
+          agentAddresses: ["agent@local"],
+        }),
+      );
+      router.handleClose(ws);
+
+      expect(seen).toEqual([["agent@local"]]);
+    });
   });
 
   describe("session subscriptions", () => {

--- a/packages/hub/src/ws/sidecar-handler.test.ts
+++ b/packages/hub/src/ws/sidecar-handler.test.ts
@@ -288,8 +288,8 @@ describe("SidecarRouter", () => {
 
     test("agent reply to non-agent address still persists outbound record", async () => {
       // When an agent replies to a human user (usr_ address), the
-      // onMailPersist callback must still persist at least the outbound
-      // record on the sender's session and call onMailPersisted so a
+      // persistMail lookup must still persist at least the outbound
+      // record on the sender's session and emit mail.persisted so a
       // mail.delivered SSE event is dispatched.
       const persisted: { id: string; address: string }[] = [];
       const router = createSidecarRouter({

--- a/packages/hub/src/ws/sidecar-handler.ts
+++ b/packages/hub/src/ws/sidecar-handler.ts
@@ -93,7 +93,14 @@ export type SidecarRouterConfig = {
   pingTimeoutMs?: number;
   /** Query handlers the wire layer issues during frame processing.
    * Each lookup is one-handler-returns-a-value; for multi-subscriber
-   * notifications use `router.events.on(...)` instead. */
+   * notifications use `router.events.on(...)` instead.
+   *
+   * `lookupDeployRef` and the `deploy.ref.stale` event are paired by
+   * convention: the wire layer only issues the staleness comparison
+   * when the lookup is set, and only emits the event on a confirmed
+   * mismatch. The host is responsible for subscribing a listener
+   * whenever the lookup is provided; the router does not enforce
+   * the pairing. */
   lookups?: SidecarLookups;
 };
 
@@ -715,17 +722,13 @@ export function createSidecarRouter(
     }
 
     // Anything not routed locally is emitted as a notification. The
-    // host decides whether to relay onto an external transport or drop.
-    // When nobody is listening we log so operators see dropped mail.
+    // host decides whether to relay onto an external transport, log,
+    // or drop. The wire layer takes no stance.
     if (unrouted.length > 0) {
-      if (events.listenerCount("mail.outbound.undelivered") === 0) {
-        logger.warn`No mail outbound listener; dropping mail for ${unrouted.join(", ")}`;
-      } else {
-        events.emit("mail.outbound.undelivered", {
-          rawMessage,
-          recipients: unrouted,
-        });
-      }
+      events.emit("mail.outbound.undelivered", {
+        rawMessage,
+        recipients: unrouted,
+      });
     }
   }
 

--- a/packages/hub/src/ws/sidecar-handler.ts
+++ b/packages/hub/src/ws/sidecar-handler.ts
@@ -11,10 +11,10 @@ import { chunkPack, createPackReceiver } from "@interchange/pack-transport";
 import { type } from "arktype";
 import {
   SidecarFrame,
-  type PackRejectReason,
   type HubFrame,
   type PackPushFrame,
   type PackDoneFrame,
+  type PackRejectReason,
 } from "@interchange/types/sidecar";
 import type {
   AbortReason,
@@ -22,6 +22,12 @@ import type {
   ProviderConfig,
 } from "@interchange/types/runtime";
 import type { GrantRule } from "@interchange/types/authz";
+import {
+  createSidecarEmitter,
+  type SidecarEventEmitter,
+  type SidecarLookups,
+  type SidecarMailPersistedRow,
+} from "./sidecar-events";
 
 const logger = getLogger(["hub", "ws", "sidecar"]);
 
@@ -70,6 +76,10 @@ export type SidecarRouter = {
 
   getConnectedSidecars(): string[];
   getRoutableAddresses(): string[];
+
+  /** Typed event emitter for the receiver-dispatch surface. See
+   * `sidecar-events.ts` for the event map and emission semantics. */
+  events: SidecarEventEmitter;
 };
 
 export type SidecarRouterConfig = {
@@ -165,6 +175,57 @@ export function createSidecarRouter(
     throw new Error(
       "lookupDeployRef and onDeployRefStale must both be provided or both omitted",
     );
+  }
+
+  // Receiver-dispatch surface. Wire-layer callsites emit events here;
+  // host code subscribes via `router.events`. The legacy callback fields
+  // on SidecarRouterConfig are folded into this emitter and `lookups`
+  // bag by the adapter block below, so existing call sites keep working
+  // without modification.
+  const events = createSidecarEmitter();
+  const lookups: SidecarLookups = {
+    ...(lookupPublicKey !== undefined ? { lookupPublicKey } : {}),
+    ...(lookupDeployRef !== undefined ? { lookupDeployRef } : {}),
+    ...(onMailPersist !== undefined ? { persistMail: onMailPersist } : {}),
+    ...(onStatePackReceived !== undefined
+      ? { receiveStatePack: onStatePackReceived }
+      : {}),
+  };
+
+  if (onAgentEvent !== undefined) {
+    events.on("agent.event", ({ agentAddress, sessionId, event }) => {
+      onAgentEvent(agentAddress, sessionId, event);
+    });
+  }
+  if (onSidecarDisconnect !== undefined) {
+    events.on("sidecar.disconnect", ({ agentAddresses }) => {
+      onSidecarDisconnect(agentAddresses);
+    });
+  }
+  if (onMailOutbound !== undefined) {
+    events.on("mail.outbound.undelivered", ({ rawMessage, recipients }) => {
+      onMailOutbound(rawMessage, recipients);
+    });
+  }
+  if (onMailPersisted !== undefined) {
+    events.on("mail.persisted", (payload) => {
+      onMailPersisted(payload);
+    });
+  }
+  if (onAgentDeployAck !== undefined) {
+    events.on("agent.deploy.ack", async ({ agentAddress, publicKey }) => {
+      await onAgentDeployAck(agentAddress, publicKey);
+    });
+  }
+  if (onAgentReconnected !== undefined) {
+    events.on("agent.reconnected", async ({ agentAddress }) => {
+      await onAgentReconnected(agentAddress);
+    });
+  }
+  if (onDeployRefStale !== undefined) {
+    events.on("deploy.ref.stale", async ({ agentAddress }) => {
+      await onDeployRefStale(agentAddress);
+    });
   }
 
   // ws handle → registered connection
@@ -347,9 +408,9 @@ export function createSidecarRouter(
       case "mail.outbound":
         if (frame.delivered !== true) {
           handleMailOutbound(frame.rawMessage, frame.recipients);
-        } else if (onMailPersist && frame.senderAddress) {
+        } else if (lookups.persistMail && frame.senderAddress) {
           void handleMailPersist(
-            onMailPersist,
+            lookups.persistMail,
             frame.rawMessage,
             frame.senderAddress,
             frame.recipients,
@@ -358,12 +419,16 @@ export function createSidecarRouter(
           if (!frame.senderAddress) {
             logger.warn`Dropping delivered mail.outbound frame with no senderAddress`;
           } else {
-            logger.warn`Dropping delivered mail.outbound frame: no onMailPersist handler configured`;
+            logger.warn`Dropping delivered mail.outbound frame: no persistMail lookup configured`;
           }
         }
         break;
       case "agent.event":
-        onAgentEvent?.(frame.agentAddress, frame.sessionId, frame.event);
+        events.emit("agent.event", {
+          agentAddress: frame.agentAddress,
+          sessionId: frame.sessionId,
+          event: frame.event,
+        });
         dispatchToSubscribers(frame.agentAddress, frame.event);
         break;
       case "session.ack":
@@ -474,8 +539,9 @@ export function createSidecarRouter(
       return;
     }
 
-    if (lookupPublicKey === undefined) {
-      logger.error`Received reconnect frame but no lookupPublicKey callback is configured`;
+    const lookupKey = lookups.lookupPublicKey;
+    if (lookupKey === undefined) {
+      logger.error`Received reconnect frame but no lookupPublicKey is configured`;
       ws.close();
       return;
     }
@@ -496,10 +562,10 @@ export function createSidecarRouter(
     if (conn === undefined) return;
 
     // Look up stored public keys for all claimed addresses.
-    const lookups = await Promise.all(
+    const keyLookups = await Promise.all(
       agentAddresses.map(async (addr) => ({
         address: addr,
-        publicKeyHex: await lookupPublicKey(addr),
+        publicKeyHex: await lookupKey(addr),
       })),
     );
 
@@ -513,7 +579,7 @@ export function createSidecarRouter(
     >();
     const challengeEntries: { address: string; nonce: string }[] = [];
 
-    for (const { address, publicKeyHex } of lookups) {
+    for (const { address, publicKeyHex } of keyLookups) {
       if (publicKeyHex === null) {
         conn.send({
           type: "challenge.failed",
@@ -632,7 +698,7 @@ export function createSidecarRouter(
     }
 
     // Add verified addresses to the routing table immediately so that
-    // the onAgentReconnected callback can use sendRequest-based methods
+    // `agent.reconnected` subscribers can use sendRequest-based methods
     // (e.g. sendGrantsUpdate). Addresses that fail governance are
     // rolled back from the routing table afterward.
     for (const addr of verified) {
@@ -644,16 +710,16 @@ export function createSidecarRouter(
     const failed: string[] = [];
 
     for (const addr of verified) {
-      if (onAgentReconnected !== undefined) {
-        try {
-          await onAgentReconnected(addr);
-          ready.push(addr);
-        } catch (err) {
-          logger.error`Failed to handle reconnection for ${addr}: ${err instanceof Error ? err.message : String(err)}`;
-          failed.push(addr);
-        }
-      } else {
+      if (events.listenerCount("agent.reconnected") === 0) {
         ready.push(addr);
+        continue;
+      }
+      try {
+        await events.emitAndAwait("agent.reconnected", { agentAddress: addr });
+        ready.push(addr);
+      } catch (err) {
+        logger.error`Failed to handle reconnection for ${addr}: ${err instanceof Error ? err.message : String(err)}`;
+        failed.push(addr);
       }
     }
 
@@ -678,18 +744,23 @@ export function createSidecarRouter(
     }
 
     // Re-deploy agents whose deploy ref is stale or absent. Fire-and-forget
-    // so reconnect completion is not blocked on pack transfer.
-    if (lookupDeployRef !== undefined && onDeployRefStale !== undefined) {
+    // so reconnect completion is not blocked on pack transfer. The
+    // wire layer owns the staleness comparison; the event fires only
+    // when staleness is confirmed.
+    const checkDeployRef = lookups.lookupDeployRef;
+    if (checkDeployRef !== undefined) {
       for (const addr of ready) {
         void (async () => {
           try {
-            const hubRef = await lookupDeployRef(addr);
+            const hubRef = await checkDeployRef(addr);
             if (hubRef === null) return;
             const sidecarRef = challenge.deployRefs[addr];
             if (sidecarRef === hubRef) return;
 
             logger.info`Re-deploying ${addr}: sidecar ref ${sidecarRef ?? "(none)"} != hub ref ${hubRef.slice(0, 8)}`;
-            await onDeployRefStale(addr);
+            await events.emitAndAwait("deploy.ref.stale", {
+              agentAddress: addr,
+            });
           } catch (err) {
             logger.error`Failed to re-deploy ${addr} after reconnect: ${err instanceof Error ? err.message : String(err)}`;
           }
@@ -744,23 +815,28 @@ export function createSidecarRouter(
       unrouted.push(recipient);
     }
 
-    // Anything not routed locally goes to the external handler.
+    // Anything not routed locally is emitted as a notification. The
+    // host decides whether to relay onto an external transport or drop.
+    // When nobody is listening we log so operators see dropped mail.
     if (unrouted.length > 0) {
-      if (onMailOutbound !== undefined) {
-        onMailOutbound(rawMessage, unrouted);
+      if (events.listenerCount("mail.outbound.undelivered") === 0) {
+        logger.warn`No mail outbound listener; dropping mail for ${unrouted.join(", ")}`;
       } else {
-        logger.warn`No mail outbound handler; dropping mail for ${unrouted.join(", ")}`;
+        events.emit("mail.outbound.undelivered", {
+          rawMessage,
+          recipients: unrouted,
+        });
       }
     }
   }
 
   async function handleMailPersist(
-    persist: NonNullable<SidecarRouterConfig["onMailPersist"]>,
+    persist: NonNullable<SidecarLookups["persistMail"]>,
     rawMessage: string,
     senderAddress: string,
     recipients: string[],
   ): Promise<void> {
-    let results;
+    let results: SidecarMailPersistedRow[];
     let raw: Uint8Array;
     try {
       raw = Uint8Array.from(atob(rawMessage), (c) => c.charCodeAt(0));
@@ -774,17 +850,15 @@ export function createSidecarRouter(
       return;
     }
 
-    if (onMailPersisted !== undefined) {
-      for (const result of results) {
-        onMailPersisted({
-          id: result.id,
-          raw,
-          createdAt: result.createdAt,
-          direction: result.direction,
-          instanceId: result.instanceId,
-          address: result.address,
-        });
-      }
+    for (const result of results) {
+      events.emit("mail.persisted", {
+        id: result.id,
+        raw,
+        createdAt: result.createdAt,
+        direction: result.direction,
+        instanceId: result.instanceId,
+        address: result.address,
+      });
     }
   }
 
@@ -869,9 +943,9 @@ export function createSidecarRouter(
       statePackReceiver.cancelByAgent(addr);
     }
 
-    if (onSidecarDisconnect !== undefined) {
-      onSidecarDisconnect([...conn.agentAddresses]);
-    }
+    events.emit("sidecar.disconnect", {
+      agentAddresses: [...conn.agentAddresses],
+    });
 
     logger.info`Sidecar ${conn.sidecarId} disconnected`;
   }
@@ -1038,7 +1112,8 @@ export function createSidecarRouter(
       return;
     }
 
-    if (onStatePackReceived === undefined) {
+    const receiveStatePack = lookups.receiveStatePack;
+    if (receiveStatePack === undefined) {
       conn.send({
         type: "pack.ack",
         agentAddress: frame.agentAddress,
@@ -1047,7 +1122,7 @@ export function createSidecarRouter(
       return;
     }
 
-    const verdict = await onStatePackReceived(
+    const verdict = await receiveStatePack(
       frame.agentAddress,
       result.pack,
       result.ref,
@@ -1170,9 +1245,12 @@ export function createSidecarRouter(
       return;
     }
 
-    if (onAgentDeployAck !== undefined) {
+    if (events.listenerCount("agent.deploy.ack") > 0) {
       try {
-        await onAgentDeployAck(agentAddress, publicKey);
+        await events.emitAndAwait("agent.deploy.ack", {
+          agentAddress,
+          publicKey,
+        });
       } catch (err) {
         rejectDeployPending(
           agentAddress,
@@ -1487,6 +1565,7 @@ export function createSidecarRouter(
     dispatchAgentEvent: dispatchToSubscribers,
     getConnectedSidecars,
     getRoutableAddresses,
+    events,
   };
 }
 

--- a/packages/hub/src/ws/sidecar-handler.ts
+++ b/packages/hub/src/ws/sidecar-handler.ts
@@ -14,7 +14,6 @@ import {
   type HubFrame,
   type PackPushFrame,
   type PackDoneFrame,
-  type PackRejectReason,
 } from "@interchange/types/sidecar";
 import type {
   AbortReason,
@@ -87,52 +86,15 @@ export type SidecarRouterConfig = {
   /** Hex-encoded 32-byte Ed25519 public key for signing deploy commits.
    * Included in agent.deploy frames so sidecars can verify pack signatures. */
   hubPublicKey?: string;
-  onAgentEvent?: (
-    agentAddress: string,
-    sessionId: string,
-    event: unknown,
-  ) => void;
-  onSidecarDisconnect?: (agentAddresses: string[]) => void;
-  onMailOutbound?: (rawMessage: string, recipients: string[]) => void;
   validateToken?: (sidecarId: string, token: string) => boolean;
-  lookupPublicKey?: (agentAddress: string) => Promise<string | null>;
-  onAgentDeployAck?: (agentAddress: string, publicKey: string) => Promise<void>;
-  onAgentReconnected?: (agentAddress: string) => Promise<void>;
-  lookupDeployRef?: (agentAddress: string) => Promise<string | null>;
-  onDeployRefStale?: (agentAddress: string) => Promise<void>;
   challengeTimeoutMs?: number;
   disconnectQueueMaxSize?: number;
   disconnectQueueTTLMs?: number;
   pingTimeoutMs?: number;
-  onMailPersist?: (args: {
-    senderAddress: string;
-    recipients: string[];
-    raw: Uint8Array;
-  }) => Promise<
-    {
-      id: string;
-      direction: "inbound" | "outbound";
-      instanceId: string | null;
-      address: string;
-      createdAt: Date;
-    }[]
-  >;
-  onMailPersisted?: (row: {
-    id: string;
-    raw: Uint8Array;
-    createdAt: Date;
-    direction: "inbound" | "outbound";
-    instanceId: string | null;
-    address: string;
-  }) => void;
-  onStatePackReceived?: (
-    agentAddress: string,
-    pack: Uint8Array,
-    ref: string,
-    commitSha: string,
-  ) => Promise<
-    { accepted: true } | { accepted: false; reason: PackRejectReason }
-  >;
+  /** Query handlers the wire layer issues during frame processing.
+   * Each lookup is one-handler-returns-a-value; for multi-subscriber
+   * notifications use `router.events.on(...)` instead. */
+  lookups?: SidecarLookups;
 };
 
 // Minimal handle so the router doesn't depend on a specific WebSocket impl.
@@ -154,79 +116,16 @@ export function createSidecarRouter(
     requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
     challengeTimeoutMs = DEFAULT_CHALLENGE_TIMEOUT_MS,
     hubPublicKey: hubPublicKeyHex,
-    onAgentEvent,
-    onSidecarDisconnect,
-    onMailOutbound,
-    onMailPersist,
-    onMailPersisted,
     validateToken,
-    lookupPublicKey,
-    onAgentDeployAck,
-    onAgentReconnected,
-    lookupDeployRef,
-    onDeployRefStale,
     disconnectQueueMaxSize = DEFAULT_DISCONNECT_QUEUE_MAX_SIZE,
     disconnectQueueTTLMs = DEFAULT_DISCONNECT_QUEUE_TTL_MS,
     pingTimeoutMs = DEFAULT_PING_TIMEOUT_MS,
-    onStatePackReceived,
+    lookups = {},
   } = config;
 
-  if ((lookupDeployRef === undefined) !== (onDeployRefStale === undefined)) {
-    throw new Error(
-      "lookupDeployRef and onDeployRefStale must both be provided or both omitted",
-    );
-  }
-
   // Receiver-dispatch surface. Wire-layer callsites emit events here;
-  // host code subscribes via `router.events`. The legacy callback fields
-  // on SidecarRouterConfig are folded into this emitter and `lookups`
-  // bag by the adapter block below, so existing call sites keep working
-  // without modification.
+  // host code subscribes via `router.events`.
   const events = createSidecarEmitter();
-  const lookups: SidecarLookups = {
-    ...(lookupPublicKey !== undefined ? { lookupPublicKey } : {}),
-    ...(lookupDeployRef !== undefined ? { lookupDeployRef } : {}),
-    ...(onMailPersist !== undefined ? { persistMail: onMailPersist } : {}),
-    ...(onStatePackReceived !== undefined
-      ? { receiveStatePack: onStatePackReceived }
-      : {}),
-  };
-
-  if (onAgentEvent !== undefined) {
-    events.on("agent.event", ({ agentAddress, sessionId, event }) => {
-      onAgentEvent(agentAddress, sessionId, event);
-    });
-  }
-  if (onSidecarDisconnect !== undefined) {
-    events.on("sidecar.disconnect", ({ agentAddresses }) => {
-      onSidecarDisconnect(agentAddresses);
-    });
-  }
-  if (onMailOutbound !== undefined) {
-    events.on("mail.outbound.undelivered", ({ rawMessage, recipients }) => {
-      onMailOutbound(rawMessage, recipients);
-    });
-  }
-  if (onMailPersisted !== undefined) {
-    events.on("mail.persisted", (payload) => {
-      onMailPersisted(payload);
-    });
-  }
-  if (onAgentDeployAck !== undefined) {
-    events.on("agent.deploy.ack", async ({ agentAddress, publicKey }) => {
-      await onAgentDeployAck(agentAddress, publicKey);
-    });
-  }
-  if (onAgentReconnected !== undefined) {
-    events.on("agent.reconnected", async ({ agentAddress }) => {
-      await onAgentReconnected(agentAddress);
-    });
-  }
-  if (onDeployRefStale !== undefined) {
-    events.on("deploy.ref.stale", async ({ agentAddress }) => {
-      await onDeployRefStale(agentAddress);
-    });
-  }
 
   // ws handle → registered connection
   const connections = new Map<WsHandle, SidecarConnection>();

--- a/packages/hub/src/ws/sidecar-handler.ts
+++ b/packages/hub/src/ws/sidecar-handler.ts
@@ -8,6 +8,7 @@ import { randomBytes } from "node:crypto";
 import { getLogger } from "@interchange/log";
 import { verifyEd25519 } from "@interchange/crypto-node";
 import { chunkPack, createPackReceiver } from "@interchange/pack-transport";
+import { hexDecode, hexEncode } from "@interchange/types";
 import { type } from "arktype";
 import {
   SidecarFrame,
@@ -1469,24 +1470,4 @@ export function createSidecarRouter(
     getRoutableAddresses,
     events,
   };
-}
-
-function hexEncode(bytes: Uint8Array): string {
-  return Array.from(bytes)
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-
-function hexDecode(hex: string): Uint8Array {
-  if (hex.length % 2 !== 0) {
-    throw new Error(`Hex string must have even length, got ${hex.length}`);
-  }
-  if (!/^[0-9a-fA-F]*$/.test(hex)) {
-    throw new Error("Hex string contains invalid characters");
-  }
-  const bytes = new Uint8Array(hex.length / 2);
-  for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
-  }
-  return bytes;
 }

--- a/packages/types/src/hex.ts
+++ b/packages/types/src/hex.ts
@@ -1,0 +1,25 @@
+// Hex codec for byte strings.
+//
+// Used across the codebase for Ed25519 key serialization, challenge
+// nonces, and signatures on the wire. Centralizing here keeps the
+// encoding stable and the error wording consistent.
+
+export function hexEncode(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export function hexDecode(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) {
+    throw new Error(`hexDecode: odd-length input (${hex.length} chars)`);
+  }
+  if (!/^[0-9a-fA-F]*$/.test(hex)) {
+    throw new Error("hexDecode: input contains non-hex characters");
+  }
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -16,5 +16,6 @@ export * from "./models";
 export * from "./observability";
 export * from "./agent-address";
 export * from "./agent-data";
+export * from "./hex";
 export * from "./audit";
 export * from "./sidecars";

--- a/tests/sidecar/deploy-flow.test.ts
+++ b/tests/sidecar/deploy-flow.test.ts
@@ -201,18 +201,20 @@ async function startHub(): Promise<HubEnv> {
   const router = createSidecarRouter({
     requestTimeoutMs: 10_000,
     hubPublicKey: hexEncode(hubSigningKey.publicKey),
-    onAgentEvent(addr, sid, event) {
-      agentEvents.push({ addr, sid, event });
+    lookups: {
+      async receiveStatePack(agentAddress, pack, ref, commitSha) {
+        const agentId = parseAgentId(agentAddress);
+        await agentRepoStore.receiveStatePack(agentId, pack, ref, commitSha);
+        statePacks.push({ agentAddress, ref, commitSha });
+        return { accepted: true };
+      },
     },
-    async onAgentDeployAck(agentAddress, publicKey) {
-      deployAcks.set(agentAddress, publicKey);
-    },
-    async onStatePackReceived(agentAddress, pack, ref, commitSha) {
-      const agentId = parseAgentId(agentAddress);
-      await agentRepoStore.receiveStatePack(agentId, pack, ref, commitSha);
-      statePacks.push({ agentAddress, ref, commitSha });
-      return { accepted: true };
-    },
+  });
+  router.events.on("agent.event", ({ agentAddress, sessionId, event }) => {
+    agentEvents.push({ addr: agentAddress, sid: sessionId, event });
+  });
+  router.events.on("agent.deploy.ack", ({ agentAddress, publicKey }) => {
+    deployAcks.set(agentAddress, publicKey);
   });
 
   const sessionService = createSessionService({

--- a/tests/sidecar/deploy-flow.test.ts
+++ b/tests/sidecar/deploy-flow.test.ts
@@ -29,6 +29,7 @@ import {
   type WsHandle,
 } from "@interchange/hub";
 import type { HarnessConfig } from "@interchange/types/runtime";
+import { hexEncode } from "@interchange/types";
 import { sanitizeAddress } from "../../apps/sidecar/src/session-manager";
 import {
   assembleSignedContent,
@@ -191,12 +192,6 @@ async function startHub(): Promise<HubEnv> {
     dataDir: hubDataDir,
     signingKey: hubSigningKey,
   });
-
-  function hexEncode(bytes: Uint8Array): string {
-    return Array.from(bytes)
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
-  }
 
   const router = createSidecarRouter({
     requestTimeoutMs: 10_000,


### PR DESCRIPTION
## Summary

- The sidecar router's receiver-dispatch surface is exposed as a typed event emitter; alternate hosts can subscribe to the events they care about without re-supplying every callback.
- The hub's inline session orchestration becomes `createHubSessionOrchestrator(deps)` in the hub package, driven by a narrow `HubSessionRouterFacade` so it can be unit-tested without spinning up a router.
- Wire-layer queries (public key, deploy ref, mail persist, state pack ingest) live as a single `lookups` struct on the router config.

## Changes

- `packages/hub/src/ws/sidecar-events.ts`: typed `SidecarEventEmitter` with `emit` (notification, per-listener try/catch) and `emitAndAwait` (sequential, rethrow-first) semantics; `SidecarLookups` struct for queries.
- `packages/hub/src/ws/sidecar-handler.ts`: wire layer emits events and reads lookups; legacy callback fields gone. `SidecarRouter` now exposes `events`.
- `packages/hub/src/hub-session-lookups.ts`: `createHubSessionLookups({ db, agentRepoStore })` returning `Required<SidecarLookups>`.
- `packages/hub/src/hub-session-orchestrator.ts`: `createHubSessionOrchestrator(deps)` subscribing to events through a narrow router facade; returns `{ dispose }`.
- `packages/hub/src/hub-session-orchestrator.test.ts`: 11 unit tests covering each subscriber, the reconnect failure paths, and disposal.
- `apps/hub/src/index.ts`: entry point rewritten — constructs lookups, router, event collectors, and orchestrator in order.
- `packages/types/src/hex.ts`: shared `hexEncode` / `hexDecode` consolidating nine local copies across hub, sidecar, and tests.

Migrated tests in `packages/hub/src/ws/sidecar-handler.test.ts`, `apps/sidecar/src/ws-client.test.ts`, and `tests/sidecar/deploy-flow.test.ts` to the new emitter + lookups surface.

## Testing

- [ ] \`make all\` (lint, type check, 1485 unit tests, 9 sidecar integration tests)
- [ ] Hub starts cleanly and registers a sidecar
- [ ] Reconnect with valid challenge → \`agent.reconnected\` listener runs: grants refreshed, providers pushed, status flipped to running, event collector restored
- [ ] Reconnect with stale deployRef → \`deploy.ref.stale\` listener re-packs and pushes
- [ ] Agent A → Agent B mail produces \`mail.delivered\` SSE events for sender (direction=outbound) and recipient (direction=inbound)

Closes INTR-65