### PR TITLE
Make hub routes composable as DI factories, split createApp

### DIFF
--- a/packages/hub/src/app.test.ts
+++ b/packages/hub/src/app.test.ts
@@ -1,8 +1,11 @@
 import { describe, test, expect } from "bun:test";
 import { type } from "arktype";
+import { Hono } from "hono";
 import type { DB } from "@interchange/db";
-import { createApp } from "./app";
+import { createApp, createHubContextMiddleware, mountHubRoutes } from "./app";
+import type { AppEnv } from "./context";
 import { createEventCollectorRegistry } from "./event-collector-registry";
+import type { GetSession } from "./session";
 import type { SessionService } from "./session-service";
 import { createSidecarRouter } from "./ws/sidecar-handler";
 
@@ -111,5 +114,73 @@ describe("app", () => {
       body: JSON.stringify({}),
     });
     expect(res.status).toBe(400);
+  });
+});
+
+describe("mountHubRoutes composition", () => {
+  const stubUser = {
+    id: "usr_compose",
+    email: "compose@example.com",
+    emailVerified: true,
+    name: "Compose Test",
+    image: null,
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-01-01"),
+  };
+  const stubSession = {
+    id: "ses_compose",
+    userId: stubUser.id,
+    token: "tok_compose",
+    expiresAt: new Date("2999-01-01"),
+    createdAt: stubUser.createdAt,
+    updatedAt: stubUser.updatedAt,
+  };
+  const getSession: GetSession = async () => ({
+    user: stubUser,
+    session: stubSession,
+  });
+
+  test("third-party Hono app shares the hub's request context", async () => {
+    const thirdParty = new Hono<AppEnv>();
+    thirdParty.use(createHubContextMiddleware({ getSession }));
+
+    // A sibling route owned by the third party reads from the same
+    // request context the hub routes use.
+    thirdParty.get("/sibling/whoami", (c) => {
+      const user = c.get("user");
+      return c.json({ userId: user?.id ?? null });
+    });
+
+    mountHubRoutes(thirdParty, {
+      db: mockDb,
+      sidecarRouter,
+      sessionService,
+      eventCollectors,
+    });
+
+    const siblingRes = await thirdParty.request("/sibling/whoami");
+    expect(siblingRes.status).toBe(200);
+    expect(await siblingRes.json()).toEqual({ userId: stubUser.id });
+
+    // Hub routes mounted on the same app respond as expected.
+    const statusRes = await thirdParty.request("/status");
+    expect(statusRes.status).toBe(200);
+    expect(await statusRes.json()).toEqual({ status: "ok" });
+  });
+
+  test("mountHubRoutes does not mount an auth handler at /api/auth/*", async () => {
+    const thirdParty = new Hono<AppEnv>();
+    thirdParty.use(createHubContextMiddleware({ getSession }));
+    mountHubRoutes(thirdParty, {
+      db: mockDb,
+      sidecarRouter,
+      sessionService,
+      eventCollectors,
+    });
+
+    // Without an auth handler mounted by the caller, /api/auth/* is
+    // free for the third party to wire as they choose.
+    const res = await thirdParty.request("/api/auth/anything");
+    expect(res.status).toBe(404);
   });
 });

--- a/packages/hub/src/app.ts
+++ b/packages/hub/src/app.ts
@@ -7,23 +7,23 @@ import type { AppEnv } from "./context";
 import { createSessionMiddleware } from "./middleware/session";
 import { requireAuth, resolveTenant } from "./middleware/tenant";
 import type { GetSession } from "./session";
-import { meRoutes } from "./routes/me";
-import { tenantRoutes } from "./routes/tenants";
-import { tenantFederationRoutes } from "./routes/tenant-federation";
-import { principalRoutes, inviteRoutes } from "./routes/principals";
-import { roleRoutes, roleAssignRoutes } from "./routes/roles";
-import { grantRoutes, evaluateRoutes } from "./routes/grants";
-import { agentRoutes } from "./routes/agents";
+import { createMeRoutes } from "./routes/me";
+import { createTenantRoutes } from "./routes/tenants";
+import { createTenantFederationRoutes } from "./routes/tenant-federation";
+import { createPrincipalRoutes, createInviteRoutes } from "./routes/principals";
+import { createRoleRoutes, createRoleAssignRoutes } from "./routes/roles";
+import { createGrantRoutes, createEvaluateRoutes } from "./routes/grants";
+import { createAgentRoutes } from "./routes/agents";
 import { createInstanceRoutes } from "./routes/instances";
 
-import { approvalRoutes } from "./routes/approvals";
-import { walletRoutes } from "./routes/wallets";
-import { providerRoutes } from "./routes/providers";
-import { oauthClientRoutes } from "./routes/oauth-clients";
-import { credentialRoutes } from "./routes/credentials";
-import { offeringRoutes, modelRoutes } from "./routes/offerings";
-import { observabilityRoutes } from "./routes/observability";
-import { agentDataRoutes } from "./routes/agent-data";
+import { createApprovalRoutes } from "./routes/approvals";
+import { createWalletRoutes } from "./routes/wallets";
+import { createProviderRoutes } from "./routes/providers";
+import { createOAuthClientRoutes } from "./routes/oauth-clients";
+import { createCredentialRoutes } from "./routes/credentials";
+import { createOfferingRoutes, createModelRoutes } from "./routes/offerings";
+import { createObservabilityRoutes } from "./routes/observability";
+import { createAgentDataRoutes } from "./routes/agent-data";
 import { createSidecarRoutes } from "./routes/sidecars";
 
 import { type DB, createGrantStore } from "@interchange/db";
@@ -85,7 +85,7 @@ export function createApp({
 
   // User-scoped (cross-tenant) -- requires auth but not tenant membership
   app.use("/api/me/*", requireAuth);
-  app.route("/api/me", meRoutes);
+  app.route("/api/me", createMeRoutes({ db }));
 
   // Tenant-scoped middleware -- require auth + tenant membership for any
   // path under /api/tenants/:tenantId/*. Must be registered before routes
@@ -93,23 +93,29 @@ export function createApp({
   app.use("/api/tenants/:tenantId/*", resolveTenant);
 
   // Global tenant routes (create needs auth, detail/update handle auth inline)
-  app.route("/api/tenants", tenantRoutes);
-  app.route("/api/models", modelRoutes);
+  app.route("/api/tenants", createTenantRoutes({ db }));
+  app.route("/api/models", createModelRoutes());
 
   // Tenant-scoped routes
-  app.route("/api/tenants/:tenantId/principals", principalRoutes);
-  app.route("/api/tenants/:tenantId/members/invite", inviteRoutes);
-  app.route("/api/tenants/:tenantId/roles", roleRoutes);
+  app.route("/api/tenants/:tenantId/principals", createPrincipalRoutes({ db }));
+  app.route(
+    "/api/tenants/:tenantId/members/invite",
+    createInviteRoutes({ db }),
+  );
+  app.route("/api/tenants/:tenantId/roles", createRoleRoutes({ db }));
   app.route(
     "/api/tenants/:tenantId/principals/:principalId/roles",
-    roleAssignRoutes,
+    createRoleAssignRoutes({ db }),
   );
-  app.route("/api/tenants/:tenantId/grants", grantRoutes);
+  app.route("/api/tenants/:tenantId/grants", createGrantRoutes({ db }));
   app.route(
     "/api/tenants/:tenantId/principals/:principalId/evaluate",
-    evaluateRoutes,
+    createEvaluateRoutes({ db, grantStore, conditionRegistry }),
   );
-  app.route("/api/tenants/:tenantId/agents/definitions", agentRoutes);
+  app.route(
+    "/api/tenants/:tenantId/agents/definitions",
+    createAgentRoutes({ db }),
+  );
   app.route(
     "/api/tenants/:tenantId/agents/instances",
     createInstanceRoutes({
@@ -122,17 +128,31 @@ export function createApp({
     }),
   );
 
-  app.route("/api/tenants/:tenantId/approvals", approvalRoutes);
-  app.route("/api/tenants/:tenantId/wallets", walletRoutes);
-  app.route("/api/tenants/:tenantId/providers", providerRoutes);
-  app.route("/api/tenants/:tenantId/oauth-clients", oauthClientRoutes);
-  app.route("/api/tenants/:tenantId/credentials", credentialRoutes);
-  app.route("/api/tenants/:tenantId/offerings", offeringRoutes);
-  app.route("/api/tenants/:tenantId", observabilityRoutes);
-  app.route("/api/tenants/:tenantId/federation", tenantFederationRoutes);
-  app.route("/api/tenants/:tenantId/agents/:agentId", agentDataRoutes);
+  app.route("/api/tenants/:tenantId/approvals", createApprovalRoutes());
+  app.route("/api/tenants/:tenantId/wallets", createWalletRoutes({ db }));
+  app.route("/api/tenants/:tenantId/providers", createProviderRoutes({ db }));
+  app.route(
+    "/api/tenants/:tenantId/oauth-clients",
+    createOAuthClientRoutes({ db }),
+  );
+  app.route(
+    "/api/tenants/:tenantId/credentials",
+    createCredentialRoutes({ db, sidecarRouter }),
+  );
+  app.route("/api/tenants/:tenantId/offerings", createOfferingRoutes({ db }));
+  app.route("/api/tenants/:tenantId", createObservabilityRoutes());
+  app.route(
+    "/api/tenants/:tenantId/federation",
+    createTenantFederationRoutes({ db }),
+  );
+  app.route("/api/tenants/:tenantId/agents/:agentId", createAgentDataRoutes());
 
-  app.route("/api/sidecars", createSidecarRoutes(sidecarWsHandler));
+  app.route(
+    "/api/sidecars",
+    createSidecarRoutes(
+      sidecarWsHandler ? { db, wsHandler: sidecarWsHandler } : { db },
+    ),
+  );
 
   app.get(
     "/openapi.json",

--- a/packages/hub/src/app.ts
+++ b/packages/hub/src/app.ts
@@ -1,12 +1,21 @@
-import type { Handler } from "hono";
+import type { Handler, MiddlewareHandler } from "hono";
 import { Hono } from "hono";
 import { openAPIRouteHandler } from "hono-openapi";
 
 import { honoLogger, type HonoContext } from "@interchange/log/hono";
+import { timeWindowEvaluator } from "@interchange/authz";
+import { type DB, createGrantStore } from "@interchange/db";
+import type { ConditionRegistry, GrantStore } from "@interchange/types/authz";
+
 import type { AppEnv } from "./context";
 import { createSessionMiddleware } from "./middleware/session";
-import { requireAuth, resolveTenant } from "./middleware/tenant";
+import { createRequireGrant, type RequireGrant } from "./middleware/grant";
+import { createResolveTenant, requireAuth } from "./middleware/tenant";
 import type { GetSession } from "./session";
+import type { SessionService } from "./session-service";
+import type { SidecarRouter } from "./ws/sidecar-handler";
+import type { EventCollectorRegistry } from "./event-collector-registry";
+
 import { createMeRoutes } from "./routes/me";
 import { createTenantRoutes } from "./routes/tenants";
 import { createTenantFederationRoutes } from "./routes/tenant-federation";
@@ -15,7 +24,6 @@ import { createRoleRoutes, createRoleAssignRoutes } from "./routes/roles";
 import { createGrantRoutes, createEvaluateRoutes } from "./routes/grants";
 import { createAgentRoutes } from "./routes/agents";
 import { createInstanceRoutes } from "./routes/instances";
-
 import { createApprovalRoutes } from "./routes/approvals";
 import { createWalletRoutes } from "./routes/wallets";
 import { createProviderRoutes } from "./routes/providers";
@@ -26,12 +34,154 @@ import { createObservabilityRoutes } from "./routes/observability";
 import { createAgentDataRoutes } from "./routes/agent-data";
 import { createSidecarRoutes } from "./routes/sidecars";
 
-import { type DB, createGrantStore } from "@interchange/db";
-import type { ConditionRegistry, GrantStore } from "@interchange/types/authz";
-import { timeWindowEvaluator } from "@interchange/authz";
-import type { SessionService } from "./session-service";
-import type { SidecarRouter } from "./ws/sidecar-handler";
-import type { EventCollectorRegistry } from "./event-collector-registry";
+export type CreateHubContextMiddlewareDeps = {
+  getSession: GetSession;
+};
+
+/**
+ * Builds the per-request context middleware that resolves the
+ * authenticated user and session from the incoming request and
+ * exposes them via the Hono variable bag.
+ */
+export function createHubContextMiddleware({
+  getSession,
+}: CreateHubContextMiddlewareDeps): MiddlewareHandler<AppEnv> {
+  return createSessionMiddleware(getSession);
+}
+
+export type MountHubRoutesDeps = {
+  db: DB["db"];
+  sidecarRouter: SidecarRouter;
+  sessionService: SessionService;
+  eventCollectors: EventCollectorRegistry;
+  grantStore?: GrantStore;
+  conditionRegistry?: ConditionRegistry;
+  sidecarWsHandler?: Handler<AppEnv>;
+};
+
+/**
+ * Mounts every hub route group, middleware, and supporting endpoint
+ * onto the provided Hono application. The caller is responsible for
+ * having mounted the request logger and the context middleware first,
+ * and for wiring their own auth handler at the path of their choice.
+ *
+ * `grantStore` and `conditionRegistry` default to the hub's standard
+ * choices (a database-backed grant store and the time-window condition
+ * evaluator) when not supplied.
+ */
+export function mountHubRoutes(
+  app: Hono<AppEnv>,
+  opts: MountHubRoutesDeps,
+): void {
+  const {
+    db,
+    sidecarRouter,
+    sessionService,
+    eventCollectors,
+    sidecarWsHandler,
+  } = opts;
+  const grantStore = opts.grantStore ?? createGrantStore(db);
+  const conditionRegistry: ConditionRegistry = opts.conditionRegistry ?? {
+    time_window: timeWindowEvaluator,
+  };
+  const requireGrant: RequireGrant = createRequireGrant({
+    grantStore,
+    conditionRegistry,
+  });
+  const resolveTenant = createResolveTenant({ db });
+
+  app.get("/status", (c) => c.json({ status: "ok" }));
+
+  // User-scoped (cross-tenant) -- requires auth but not tenant membership
+  app.use("/api/me/*", requireAuth);
+  app.route("/api/me", createMeRoutes({ db }));
+
+  // Tenant-scoped middleware -- require auth + tenant membership for any
+  // path under /api/tenants/:tenantId/*. Must be registered before routes
+  // so Hono includes it in the middleware chain.
+  app.use("/api/tenants/:tenantId/*", resolveTenant);
+
+  // Global tenant routes (create needs auth, detail/update handle auth inline)
+  app.route("/api/tenants", createTenantRoutes({ db }));
+  app.route("/api/models", createModelRoutes());
+
+  // Tenant-scoped routes
+  app.route(
+    "/api/tenants/:tenantId/principals",
+    createPrincipalRoutes({ db, requireGrant }),
+  );
+  app.route(
+    "/api/tenants/:tenantId/members/invite",
+    createInviteRoutes({ db, requireGrant }),
+  );
+  app.route(
+    "/api/tenants/:tenantId/roles",
+    createRoleRoutes({ db, requireGrant }),
+  );
+  app.route(
+    "/api/tenants/:tenantId/principals/:principalId/roles",
+    createRoleAssignRoutes({ db, requireGrant }),
+  );
+  app.route(
+    "/api/tenants/:tenantId/grants",
+    createGrantRoutes({ db, requireGrant }),
+  );
+  app.route(
+    "/api/tenants/:tenantId/principals/:principalId/evaluate",
+    createEvaluateRoutes({ db, grantStore, conditionRegistry }),
+  );
+  app.route(
+    "/api/tenants/:tenantId/agents/definitions",
+    createAgentRoutes({ db, requireGrant }),
+  );
+  app.route(
+    "/api/tenants/:tenantId/agents/instances",
+    createInstanceRoutes({
+      db,
+      sessionService,
+      sidecarRouter,
+      eventCollectors,
+      grantStore,
+      conditionRegistry,
+      requireGrant,
+    }),
+  );
+
+  app.route("/api/tenants/:tenantId/approvals", createApprovalRoutes());
+  app.route(
+    "/api/tenants/:tenantId/wallets",
+    createWalletRoutes({ db, requireGrant }),
+  );
+  app.route(
+    "/api/tenants/:tenantId/providers",
+    createProviderRoutes({ db, requireGrant }),
+  );
+  app.route(
+    "/api/tenants/:tenantId/oauth-clients",
+    createOAuthClientRoutes({ db, requireGrant }),
+  );
+  app.route(
+    "/api/tenants/:tenantId/credentials",
+    createCredentialRoutes({ db, sidecarRouter, requireGrant }),
+  );
+  app.route(
+    "/api/tenants/:tenantId/offerings",
+    createOfferingRoutes({ db, requireGrant }),
+  );
+  app.route("/api/tenants/:tenantId", createObservabilityRoutes());
+  app.route(
+    "/api/tenants/:tenantId/federation",
+    createTenantFederationRoutes({ db }),
+  );
+  app.route("/api/tenants/:tenantId/agents/:agentId", createAgentDataRoutes());
+
+  app.route(
+    "/api/sidecars",
+    createSidecarRoutes(
+      sidecarWsHandler ? { db, wsHandler: sidecarWsHandler } : { db },
+    ),
+  );
+}
 
 export type CreateAppOpts = {
   getSession: GetSession;
@@ -51,14 +201,10 @@ export function createApp({
   sidecarRouter,
   sessionService,
   eventCollectors,
-  grantStore: externalGrantStore,
+  grantStore,
   sidecarWsHandler,
 }: CreateAppOpts) {
   const app = new Hono<AppEnv>();
-  const grantStore = externalGrantStore ?? createGrantStore(db);
-  const conditionRegistry: ConditionRegistry = {
-    time_window: timeWindowEvaluator,
-  };
 
   app.use(
     honoLogger({
@@ -67,92 +213,18 @@ export function createApp({
     }),
   );
 
-  app.use(async (c, next) => {
-    c.set("db", db);
-    c.set("grantStore", grantStore);
-    c.set("conditionRegistry", conditionRegistry);
-    c.set("sidecarRouter", sidecarRouter);
-    c.set("sessionService", sessionService);
-    c.set("eventCollectors", eventCollectors);
-    await next();
-  });
-
-  app.use(createSessionMiddleware(getSession));
+  app.use(createHubContextMiddleware({ getSession }));
 
   app.all("/api/auth/*", authHandler);
 
-  app.get("/status", (c) => c.json({ status: "ok" }));
-
-  // User-scoped (cross-tenant) -- requires auth but not tenant membership
-  app.use("/api/me/*", requireAuth);
-  app.route("/api/me", createMeRoutes({ db }));
-
-  // Tenant-scoped middleware -- require auth + tenant membership for any
-  // path under /api/tenants/:tenantId/*. Must be registered before routes
-  // so Hono includes it in the middleware chain.
-  app.use("/api/tenants/:tenantId/*", resolveTenant);
-
-  // Global tenant routes (create needs auth, detail/update handle auth inline)
-  app.route("/api/tenants", createTenantRoutes({ db }));
-  app.route("/api/models", createModelRoutes());
-
-  // Tenant-scoped routes
-  app.route("/api/tenants/:tenantId/principals", createPrincipalRoutes({ db }));
-  app.route(
-    "/api/tenants/:tenantId/members/invite",
-    createInviteRoutes({ db }),
-  );
-  app.route("/api/tenants/:tenantId/roles", createRoleRoutes({ db }));
-  app.route(
-    "/api/tenants/:tenantId/principals/:principalId/roles",
-    createRoleAssignRoutes({ db }),
-  );
-  app.route("/api/tenants/:tenantId/grants", createGrantRoutes({ db }));
-  app.route(
-    "/api/tenants/:tenantId/principals/:principalId/evaluate",
-    createEvaluateRoutes({ db, grantStore, conditionRegistry }),
-  );
-  app.route(
-    "/api/tenants/:tenantId/agents/definitions",
-    createAgentRoutes({ db }),
-  );
-  app.route(
-    "/api/tenants/:tenantId/agents/instances",
-    createInstanceRoutes({
-      db,
-      sessionService,
-      sidecarRouter,
-      eventCollectors,
-      grantStore,
-      conditionRegistry,
-    }),
-  );
-
-  app.route("/api/tenants/:tenantId/approvals", createApprovalRoutes());
-  app.route("/api/tenants/:tenantId/wallets", createWalletRoutes({ db }));
-  app.route("/api/tenants/:tenantId/providers", createProviderRoutes({ db }));
-  app.route(
-    "/api/tenants/:tenantId/oauth-clients",
-    createOAuthClientRoutes({ db }),
-  );
-  app.route(
-    "/api/tenants/:tenantId/credentials",
-    createCredentialRoutes({ db, sidecarRouter }),
-  );
-  app.route("/api/tenants/:tenantId/offerings", createOfferingRoutes({ db }));
-  app.route("/api/tenants/:tenantId", createObservabilityRoutes());
-  app.route(
-    "/api/tenants/:tenantId/federation",
-    createTenantFederationRoutes({ db }),
-  );
-  app.route("/api/tenants/:tenantId/agents/:agentId", createAgentDataRoutes());
-
-  app.route(
-    "/api/sidecars",
-    createSidecarRoutes(
-      sidecarWsHandler ? { db, wsHandler: sidecarWsHandler } : { db },
-    ),
-  );
+  mountHubRoutes(app, {
+    db,
+    sidecarRouter,
+    sessionService,
+    eventCollectors,
+    ...(grantStore ? { grantStore } : {}),
+    ...(sidecarWsHandler ? { sidecarWsHandler } : {}),
+  });
 
   app.get(
     "/openapi.json",

--- a/packages/hub/src/app.ts
+++ b/packages/hub/src/app.ts
@@ -14,7 +14,7 @@ import { principalRoutes, inviteRoutes } from "./routes/principals";
 import { roleRoutes, roleAssignRoutes } from "./routes/roles";
 import { grantRoutes, evaluateRoutes } from "./routes/grants";
 import { agentRoutes } from "./routes/agents";
-import { instanceRoutes } from "./routes/instances";
+import { createInstanceRoutes } from "./routes/instances";
 
 import { approvalRoutes } from "./routes/approvals";
 import { walletRoutes } from "./routes/wallets";
@@ -110,7 +110,17 @@ export function createApp({
     evaluateRoutes,
   );
   app.route("/api/tenants/:tenantId/agents/definitions", agentRoutes);
-  app.route("/api/tenants/:tenantId/agents/instances", instanceRoutes);
+  app.route(
+    "/api/tenants/:tenantId/agents/instances",
+    createInstanceRoutes({
+      db,
+      sessionService,
+      sidecarRouter,
+      eventCollectors,
+      grantStore,
+      conditionRegistry,
+    }),
+  );
 
   app.route("/api/tenants/:tenantId/approvals", approvalRoutes);
   app.route("/api/tenants/:tenantId/wallets", walletRoutes);

--- a/packages/hub/src/context.ts
+++ b/packages/hub/src/context.ts
@@ -1,11 +1,6 @@
-import type { DB } from "@interchange/db";
-import type { ConditionRegistry, GrantStore } from "@interchange/types/authz";
 import type { Env } from "hono";
 
-import type { EventCollectorRegistry } from "./event-collector-registry";
 import type { SessionInfo, SessionUser } from "./session";
-import type { SessionService } from "./session-service";
-import type { SidecarRouter } from "./ws/sidecar-handler";
 
 export type TenantRow = {
   id: string;
@@ -30,12 +25,6 @@ export type PrincipalRow = {
 
 export type AppEnv = Env & {
   Variables: {
-    db: DB["db"];
-    grantStore: GrantStore;
-    conditionRegistry: ConditionRegistry;
-    sidecarRouter: SidecarRouter;
-    sessionService: SessionService;
-    eventCollectors: EventCollectorRegistry;
     user: SessionUser | null;
     session: SessionInfo | null;
   };

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -9,7 +9,27 @@ export {
   SessionLaunchError,
   type SessionService,
 } from "./session-service";
-export { createApp, type App, type CreateAppOpts } from "./app";
+export {
+  createApp,
+  createHubContextMiddleware,
+  mountHubRoutes,
+  type App,
+  type CreateAppOpts,
+  type CreateHubContextMiddlewareDeps,
+  type MountHubRoutesDeps,
+} from "./app";
+export {
+  createRequireGrant,
+  idResource,
+  type CreateRequireGrantDeps,
+  type RequireGrant,
+} from "./middleware/grant";
+export type { ConditionRegistry, GrantStore } from "@interchange/types/authz";
+export {
+  createResolveTenant,
+  requireAuth,
+  type CreateResolveTenantDeps,
+} from "./middleware/tenant";
 export type { AppEnv, TenantEnv, TenantRow, PrincipalRow } from "./context";
 export type { GetSession, SessionInfo, SessionUser } from "./session";
 export {

--- a/packages/hub/src/middleware/grant.ts
+++ b/packages/hub/src/middleware/grant.ts
@@ -1,7 +1,9 @@
 import { createMiddleware } from "hono/factory";
+import type { MiddlewareHandler } from "hono";
 
 import { authorize } from "@interchange/authz";
 import { getLogger } from "@interchange/log";
+import type { ConditionRegistry, GrantStore } from "@interchange/types/authz";
 
 import type { TenantEnv } from "../context";
 
@@ -12,63 +14,78 @@ type ResourceFn = (c: {
 }) => string;
 
 /**
- * Middleware factory that checks authorization grants before
- * allowing a request to proceed.
- *
- * The resource can be a static string or a function that extracts
- * the resource identifier from request parameters.
- *
- * Usage:
- *   app.get("/", requireGrant("agent:*", "read"), handler)
- *   app.delete("/:agentId", requireGrant(idResource("agent", "agentId"), "manage"), handler)
+ * Closure-bound grant-check middleware factory returned by
+ * `createRequireGrant`. Returns a Hono middleware that authorizes the
+ * current principal against the given resource and action. The function
+ * form of `resource` is intended to be built with `idResource(...)`.
  */
-export function requireGrant(resource: string | ResourceFn, action: string) {
-  return createMiddleware<TenantEnv>(async (c, next) => {
-    const grantStore = c.get("grantStore");
-    const conditionRegistry = c.get("conditionRegistry");
-    const principal = c.get("principal");
-    const tenant = c.get("tenant");
+export type RequireGrant = (
+  resource: string | ResourceFn,
+  action: string,
+) => MiddlewareHandler<TenantEnv>;
 
-    const resolvedResource =
-      typeof resource === "function"
-        ? resource({ param: (name) => c.req.param(name) })
-        : resource;
+export type CreateRequireGrantDeps = {
+  grantStore: GrantStore;
+  conditionRegistry: ConditionRegistry;
+};
 
-    const result = await authorize(
-      grantStore,
-      principal.id,
-      tenant.id,
-      resolvedResource,
-      action,
-      conditionRegistry,
-    );
+/**
+ * Builds a `requireGrant` middleware factory bound to the application's
+ * grant store and condition registry. Usage:
+ *
+ *   const requireGrant = createRequireGrant({ grantStore, conditionRegistry });
+ *   app.get("/", requireGrant("agent:*", "read"), handler);
+ */
+export function createRequireGrant({
+  grantStore,
+  conditionRegistry,
+}: CreateRequireGrantDeps): RequireGrant {
+  return function requireGrant(resource, action) {
+    return createMiddleware<TenantEnv>(async (c, next) => {
+      const principal = c.get("principal");
+      const tenant = c.get("tenant");
 
-    if (result.effect === "allow") {
-      await next();
-      return;
-    }
+      const resolvedResource =
+        typeof resource === "function"
+          ? resource({ param: (name) => c.req.param(name) })
+          : resource;
 
-    log.info(
-      "Authorization denied for {principalId}: {resource} {action} -> {effect}",
-      {
-        principalId: principal.id,
-        resource: resolvedResource,
+      const result = await authorize(
+        grantStore,
+        principal.id,
+        tenant.id,
+        resolvedResource,
         action,
-        effect: result.effect ?? "no_match",
-        resolvedBy: result.resolvedBy?.id ?? null,
-      },
-    );
+        conditionRegistry,
+      );
 
-    return c.json(
-      {
-        error: {
-          code: "forbidden",
-          message: "You do not have permission to perform this action",
+      if (result.effect === "allow") {
+        await next();
+        return;
+      }
+
+      log.info(
+        "Authorization denied for {principalId}: {resource} {action} -> {effect}",
+        {
+          principalId: principal.id,
+          resource: resolvedResource,
+          action,
+          effect: result.effect ?? "no_match",
+          resolvedBy: result.resolvedBy?.id ?? null,
         },
-      },
-      403,
-    );
-  });
+      );
+
+      return c.json(
+        {
+          error: {
+            code: "forbidden",
+            message: "You do not have permission to perform this action",
+          },
+        },
+        403,
+      );
+    });
+  };
 }
 
 /**

--- a/packages/hub/src/middleware/tenant.ts
+++ b/packages/hub/src/middleware/tenant.ts
@@ -1,7 +1,8 @@
 import { eq, and } from "drizzle-orm";
-import type { Context, Next } from "hono";
+import type { Context, MiddlewareHandler, Next } from "hono";
 
 import { tenant, principal } from "@interchange/db/schema";
+import type { DB } from "@interchange/db";
 import { getLogger } from "@interchange/log";
 
 import type { AppEnv, TenantEnv } from "../context";
@@ -19,74 +20,80 @@ export async function requireAuth(c: Context<AppEnv>, next: Next) {
   await next();
 }
 
-export async function resolveTenant(c: Context<TenantEnv>, next: Next) {
-  const user = c.get("user");
-  if (!user) {
-    return c.json(
-      { error: { code: "unauthorized", message: "Authentication required" } },
-      401,
-    );
-  }
+export type CreateResolveTenantDeps = {
+  db: DB["db"];
+};
 
-  const tenantId = c.req.param("tenantId");
-  if (!tenantId) {
-    return c.json(
-      { error: { code: "bad_request", message: "Missing tenantId" } },
-      400,
-    );
-  }
+export function createResolveTenant({
+  db,
+}: CreateResolveTenantDeps): MiddlewareHandler<TenantEnv> {
+  return async (c, next) => {
+    const user = c.get("user");
+    if (!user) {
+      return c.json(
+        { error: { code: "unauthorized", message: "Authentication required" } },
+        401,
+      );
+    }
 
-  const db = c.get("db");
+    const tenantId = c.req.param("tenantId");
+    if (!tenantId) {
+      return c.json(
+        { error: { code: "bad_request", message: "Missing tenantId" } },
+        400,
+      );
+    }
 
-  const tenantRow = await db.query.tenant.findFirst({
-    where: eq(tenant.id, tenantId),
-  });
-
-  if (!tenantRow) {
-    return c.json(
-      { error: { code: "not_found", message: "Tenant not found" } },
-      404,
-    );
-  }
-
-  const principalRow = await db.query.principal.findFirst({
-    where: and(
-      eq(principal.tenantId, tenantId),
-      eq(principal.kind, "user"),
-      eq(principal.refId, user.id),
-    ),
-  });
-
-  if (!principalRow) {
-    return c.json(
-      {
-        error: {
-          code: "forbidden",
-          message: "Not a member of this tenant",
-        },
-      },
-      403,
-    );
-  }
-
-  if (principalRow.status !== "active") {
-    log.info("Principal {principalId} has status {status}, denying access", {
-      principalId: principalRow.id,
-      status: principalRow.status,
+    const tenantRow = await db.query.tenant.findFirst({
+      where: eq(tenant.id, tenantId),
     });
-    return c.json(
-      {
-        error: {
-          code: "forbidden",
-          message: "Your membership in this tenant is not active",
+
+    if (!tenantRow) {
+      return c.json(
+        { error: { code: "not_found", message: "Tenant not found" } },
+        404,
+      );
+    }
+
+    const principalRow = await db.query.principal.findFirst({
+      where: and(
+        eq(principal.tenantId, tenantId),
+        eq(principal.kind, "user"),
+        eq(principal.refId, user.id),
+      ),
+    });
+
+    if (!principalRow) {
+      return c.json(
+        {
+          error: {
+            code: "forbidden",
+            message: "Not a member of this tenant",
+          },
         },
-      },
-      403,
-    );
-  }
+        403,
+      );
+    }
 
-  c.set("tenant", tenantRow);
-  c.set("principal", principalRow);
+    if (principalRow.status !== "active") {
+      log.info("Principal {principalId} has status {status}, denying access", {
+        principalId: principalRow.id,
+        status: principalRow.status,
+      });
+      return c.json(
+        {
+          error: {
+            code: "forbidden",
+            message: "Your membership in this tenant is not active",
+          },
+        },
+        403,
+      );
+    }
 
-  await next();
+    c.set("tenant", tenantRow);
+    c.set("principal", principalRow);
+
+    await next();
+  };
 }

--- a/packages/hub/src/routes/agent-data.ts
+++ b/packages/hub/src/routes/agent-data.ts
@@ -11,167 +11,169 @@ import {
 
 import type { AppEnv } from "../context";
 
-const app = new Hono<AppEnv>();
+export function createAgentDataRoutes(): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
 
-app.get(
-  "/data",
-  describeRoute({
-    tags: ["Agent Data"],
-    summary: "List files in agent working directory",
-    responses: {
-      200: {
-        description: "File listing",
-        content: {
-          "application/json": {
-            schema: resolver(FileEntry.array()),
+  app.get(
+    "/data",
+    describeRoute({
+      tags: ["Agent Data"],
+      summary: "List files in agent working directory",
+      responses: {
+        200: {
+          description: "File listing",
+          content: {
+            "application/json": {
+              schema: resolver(FileEntry.array()),
+            },
+          },
+        },
+        404: {
+          description: "Agent not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
           },
         },
       },
-      404: {
-        description: "Agent not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  (c) =>
-    c.json(
-      { error: { code: "not_implemented", message: "Not implemented" } },
-      501,
-    ),
-);
+    }),
+    (c) =>
+      c.json(
+        { error: { code: "not_implemented", message: "Not implemented" } },
+        501,
+      ),
+  );
 
-app.get(
-  "/data/*",
-  describeRoute({
-    tags: ["Agent Data"],
-    summary: "Read a file from agent storage",
-    description: "Reads a file by path from the agent's local storage.",
-    responses: {
-      200: {
-        description: "File content",
-        content: {
-          "application/json": { schema: resolver(FileContent) },
+  app.get(
+    "/data/*",
+    describeRoute({
+      tags: ["Agent Data"],
+      summary: "Read a file from agent storage",
+      description: "Reads a file by path from the agent's local storage.",
+      responses: {
+        200: {
+          description: "File content",
+          content: {
+            "application/json": { schema: resolver(FileContent) },
+          },
         },
-      },
-      404: {
-        description: "File or agent not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  (c) =>
-    c.json(
-      { error: { code: "not_implemented", message: "Not implemented" } },
-      501,
-    ),
-);
-
-app.get(
-  "/history",
-  describeRoute({
-    tags: ["Agent Data"],
-    summary: "List commits and checkpoints",
-    description:
-      "Returns the agent's change history with commit messages and timestamps.",
-    responses: {
-      200: {
-        description: "History entries",
-        content: {
-          "application/json": {
-            schema: resolver(HistoryEntry.array()),
+        404: {
+          description: "File or agent not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
           },
         },
       },
-    },
-  }),
-  (c) =>
-    c.json(
-      { error: { code: "not_implemented", message: "Not implemented" } },
-      501,
-    ),
-);
+    }),
+    (c) =>
+      c.json(
+        { error: { code: "not_implemented", message: "Not implemented" } },
+        501,
+      ),
+  );
 
-app.get(
-  "/history/:ref",
-  describeRoute({
-    tags: ["Agent Data"],
-    summary: "Show changes in a commit",
-    description:
-      "Returns the files changed in a specific commit with additions/deletions counts.",
-    responses: {
-      200: {
-        description: "Commit details",
-        content: {
-          "application/json": { schema: resolver(CommitDetail) },
-        },
-      },
-      404: {
-        description: "Commit not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  (c) =>
-    c.json(
-      { error: { code: "not_implemented", message: "Not implemented" } },
-      501,
-    ),
-);
-
-app.get(
-  "/branches",
-  describeRoute({
-    tags: ["Agent Data"],
-    summary: "List branches",
-    description: "Lists branches in the agent's data repository.",
-    responses: {
-      200: {
-        description: "List of branches",
-        content: {
-          "application/json": {
-            schema: resolver(BranchInfo.array()),
+  app.get(
+    "/history",
+    describeRoute({
+      tags: ["Agent Data"],
+      summary: "List commits and checkpoints",
+      description:
+        "Returns the agent's change history with commit messages and timestamps.",
+      responses: {
+        200: {
+          description: "History entries",
+          content: {
+            "application/json": {
+              schema: resolver(HistoryEntry.array()),
+            },
           },
         },
       },
-    },
-  }),
-  (c) =>
-    c.json(
-      { error: { code: "not_implemented", message: "Not implemented" } },
-      501,
-    ),
-);
+    }),
+    (c) =>
+      c.json(
+        { error: { code: "not_implemented", message: "Not implemented" } },
+        501,
+      ),
+  );
 
-app.post(
-  "/history/:ref/restore",
-  describeRoute({
-    tags: ["Agent Data"],
-    summary: "Restore agent data to a previous state",
-    description:
-      "Restores the agent's working directory to the state at the specified commit.",
-    responses: {
-      204: {
-        description: "Data restored",
-      },
-      404: {
-        description: "Commit not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
+  app.get(
+    "/history/:ref",
+    describeRoute({
+      tags: ["Agent Data"],
+      summary: "Show changes in a commit",
+      description:
+        "Returns the files changed in a specific commit with additions/deletions counts.",
+      responses: {
+        200: {
+          description: "Commit details",
+          content: {
+            "application/json": { schema: resolver(CommitDetail) },
+          },
+        },
+        404: {
+          description: "Commit not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-    },
-  }),
-  (c) =>
-    c.json(
-      { error: { code: "not_implemented", message: "Not implemented" } },
-      501,
-    ),
-);
+    }),
+    (c) =>
+      c.json(
+        { error: { code: "not_implemented", message: "Not implemented" } },
+        501,
+      ),
+  );
 
-export { app as agentDataRoutes };
+  app.get(
+    "/branches",
+    describeRoute({
+      tags: ["Agent Data"],
+      summary: "List branches",
+      description: "Lists branches in the agent's data repository.",
+      responses: {
+        200: {
+          description: "List of branches",
+          content: {
+            "application/json": {
+              schema: resolver(BranchInfo.array()),
+            },
+          },
+        },
+      },
+    }),
+    (c) =>
+      c.json(
+        { error: { code: "not_implemented", message: "Not implemented" } },
+        501,
+      ),
+  );
+
+  app.post(
+    "/history/:ref/restore",
+    describeRoute({
+      tags: ["Agent Data"],
+      summary: "Restore agent data to a previous state",
+      description:
+        "Restores the agent's working directory to the state at the specified commit.",
+      responses: {
+        204: {
+          description: "Data restored",
+        },
+        404: {
+          description: "Commit not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    (c) =>
+      c.json(
+        { error: { code: "not_implemented", message: "Not implemented" } },
+        501,
+      ),
+  );
+
+  return app;
+}

--- a/packages/hub/src/routes/agents.ts
+++ b/packages/hub/src/routes/agents.ts
@@ -9,6 +9,7 @@ import {
   agentVersion,
 } from "@interchange/db/schema";
 import { parseAgentRow, parseAgentVersionRow } from "@interchange/db";
+import type { DB } from "@interchange/db";
 import {
   CreateAgent,
   UpdateAgent,
@@ -75,301 +76,142 @@ async function loadAgentRoles(
   return roles.map((r) => ({ id: r.id, name: r.name }));
 }
 
-const app = new Hono<TenantEnv>();
+export type CreateAgentRoutesDeps = {
+  db: DB["db"];
+};
 
-app.get(
-  "/",
-  requireGrant("agent:*", "read"),
-  describeRoute({
-    tags: ["Agents"],
-    summary: "List agents in the tenant",
-    description: "Filterable by offering and status.",
-    parameters: [
-      { name: "offering", in: "query", schema: { type: "string" } },
-      {
-        name: "status",
-        in: "query",
-        schema: {
-          type: "string",
-          enum: ["deployed", "stopped"],
-        },
-      },
-      ...pageParameters,
-    ],
-    responses: {
-      200: {
-        description: "List of agents",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(AgentResponse)),
+export function createAgentRoutes({
+  db,
+}: CreateAgentRoutesDeps): Hono<TenantEnv> {
+  const app = new Hono<TenantEnv>();
+
+  app.get(
+    "/",
+    requireGrant("agent:*", "read"),
+    describeRoute({
+      tags: ["Agents"],
+      summary: "List agents in the tenant",
+      description: "Filterable by offering and status.",
+      parameters: [
+        { name: "offering", in: "query", schema: { type: "string" } },
+        {
+          name: "status",
+          in: "query",
+          schema: {
+            type: "string",
+            enum: ["deployed", "stopped"],
           },
         },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
-    const status = c.req.query("status");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
-
-    const conditions = [eq(agent.tenantId, tenantCtx.id)];
-    if (status === "deployed" || status === "stopped") {
-      conditions.push(eq(agent.status, status));
-    }
-    if (cursor) {
-      conditions.push(cursorCondition(agent.createdAt, agent.id, cursor));
-    }
-
-    const rows = await db.query.agent.findMany({
-      where: and(...conditions),
-      orderBy: pageOrder(agent.createdAt, agent.id),
-      limit,
-    });
-
-    const allAssignments =
-      rows.length > 0
-        ? await db.query.agentRole.findMany({
-            where: (ar, { inArray }) =>
-              inArray(
-                ar.agentId,
-                rows.map((r) => r.id),
-              ),
-          })
-        : [];
-
-    const roleIds = [...new Set(allAssignments.map((a) => a.roleId))];
-    const allRoles =
-      roleIds.length > 0
-        ? await db.query.role.findMany({
-            where: (r, { inArray, and: a }) =>
-              a(inArray(r.id, roleIds), eq(r.tenantId, tenantCtx.id)),
-          })
-        : [];
-    const roleMap = new Map(allRoles.map((r) => [r.id, r]));
-
-    const rolesByAgent = new Map<string, { id: string; name: string }[]>();
-    for (const a of allAssignments) {
-      const r = roleMap.get(a.roleId);
-      if (!r) continue;
-      const list = rolesByAgent.get(a.agentId) ?? [];
-      list.push({ id: r.id, name: r.name });
-      rolesByAgent.set(a.agentId, list);
-    }
-
-    return c.json(
-      paginatedResponse(
-        rows.map((r) => formatAgent(r, rolesByAgent.get(r.id) ?? [])),
-        rows,
-        limit,
-      ),
-    );
-  },
-);
-
-app.post(
-  "/",
-  requireGrant("agent:*", "create"),
-  describeRoute({
-    tags: ["Agents"],
-    summary: "Create an agent",
-    description:
-      "Creates an agent definition. Grant requirements are stored as a manifest and resolved at instance launch time.",
-    responses: {
-      201: {
-        description: "Agent created",
-        content: {
-          "application/json": { schema: resolver(AgentResponse) },
-        },
-      },
-      400: {
-        description: "Validation error",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", CreateAgent),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const creatorPrincipal = c.get("principal");
-    const body = c.req.valid("json");
-    const db = c.get("db");
-
-    const now = new Date();
-    const agentId = generateId("agent");
-
-    // Validate role IDs before writing anything.
-    const uniqueRoleIds = [...new Set(body.roleIds ?? [])];
-    let validRoles: { id: string; name: string }[] = [];
-    if (uniqueRoleIds.length > 0) {
-      const found = await db.query.role.findMany({
-        where: (r, { inArray, and: a }) =>
-          a(inArray(r.id, uniqueRoleIds), eq(r.tenantId, tenantCtx.id)),
-      });
-      if (found.length !== uniqueRoleIds.length) {
-        const validIds = new Set(found.map((r) => r.id));
-        const invalid = uniqueRoleIds.filter((id) => !validIds.has(id));
-        return c.json(
-          {
-            error: {
-              code: "bad_request",
-              message: `Roles not found in tenant: ${invalid.join(", ")}`,
+        ...pageParameters,
+      ],
+      responses: {
+        200: {
+          description: "List of agents",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(AgentResponse)),
             },
           },
-          400,
-        );
-      }
-      validRoles = found.map((r) => ({ id: r.id, name: r.name }));
-    }
-
-    const agentRow = await db.transaction(async (tx) => {
-      const row = first(
-        await tx
-          .insert(agent)
-          .values({
-            id: agentId,
-            tenantId: tenantCtx.id,
-            creatorPrincipalId: creatorPrincipal.id,
-            name: body.name,
-            description: body.description ?? null,
-            systemPrompt: body.systemPrompt ?? null,
-            skills: body.skills ?? null,
-            contextConfig: body.contextConfig ?? null,
-            initialState: body.initialState ?? null,
-            modelConfig: body.modelConfig ?? null,
-            capabilities: body.capabilities ?? null,
-            credentialRequirements: body.credentialRequirements ?? null,
-            grantRequirements: body.grantRequirements ?? null,
-            currentVersion: "1",
-            status: "deployed",
-            createdAt: now,
-            updatedAt: now,
-          })
-          .returning(),
-      );
-
-      await tx.insert(agentVersion).values({
-        id: generateId("agentVersion"),
-        agentId,
-        version: "1",
-        status: "active",
-        createdAt: now,
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const status = c.req.query("status");
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
       });
 
-      if (uniqueRoleIds.length > 0) {
-        await tx.insert(agentRole).values(
-          uniqueRoleIds.map((roleId) => ({
-            agentId,
-            roleId,
-            createdAt: now,
-          })),
-        );
+      const conditions = [eq(agent.tenantId, tenantCtx.id)];
+      if (status === "deployed" || status === "stopped") {
+        conditions.push(eq(agent.status, status));
+      }
+      if (cursor) {
+        conditions.push(cursorCondition(agent.createdAt, agent.id, cursor));
       }
 
-      return row;
-    });
+      const rows = await db.query.agent.findMany({
+        where: and(...conditions),
+        orderBy: pageOrder(agent.createdAt, agent.id),
+        limit,
+      });
 
-    return c.json(formatAgent(agentRow, validRoles), 201);
-  },
-);
+      const allAssignments =
+        rows.length > 0
+          ? await db.query.agentRole.findMany({
+              where: (ar, { inArray }) =>
+                inArray(
+                  ar.agentId,
+                  rows.map((r) => r.id),
+                ),
+            })
+          : [];
 
-app.get(
-  "/:agentId",
-  requireGrant(idResource("agent", "agentId"), "read"),
-  describeRoute({
-    tags: ["Agents"],
-    summary: "Get agent details",
-    description:
-      "Returns the agent definition, status, health, and capabilities.",
-    responses: {
-      200: {
-        description: "Agent details",
-        content: {
-          "application/json": { schema: resolver(AgentResponse) },
-        },
-      },
-      404: {
-        description: "Agent not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const agentId = c.req.param("agentId");
-    const db = c.get("db");
+      const roleIds = [...new Set(allAssignments.map((a) => a.roleId))];
+      const allRoles =
+        roleIds.length > 0
+          ? await db.query.role.findMany({
+              where: (r, { inArray, and: a }) =>
+                a(inArray(r.id, roleIds), eq(r.tenantId, tenantCtx.id)),
+            })
+          : [];
+      const roleMap = new Map(allRoles.map((r) => [r.id, r]));
 
-    const row = await db.query.agent.findFirst({
-      where: and(eq(agent.id, agentId), eq(agent.tenantId, tenantCtx.id)),
-    });
+      const rolesByAgent = new Map<string, { id: string; name: string }[]>();
+      for (const a of allAssignments) {
+        const r = roleMap.get(a.roleId);
+        if (!r) continue;
+        const list = rolesByAgent.get(a.agentId) ?? [];
+        list.push({ id: r.id, name: r.name });
+        rolesByAgent.set(a.agentId, list);
+      }
 
-    if (!row) {
       return c.json(
-        { error: { code: "not_found", message: "Agent not found" } },
-        404,
+        paginatedResponse(
+          rows.map((r) => formatAgent(r, rolesByAgent.get(r.id) ?? [])),
+          rows,
+          limit,
+        ),
       );
-    }
-
-    const roles = await loadAgentRoles(db, agentId, tenantCtx.id);
-    return c.json(formatAgent(row, roles));
-  },
-);
-
-app.patch(
-  "/:agentId",
-  requireGrant(idResource("agent", "agentId"), "manage"),
-  describeRoute({
-    tags: ["Agents"],
-    summary: "Update agent definition",
-    description:
-      "Updates the agent definition and creates a new version. The new version is deployed alongside the current version until health checks pass.",
-    responses: {
-      200: {
-        description: "Agent updated",
-        content: {
-          "application/json": { schema: resolver(AgentResponse) },
-        },
-      },
-      400: {
-        description: "Validation error",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
     },
-  }),
-  validator("json", UpdateAgent),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const agentId = c.req.param("agentId");
-    const body = c.req.valid("json");
-    const db = c.get("db");
+  );
 
-    const existing = await db.query.agent.findFirst({
-      where: and(eq(agent.id, agentId), eq(agent.tenantId, tenantCtx.id)),
-    });
+  app.post(
+    "/",
+    requireGrant("agent:*", "create"),
+    describeRoute({
+      tags: ["Agents"],
+      summary: "Create an agent",
+      description:
+        "Creates an agent definition. Grant requirements are stored as a manifest and resolved at instance launch time.",
+      responses: {
+        201: {
+          description: "Agent created",
+          content: {
+            "application/json": { schema: resolver(AgentResponse) },
+          },
+        },
+        400: {
+          description: "Validation error",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    validator("json", CreateAgent),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const creatorPrincipal = c.get("principal");
+      const body = c.req.valid("json");
 
-    if (!existing) {
-      return c.json(
-        { error: { code: "not_found", message: "Agent not found" } },
-        404,
-      );
-    }
+      const now = new Date();
+      const agentId = generateId("agent");
 
-    const now = new Date();
-    const newVersion = String(Number(existing.currentVersion) + 1);
-
-    // Validate role IDs before writing anything.
-    let validRoles: { id: string; name: string }[] | undefined;
-    if (body.roleIds !== undefined) {
-      const uniqueRoleIds = [...new Set(body.roleIds)];
+      // Validate role IDs before writing anything.
+      const uniqueRoleIds = [...new Set(body.roleIds ?? [])];
+      let validRoles: { id: string; name: string }[] = [];
       if (uniqueRoleIds.length > 0) {
         const found = await db.query.role.findMany({
           where: (r, { inArray, and: a }) =>
@@ -389,44 +231,424 @@ app.patch(
           );
         }
         validRoles = found.map((r) => ({ id: r.id, name: r.name }));
-      } else {
-        validRoles = [];
       }
-    }
 
-    const updates: Record<string, unknown> = {
-      updatedAt: now,
-      currentVersion: newVersion,
-    };
-    if (body.name !== undefined) updates["name"] = body.name;
-    if (body.description !== undefined)
-      updates["description"] = body.description;
-    if (body.systemPrompt !== undefined)
-      updates["systemPrompt"] = body.systemPrompt;
-    if (body.skills !== undefined) updates["skills"] = body.skills;
-    if (body.contextConfig !== undefined)
-      updates["contextConfig"] = body.contextConfig;
-    if (body.initialState !== undefined)
-      updates["initialState"] = body.initialState;
-    if (body.modelConfig !== undefined)
-      updates["modelConfig"] = body.modelConfig;
-    if (body.capabilities !== undefined)
-      updates["capabilities"] = body.capabilities;
-    if (body.credentialRequirements !== undefined)
-      updates["credentialRequirements"] = body.credentialRequirements;
-    if (body.grantRequirements !== undefined)
-      updates["grantRequirements"] = body.grantRequirements;
+      const agentRow = await db.transaction(async (tx) => {
+        const row = first(
+          await tx
+            .insert(agent)
+            .values({
+              id: agentId,
+              tenantId: tenantCtx.id,
+              creatorPrincipalId: creatorPrincipal.id,
+              name: body.name,
+              description: body.description ?? null,
+              systemPrompt: body.systemPrompt ?? null,
+              skills: body.skills ?? null,
+              contextConfig: body.contextConfig ?? null,
+              initialState: body.initialState ?? null,
+              modelConfig: body.modelConfig ?? null,
+              capabilities: body.capabilities ?? null,
+              credentialRequirements: body.credentialRequirements ?? null,
+              grantRequirements: body.grantRequirements ?? null,
+              currentVersion: "1",
+              status: "deployed",
+              createdAt: now,
+              updatedAt: now,
+            })
+            .returning(),
+        );
 
-    const updated = await db.transaction(async (tx) => {
-      const row = first(
+        await tx.insert(agentVersion).values({
+          id: generateId("agentVersion"),
+          agentId,
+          version: "1",
+          status: "active",
+          createdAt: now,
+        });
+
+        if (uniqueRoleIds.length > 0) {
+          await tx.insert(agentRole).values(
+            uniqueRoleIds.map((roleId) => ({
+              agentId,
+              roleId,
+              createdAt: now,
+            })),
+          );
+        }
+
+        return row;
+      });
+
+      return c.json(formatAgent(agentRow, validRoles), 201);
+    },
+  );
+
+  app.get(
+    "/:agentId",
+    requireGrant(idResource("agent", "agentId"), "read"),
+    describeRoute({
+      tags: ["Agents"],
+      summary: "Get agent details",
+      description:
+        "Returns the agent definition, status, health, and capabilities.",
+      responses: {
+        200: {
+          description: "Agent details",
+          content: {
+            "application/json": { schema: resolver(AgentResponse) },
+          },
+        },
+        404: {
+          description: "Agent not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const agentId = c.req.param("agentId");
+
+      const row = await db.query.agent.findFirst({
+        where: and(eq(agent.id, agentId), eq(agent.tenantId, tenantCtx.id)),
+      });
+
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Agent not found" } },
+          404,
+        );
+      }
+
+      const roles = await loadAgentRoles(db, agentId, tenantCtx.id);
+      return c.json(formatAgent(row, roles));
+    },
+  );
+
+  app.patch(
+    "/:agentId",
+    requireGrant(idResource("agent", "agentId"), "manage"),
+    describeRoute({
+      tags: ["Agents"],
+      summary: "Update agent definition",
+      description:
+        "Updates the agent definition and creates a new version. The new version is deployed alongside the current version until health checks pass.",
+      responses: {
+        200: {
+          description: "Agent updated",
+          content: {
+            "application/json": { schema: resolver(AgentResponse) },
+          },
+        },
+        400: {
+          description: "Validation error",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    validator("json", UpdateAgent),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const agentId = c.req.param("agentId");
+      const body = c.req.valid("json");
+
+      const existing = await db.query.agent.findFirst({
+        where: and(eq(agent.id, agentId), eq(agent.tenantId, tenantCtx.id)),
+      });
+
+      if (!existing) {
+        return c.json(
+          { error: { code: "not_found", message: "Agent not found" } },
+          404,
+        );
+      }
+
+      const now = new Date();
+      const newVersion = String(Number(existing.currentVersion) + 1);
+
+      // Validate role IDs before writing anything.
+      let validRoles: { id: string; name: string }[] | undefined;
+      if (body.roleIds !== undefined) {
+        const uniqueRoleIds = [...new Set(body.roleIds)];
+        if (uniqueRoleIds.length > 0) {
+          const found = await db.query.role.findMany({
+            where: (r, { inArray, and: a }) =>
+              a(inArray(r.id, uniqueRoleIds), eq(r.tenantId, tenantCtx.id)),
+          });
+          if (found.length !== uniqueRoleIds.length) {
+            const validIds = new Set(found.map((r) => r.id));
+            const invalid = uniqueRoleIds.filter((id) => !validIds.has(id));
+            return c.json(
+              {
+                error: {
+                  code: "bad_request",
+                  message: `Roles not found in tenant: ${invalid.join(", ")}`,
+                },
+              },
+              400,
+            );
+          }
+          validRoles = found.map((r) => ({ id: r.id, name: r.name }));
+        } else {
+          validRoles = [];
+        }
+      }
+
+      const updates: Record<string, unknown> = {
+        updatedAt: now,
+        currentVersion: newVersion,
+      };
+      if (body.name !== undefined) updates["name"] = body.name;
+      if (body.description !== undefined)
+        updates["description"] = body.description;
+      if (body.systemPrompt !== undefined)
+        updates["systemPrompt"] = body.systemPrompt;
+      if (body.skills !== undefined) updates["skills"] = body.skills;
+      if (body.contextConfig !== undefined)
+        updates["contextConfig"] = body.contextConfig;
+      if (body.initialState !== undefined)
+        updates["initialState"] = body.initialState;
+      if (body.modelConfig !== undefined)
+        updates["modelConfig"] = body.modelConfig;
+      if (body.capabilities !== undefined)
+        updates["capabilities"] = body.capabilities;
+      if (body.credentialRequirements !== undefined)
+        updates["credentialRequirements"] = body.credentialRequirements;
+      if (body.grantRequirements !== undefined)
+        updates["grantRequirements"] = body.grantRequirements;
+
+      const updated = await db.transaction(async (tx) => {
+        const row = first(
+          await tx
+            .update(agent)
+            .set(updates)
+            .where(eq(agent.id, agentId))
+            .returning(),
+        );
+
         await tx
-          .update(agent)
-          .set(updates)
-          .where(eq(agent.id, agentId))
-          .returning(),
-      );
+          .update(agentVersion)
+          .set({ status: "inactive" })
+          .where(
+            and(
+              eq(agentVersion.agentId, agentId),
+              eq(agentVersion.version, existing.currentVersion),
+            ),
+          );
 
-      await tx
+        await tx.insert(agentVersion).values({
+          id: generateId("agentVersion"),
+          agentId,
+          version: newVersion,
+          status: "active",
+          createdAt: now,
+        });
+
+        if (validRoles !== undefined) {
+          await tx.delete(agentRole).where(eq(agentRole.agentId, agentId));
+          if (validRoles.length > 0) {
+            await tx.insert(agentRole).values(
+              validRoles.map((r) => ({
+                agentId,
+                roleId: r.id,
+                createdAt: now,
+              })),
+            );
+          }
+        }
+
+        return row;
+      });
+
+      const roles =
+        validRoles ?? (await loadAgentRoles(db, agentId, tenantCtx.id));
+
+      return c.json(formatAgent(updated, roles));
+    },
+  );
+
+  app.delete(
+    "/:agentId",
+    requireGrant(idResource("agent", "agentId"), "manage"),
+    describeRoute({
+      tags: ["Agents"],
+      summary: "Retire an agent",
+      description:
+        "Retires the agent definition and marks all running instances as stopped. Does not signal running sidecars; in-flight sessions continue until the sidecar disconnects.",
+      responses: {
+        204: {
+          description: "Agent retirement initiated",
+        },
+        404: {
+          description: "Agent not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const agentId = c.req.param("agentId");
+
+      const existing = await db.query.agent.findFirst({
+        where: and(eq(agent.id, agentId), eq(agent.tenantId, tenantCtx.id)),
+      });
+
+      if (!existing) {
+        return c.json(
+          { error: { code: "not_found", message: "Agent not found" } },
+          404,
+        );
+      }
+
+      const retiredAt = new Date();
+
+      // TODO: This is DB-only — it does not signal the sidecar to stop
+      // or end the agentSession. A running sidecar will continue until
+      // it disconnects naturally. Add sidecar teardown coordination.
+      await db
+        .update(agentInstance)
+        .set({
+          status: "stopped",
+          sessionId: null,
+          updatedAt: retiredAt,
+          endedAt: retiredAt,
+        })
+        .where(
+          and(
+            eq(agentInstance.agentId, agentId),
+            isNull(agentInstance.endedAt),
+          ),
+        );
+
+      // Set agent status to stopped
+      await db
+        .update(agent)
+        .set({ status: "stopped", updatedAt: retiredAt })
+        .where(eq(agent.id, agentId));
+
+      return c.body(null, 204);
+    },
+  );
+
+  app.get(
+    "/:agentId/versions",
+    requireGrant(idResource("agent", "agentId"), "read"),
+    describeRoute({
+      tags: ["Agents"],
+      summary: "List agent versions",
+      description: "Lists all versions with their deployment status.",
+      parameters: [...pageParameters],
+      responses: {
+        200: {
+          description: "List of versions",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(AgentVersion)),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const agentId = c.req.param("agentId");
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
+
+      const conditions = [eq(agentVersion.agentId, agentId)];
+      if (cursor) {
+        conditions.push(
+          cursorCondition(agentVersion.createdAt, agentVersion.id, cursor),
+        );
+      }
+
+      const rows = await db.query.agentVersion.findMany({
+        where: and(...conditions),
+        orderBy: pageOrder(agentVersion.createdAt, agentVersion.id),
+        limit,
+      });
+
+      const items = rows.map((v) => {
+        const parsed = parseAgentVersionRow(v);
+        return {
+          version: parsed.version,
+          status: parsed.status,
+          createdAt: ts(parsed.createdAt),
+        };
+      });
+
+      return c.json(paginatedResponse(items, rows, limit));
+    },
+  );
+
+  app.post(
+    "/:agentId/rollback",
+    requireGrant(idResource("agent", "agentId"), "manage"),
+    describeRoute({
+      tags: ["Agents"],
+      summary: "Rollback to a previous version",
+      description:
+        "Shifts traffic back to the specified version. The current version is stopped.",
+      responses: {
+        200: {
+          description: "Rollback initiated",
+          content: {
+            "application/json": { schema: resolver(AgentResponse) },
+          },
+        },
+        400: {
+          description: "Invalid version",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    validator("json", RollbackRequest),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const agentId = c.req.param("agentId");
+      const body = c.req.valid("json");
+
+      const existing = await db.query.agent.findFirst({
+        where: and(eq(agent.id, agentId), eq(agent.tenantId, tenantCtx.id)),
+      });
+      if (!existing) {
+        return c.json(
+          { error: { code: "not_found", message: "Agent not found" } },
+          404,
+        );
+      }
+
+      const targetVersion = await db.query.agentVersion.findFirst({
+        where: and(
+          eq(agentVersion.agentId, agentId),
+          eq(agentVersion.version, body.version),
+        ),
+      });
+      if (!targetVersion) {
+        return c.json(
+          {
+            error: {
+              code: "bad_request",
+              message: "Target version not found",
+            },
+          },
+          400,
+        );
+      }
+
+      const now = new Date();
+
+      // Deactivate current version
+      await db
         .update(agentVersion)
         .set({ status: "inactive" })
         .where(
@@ -436,247 +658,30 @@ app.patch(
           ),
         );
 
-      await tx.insert(agentVersion).values({
-        id: generateId("agentVersion"),
-        agentId,
-        version: newVersion,
-        status: "active",
-        createdAt: now,
-      });
-
-      if (validRoles !== undefined) {
-        await tx.delete(agentRole).where(eq(agentRole.agentId, agentId));
-        if (validRoles.length > 0) {
-          await tx.insert(agentRole).values(
-            validRoles.map((r) => ({
-              agentId,
-              roleId: r.id,
-              createdAt: now,
-            })),
-          );
-        }
-      }
-
-      return row;
-    });
-
-    const roles =
-      validRoles ?? (await loadAgentRoles(db, agentId, tenantCtx.id));
-
-    return c.json(formatAgent(updated, roles));
-  },
-);
-
-app.delete(
-  "/:agentId",
-  requireGrant(idResource("agent", "agentId"), "manage"),
-  describeRoute({
-    tags: ["Agents"],
-    summary: "Retire an agent",
-    description:
-      "Retires the agent definition and marks all running instances as stopped. Does not signal running sidecars; in-flight sessions continue until the sidecar disconnects.",
-    responses: {
-      204: {
-        description: "Agent retirement initiated",
-      },
-      404: {
-        description: "Agent not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const agentId = c.req.param("agentId");
-    const db = c.get("db");
-
-    const existing = await db.query.agent.findFirst({
-      where: and(eq(agent.id, agentId), eq(agent.tenantId, tenantCtx.id)),
-    });
-
-    if (!existing) {
-      return c.json(
-        { error: { code: "not_found", message: "Agent not found" } },
-        404,
-      );
-    }
-
-    const retiredAt = new Date();
-
-    // TODO: This is DB-only — it does not signal the sidecar to stop
-    // or end the agentSession. A running sidecar will continue until
-    // it disconnects naturally. Add sidecar teardown coordination.
-    await db
-      .update(agentInstance)
-      .set({
-        status: "stopped",
-        sessionId: null,
-        updatedAt: retiredAt,
-        endedAt: retiredAt,
-      })
-      .where(
-        and(eq(agentInstance.agentId, agentId), isNull(agentInstance.endedAt)),
-      );
-
-    // Set agent status to stopped
-    await db
-      .update(agent)
-      .set({ status: "stopped", updatedAt: retiredAt })
-      .where(eq(agent.id, agentId));
-
-    return c.body(null, 204);
-  },
-);
-
-app.get(
-  "/:agentId/versions",
-  requireGrant(idResource("agent", "agentId"), "read"),
-  describeRoute({
-    tags: ["Agents"],
-    summary: "List agent versions",
-    description: "Lists all versions with their deployment status.",
-    parameters: [...pageParameters],
-    responses: {
-      200: {
-        description: "List of versions",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(AgentVersion)),
-          },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const agentId = c.req.param("agentId");
-    const db = c.get("db");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
-
-    const conditions = [eq(agentVersion.agentId, agentId)];
-    if (cursor) {
-      conditions.push(
-        cursorCondition(agentVersion.createdAt, agentVersion.id, cursor),
-      );
-    }
-
-    const rows = await db.query.agentVersion.findMany({
-      where: and(...conditions),
-      orderBy: pageOrder(agentVersion.createdAt, agentVersion.id),
-      limit,
-    });
-
-    const items = rows.map((v) => {
-      const parsed = parseAgentVersionRow(v);
-      return {
-        version: parsed.version,
-        status: parsed.status,
-        createdAt: ts(parsed.createdAt),
-      };
-    });
-
-    return c.json(paginatedResponse(items, rows, limit));
-  },
-);
-
-app.post(
-  "/:agentId/rollback",
-  requireGrant(idResource("agent", "agentId"), "manage"),
-  describeRoute({
-    tags: ["Agents"],
-    summary: "Rollback to a previous version",
-    description:
-      "Shifts traffic back to the specified version. The current version is stopped.",
-    responses: {
-      200: {
-        description: "Rollback initiated",
-        content: {
-          "application/json": { schema: resolver(AgentResponse) },
-        },
-      },
-      400: {
-        description: "Invalid version",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", RollbackRequest),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const agentId = c.req.param("agentId");
-    const body = c.req.valid("json");
-    const db = c.get("db");
-
-    const existing = await db.query.agent.findFirst({
-      where: and(eq(agent.id, agentId), eq(agent.tenantId, tenantCtx.id)),
-    });
-    if (!existing) {
-      return c.json(
-        { error: { code: "not_found", message: "Agent not found" } },
-        404,
-      );
-    }
-
-    const targetVersion = await db.query.agentVersion.findFirst({
-      where: and(
-        eq(agentVersion.agentId, agentId),
-        eq(agentVersion.version, body.version),
-      ),
-    });
-    if (!targetVersion) {
-      return c.json(
-        {
-          error: {
-            code: "bad_request",
-            message: "Target version not found",
-          },
-        },
-        400,
-      );
-    }
-
-    const now = new Date();
-
-    // Deactivate current version
-    await db
-      .update(agentVersion)
-      .set({ status: "inactive" })
-      .where(
-        and(
-          eq(agentVersion.agentId, agentId),
-          eq(agentVersion.version, existing.currentVersion),
-        ),
-      );
-
-    // Activate target version
-    await db
-      .update(agentVersion)
-      .set({ status: "active" })
-      .where(
-        and(
-          eq(agentVersion.agentId, agentId),
-          eq(agentVersion.version, body.version),
-        ),
-      );
-
-    // Update agent
-    const updated = first(
+      // Activate target version
       await db
-        .update(agent)
-        .set({ currentVersion: body.version, updatedAt: now })
-        .where(eq(agent.id, agentId))
-        .returning(),
-    );
+        .update(agentVersion)
+        .set({ status: "active" })
+        .where(
+          and(
+            eq(agentVersion.agentId, agentId),
+            eq(agentVersion.version, body.version),
+          ),
+        );
 
-    const roles = await loadAgentRoles(db, updated.id, tenantCtx.id);
-    return c.json(formatAgent(updated, roles));
-  },
-);
+      // Update agent
+      const updated = first(
+        await db
+          .update(agent)
+          .set({ currentVersion: body.version, updatedAt: now })
+          .where(eq(agent.id, agentId))
+          .returning(),
+      );
 
-export { app as agentRoutes };
+      const roles = await loadAgentRoles(db, updated.id, tenantCtx.id);
+      return c.json(formatAgent(updated, roles));
+    },
+  );
+
+  return app;
+}

--- a/packages/hub/src/routes/agents.ts
+++ b/packages/hub/src/routes/agents.ts
@@ -23,7 +23,8 @@ import {
 import type { TenantEnv } from "../context";
 import { first, ts } from "../format";
 import { generateId } from "../ids";
-import { requireGrant, idResource } from "../middleware/grant";
+import { idResource } from "../middleware/grant";
+import type { RequireGrant } from "../middleware/grant";
 import {
   parsePageParams,
   cursorCondition,
@@ -60,7 +61,7 @@ function formatAgent(
 }
 
 async function loadAgentRoles(
-  db: TenantEnv["Variables"]["db"],
+  db: DB["db"],
   agentId: string,
   tenantId: string,
 ): Promise<{ id: string; name: string }[]> {
@@ -78,10 +79,12 @@ async function loadAgentRoles(
 
 export type CreateAgentRoutesDeps = {
   db: DB["db"];
+  requireGrant: RequireGrant;
 };
 
 export function createAgentRoutes({
   db,
+  requireGrant,
 }: CreateAgentRoutesDeps): Hono<TenantEnv> {
   const app = new Hono<TenantEnv>();
 

--- a/packages/hub/src/routes/approvals.ts
+++ b/packages/hub/src/routes/approvals.ts
@@ -9,120 +9,122 @@ import {
 
 import type { AppEnv } from "../context";
 
-const app = new Hono<AppEnv>();
+export function createApprovalRoutes(): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
 
-app.get(
-  "/",
-  describeRoute({
-    tags: ["Approvals"],
-    summary: "List pending approvals in the tenant",
-    description:
-      "Returns pending approval requests for the authenticated user within this tenant.",
-    responses: {
-      200: {
-        description: "List of approvals",
-        content: {
-          "application/json": {
-            schema: resolver(ApprovalResponse.array()),
+  app.get(
+    "/",
+    describeRoute({
+      tags: ["Approvals"],
+      summary: "List pending approvals in the tenant",
+      description:
+        "Returns pending approval requests for the authenticated user within this tenant.",
+      responses: {
+        200: {
+          description: "List of approvals",
+          content: {
+            "application/json": {
+              schema: resolver(ApprovalResponse.array()),
+            },
           },
         },
       },
-    },
-  }),
-  (c) =>
-    c.json(
-      { error: { code: "not_implemented", message: "Not implemented" } },
-      501,
-    ),
-);
+    }),
+    (c) =>
+      c.json(
+        { error: { code: "not_implemented", message: "Not implemented" } },
+        501,
+      ),
+  );
 
-app.get(
-  "/:approvalId",
-  describeRoute({
-    tags: ["Approvals"],
-    summary: "Get approval details",
-    description:
-      "Returns the proposed action, context, originating agent, and session.",
-    responses: {
-      200: {
-        description: "Approval details",
-        content: {
-          "application/json": { schema: resolver(ApprovalResponse) },
+  app.get(
+    "/:approvalId",
+    describeRoute({
+      tags: ["Approvals"],
+      summary: "Get approval details",
+      description:
+        "Returns the proposed action, context, originating agent, and session.",
+      responses: {
+        200: {
+          description: "Approval details",
+          content: {
+            "application/json": { schema: resolver(ApprovalResponse) },
+          },
+        },
+        404: {
+          description: "Approval not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-      404: {
-        description: "Approval not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  (c) =>
-    c.json(
-      { error: { code: "not_implemented", message: "Not implemented" } },
-      501,
-    ),
-);
+    }),
+    (c) =>
+      c.json(
+        { error: { code: "not_implemented", message: "Not implemented" } },
+        501,
+      ),
+  );
 
-app.post(
-  "/:approvalId/approve",
-  describeRoute({
-    tags: ["Approvals"],
-    summary: "Approve an action",
-    description:
-      "Approves the pending action. With scope 'once', the approval is one-time. With scope 'always', a persistent grant is created so the agent won't need to ask again.",
-    responses: {
-      200: {
-        description: "Action approved",
-        content: {
-          "application/json": { schema: resolver(ApprovalResponse) },
+  app.post(
+    "/:approvalId/approve",
+    describeRoute({
+      tags: ["Approvals"],
+      summary: "Approve an action",
+      description:
+        "Approves the pending action. With scope 'once', the approval is one-time. With scope 'always', a persistent grant is created so the agent won't need to ask again.",
+      responses: {
+        200: {
+          description: "Action approved",
+          content: {
+            "application/json": { schema: resolver(ApprovalResponse) },
+          },
+        },
+        404: {
+          description: "Approval not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-      404: {
-        description: "Approval not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", ApproveAction),
-  (c) =>
-    c.json(
-      { error: { code: "not_implemented", message: "Not implemented" } },
-      501,
-    ),
-);
+    }),
+    validator("json", ApproveAction),
+    (c) =>
+      c.json(
+        { error: { code: "not_implemented", message: "Not implemented" } },
+        501,
+      ),
+  );
 
-app.post(
-  "/:approvalId/reject",
-  describeRoute({
-    tags: ["Approvals"],
-    summary: "Reject an action",
-    description:
-      "Rejects the pending action. An optional message provides feedback to the agent.",
-    responses: {
-      200: {
-        description: "Action rejected",
-        content: {
-          "application/json": { schema: resolver(ApprovalResponse) },
+  app.post(
+    "/:approvalId/reject",
+    describeRoute({
+      tags: ["Approvals"],
+      summary: "Reject an action",
+      description:
+        "Rejects the pending action. An optional message provides feedback to the agent.",
+      responses: {
+        200: {
+          description: "Action rejected",
+          content: {
+            "application/json": { schema: resolver(ApprovalResponse) },
+          },
+        },
+        404: {
+          description: "Approval not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-      404: {
-        description: "Approval not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", RejectAction),
-  (c) =>
-    c.json(
-      { error: { code: "not_implemented", message: "Not implemented" } },
-      501,
-    ),
-);
+    }),
+    validator("json", RejectAction),
+    (c) =>
+      c.json(
+        { error: { code: "not_implemented", message: "Not implemented" } },
+        501,
+      ),
+  );
 
-export { app as approvalRoutes };
+  return app;
+}

--- a/packages/hub/src/routes/credentials.ts
+++ b/packages/hub/src/routes/credentials.ts
@@ -8,6 +8,7 @@ import {
   resolveCredentialByName,
   parseCredentialRow,
 } from "@interchange/db";
+import type { DB } from "@interchange/db";
 import {
   CreateCredential,
   UpdateCredential,
@@ -28,6 +29,7 @@ import {
   pageParameters,
 } from "../pagination";
 import { pushProviderUpdates } from "../credential-push";
+import type { SidecarRouter } from "../ws/sidecar-handler";
 
 function formatCredential(row: typeof credential.$inferSelect) {
   const parsed = parseCredentialRow(row);
@@ -49,379 +51,382 @@ function formatCredential(row: typeof credential.$inferSelect) {
   };
 }
 
-const app = new Hono<TenantEnv>();
+export type CreateCredentialRoutesDeps = {
+  db: DB["db"];
+  sidecarRouter: SidecarRouter;
+};
 
-app.get(
-  "/",
-  requireGrant("credential:*", "read"),
-  describeRoute({
-    tags: ["Credentials"],
-    summary: "List credentials",
-    description:
-      "Lists credential metadata. Secrets are never returned. Filterable by owner type.",
-    parameters: [
-      {
-        name: "owner",
-        in: "query",
-        schema: { type: "string", enum: ["me", "org", "all"] },
-      },
-      ...pageParameters,
-    ],
-    responses: {
-      200: {
-        description: "List of credentials",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(CredentialResponse)),
-          },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const principalCtx = c.get("principal");
-    const db = c.get("db");
-    const owner = c.req.query("owner") ?? "all";
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
+export function createCredentialRoutes({
+  db,
+  sidecarRouter,
+}: CreateCredentialRoutesDeps): Hono<TenantEnv> {
+  const app = new Hono<TenantEnv>();
 
-    const conditions = [eq(credential.tenantId, tenantCtx.id)];
-
-    if (owner === "me") {
-      conditions.push(eq(credential.principalId, principalCtx.id));
-    } else if (owner === "org") {
-      conditions.push(isNull(credential.principalId));
-    }
-
-    if (cursor) {
-      conditions.push(
-        cursorCondition(credential.createdAt, credential.id, cursor),
-      );
-    }
-
-    const rows = await db.query.credential.findMany({
-      where: and(...conditions),
-      orderBy: pageOrder(credential.createdAt, credential.id),
-      limit,
-    });
-
-    return c.json(paginatedResponse(rows.map(formatCredential), rows, limit));
-  },
-);
-
-app.post(
-  "/",
-  requireGrant("credential:*", "create"),
-  describeRoute({
-    tags: ["Credentials"],
-    summary: "Store a credential",
-    description:
-      "Stores a credential (API key, OAuth token, etc.). The secret is stored securely and never returned in subsequent reads. A provider must be specified.",
-    responses: {
-      201: {
-        description: "Credential stored",
-        content: {
-          "application/json": { schema: resolver(CredentialResponse) },
-        },
-      },
-      400: {
-        description: "Validation error",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      404: {
-        description: "Provider not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      409: {
-        description: "Credential name already exists in this tenant",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", CreateCredential),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const body = c.req.valid("json");
-    const db = c.get("db");
-
-    const providerRow = await db.query.provider.findFirst({
-      where: eq(provider.id, body.providerId),
-    });
-    if (!providerRow) {
-      return c.json(
-        { error: { code: "not_found", message: "Provider not found" } },
-        404,
-      );
-    }
-
-    const chain = await getAncestorChain(db, tenantCtx.id);
-    if (!chain.includes(providerRow.tenantId)) {
-      return c.json(
-        { error: { code: "not_found", message: "Provider not found" } },
-        404,
-      );
-    }
-
-    const existing = await db.query.credential.findFirst({
-      where: and(
-        eq(credential.tenantId, tenantCtx.id),
-        eq(credential.name, body.name),
-      ),
-    });
-    if (existing) {
-      return c.json(
+  app.get(
+    "/",
+    requireGrant("credential:*", "read"),
+    describeRoute({
+      tags: ["Credentials"],
+      summary: "List credentials",
+      description:
+        "Lists credential metadata. Secrets are never returned. Filterable by owner type.",
+      parameters: [
         {
-          error: {
-            code: "conflict",
-            message: "Credential name already exists in this tenant",
+          name: "owner",
+          in: "query",
+          schema: { type: "string", enum: ["me", "org", "all"] },
+        },
+        ...pageParameters,
+      ],
+      responses: {
+        200: {
+          description: "List of credentials",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(CredentialResponse)),
+            },
           },
         },
-        409,
-      );
-    }
-
-    const now = new Date();
-    const row = first(
-      await db
-        .insert(credential)
-        .values({
-          id: generateId("credential"),
-          tenantId: tenantCtx.id,
-          providerId: body.providerId,
-          principalId: body.principalId ?? null,
-          oauthClientId: body.oauthClientId ?? null,
-          name: body.name,
-          type: body.type,
-          description: body.description ?? null,
-          secret: body.secret,
-          refreshSecret: body.refreshSecret ?? null,
-          scopes: body.scopes ?? null,
-          expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
-          metadata: body.metadata ?? null,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning(),
-    );
-
-    return c.json(formatCredential(row), 201);
-  },
-);
-
-app.get(
-  "/resolve/:name",
-  requireGrant("credential:*", "read"),
-  describeRoute({
-    tags: ["Credentials"],
-    summary: "Resolve a credential by name",
-    description:
-      "Resolves a credential by name, walking the tenant hierarchy. Returns metadata only (no secret). Useful for discovering which credential an agent would get.",
-    responses: {
-      200: {
-        description: "Credential metadata",
-        content: {
-          "application/json": { schema: resolver(CredentialResponse) },
-        },
       },
-      404: {
-        description: "Credential not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const principalCtx = c.get("principal");
+      const owner = c.req.query("owner") ?? "all";
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
+
+      const conditions = [eq(credential.tenantId, tenantCtx.id)];
+
+      if (owner === "me") {
+        conditions.push(eq(credential.principalId, principalCtx.id));
+      } else if (owner === "org") {
+        conditions.push(isNull(credential.principalId));
+      }
+
+      if (cursor) {
+        conditions.push(
+          cursorCondition(credential.createdAt, credential.id, cursor),
+        );
+      }
+
+      const rows = await db.query.credential.findMany({
+        where: and(...conditions),
+        orderBy: pageOrder(credential.createdAt, credential.id),
+        limit,
+      });
+
+      return c.json(paginatedResponse(rows.map(formatCredential), rows, limit));
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const name = c.req.param("name");
-    const db = c.get("db");
+  );
 
-    const row = await resolveCredentialByName(db, tenantCtx.id, name);
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Credential not found" } },
-        404,
-      );
-    }
-
-    return c.json(formatCredential(row));
-  },
-);
-
-app.get(
-  "/:credentialId",
-  requireGrant(idResource("credential", "credentialId"), "read"),
-  describeRoute({
-    tags: ["Credentials"],
-    summary: "Get credential metadata",
-    description:
-      "Returns credential metadata. The secret is never included. Supports hierarchy-aware access.",
-    responses: {
-      200: {
-        description: "Credential metadata",
-        content: {
-          "application/json": { schema: resolver(CredentialResponse) },
+  app.post(
+    "/",
+    requireGrant("credential:*", "create"),
+    describeRoute({
+      tags: ["Credentials"],
+      summary: "Store a credential",
+      description:
+        "Stores a credential (API key, OAuth token, etc.). The secret is stored securely and never returned in subsequent reads. A provider must be specified.",
+      responses: {
+        201: {
+          description: "Credential stored",
+          content: {
+            "application/json": { schema: resolver(CredentialResponse) },
+          },
+        },
+        400: {
+          description: "Validation error",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        404: {
+          description: "Provider not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        409: {
+          description: "Credential name already exists in this tenant",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-      404: {
-        description: "Credential not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const credentialId = c.req.param("credentialId");
-    const db = c.get("db");
+    }),
+    validator("json", CreateCredential),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const body = c.req.valid("json");
 
-    const row = await db.query.credential.findFirst({
-      where: eq(credential.id, credentialId),
-    });
+      const providerRow = await db.query.provider.findFirst({
+        where: eq(provider.id, body.providerId),
+      });
+      if (!providerRow) {
+        return c.json(
+          { error: { code: "not_found", message: "Provider not found" } },
+          404,
+        );
+      }
 
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Credential not found" } },
-        404,
-      );
-    }
+      const chain = await getAncestorChain(db, tenantCtx.id);
+      if (!chain.includes(providerRow.tenantId)) {
+        return c.json(
+          { error: { code: "not_found", message: "Provider not found" } },
+          404,
+        );
+      }
 
-    const chain = await getAncestorChain(db, tenantCtx.id);
-    if (!chain.includes(row.tenantId)) {
-      return c.json(
-        { error: { code: "not_found", message: "Credential not found" } },
-        404,
-      );
-    }
-
-    return c.json(formatCredential(row));
-  },
-);
-
-app.patch(
-  "/:credentialId",
-  requireGrant(idResource("credential", "credentialId"), "manage"),
-  describeRoute({
-    tags: ["Credentials"],
-    summary: "Rotate or update a credential",
-    description: "Only credentials owned by this tenant can be updated.",
-    responses: {
-      200: {
-        description: "Credential updated",
-        content: {
-          "application/json": { schema: resolver(CredentialResponse) },
-        },
-      },
-      404: {
-        description: "Credential not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", UpdateCredential),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const credentialId = c.req.param("credentialId");
-    const body = c.req.valid("json");
-    const db = c.get("db");
-
-    const updates: Record<string, unknown> = { updatedAt: new Date() };
-    if (body.name !== undefined) updates["name"] = body.name;
-    if (body.description !== undefined)
-      updates["description"] = body.description;
-    if (body.secret !== undefined) updates["secret"] = body.secret;
-    if (body.refreshSecret !== undefined)
-      updates["refreshSecret"] = body.refreshSecret;
-    if (body.scopes !== undefined) updates["scopes"] = body.scopes;
-    if (body.expiresAt !== undefined)
-      updates["expiresAt"] = body.expiresAt ? new Date(body.expiresAt) : null;
-    if (body.status !== undefined) updates["status"] = body.status;
-    if (body.metadata !== undefined) updates["metadata"] = body.metadata;
-
-    const [updated] = await db
-      .update(credential)
-      .set(updates)
-      .where(
-        and(
-          eq(credential.id, credentialId),
+      const existing = await db.query.credential.findFirst({
+        where: and(
           eq(credential.tenantId, tenantCtx.id),
+          eq(credential.name, body.name),
         ),
-      )
-      .returning();
+      });
+      if (existing) {
+        return c.json(
+          {
+            error: {
+              code: "conflict",
+              message: "Credential name already exists in this tenant",
+            },
+          },
+          409,
+        );
+      }
 
-    if (!updated) {
-      return c.json(
-        { error: { code: "not_found", message: "Credential not found" } },
-        404,
+      const now = new Date();
+      const row = first(
+        await db
+          .insert(credential)
+          .values({
+            id: generateId("credential"),
+            tenantId: tenantCtx.id,
+            providerId: body.providerId,
+            principalId: body.principalId ?? null,
+            oauthClientId: body.oauthClientId ?? null,
+            name: body.name,
+            type: body.type,
+            description: body.description ?? null,
+            secret: body.secret,
+            refreshSecret: body.refreshSecret ?? null,
+            scopes: body.scopes ?? null,
+            expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
+            metadata: body.metadata ?? null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning(),
       );
-    }
 
-    // If the secret was updated, push new provider config to running instances.
-    if (body.secret !== undefined) {
-      const sidecarRouter = c.get("sidecarRouter");
-      void pushProviderUpdates(db, sidecarRouter, updated.tenantId);
-    }
+      return c.json(formatCredential(row), 201);
+    },
+  );
 
-    return c.json(formatCredential(updated));
-  },
-);
-
-app.delete(
-  "/:credentialId",
-  requireGrant(idResource("credential", "credentialId"), "manage"),
-  describeRoute({
-    tags: ["Credentials"],
-    summary: "Revoke a credential",
-    description: "Only credentials owned by this tenant can be revoked.",
-    responses: {
-      204: {
-        description: "Credential revoked",
-      },
-      404: {
-        description: "Credential not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
+  app.get(
+    "/resolve/:name",
+    requireGrant("credential:*", "read"),
+    describeRoute({
+      tags: ["Credentials"],
+      summary: "Resolve a credential by name",
+      description:
+        "Resolves a credential by name, walking the tenant hierarchy. Returns metadata only (no secret). Useful for discovering which credential an agent would get.",
+      responses: {
+        200: {
+          description: "Credential metadata",
+          content: {
+            "application/json": { schema: resolver(CredentialResponse) },
+          },
+        },
+        404: {
+          description: "Credential not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const name = c.req.param("name");
+
+      const row = await resolveCredentialByName(db, tenantCtx.id, name);
+
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Credential not found" } },
+          404,
+        );
+      }
+
+      return c.json(formatCredential(row));
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const credentialId = c.req.param("credentialId");
-    const db = c.get("db");
+  );
 
-    const deleted = await db
-      .delete(credential)
-      .where(
-        and(
-          eq(credential.id, credentialId),
-          eq(credential.tenantId, tenantCtx.id),
-        ),
-      )
-      .returning();
+  app.get(
+    "/:credentialId",
+    requireGrant(idResource("credential", "credentialId"), "read"),
+    describeRoute({
+      tags: ["Credentials"],
+      summary: "Get credential metadata",
+      description:
+        "Returns credential metadata. The secret is never included. Supports hierarchy-aware access.",
+      responses: {
+        200: {
+          description: "Credential metadata",
+          content: {
+            "application/json": { schema: resolver(CredentialResponse) },
+          },
+        },
+        404: {
+          description: "Credential not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const credentialId = c.req.param("credentialId");
 
-    if (deleted.length === 0) {
-      return c.json(
-        { error: { code: "not_found", message: "Credential not found" } },
-        404,
-      );
-    }
+      const row = await db.query.credential.findFirst({
+        where: eq(credential.id, credentialId),
+      });
 
-    return c.body(null, 204);
-  },
-);
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Credential not found" } },
+          404,
+        );
+      }
 
-export { app as credentialRoutes };
+      const chain = await getAncestorChain(db, tenantCtx.id);
+      if (!chain.includes(row.tenantId)) {
+        return c.json(
+          { error: { code: "not_found", message: "Credential not found" } },
+          404,
+        );
+      }
+
+      return c.json(formatCredential(row));
+    },
+  );
+
+  app.patch(
+    "/:credentialId",
+    requireGrant(idResource("credential", "credentialId"), "manage"),
+    describeRoute({
+      tags: ["Credentials"],
+      summary: "Rotate or update a credential",
+      description: "Only credentials owned by this tenant can be updated.",
+      responses: {
+        200: {
+          description: "Credential updated",
+          content: {
+            "application/json": { schema: resolver(CredentialResponse) },
+          },
+        },
+        404: {
+          description: "Credential not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    validator("json", UpdateCredential),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const credentialId = c.req.param("credentialId");
+      const body = c.req.valid("json");
+
+      const updates: Record<string, unknown> = { updatedAt: new Date() };
+      if (body.name !== undefined) updates["name"] = body.name;
+      if (body.description !== undefined)
+        updates["description"] = body.description;
+      if (body.secret !== undefined) updates["secret"] = body.secret;
+      if (body.refreshSecret !== undefined)
+        updates["refreshSecret"] = body.refreshSecret;
+      if (body.scopes !== undefined) updates["scopes"] = body.scopes;
+      if (body.expiresAt !== undefined)
+        updates["expiresAt"] = body.expiresAt ? new Date(body.expiresAt) : null;
+      if (body.status !== undefined) updates["status"] = body.status;
+      if (body.metadata !== undefined) updates["metadata"] = body.metadata;
+
+      const [updated] = await db
+        .update(credential)
+        .set(updates)
+        .where(
+          and(
+            eq(credential.id, credentialId),
+            eq(credential.tenantId, tenantCtx.id),
+          ),
+        )
+        .returning();
+
+      if (!updated) {
+        return c.json(
+          { error: { code: "not_found", message: "Credential not found" } },
+          404,
+        );
+      }
+
+      // If the secret was updated, push new provider config to running instances.
+      if (body.secret !== undefined) {
+        void pushProviderUpdates(db, sidecarRouter, updated.tenantId);
+      }
+
+      return c.json(formatCredential(updated));
+    },
+  );
+
+  app.delete(
+    "/:credentialId",
+    requireGrant(idResource("credential", "credentialId"), "manage"),
+    describeRoute({
+      tags: ["Credentials"],
+      summary: "Revoke a credential",
+      description: "Only credentials owned by this tenant can be revoked.",
+      responses: {
+        204: {
+          description: "Credential revoked",
+        },
+        404: {
+          description: "Credential not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const credentialId = c.req.param("credentialId");
+
+      const deleted = await db
+        .delete(credential)
+        .where(
+          and(
+            eq(credential.id, credentialId),
+            eq(credential.tenantId, tenantCtx.id),
+          ),
+        )
+        .returning();
+
+      if (deleted.length === 0) {
+        return c.json(
+          { error: { code: "not_found", message: "Credential not found" } },
+          404,
+        );
+      }
+
+      return c.body(null, 204);
+    },
+  );
+
+  return app;
+}

--- a/packages/hub/src/routes/credentials.ts
+++ b/packages/hub/src/routes/credentials.ts
@@ -20,7 +20,8 @@ import {
 import type { TenantEnv } from "../context";
 import { first, ts } from "../format";
 import { generateId } from "../ids";
-import { requireGrant, idResource } from "../middleware/grant";
+import { idResource } from "../middleware/grant";
+import type { RequireGrant } from "../middleware/grant";
 import {
   parsePageParams,
   cursorCondition,
@@ -54,11 +55,13 @@ function formatCredential(row: typeof credential.$inferSelect) {
 export type CreateCredentialRoutesDeps = {
   db: DB["db"];
   sidecarRouter: SidecarRouter;
+  requireGrant: RequireGrant;
 };
 
 export function createCredentialRoutes({
   db,
   sidecarRouter,
+  requireGrant,
 }: CreateCredentialRoutesDeps): Hono<TenantEnv> {
   const app = new Hono<TenantEnv>();
 

--- a/packages/hub/src/routes/grants.ts
+++ b/packages/hub/src/routes/grants.ts
@@ -5,6 +5,8 @@ import { describeRoute, resolver, validator } from "hono-openapi";
 import { authorize } from "@interchange/authz";
 import { grant, principal } from "@interchange/db/schema";
 import { parseGrantRow } from "@interchange/db";
+import type { DB } from "@interchange/db";
+import type { ConditionRegistry, GrantStore } from "@interchange/types/authz";
 import {
   CreateGrant,
   UpdateGrant,
@@ -145,348 +147,360 @@ async function resolveGrantNames(
   return { roleNames, principalNames };
 }
 
-const app = new Hono<TenantEnv>();
+export type CreateGrantRoutesDeps = {
+  db: DB["db"];
+};
 
-app.get(
-  "/",
-  requireGrant("grant:*", "read"),
-  describeRoute({
-    tags: ["Grants"],
-    summary: "List grants in the tenant",
-    description:
-      "Lists all grants. Filterable by principalId, roleId, resource pattern, and effect.",
-    parameters: [
-      { name: "principalId", in: "query", schema: { type: "string" } },
-      { name: "roleId", in: "query", schema: { type: "string" } },
-      { name: "resource", in: "query", schema: { type: "string" } },
-      {
-        name: "effect",
-        in: "query",
-        schema: { type: "string", enum: ["allow", "deny", "ask"] },
-      },
-      ...pageParameters,
-    ],
-    responses: {
-      200: {
-        description: "List of grants",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(GrantResponse)),
-          },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
+export function createGrantRoutes({
+  db,
+}: CreateGrantRoutesDeps): Hono<TenantEnv> {
+  const app = new Hono<TenantEnv>();
 
-    const principalId = c.req.query("principalId");
-    const roleId = c.req.query("roleId");
-    const resource = c.req.query("resource");
-    const effect = c.req.query("effect");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
-
-    const conditions = [eq(grant.tenantId, tenantCtx.id)];
-    if (principalId) conditions.push(eq(grant.principalId, principalId));
-    if (roleId) conditions.push(eq(grant.roleId, roleId));
-    if (resource) conditions.push(eq(grant.resource, resource));
-    if (effect === "allow" || effect === "deny" || effect === "ask") {
-      conditions.push(eq(grant.effect, effect));
-    }
-    if (cursor) {
-      conditions.push(cursorCondition(grant.createdAt, grant.id, cursor));
-    }
-
-    const rows = await db.query.grant.findMany({
-      where: and(...conditions),
-      orderBy: pageOrder(grant.createdAt, grant.id),
-      limit,
-    });
-
-    const names = await resolveGrantNames(db, rows);
-    return c.json(
-      paginatedResponse(
-        rows.map((g) => formatGrant(g, names)),
-        rows,
-        limit,
-      ),
-    );
-  },
-);
-
-app.post(
-  "/",
-  requireGrant("grant:*", "create"),
-  describeRoute({
-    tags: ["Grants"],
-    summary: "Create a grant",
-    description:
-      "Creates a grant targeting either a role or a principal directly. Exactly one of roleId or principalId must be provided.",
-    responses: {
-      201: {
-        description: "Grant created",
-        content: {
-          "application/json": { schema: resolver(GrantResponse) },
-        },
-      },
-      400: {
-        description: "Validation error",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", CreateGrant),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const body = c.req.valid("json");
-    const db = c.get("db");
-
-    if (!body.roleId && !body.principalId) {
-      return c.json(
+  app.get(
+    "/",
+    requireGrant("grant:*", "read"),
+    describeRoute({
+      tags: ["Grants"],
+      summary: "List grants in the tenant",
+      description:
+        "Lists all grants. Filterable by principalId, roleId, resource pattern, and effect.",
+      parameters: [
+        { name: "principalId", in: "query", schema: { type: "string" } },
+        { name: "roleId", in: "query", schema: { type: "string" } },
+        { name: "resource", in: "query", schema: { type: "string" } },
         {
-          error: {
-            code: "bad_request",
-            message: "Either roleId or principalId must be provided",
+          name: "effect",
+          in: "query",
+          schema: { type: "string", enum: ["allow", "deny", "ask"] },
+        },
+        ...pageParameters,
+      ],
+      responses: {
+        200: {
+          description: "List of grants",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(GrantResponse)),
+            },
           },
         },
-        400,
-      );
-    }
-
-    const now = new Date();
-    const row = first(
-      await db
-        .insert(grant)
-        .values({
-          id: generateId("grant"),
-          tenantId: tenantCtx.id,
-          roleId: body.roleId ?? null,
-          principalId: body.principalId ?? null,
-          resource: body.resource,
-          action: body.action,
-          effect: body.effect,
-          conditions: body.conditions ?? null,
-          origin: body.origin,
-          expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning(),
-    );
-
-    return c.json(formatGrant(row), 201);
-  },
-);
-
-app.get(
-  "/:grantId",
-  requireGrant(idResource("grant", "grantId"), "read"),
-  describeRoute({
-    tags: ["Grants"],
-    summary: "Get grant details",
-    responses: {
-      200: {
-        description: "Grant details",
-        content: {
-          "application/json": { schema: resolver(GrantResponse) },
-        },
       },
-      404: {
-        description: "Grant not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const grantId = c.req.param("grantId");
-    const db = c.get("db");
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
 
-    const row = await db.query.grant.findFirst({
-      where: and(eq(grant.id, grantId), eq(grant.tenantId, tenantCtx.id)),
-    });
+      const principalId = c.req.query("principalId");
+      const roleId = c.req.query("roleId");
+      const resource = c.req.query("resource");
+      const effect = c.req.query("effect");
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
 
-    if (!row) {
+      const conditions = [eq(grant.tenantId, tenantCtx.id)];
+      if (principalId) conditions.push(eq(grant.principalId, principalId));
+      if (roleId) conditions.push(eq(grant.roleId, roleId));
+      if (resource) conditions.push(eq(grant.resource, resource));
+      if (effect === "allow" || effect === "deny" || effect === "ask") {
+        conditions.push(eq(grant.effect, effect));
+      }
+      if (cursor) {
+        conditions.push(cursorCondition(grant.createdAt, grant.id, cursor));
+      }
+
+      const rows = await db.query.grant.findMany({
+        where: and(...conditions),
+        orderBy: pageOrder(grant.createdAt, grant.id),
+        limit,
+      });
+
+      const names = await resolveGrantNames(db, rows);
       return c.json(
-        { error: { code: "not_found", message: "Grant not found" } },
-        404,
+        paginatedResponse(
+          rows.map((g) => formatGrant(g, names)),
+          rows,
+          limit,
+        ),
       );
-    }
-
-    return c.json(formatGrant(row));
-  },
-);
-
-app.patch(
-  "/:grantId",
-  requireGrant(idResource("grant", "grantId"), "manage"),
-  describeRoute({
-    tags: ["Grants"],
-    summary: "Update a grant",
-    description: "Update effect, conditions, or expiry on an existing grant.",
-    responses: {
-      200: {
-        description: "Grant updated",
-        content: {
-          "application/json": { schema: resolver(GrantResponse) },
-        },
-      },
-      404: {
-        description: "Grant not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
     },
-  }),
-  validator("json", UpdateGrant),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const grantId = c.req.param("grantId");
-    const body = c.req.valid("json");
-    const db = c.get("db");
+  );
 
-    const updates: Record<string, unknown> = { updatedAt: new Date() };
-    if (body.effect !== undefined) updates["effect"] = body.effect;
-    if (body.conditions !== undefined) updates["conditions"] = body.conditions;
-    if (body.expiresAt !== undefined) {
-      updates["expiresAt"] = body.expiresAt ? new Date(body.expiresAt) : null;
-    }
-
-    const [updated] = await db
-      .update(grant)
-      .set(updates)
-      .where(and(eq(grant.id, grantId), eq(grant.tenantId, tenantCtx.id)))
-      .returning();
-
-    if (!updated) {
-      return c.json(
-        { error: { code: "not_found", message: "Grant not found" } },
-        404,
-      );
-    }
-
-    return c.json(formatGrant(updated));
-  },
-);
-
-app.delete(
-  "/:grantId",
-  requireGrant(idResource("grant", "grantId"), "manage"),
-  describeRoute({
-    tags: ["Grants"],
-    summary: "Revoke a grant",
-    responses: {
-      204: {
-        description: "Grant revoked",
-      },
-      404: {
-        description: "Grant not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
+  app.post(
+    "/",
+    requireGrant("grant:*", "create"),
+    describeRoute({
+      tags: ["Grants"],
+      summary: "Create a grant",
+      description:
+        "Creates a grant targeting either a role or a principal directly. Exactly one of roleId or principalId must be provided.",
+      responses: {
+        201: {
+          description: "Grant created",
+          content: {
+            "application/json": { schema: resolver(GrantResponse) },
+          },
+        },
+        400: {
+          description: "Validation error",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const grantId = c.req.param("grantId");
-    const db = c.get("db");
+    }),
+    validator("json", CreateGrant),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const body = c.req.valid("json");
 
-    const deleted = await db
-      .delete(grant)
-      .where(and(eq(grant.id, grantId), eq(grant.tenantId, tenantCtx.id)))
-      .returning();
+      if (!body.roleId && !body.principalId) {
+        return c.json(
+          {
+            error: {
+              code: "bad_request",
+              message: "Either roleId or principalId must be provided",
+            },
+          },
+          400,
+        );
+      }
 
-    if (deleted.length === 0) {
-      return c.json(
-        { error: { code: "not_found", message: "Grant not found" } },
-        404,
+      const now = new Date();
+      const row = first(
+        await db
+          .insert(grant)
+          .values({
+            id: generateId("grant"),
+            tenantId: tenantCtx.id,
+            roleId: body.roleId ?? null,
+            principalId: body.principalId ?? null,
+            resource: body.resource,
+            action: body.action,
+            effect: body.effect,
+            conditions: body.conditions ?? null,
+            origin: body.origin,
+            expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning(),
       );
-    }
 
-    return c.body(null, 204);
-  },
-);
+      return c.json(formatGrant(row), 201);
+    },
+  );
 
-export { app as grantRoutes };
+  app.get(
+    "/:grantId",
+    requireGrant(idResource("grant", "grantId"), "read"),
+    describeRoute({
+      tags: ["Grants"],
+      summary: "Get grant details",
+      responses: {
+        200: {
+          description: "Grant details",
+          content: {
+            "application/json": { schema: resolver(GrantResponse) },
+          },
+        },
+        404: {
+          description: "Grant not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const grantId = c.req.param("grantId");
+
+      const row = await db.query.grant.findFirst({
+        where: and(eq(grant.id, grantId), eq(grant.tenantId, tenantCtx.id)),
+      });
+
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Grant not found" } },
+          404,
+        );
+      }
+
+      return c.json(formatGrant(row));
+    },
+  );
+
+  app.patch(
+    "/:grantId",
+    requireGrant(idResource("grant", "grantId"), "manage"),
+    describeRoute({
+      tags: ["Grants"],
+      summary: "Update a grant",
+      description: "Update effect, conditions, or expiry on an existing grant.",
+      responses: {
+        200: {
+          description: "Grant updated",
+          content: {
+            "application/json": { schema: resolver(GrantResponse) },
+          },
+        },
+        404: {
+          description: "Grant not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    validator("json", UpdateGrant),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const grantId = c.req.param("grantId");
+      const body = c.req.valid("json");
+
+      const updates: Record<string, unknown> = { updatedAt: new Date() };
+      if (body.effect !== undefined) updates["effect"] = body.effect;
+      if (body.conditions !== undefined)
+        updates["conditions"] = body.conditions;
+      if (body.expiresAt !== undefined) {
+        updates["expiresAt"] = body.expiresAt ? new Date(body.expiresAt) : null;
+      }
+
+      const [updated] = await db
+        .update(grant)
+        .set(updates)
+        .where(and(eq(grant.id, grantId), eq(grant.tenantId, tenantCtx.id)))
+        .returning();
+
+      if (!updated) {
+        return c.json(
+          { error: { code: "not_found", message: "Grant not found" } },
+          404,
+        );
+      }
+
+      return c.json(formatGrant(updated));
+    },
+  );
+
+  app.delete(
+    "/:grantId",
+    requireGrant(idResource("grant", "grantId"), "manage"),
+    describeRoute({
+      tags: ["Grants"],
+      summary: "Revoke a grant",
+      responses: {
+        204: {
+          description: "Grant revoked",
+        },
+        404: {
+          description: "Grant not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const grantId = c.req.param("grantId");
+
+      const deleted = await db
+        .delete(grant)
+        .where(and(eq(grant.id, grantId), eq(grant.tenantId, tenantCtx.id)))
+        .returning();
+
+      if (deleted.length === 0) {
+        return c.json(
+          { error: { code: "not_found", message: "Grant not found" } },
+          404,
+        );
+      }
+
+      return c.body(null, 204);
+    },
+  );
+
+  return app;
+}
 
 // Evaluate endpoint is mounted under principals
-const evaluateApp = new Hono<TenantEnv>();
+export type CreateEvaluateRoutesDeps = {
+  db: DB["db"];
+  grantStore: GrantStore;
+  conditionRegistry: ConditionRegistry;
+};
 
-evaluateApp.post(
-  "/",
-  describeRoute({
-    tags: ["Grants"],
-    summary: "Evaluate grants for a principal",
-    description:
-      "Evaluates what would happen if a principal attempted an operation. Returns the resolved effect and all matching grants. Useful for debugging authorization.",
-    responses: {
-      200: {
-        description: "Evaluation result",
-        content: {
-          "application/json": { schema: resolver(EvaluateResult) },
+export function createEvaluateRoutes({
+  db,
+  grantStore,
+  conditionRegistry,
+}: CreateEvaluateRoutesDeps): Hono<TenantEnv> {
+  const evaluateApp = new Hono<TenantEnv>();
+
+  evaluateApp.post(
+    "/",
+    describeRoute({
+      tags: ["Grants"],
+      summary: "Evaluate grants for a principal",
+      description:
+        "Evaluates what would happen if a principal attempted an operation. Returns the resolved effect and all matching grants. Useful for debugging authorization.",
+      responses: {
+        200: {
+          description: "Evaluation result",
+          content: {
+            "application/json": { schema: resolver(EvaluateResult) },
+          },
+        },
+        404: {
+          description: "Principal not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-      404: {
-        description: "Principal not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", EvaluateRequest),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const principalId = c.req.param("principalId") ?? "";
-    const body = c.req.valid("json");
-    const db = c.get("db");
-    const grantStore = c.get("grantStore");
-    const conditionRegistry = c.get("conditionRegistry");
+    }),
+    validator("json", EvaluateRequest),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const principalId = c.req.param("principalId") ?? "";
+      const body = c.req.valid("json");
+      const principalRow = await db.query.principal.findFirst({
+        where: and(
+          eq(principal.id, principalId),
+          eq(principal.tenantId, tenantCtx.id),
+        ),
+      });
 
-    const principalRow = await db.query.principal.findFirst({
-      where: and(
-        eq(principal.id, principalId),
-        eq(principal.tenantId, tenantCtx.id),
-      ),
-    });
+      if (!principalRow) {
+        return c.json(
+          { error: { code: "not_found", message: "Principal not found" } },
+          404,
+        );
+      }
 
-    if (!principalRow) {
-      return c.json(
-        { error: { code: "not_found", message: "Principal not found" } },
-        404,
+      const result = await authorize(
+        grantStore,
+        principalId,
+        tenantCtx.id,
+        body.resource,
+        body.action,
+        conditionRegistry,
       );
-    }
 
-    const result = await authorize(
-      grantStore,
-      principalId,
-      tenantCtx.id,
-      body.resource,
-      body.action,
-      conditionRegistry,
-    );
+      return c.json({
+        effect: result.effect ?? "deny",
+        matchingGrants: result.matchingGrants.map((g) => ({
+          id: g.id,
+          resource: g.resource,
+          action: g.action,
+          effect: g.effect,
+          origin: g.origin,
+        })),
+      });
+    },
+  );
 
-    return c.json({
-      effect: result.effect ?? "deny",
-      matchingGrants: result.matchingGrants.map((g) => ({
-        id: g.id,
-        resource: g.resource,
-        action: g.action,
-        effect: g.effect,
-        origin: g.origin,
-      })),
-    });
-  },
-);
-
-export { evaluateApp as evaluateRoutes };
+  return evaluateApp;
+}

--- a/packages/hub/src/routes/grants.ts
+++ b/packages/hub/src/routes/grants.ts
@@ -20,7 +20,8 @@ import {
 import type { TenantEnv } from "../context";
 import { first, ts } from "../format";
 import { generateId } from "../ids";
-import { requireGrant, idResource } from "../middleware/grant";
+import { idResource } from "../middleware/grant";
+import type { RequireGrant } from "../middleware/grant";
 import {
   parsePageParams,
   cursorCondition,
@@ -57,7 +58,7 @@ function formatGrant(row: typeof grant.$inferSelect, names?: ResolvedNames) {
 }
 
 async function resolveGrantNames(
-  db: TenantEnv["Variables"]["db"],
+  db: DB["db"],
   grants: (typeof grant.$inferSelect)[],
 ): Promise<ResolvedNames> {
   const roleIds = [
@@ -149,10 +150,12 @@ async function resolveGrantNames(
 
 export type CreateGrantRoutesDeps = {
   db: DB["db"];
+  requireGrant: RequireGrant;
 };
 
 export function createGrantRoutes({
   db,
+  requireGrant,
 }: CreateGrantRoutesDeps): Hono<TenantEnv> {
   const app = new Hono<TenantEnv>();
 

--- a/packages/hub/src/routes/instances.ts
+++ b/packages/hub/src/routes/instances.ts
@@ -23,7 +23,9 @@ import {
   parseAgentSkills,
   ProviderMetadata,
 } from "@interchange/db";
+import type { DB } from "@interchange/db";
 import { evaluateGrants, authorize } from "@interchange/authz";
+import type { ConditionRegistry, GrantStore } from "@interchange/types/authz";
 import { parseMailToEmail, extractPartByPath } from "@interchange/mime";
 
 import { generateKeyPair, createNodeCrypto } from "@interchange/crypto-node";
@@ -47,6 +49,9 @@ import type {
   ProviderConfig,
 } from "@interchange/types/runtime";
 import { SessionLaunchError } from "../session-service";
+import type { SessionService } from "../session-service";
+import type { SidecarRouter } from "../ws/sidecar-handler";
+import type { EventCollectorRegistry } from "../event-collector-registry";
 import { formatOffering } from "./offerings";
 
 import type { TenantEnv } from "../context";
@@ -93,1659 +98,1658 @@ function formatInstance(
   };
 }
 
-const app = new Hono<TenantEnv>();
+export type CreateInstanceRoutesDeps = {
+  db: DB["db"];
+  sessionService: SessionService;
+  sidecarRouter: SidecarRouter;
+  eventCollectors: EventCollectorRegistry;
+  grantStore: GrantStore;
+  conditionRegistry: ConditionRegistry;
+};
 
-app.post(
-  "/",
-  requireGrant("instance:*", "create"),
-  describeRoute({
-    tags: ["Instances"],
-    summary: "Deploy an agent instance",
-    description:
-      "Creates a new running instance of the specified agent definition. Resolves the definition's credential and grant requirements, materializes grants on a new agent principal, provisions the agent on a sidecar, and starts it. The invoker can provide invokerGrants to delegate additional capabilities, resolved against the invoker's own authority at launch.",
-    responses: {
-      201: {
-        description: "Instance deployed",
-        content: {
-          "application/json": { schema: resolver(AgentInstanceResponse) },
-        },
-      },
-      404: {
-        description: "Agent definition not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      409: {
-        description: "Agent not launchable",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      502: {
-        description: "Sidecar unavailable",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", CreateAgentInstance),
-  async (c) => {
-    const tenant = c.get("tenant");
-    const principal = c.get("principal");
-    const db = c.get("db");
-    const sessionService = c.get("sessionService");
-    const body = c.req.valid("json");
+export function createInstanceRoutes({
+  db,
+  sessionService,
+  sidecarRouter,
+  eventCollectors,
+  grantStore,
+  conditionRegistry,
+}: CreateInstanceRoutesDeps): Hono<TenantEnv> {
+  const app = new Hono<TenantEnv>();
 
-    const row = await db.query.agent.findFirst({
-      where: and(eq(agent.id, body.agentId), eq(agent.tenantId, tenant.id)),
-    });
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Agent not found" } },
-        404,
-      );
-    }
-
-    if (row.status !== "deployed") {
-      return c.json(
-        {
-          error: {
-            code: "conflict",
-            message: `Agent is not in a launchable state (status: ${row.status})`,
+  app.post(
+    "/",
+    requireGrant("instance:*", "create"),
+    describeRoute({
+      tags: ["Instances"],
+      summary: "Deploy an agent instance",
+      description:
+        "Creates a new running instance of the specified agent definition. Resolves the definition's credential and grant requirements, materializes grants on a new agent principal, provisions the agent on a sidecar, and starts it. The invoker can provide invokerGrants to delegate additional capabilities, resolved against the invoker's own authority at launch.",
+      responses: {
+        201: {
+          description: "Instance deployed",
+          content: {
+            "application/json": { schema: resolver(AgentInstanceResponse) },
           },
         },
-        409,
-      );
-    }
-
-    if (!row.systemPrompt) {
-      return c.json(
-        {
-          error: {
-            code: "not_launchable",
-            message:
-              "Agent cannot be launched without a system prompt configured",
+        404: {
+          description: "Agent definition not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
           },
         },
-        409,
-      );
-    }
-
-    const instanceId = generateId("instance");
-    const agentAddress = formatAgentAddress(instanceId, tenant.domain);
-
-    // --- Credential resolution ---
-
-    const parsedRequirements = CredentialRequirements(
-      row.credentialRequirements ?? [],
-    );
-    if (parsedRequirements instanceof type.errors) {
-      return c.json(
-        {
-          error: {
-            code: "not_launchable",
-            message: `Invalid credential requirements: ${parsedRequirements.summary}`,
+        409: {
+          description: "Agent not launchable",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
           },
         },
-        409,
-      );
-    }
-
-    const creatorPrincipalId = row.creatorPrincipalId;
-    if (!creatorPrincipalId) {
-      return c.json(
-        {
-          error: {
-            code: "not_launchable",
-            message:
-              "Definition has no creator principal for credential resolution",
+        502: {
+          description: "Sidecar unavailable",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
           },
         },
-        409,
-      );
-    }
+      },
+    }),
+    validator("json", CreateAgentInstance),
+    async (c) => {
+      const tenant = c.get("tenant");
+      const principal = c.get("principal");
+      const body = c.req.valid("json");
 
-    const providers: ProviderConfig[] = [];
-    for (const req of parsedRequirements) {
-      let resolved;
+      const row = await db.query.agent.findFirst({
+        where: and(eq(agent.id, body.agentId), eq(agent.tenantId, tenant.id)),
+      });
+
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Agent not found" } },
+          404,
+        );
+      }
+
+      if (row.status !== "deployed") {
+        return c.json(
+          {
+            error: {
+              code: "conflict",
+              message: `Agent is not in a launchable state (status: ${row.status})`,
+            },
+          },
+          409,
+        );
+      }
+
+      if (!row.systemPrompt) {
+        return c.json(
+          {
+            error: {
+              code: "not_launchable",
+              message:
+                "Agent cannot be launched without a system prompt configured",
+            },
+          },
+          409,
+        );
+      }
+
+      const instanceId = generateId("instance");
+      const agentAddress = formatAgentAddress(instanceId, tenant.domain);
+
+      // --- Credential resolution ---
+
+      const parsedRequirements = CredentialRequirements(
+        row.credentialRequirements ?? [],
+      );
+      if (parsedRequirements instanceof type.errors) {
+        return c.json(
+          {
+            error: {
+              code: "not_launchable",
+              message: `Invalid credential requirements: ${parsedRequirements.summary}`,
+            },
+          },
+          409,
+        );
+      }
+
+      const creatorPrincipalId = row.creatorPrincipalId;
+      if (!creatorPrincipalId) {
+        return c.json(
+          {
+            error: {
+              code: "not_launchable",
+              message:
+                "Definition has no creator principal for credential resolution",
+            },
+          },
+          409,
+        );
+      }
+
+      const providers: ProviderConfig[] = [];
+      for (const req of parsedRequirements) {
+        let resolved;
+        try {
+          resolved = await resolveCredentialRequirement(
+            db,
+            tenant.id,
+            req,
+            creatorPrincipalId,
+            principal.id,
+          );
+        } catch (err) {
+          return c.json(
+            {
+              error: {
+                code: "credential_error",
+                message:
+                  err instanceof Error
+                    ? err.message
+                    : "Credential resolution failed",
+              },
+            },
+            409,
+          );
+        }
+
+        if (!resolved) {
+          return c.json(
+            {
+              error: {
+                code: "credential_missing",
+                message: `No credential found for provider "${req.providerName}" (source: ${req.source})`,
+              },
+            },
+            409,
+          );
+        }
+
+        const providerRow = await db.query.provider.findFirst({
+          where: eq(provider.id, resolved.providerId),
+        });
+
+        if (!providerRow) {
+          return c.json(
+            {
+              error: {
+                code: "provider_missing",
+                message: `Provider not found for credential "${resolved.id}"`,
+              },
+            },
+            409,
+          );
+        }
+
+        const metadata = ProviderMetadata(providerRow.metadata ?? {});
+        if (metadata instanceof type.errors) {
+          return c.json(
+            {
+              error: {
+                code: "provider_misconfigured",
+                message: `Provider "${providerRow.name}" metadata is invalid: ${metadata.summary}`,
+              },
+            },
+            409,
+          );
+        }
+
+        providers.push({
+          provider: providerRow.plugin,
+          baseURL: metadata.baseURL,
+          apiKey: resolved.secret,
+        });
+      }
+
+      // --- Model config ---
+
+      const modelConfig = ModelConfig(row.modelConfig ?? {});
+      if (modelConfig instanceof type.errors) {
+        return c.json(
+          {
+            error: {
+              code: "not_launchable",
+              message: `Agent model configuration is invalid: ${modelConfig.summary}`,
+            },
+          },
+          409,
+        );
+      }
+
+      // --- Grant requirement resolution (creator/invoker delegation) ---
+
+      const instancePrincipalId = generateId("principal");
+
+      // Collect invoker's grants once — used for both creator and invoker resolution.
+      const invokerGrants = await grantStore.collectGrants(
+        principal.id,
+        tenant.id,
+      );
+      // Only system/role/creator grants can be delegated. Invoker-sourced
+      // grants cannot be transitively re-delegated.
+      const delegatableInvokerGrants = invokerGrants.filter(
+        (g) => g.origin !== "invoker",
+      );
+
+      // Accumulate grant rows in memory; write to DB only after all
+      // requirements resolve. This avoids orphaned rows on partial failure.
+      const grantRows: {
+        id: string;
+        tenantId: string;
+        principalId: string;
+        resource: string;
+        action: string;
+        effect: GrantEffect;
+        conditions: Record<string, unknown> | null;
+        origin: GrantOrigin;
+        expiresAt: Date | null;
+        createdAt: Date;
+        updatedAt: Date;
+      }[] = [];
+
+      const now = new Date();
+      const INVOKER_GRANT_TTL_MS = 24 * 60 * 60 * 1000;
+      const invokerExpiresAt = new Date(now.getTime() + INVOKER_GRANT_TTL_MS);
+
+      const parsedGrantReqs = GrantRequirements(row.grantRequirements ?? []);
+      if (parsedGrantReqs instanceof type.errors) {
+        return c.json(
+          {
+            error: {
+              code: "not_launchable",
+              message: `Invalid grant requirements: ${parsedGrantReqs.summary}`,
+            },
+          },
+          409,
+        );
+      }
+
+      // Collect creator's grants once for all creator-sourced requirements.
+      const hasCreatorReqs = parsedGrantReqs.some(
+        (r) => r.source === "creator",
+      );
+      const creatorGrants = hasCreatorReqs
+        ? await grantStore.collectGrants(creatorPrincipalId, tenant.id)
+        : [];
+
+      for (const req of parsedGrantReqs) {
+        const effect = req.effect ?? "allow";
+
+        if (req.source === "creator") {
+          const result = await evaluateGrants(
+            creatorGrants,
+            req.resource,
+            req.action,
+          );
+          if (result.effect !== "allow") {
+            return c.json(
+              {
+                error: {
+                  code: "insufficient_grants",
+                  message: `Creator lacks authority to delegate ${req.resource}/${req.action}`,
+                },
+              },
+              403,
+            );
+          }
+          grantRows.push({
+            id: generateId("grant"),
+            tenantId: tenant.id,
+            principalId: instancePrincipalId,
+            resource: req.resource,
+            action: req.action,
+            effect,
+            conditions: req.conditions ?? null,
+            origin: "creator",
+            expiresAt: null,
+            createdAt: now,
+            updatedAt: now,
+          });
+        } else if (req.source === "invoker") {
+          const result = await evaluateGrants(
+            delegatableInvokerGrants,
+            req.resource,
+            req.action,
+          );
+          if (result.effect !== "allow") {
+            return c.json(
+              {
+                error: {
+                  code: "insufficient_grants",
+                  message: `Invoker lacks authority for ${req.resource}/${req.action}`,
+                },
+              },
+              403,
+            );
+          }
+          grantRows.push({
+            id: generateId("grant"),
+            tenantId: tenant.id,
+            principalId: instancePrincipalId,
+            resource: req.resource,
+            action: req.action,
+            effect,
+            conditions: req.conditions ?? null,
+            origin: "invoker",
+            expiresAt: invokerExpiresAt,
+            createdAt: now,
+            updatedAt: now,
+          });
+        } else {
+          return c.json(
+            {
+              error: {
+                code: "not_launchable",
+                message: `Unknown grant requirement source: ${req.source}`,
+              },
+            },
+            409,
+          );
+        }
+      }
+
+      // Process ad-hoc invoker grants from the launch request.
+      if (body.invokerGrants) {
+        for (const ig of body.invokerGrants) {
+          const effect = ig.effect ?? "allow";
+          const result = await evaluateGrants(
+            delegatableInvokerGrants,
+            ig.resource,
+            ig.action,
+          );
+          if (result.effect !== "allow") {
+            return c.json(
+              {
+                error: {
+                  code: "insufficient_grants",
+                  message: `Invoker lacks authority for ${ig.resource}/${ig.action}`,
+                },
+              },
+              403,
+            );
+          }
+          grantRows.push({
+            id: generateId("grant"),
+            tenantId: tenant.id,
+            principalId: instancePrincipalId,
+            resource: ig.resource,
+            action: ig.action,
+            effect,
+            conditions: ig.conditions ?? null,
+            origin: "invoker",
+            expiresAt: invokerExpiresAt,
+            createdAt: now,
+            updatedAt: now,
+          });
+        }
+      }
+
+      // --- Resolve agent role assignments for the instance principal ---
+
+      const agentRoleRows = await db.query.agentRole.findMany({
+        where: eq(agentRole.agentId, row.id),
+      });
+      const agentRoleIds = agentRoleRows.map((a) => a.roleId);
+      const agentRoleAssignments =
+        agentRoleIds.length > 0
+          ? (
+              await db.query.role.findMany({
+                where: (r, { inArray, and: a }) =>
+                  a(inArray(r.id, agentRoleIds), eq(r.tenantId, tenant.id)),
+                columns: { id: true },
+              })
+            ).map((r) => ({ roleId: r.id }))
+          : [];
+
+      // --- Write all DB rows in a transaction ---
+
+      const sessionId = generateId("session");
+
+      await db.transaction(async (tx) => {
+        // Create per-instance principal
+        await tx.insert(principalTable).values({
+          id: instancePrincipalId,
+          tenantId: tenant.id,
+          kind: "agent",
+          refId: instanceId,
+          status: "active",
+          createdAt: now,
+          updatedAt: now,
+        });
+
+        // Assign the agent definition's roles to the instance principal so
+        // that grants flow through the existing RBAC path (collectGrants).
+        for (const { roleId } of agentRoleAssignments) {
+          await tx.insert(principalRole).values({
+            principalId: instancePrincipalId,
+            roleId,
+            createdAt: now,
+          });
+        }
+
+        // Materialize grants on the instance principal
+        for (const g of grantRows) {
+          await tx.insert(grantTable).values(g);
+        }
+
+        // Transitional agentSession row (FK requirement)
+        await tx.insert(agentSession).values({
+          id: sessionId,
+          tenantId: tenant.id,
+          agentId: row.id,
+          principalId: principal.id,
+          status: "active",
+          createdAt: now,
+          updatedAt: now,
+        });
+
+        // Create instance row
+        await tx.insert(agentInstance).values({
+          id: instanceId,
+          agentId: row.id,
+          tenantId: tenant.id,
+          principalId: instancePrincipalId,
+          address: agentAddress,
+          sessionId,
+          status: "deployed",
+          createdAt: now,
+          updatedAt: now,
+        });
+      });
+
+      // Collect the materialized grants for the deploy frame
+      const grants = await grantStore.collectGrants(
+        instancePrincipalId,
+        tenant.id,
+      );
+
+      eventCollectors.create(agentAddress, tenant.id, sessionId, instanceId);
+
+      const skills = parseAgentSkills(row.skills);
+
       try {
-        resolved = await resolveCredentialRequirement(
-          db,
-          tenant.id,
-          req,
-          creatorPrincipalId,
-          principal.id,
+        await sessionService.launchSession({
+          agentAddress,
+          agentId: row.id,
+          config: {
+            sessionId,
+            agentId: row.id,
+            tenantId: tenant.id,
+            principalId: instancePrincipalId,
+            agentAddress,
+            systemPrompt: row.systemPrompt,
+            tools: [],
+            grants,
+            providers,
+            defaultModel: modelConfig.defaultModel,
+          },
+          deployContent: {
+            systemPrompt: row.systemPrompt,
+            skills,
+          },
+        });
+      } catch (err) {
+        eventCollectors.abandon(agentAddress);
+
+        const failedAt = new Date();
+
+        await db
+          .update(agentSession)
+          .set({ status: "ended", endedAt: failedAt, updatedAt: failedAt })
+          .where(eq(agentSession.id, sessionId));
+
+        const leaked = err instanceof SessionLaunchError && err.leakedAgent;
+
+        if (leaked) {
+          await db
+            .update(agentInstance)
+            .set({ status: "error", updatedAt: failedAt })
+            .where(eq(agentInstance.id, instanceId));
+        } else {
+          await db
+            .delete(agentInstance)
+            .where(eq(agentInstance.id, instanceId));
+        }
+
+        // Deactivate the instance principal created during this launch
+        await db
+          .update(principalTable)
+          .set({ status: "deactivated", updatedAt: failedAt })
+          .where(eq(principalTable.id, instancePrincipalId));
+
+        return c.json(
+          {
+            error: {
+              code: "sidecar_unavailable",
+              message:
+                err instanceof Error
+                  ? err.message
+                  : "Failed to dispatch agent to sidecar",
+            },
+          },
+          502,
+        );
+      }
+
+      const launchedAt = new Date();
+
+      const launched = first(
+        await db
+          .update(agentInstance)
+          .set({ status: "running", updatedAt: launchedAt })
+          .where(eq(agentInstance.id, instanceId))
+          .returning(),
+      );
+
+      return c.json(formatInstance(launched, row.name), 201);
+    },
+  );
+
+  app.get(
+    "/",
+    requireGrant("instance:*", "read"),
+    describeRoute({
+      tags: ["Instances"],
+      summary: "List agent instances",
+      description:
+        "Lists agent instances in the tenant. Filterable by agentId and status.",
+      parameters: [
+        { name: "agentId", in: "query", schema: { type: "string" } },
+        {
+          name: "status",
+          in: "query",
+          schema: {
+            type: "string",
+            enum: ["deployed", "running", "updating", "error", "stopped"],
+          },
+        },
+        ...pageParameters,
+      ],
+      responses: {
+        200: {
+          description: "List of instances",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(AgentInstanceResponse)),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const agentId = c.req.query("agentId");
+      const status = c.req.query("status");
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
+
+      const conditions = [eq(agentInstance.tenantId, tenantCtx.id)];
+      if (agentId !== undefined) {
+        conditions.push(eq(agentInstance.agentId, agentId));
+      }
+      if (
+        status === "deployed" ||
+        status === "running" ||
+        status === "updating" ||
+        status === "error" ||
+        status === "stopped"
+      ) {
+        conditions.push(eq(agentInstance.status, status));
+      }
+      if (cursor) {
+        conditions.push(
+          cursorCondition(agentInstance.createdAt, agentInstance.id, cursor),
+        );
+      }
+
+      const rows = await db
+        .select({
+          instance: agentInstance,
+          agentName: agent.name,
+        })
+        .from(agentInstance)
+        .innerJoin(agent, eq(agentInstance.agentId, agent.id))
+        .where(and(...conditions))
+        .orderBy(...pageOrder(agentInstance.createdAt, agentInstance.id))
+        .limit(limit);
+
+      return c.json(
+        paginatedResponse(
+          rows.map((r) => formatInstance(r.instance, r.agentName)),
+          rows.map((r) => r.instance),
+          limit,
+        ),
+      );
+    },
+  );
+
+  app.get(
+    "/blobs/:blobId",
+    describeRoute({
+      tags: ["Instances"],
+      summary: "Fetch a blob by ID",
+      description:
+        "Returns raw bytes for a MIME part. Blob IDs are issued by the mail parsing layer.",
+      responses: {
+        200: {
+          description: "Blob bytes",
+          content: { "application/octet-stream": {} },
+        },
+        400: {
+          description: "Invalid blob ID",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        403: {
+          description: "Forbidden",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        404: {
+          description: "Blob not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const blobId = c.req.param("blobId");
+
+      // Blob IDs have the format: blob_<mailId>_<partPath>
+      // where partPath is an IMAP-style section specifier (digits and dots only).
+      // mailId may itself contain underscores, so we match the suffix.
+      const blobMatch = /^blob_(.+?)_(\d[\d.]*)$/.exec(blobId);
+      if (!blobMatch) {
+        return c.json(
+          { error: { code: "bad_request", message: "Invalid blob ID format" } },
+          400,
+        );
+      }
+
+      const mailId = blobMatch[1];
+      const partPath = blobMatch[2];
+
+      if (!mailId || !partPath) {
+        return c.json(
+          { error: { code: "bad_request", message: "Invalid blob ID format" } },
+          400,
+        );
+      }
+
+      const tenant = c.get("tenant");
+
+      const mailRow = await db.query.sessionMail.findFirst({
+        where: and(
+          eq(sessionMail.id, mailId),
+          eq(sessionMail.tenantId, tenant.id),
+        ),
+      });
+
+      if (!mailRow) {
+        return c.json(
+          { error: { code: "not_found", message: "Blob not found" } },
+          404,
+        );
+      }
+
+      const resolvedInstanceId = mailRow.instanceId;
+      if (!resolvedInstanceId) {
+        return c.json(
+          { error: { code: "not_found", message: "Blob not found" } },
+          404,
+        );
+      }
+
+      const principal = c.get("principal");
+
+      const authResult = await authorize(
+        grantStore,
+        principal.id,
+        tenant.id,
+        `instance:${resolvedInstanceId}`,
+        "read",
+        conditionRegistry,
+      );
+
+      if (authResult.effect !== "allow") {
+        return c.json(
+          {
+            error: {
+              code: "forbidden",
+              message: "You do not have permission to perform this action",
+            },
+          },
+          403,
+        );
+      }
+
+      let partBytes: Uint8Array;
+      try {
+        partBytes = extractPartByPath(mailRow.raw, partPath);
+      } catch {
+        return c.json(
+          { error: { code: "not_found", message: "Blob not found" } },
+          404,
+        );
+      }
+
+      return c.body(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Uint8Array.buffer.slice always returns ArrayBuffer
+        partBytes.buffer.slice(
+          partBytes.byteOffset,
+          partBytes.byteOffset + partBytes.byteLength,
+        ) as ArrayBuffer,
+        200,
+        {
+          "Content-Type": "application/octet-stream",
+        },
+      );
+    },
+  );
+
+  app.get(
+    "/:instanceId",
+    requireGrant(idResource("instance", "instanceId"), "read"),
+    describeRoute({
+      tags: ["Instances"],
+      summary: "Get instance detail",
+      description:
+        "Returns instance runtime state including status, public key, and sidecar assignment.",
+      responses: {
+        200: {
+          description: "Instance detail",
+          content: {
+            "application/json": { schema: resolver(AgentInstanceResponse) },
+          },
+        },
+        404: {
+          description: "Instance not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const instanceId = c.req.param("instanceId");
+
+      const [row] = await db
+        .select({
+          instance: agentInstance,
+          agentName: agent.name,
+        })
+        .from(agentInstance)
+        .innerJoin(agent, eq(agentInstance.agentId, agent.id))
+        .where(
+          and(
+            eq(agentInstance.id, instanceId),
+            eq(agentInstance.tenantId, tenantCtx.id),
+          ),
+        )
+        .limit(1);
+
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Instance not found" } },
+          404,
+        );
+      }
+
+      const result = formatInstance(row.instance, row.agentName) as Record<
+        string,
+        unknown
+      >;
+
+      // Enrich with runtime status from the event collector if available.
+      const runtimeStatus = eventCollectors.getStatus(row.instance.address);
+      if (runtimeStatus !== undefined) {
+        result["runtimeStatus"] = runtimeStatus.status;
+      }
+
+      return c.json(result);
+    },
+  );
+
+  app.get(
+    "/:instanceId/health",
+    requireGrant(idResource("instance", "instanceId"), "read"),
+    describeRoute({
+      tags: ["Instances"],
+      summary: "Get instance health",
+      description:
+        "Returns liveness and readiness for a running instance. Liveness reflects whether the instance's sidecar connection is active. Readiness reflects whether the instance has an active event collector and can process work.",
+      responses: {
+        200: {
+          description: "Health status",
+          content: {
+            "application/json": { schema: resolver(AgentHealth) },
+          },
+        },
+        404: {
+          description: "Instance not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        410: {
+          description: "Instance stopped",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const instanceId = c.req.param("instanceId");
+
+      const row = await db.query.agentInstance.findFirst({
+        where: and(
+          eq(agentInstance.id, instanceId),
+          eq(agentInstance.tenantId, tenantCtx.id),
+        ),
+      });
+
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Instance not found" } },
+          404,
+        );
+      }
+
+      if (row.status === "stopped") {
+        return c.json(
+          { error: { code: "gone", message: "Instance has stopped" } },
+          410,
+        );
+      }
+
+      const routableAddresses = sidecarRouter.getRoutableAddresses();
+      const liveness = routableAddresses.includes(row.address)
+        ? "ok"
+        : "unhealthy";
+
+      const status = eventCollectors.getStatus(row.address);
+      const readiness = status !== undefined ? "ok" : "not_ready";
+
+      return c.json({ liveness, readiness, lastCheckedAt: null });
+    },
+  );
+
+  app.get(
+    "/:instanceId/offerings",
+    requireGrant(idResource("instance", "instanceId"), "read"),
+    describeRoute({
+      tags: ["Instances"],
+      summary: "List instance offerings",
+      description:
+        "Returns the offerings associated with the instance's agent definition. These represent the capabilities the instance can provide.",
+      responses: {
+        200: {
+          description: "List of offerings",
+          content: {
+            "application/json": {
+              schema: resolver(OfferingDetail.array()),
+            },
+          },
+        },
+        404: {
+          description: "Instance not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const instanceId = c.req.param("instanceId");
+
+      const [row] = await db
+        .select({
+          instance: agentInstance,
+          agentName: agent.name,
+        })
+        .from(agentInstance)
+        .innerJoin(agent, eq(agentInstance.agentId, agent.id))
+        .where(
+          and(
+            eq(agentInstance.id, instanceId),
+            eq(agentInstance.tenantId, tenantCtx.id),
+          ),
+        )
+        .limit(1);
+
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Instance not found" } },
+          404,
+        );
+      }
+
+      const offerings = await db.query.offering.findMany({
+        where: and(
+          eq(offering.agentId, row.instance.agentId),
+          eq(offering.tenantId, tenantCtx.id),
+        ),
+      });
+
+      return c.json(offerings.map((o) => formatOffering(o, row.agentName)));
+    },
+  );
+
+  app.delete(
+    "/:instanceId",
+    requireGrant(idResource("instance", "instanceId"), "manage"),
+    describeRoute({
+      tags: ["Instances"],
+      summary: "Stop an instance",
+      description:
+        "Stops the running instance and undeploys the agent from the sidecar.",
+      responses: {
+        204: {
+          description: "Instance stopped",
+        },
+        404: {
+          description: "Instance not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        409: {
+          description: "Instance already stopped",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        502: {
+          description: "Sidecar unavailable",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const instanceId = c.req.param("instanceId");
+
+      const row = await db.query.agentInstance.findFirst({
+        where: and(
+          eq(agentInstance.id, instanceId),
+          eq(agentInstance.tenantId, tenantCtx.id),
+        ),
+      });
+
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Instance not found" } },
+          404,
+        );
+      }
+
+      if (row.status === "stopped") {
+        return c.json(
+          {
+            error: {
+              code: "conflict",
+              message: "Instance is already stopped",
+            },
+          },
+          409,
+        );
+      }
+
+      try {
+        await sessionService.endSession(row.address, "instance_stopped");
+      } catch (err) {
+        return c.json(
+          {
+            error: {
+              code: "sidecar_unavailable",
+              message:
+                err instanceof Error
+                  ? err.message
+                  : "Failed to reach sidecar for instance teardown",
+            },
+          },
+          502,
+        );
+      }
+
+      const endedAt = new Date();
+
+      await db
+        .update(agentInstance)
+        .set({
+          status: "stopped",
+          sessionId: null,
+          updatedAt: endedAt,
+          endedAt,
+        })
+        .where(eq(agentInstance.id, instanceId));
+
+      // Deactivate the per-instance principal. The refId guard ensures we
+      // only deactivate the principal created for this specific instance.
+      await db
+        .update(principalTable)
+        .set({ status: "deactivated", updatedAt: endedAt })
+        .where(
+          and(
+            eq(principalTable.id, row.principalId),
+            eq(principalTable.refId, instanceId),
+          ),
+        );
+
+      // End associated session rows.
+      if (row.sessionId) {
+        await db
+          .update(agentSession)
+          .set({ status: "ended", endedAt, updatedAt: endedAt })
+          .where(eq(agentSession.id, row.sessionId));
+      }
+
+      eventCollectors.abandon(row.address);
+      instanceKeyCache.delete(instanceId);
+
+      sidecarRouter.dispatchAgentEvent(row.address, {
+        type: "session.ended",
+      });
+
+      return c.body(null, 204);
+    },
+  );
+
+  app.get(
+    "/:instanceId/events",
+    requireGrant(idResource("instance", "instanceId"), "read"),
+    describeRoute({
+      tags: ["Instances"],
+      summary: "SSE event stream",
+      description:
+        "Server-Sent Events stream for agent events. Use POST .../messages for client-to-server messaging.",
+      responses: {
+        200: {
+          description: "SSE event stream",
+          content: {
+            "text/event-stream": {},
+          },
+        },
+        404: {
+          description: "Instance not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        410: {
+          description: "Instance stopped",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const instanceId = c.req.param("instanceId");
+
+      const row = await db.query.agentInstance.findFirst({
+        where: and(
+          eq(agentInstance.id, instanceId),
+          eq(agentInstance.tenantId, tenantCtx.id),
+        ),
+      });
+
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Instance not found" } },
+          404,
+        );
+      }
+
+      if (row.status === "stopped") {
+        return c.json(
+          { error: { code: "gone", message: "Instance has stopped" } },
+          410,
+        );
+      }
+
+      return streamSSE(c, async (stream) => {
+        const noop = () => undefined;
+
+        // Emit the replay before subscribing to live events so that a
+        // delta arriving between subscribe() and the replay write cannot
+        // beat the catch-up text onto the stream.
+        const status = eventCollectors.getStatus(row.address);
+        if (status?.status === "busy") {
+          await stream.writeSSE({
+            event: "agent.event",
+            data: JSON.stringify({
+              type: "inference.start",
+              seq: 0,
+              data: { model: "unknown" },
+            }),
+          });
+        }
+        const accumulatedText = eventCollectors.getAccumulatedText(row.address);
+        if (accumulatedText !== undefined && accumulatedText !== "") {
+          const turnId = eventCollectors.getLastTurnId(row.address);
+          await stream.writeSSE({
+            event: "agent.event",
+            data: JSON.stringify({
+              type: "inference.text.replay",
+              data: { turnId, text: accumulatedText },
+            }),
+          });
+        }
+
+        const unsubscribe = sidecarRouter.subscribeAgent(
+          row.address,
+          (event) => {
+            stream
+              .writeSSE({
+                event: "agent.event",
+                data: JSON.stringify(event),
+              })
+              .catch(noop);
+          },
+        );
+
+        const keepalive = setInterval(() => {
+          stream.write(": keepalive\n\n").catch(noop);
+        }, 30_000);
+
+        stream.onAbort(() => {
+          clearInterval(keepalive);
+          unsubscribe();
+        });
+
+        // Keep the stream open until the client disconnects.
+        await new Promise<void>(noop);
+      });
+    },
+  );
+
+  app.post(
+    "/:instanceId/abort",
+    requireGrant(idResource("instance", "instanceId"), "manage"),
+    describeRoute({
+      tags: ["Instances"],
+      summary: "Abort current operation",
+      description: "Aborts the agent's current inference or tool execution.",
+      responses: {
+        204: {
+          description: "Abort signal sent",
+        },
+        404: {
+          description: "Instance not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        409: {
+          description: "Instance not running",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        502: {
+          description: "Sidecar unavailable",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    validator("json", AbortBody),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const instanceId = c.req.param("instanceId");
+      const body = c.req.valid("json");
+
+      const row = await db.query.agentInstance.findFirst({
+        where: and(
+          eq(agentInstance.id, instanceId),
+          eq(agentInstance.tenantId, tenantCtx.id),
+        ),
+      });
+
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Instance not found" } },
+          404,
+        );
+      }
+
+      if (row.status !== "running") {
+        return c.json(
+          {
+            error: {
+              code: "conflict",
+              message: `Instance is not running (status: ${row.status})`,
+            },
+          },
+          409,
+        );
+      }
+
+      try {
+        await sidecarRouter.sendSessionAbort(
+          row.address,
+          body.reason ?? "user_disconnect",
         );
       } catch (err) {
         return c.json(
           {
             error: {
-              code: "credential_error",
+              code: "sidecar_unavailable",
               message:
                 err instanceof Error
                   ? err.message
-                  : "Credential resolution failed",
+                  : "Failed to reach sidecar for abort",
             },
           },
-          409,
+          502,
         );
       }
 
-      if (!resolved) {
-        return c.json(
-          {
-            error: {
-              code: "credential_missing",
-              message: `No credential found for provider "${req.providerName}" (source: ${req.source})`,
-            },
-          },
-          409,
-        );
-      }
-
-      const providerRow = await db.query.provider.findFirst({
-        where: eq(provider.id, resolved.providerId),
-      });
-
-      if (!providerRow) {
-        return c.json(
-          {
-            error: {
-              code: "provider_missing",
-              message: `Provider not found for credential "${resolved.id}"`,
-            },
-          },
-          409,
-        );
-      }
-
-      const metadata = ProviderMetadata(providerRow.metadata ?? {});
-      if (metadata instanceof type.errors) {
-        return c.json(
-          {
-            error: {
-              code: "provider_misconfigured",
-              message: `Provider "${providerRow.name}" metadata is invalid: ${metadata.summary}`,
-            },
-          },
-          409,
-        );
-      }
-
-      providers.push({
-        provider: providerRow.plugin,
-        baseURL: metadata.baseURL,
-        apiKey: resolved.secret,
-      });
-    }
-
-    // --- Model config ---
-
-    const modelConfig = ModelConfig(row.modelConfig ?? {});
-    if (modelConfig instanceof type.errors) {
-      return c.json(
-        {
-          error: {
-            code: "not_launchable",
-            message: `Agent model configuration is invalid: ${modelConfig.summary}`,
-          },
-        },
-        409,
-      );
-    }
-
-    // --- Grant requirement resolution (creator/invoker delegation) ---
-
-    const grantStore = c.get("grantStore");
-    const instancePrincipalId = generateId("principal");
-
-    // Collect invoker's grants once — used for both creator and invoker resolution.
-    const invokerGrants = await grantStore.collectGrants(
-      principal.id,
-      tenant.id,
-    );
-    // Only system/role/creator grants can be delegated. Invoker-sourced
-    // grants cannot be transitively re-delegated.
-    const delegatableInvokerGrants = invokerGrants.filter(
-      (g) => g.origin !== "invoker",
-    );
-
-    // Accumulate grant rows in memory; write to DB only after all
-    // requirements resolve. This avoids orphaned rows on partial failure.
-    const grantRows: {
-      id: string;
-      tenantId: string;
-      principalId: string;
-      resource: string;
-      action: string;
-      effect: GrantEffect;
-      conditions: Record<string, unknown> | null;
-      origin: GrantOrigin;
-      expiresAt: Date | null;
-      createdAt: Date;
-      updatedAt: Date;
-    }[] = [];
-
-    const now = new Date();
-    const INVOKER_GRANT_TTL_MS = 24 * 60 * 60 * 1000;
-    const invokerExpiresAt = new Date(now.getTime() + INVOKER_GRANT_TTL_MS);
-
-    const parsedGrantReqs = GrantRequirements(row.grantRequirements ?? []);
-    if (parsedGrantReqs instanceof type.errors) {
-      return c.json(
-        {
-          error: {
-            code: "not_launchable",
-            message: `Invalid grant requirements: ${parsedGrantReqs.summary}`,
-          },
-        },
-        409,
-      );
-    }
-
-    // Collect creator's grants once for all creator-sourced requirements.
-    const hasCreatorReqs = parsedGrantReqs.some((r) => r.source === "creator");
-    const creatorGrants = hasCreatorReqs
-      ? await grantStore.collectGrants(creatorPrincipalId, tenant.id)
-      : [];
-
-    for (const req of parsedGrantReqs) {
-      const effect = req.effect ?? "allow";
-
-      if (req.source === "creator") {
-        const result = await evaluateGrants(
-          creatorGrants,
-          req.resource,
-          req.action,
-        );
-        if (result.effect !== "allow") {
-          return c.json(
-            {
-              error: {
-                code: "insufficient_grants",
-                message: `Creator lacks authority to delegate ${req.resource}/${req.action}`,
-              },
-            },
-            403,
-          );
-        }
-        grantRows.push({
-          id: generateId("grant"),
-          tenantId: tenant.id,
-          principalId: instancePrincipalId,
-          resource: req.resource,
-          action: req.action,
-          effect,
-          conditions: req.conditions ?? null,
-          origin: "creator",
-          expiresAt: null,
-          createdAt: now,
-          updatedAt: now,
-        });
-      } else if (req.source === "invoker") {
-        const result = await evaluateGrants(
-          delegatableInvokerGrants,
-          req.resource,
-          req.action,
-        );
-        if (result.effect !== "allow") {
-          return c.json(
-            {
-              error: {
-                code: "insufficient_grants",
-                message: `Invoker lacks authority for ${req.resource}/${req.action}`,
-              },
-            },
-            403,
-          );
-        }
-        grantRows.push({
-          id: generateId("grant"),
-          tenantId: tenant.id,
-          principalId: instancePrincipalId,
-          resource: req.resource,
-          action: req.action,
-          effect,
-          conditions: req.conditions ?? null,
-          origin: "invoker",
-          expiresAt: invokerExpiresAt,
-          createdAt: now,
-          updatedAt: now,
-        });
-      } else {
-        return c.json(
-          {
-            error: {
-              code: "not_launchable",
-              message: `Unknown grant requirement source: ${req.source}`,
-            },
-          },
-          409,
-        );
-      }
-    }
-
-    // Process ad-hoc invoker grants from the launch request.
-    if (body.invokerGrants) {
-      for (const ig of body.invokerGrants) {
-        const effect = ig.effect ?? "allow";
-        const result = await evaluateGrants(
-          delegatableInvokerGrants,
-          ig.resource,
-          ig.action,
-        );
-        if (result.effect !== "allow") {
-          return c.json(
-            {
-              error: {
-                code: "insufficient_grants",
-                message: `Invoker lacks authority for ${ig.resource}/${ig.action}`,
-              },
-            },
-            403,
-          );
-        }
-        grantRows.push({
-          id: generateId("grant"),
-          tenantId: tenant.id,
-          principalId: instancePrincipalId,
-          resource: ig.resource,
-          action: ig.action,
-          effect,
-          conditions: ig.conditions ?? null,
-          origin: "invoker",
-          expiresAt: invokerExpiresAt,
-          createdAt: now,
-          updatedAt: now,
-        });
-      }
-    }
-
-    // --- Resolve agent role assignments for the instance principal ---
-
-    const agentRoleRows = await db.query.agentRole.findMany({
-      where: eq(agentRole.agentId, row.id),
-    });
-    const agentRoleIds = agentRoleRows.map((a) => a.roleId);
-    const agentRoleAssignments =
-      agentRoleIds.length > 0
-        ? (
-            await db.query.role.findMany({
-              where: (r, { inArray, and: a }) =>
-                a(inArray(r.id, agentRoleIds), eq(r.tenantId, tenant.id)),
-              columns: { id: true },
-            })
-          ).map((r) => ({ roleId: r.id }))
-        : [];
-
-    // --- Write all DB rows in a transaction ---
-
-    const sessionId = generateId("session");
-
-    await db.transaction(async (tx) => {
-      // Create per-instance principal
-      await tx.insert(principalTable).values({
-        id: instancePrincipalId,
-        tenantId: tenant.id,
-        kind: "agent",
-        refId: instanceId,
-        status: "active",
-        createdAt: now,
-        updatedAt: now,
-      });
-
-      // Assign the agent definition's roles to the instance principal so
-      // that grants flow through the existing RBAC path (collectGrants).
-      for (const { roleId } of agentRoleAssignments) {
-        await tx.insert(principalRole).values({
-          principalId: instancePrincipalId,
-          roleId,
-          createdAt: now,
-        });
-      }
-
-      // Materialize grants on the instance principal
-      for (const g of grantRows) {
-        await tx.insert(grantTable).values(g);
-      }
-
-      // Transitional agentSession row (FK requirement)
-      await tx.insert(agentSession).values({
-        id: sessionId,
-        tenantId: tenant.id,
-        agentId: row.id,
-        principalId: principal.id,
-        status: "active",
-        createdAt: now,
-        updatedAt: now,
-      });
-
-      // Create instance row
-      await tx.insert(agentInstance).values({
-        id: instanceId,
-        agentId: row.id,
-        tenantId: tenant.id,
-        principalId: instancePrincipalId,
-        address: agentAddress,
-        sessionId,
-        status: "deployed",
-        createdAt: now,
-        updatedAt: now,
-      });
-    });
-
-    // Collect the materialized grants for the deploy frame
-    const grants = await grantStore.collectGrants(
-      instancePrincipalId,
-      tenant.id,
-    );
-
-    const eventCollectors = c.get("eventCollectors");
-    eventCollectors.create(agentAddress, tenant.id, sessionId, instanceId);
-
-    const skills = parseAgentSkills(row.skills);
-
-    try {
-      await sessionService.launchSession({
-        agentAddress,
-        agentId: row.id,
-        config: {
-          sessionId,
-          agentId: row.id,
-          tenantId: tenant.id,
-          principalId: instancePrincipalId,
-          agentAddress,
-          systemPrompt: row.systemPrompt,
-          tools: [],
-          grants,
-          providers,
-          defaultModel: modelConfig.defaultModel,
-        },
-        deployContent: {
-          systemPrompt: row.systemPrompt,
-          skills,
-        },
-      });
-    } catch (err) {
-      eventCollectors.abandon(agentAddress);
-
-      const failedAt = new Date();
-
-      await db
-        .update(agentSession)
-        .set({ status: "ended", endedAt: failedAt, updatedAt: failedAt })
-        .where(eq(agentSession.id, sessionId));
-
-      const leaked = err instanceof SessionLaunchError && err.leakedAgent;
-
-      if (leaked) {
-        await db
-          .update(agentInstance)
-          .set({ status: "error", updatedAt: failedAt })
-          .where(eq(agentInstance.id, instanceId));
-      } else {
-        await db.delete(agentInstance).where(eq(agentInstance.id, instanceId));
-      }
-
-      // Deactivate the instance principal created during this launch
-      await db
-        .update(principalTable)
-        .set({ status: "deactivated", updatedAt: failedAt })
-        .where(eq(principalTable.id, instancePrincipalId));
-
-      return c.json(
-        {
-          error: {
-            code: "sidecar_unavailable",
-            message:
-              err instanceof Error
-                ? err.message
-                : "Failed to dispatch agent to sidecar",
-          },
-        },
-        502,
-      );
-    }
-
-    const launchedAt = new Date();
-
-    const launched = first(
-      await db
-        .update(agentInstance)
-        .set({ status: "running", updatedAt: launchedAt })
-        .where(eq(agentInstance.id, instanceId))
-        .returning(),
-    );
-
-    return c.json(formatInstance(launched, row.name), 201);
-  },
-);
-
-app.get(
-  "/",
-  requireGrant("instance:*", "read"),
-  describeRoute({
-    tags: ["Instances"],
-    summary: "List agent instances",
-    description:
-      "Lists agent instances in the tenant. Filterable by agentId and status.",
-    parameters: [
-      { name: "agentId", in: "query", schema: { type: "string" } },
-      {
-        name: "status",
-        in: "query",
-        schema: {
-          type: "string",
-          enum: ["deployed", "running", "updating", "error", "stopped"],
-        },
-      },
-      ...pageParameters,
-    ],
-    responses: {
-      200: {
-        description: "List of instances",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(AgentInstanceResponse)),
-          },
-        },
-      },
+      return c.body(null, 204);
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
-    const agentId = c.req.query("agentId");
-    const status = c.req.query("status");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
+  );
 
-    const conditions = [eq(agentInstance.tenantId, tenantCtx.id)];
-    if (agentId !== undefined) {
-      conditions.push(eq(agentInstance.agentId, agentId));
-    }
-    if (
-      status === "deployed" ||
-      status === "running" ||
-      status === "updating" ||
-      status === "error" ||
-      status === "stopped"
-    ) {
-      conditions.push(eq(agentInstance.status, status));
-    }
-    if (cursor) {
-      conditions.push(
-        cursorCondition(agentInstance.createdAt, agentInstance.id, cursor),
-      );
-    }
+  // Crypto providers for signing outbound messages, keyed by instance ID.
+  // Evicted when an instance is stopped. The cache is per-factory call,
+  // not per-process; two createInstanceRoutes() calls in the same process
+  // do not share signing keys, which is intentional — each router owns
+  // its own crypto state and lifecycle.
+  const instanceKeyCache = new Map<string, Promise<CryptoProvider>>();
 
-    const rows = await db
-      .select({
-        instance: agentInstance,
-        agentName: agent.name,
-      })
-      .from(agentInstance)
-      .innerJoin(agent, eq(agentInstance.agentId, agent.id))
-      .where(and(...conditions))
-      .orderBy(...pageOrder(agentInstance.createdAt, agentInstance.id))
-      .limit(limit);
+  function getInstanceCryptoProvider(
+    instanceId: string,
+  ): Promise<CryptoProvider> {
+    let pending = instanceKeyCache.get(instanceId);
+    if (pending !== undefined) return pending;
+    pending = generateKeyPair().then((kp) => createNodeCrypto(kp));
+    instanceKeyCache.set(instanceId, pending);
+    return pending;
+  }
 
-    return c.json(
-      paginatedResponse(
-        rows.map((r) => formatInstance(r.instance, r.agentName)),
-        rows.map((r) => r.instance),
-        limit,
-      ),
-    );
-  },
-);
-
-app.get(
-  "/blobs/:blobId",
-  describeRoute({
-    tags: ["Instances"],
-    summary: "Fetch a blob by ID",
-    description:
-      "Returns raw bytes for a MIME part. Blob IDs are issued by the mail parsing layer.",
-    responses: {
-      200: {
-        description: "Blob bytes",
-        content: { "application/octet-stream": {} },
-      },
-      400: {
-        description: "Invalid blob ID",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      403: {
-        description: "Forbidden",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      404: {
-        description: "Blob not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const blobId = c.req.param("blobId");
-
-    // Blob IDs have the format: blob_<mailId>_<partPath>
-    // where partPath is an IMAP-style section specifier (digits and dots only).
-    // mailId may itself contain underscores, so we match the suffix.
-    const blobMatch = /^blob_(.+?)_(\d[\d.]*)$/.exec(blobId);
-    if (!blobMatch) {
-      return c.json(
-        { error: { code: "bad_request", message: "Invalid blob ID format" } },
-        400,
-      );
-    }
-
-    const mailId = blobMatch[1];
-    const partPath = blobMatch[2];
-
-    if (!mailId || !partPath) {
-      return c.json(
-        { error: { code: "bad_request", message: "Invalid blob ID format" } },
-        400,
-      );
-    }
-
-    const tenant = c.get("tenant");
-    const db = c.get("db");
-
-    const mailRow = await db.query.sessionMail.findFirst({
-      where: and(
-        eq(sessionMail.id, mailId),
-        eq(sessionMail.tenantId, tenant.id),
-      ),
-    });
-
-    if (!mailRow) {
-      return c.json(
-        { error: { code: "not_found", message: "Blob not found" } },
-        404,
-      );
-    }
-
-    const resolvedInstanceId = mailRow.instanceId;
-    if (!resolvedInstanceId) {
-      return c.json(
-        { error: { code: "not_found", message: "Blob not found" } },
-        404,
-      );
-    }
-
-    const principal = c.get("principal");
-    const grantStore = c.get("grantStore");
-    const conditionRegistry = c.get("conditionRegistry");
-
-    const authResult = await authorize(
-      grantStore,
-      principal.id,
-      tenant.id,
-      `instance:${resolvedInstanceId}`,
-      "read",
-      conditionRegistry,
-    );
-
-    if (authResult.effect !== "allow") {
-      return c.json(
-        {
-          error: {
-            code: "forbidden",
-            message: "You do not have permission to perform this action",
+  app.post(
+    "/:instanceId/mail",
+    requireGrant(idResource("instance", "instanceId"), "write"),
+    describeRoute({
+      tags: ["Instances"],
+      summary: "Send mail to the agent",
+      description:
+        "Persists the user message as a mail record and dispatches it to the running agent. Returns JMAP Email-shaped response.",
+      responses: {
+        201: {
+          description: "Mail sent",
+          content: {
+            "application/json": { schema: resolver(MailResponse) },
           },
         },
-        403,
-      );
-    }
-
-    let partBytes: Uint8Array;
-    try {
-      partBytes = extractPartByPath(mailRow.raw, partPath);
-    } catch {
-      return c.json(
-        { error: { code: "not_found", message: "Blob not found" } },
-        404,
-      );
-    }
-
-    return c.body(
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Uint8Array.buffer.slice always returns ArrayBuffer
-      partBytes.buffer.slice(
-        partBytes.byteOffset,
-        partBytes.byteOffset + partBytes.byteLength,
-      ) as ArrayBuffer,
-      200,
-      {
-        "Content-Type": "application/octet-stream",
-      },
-    );
-  },
-);
-
-app.get(
-  "/:instanceId",
-  requireGrant(idResource("instance", "instanceId"), "read"),
-  describeRoute({
-    tags: ["Instances"],
-    summary: "Get instance detail",
-    description:
-      "Returns instance runtime state including status, public key, and sidecar assignment.",
-    responses: {
-      200: {
-        description: "Instance detail",
-        content: {
-          "application/json": { schema: resolver(AgentInstanceResponse) },
+        400: {
+          description: "Validation error",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        404: {
+          description: "Instance not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        409: {
+          description: "Instance not running",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        502: {
+          description: "Sidecar unavailable",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-      404: {
-        description: "Instance not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
-    const eventCollectors = c.get("eventCollectors");
-    const instanceId = c.req.param("instanceId");
+    }),
+    validator("json", SendMessage),
+    async (c) => {
+      const tenant = c.get("tenant");
+      const principal = c.get("principal");
+      const instanceId = c.req.param("instanceId");
+      const body = c.req.valid("json");
 
-    const [row] = await db
-      .select({
-        instance: agentInstance,
-        agentName: agent.name,
-      })
-      .from(agentInstance)
-      .innerJoin(agent, eq(agentInstance.agentId, agent.id))
-      .where(
-        and(
+      const row = await db.query.agentInstance.findFirst({
+        where: and(
           eq(agentInstance.id, instanceId),
-          eq(agentInstance.tenantId, tenantCtx.id),
+          eq(agentInstance.tenantId, tenant.id),
         ),
-      )
-      .limit(1);
+      });
 
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Instance not found" } },
-        404,
-      );
-    }
-
-    const result = formatInstance(row.instance, row.agentName) as Record<
-      string,
-      unknown
-    >;
-
-    // Enrich with runtime status from the event collector if available.
-    const runtimeStatus = eventCollectors.getStatus(row.instance.address);
-    if (runtimeStatus !== undefined) {
-      result["runtimeStatus"] = runtimeStatus.status;
-    }
-
-    return c.json(result);
-  },
-);
-
-app.get(
-  "/:instanceId/health",
-  requireGrant(idResource("instance", "instanceId"), "read"),
-  describeRoute({
-    tags: ["Instances"],
-    summary: "Get instance health",
-    description:
-      "Returns liveness and readiness for a running instance. Liveness reflects whether the instance's sidecar connection is active. Readiness reflects whether the instance has an active event collector and can process work.",
-    responses: {
-      200: {
-        description: "Health status",
-        content: {
-          "application/json": { schema: resolver(AgentHealth) },
-        },
-      },
-      404: {
-        description: "Instance not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      410: {
-        description: "Instance stopped",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
-    const sidecarRouter = c.get("sidecarRouter");
-    const eventCollectors = c.get("eventCollectors");
-    const instanceId = c.req.param("instanceId");
-
-    const row = await db.query.agentInstance.findFirst({
-      where: and(
-        eq(agentInstance.id, instanceId),
-        eq(agentInstance.tenantId, tenantCtx.id),
-      ),
-    });
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Instance not found" } },
-        404,
-      );
-    }
-
-    if (row.status === "stopped") {
-      return c.json(
-        { error: { code: "gone", message: "Instance has stopped" } },
-        410,
-      );
-    }
-
-    const routableAddresses = sidecarRouter.getRoutableAddresses();
-    const liveness = routableAddresses.includes(row.address)
-      ? "ok"
-      : "unhealthy";
-
-    const status = eventCollectors.getStatus(row.address);
-    const readiness = status !== undefined ? "ok" : "not_ready";
-
-    return c.json({ liveness, readiness, lastCheckedAt: null });
-  },
-);
-
-app.get(
-  "/:instanceId/offerings",
-  requireGrant(idResource("instance", "instanceId"), "read"),
-  describeRoute({
-    tags: ["Instances"],
-    summary: "List instance offerings",
-    description:
-      "Returns the offerings associated with the instance's agent definition. These represent the capabilities the instance can provide.",
-    responses: {
-      200: {
-        description: "List of offerings",
-        content: {
-          "application/json": {
-            schema: resolver(OfferingDetail.array()),
-          },
-        },
-      },
-      404: {
-        description: "Instance not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
-    const instanceId = c.req.param("instanceId");
-
-    const [row] = await db
-      .select({
-        instance: agentInstance,
-        agentName: agent.name,
-      })
-      .from(agentInstance)
-      .innerJoin(agent, eq(agentInstance.agentId, agent.id))
-      .where(
-        and(
-          eq(agentInstance.id, instanceId),
-          eq(agentInstance.tenantId, tenantCtx.id),
-        ),
-      )
-      .limit(1);
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Instance not found" } },
-        404,
-      );
-    }
-
-    const offerings = await db.query.offering.findMany({
-      where: and(
-        eq(offering.agentId, row.instance.agentId),
-        eq(offering.tenantId, tenantCtx.id),
-      ),
-    });
-
-    return c.json(offerings.map((o) => formatOffering(o, row.agentName)));
-  },
-);
-
-app.delete(
-  "/:instanceId",
-  requireGrant(idResource("instance", "instanceId"), "manage"),
-  describeRoute({
-    tags: ["Instances"],
-    summary: "Stop an instance",
-    description:
-      "Stops the running instance and undeploys the agent from the sidecar.",
-    responses: {
-      204: {
-        description: "Instance stopped",
-      },
-      404: {
-        description: "Instance not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      409: {
-        description: "Instance already stopped",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      502: {
-        description: "Sidecar unavailable",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
-    const sessionService = c.get("sessionService");
-    const sidecarRouter = c.get("sidecarRouter");
-    const instanceId = c.req.param("instanceId");
-
-    const row = await db.query.agentInstance.findFirst({
-      where: and(
-        eq(agentInstance.id, instanceId),
-        eq(agentInstance.tenantId, tenantCtx.id),
-      ),
-    });
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Instance not found" } },
-        404,
-      );
-    }
-
-    if (row.status === "stopped") {
-      return c.json(
-        {
-          error: {
-            code: "conflict",
-            message: "Instance is already stopped",
-          },
-        },
-        409,
-      );
-    }
-
-    const eventCollectors = c.get("eventCollectors");
-
-    try {
-      await sessionService.endSession(row.address, "instance_stopped");
-    } catch (err) {
-      return c.json(
-        {
-          error: {
-            code: "sidecar_unavailable",
-            message:
-              err instanceof Error
-                ? err.message
-                : "Failed to reach sidecar for instance teardown",
-          },
-        },
-        502,
-      );
-    }
-
-    const endedAt = new Date();
-
-    await db
-      .update(agentInstance)
-      .set({
-        status: "stopped",
-        sessionId: null,
-        updatedAt: endedAt,
-        endedAt,
-      })
-      .where(eq(agentInstance.id, instanceId));
-
-    // Deactivate the per-instance principal. The refId guard ensures we
-    // only deactivate the principal created for this specific instance.
-    await db
-      .update(principalTable)
-      .set({ status: "deactivated", updatedAt: endedAt })
-      .where(
-        and(
-          eq(principalTable.id, row.principalId),
-          eq(principalTable.refId, instanceId),
-        ),
-      );
-
-    // End associated session rows.
-    if (row.sessionId) {
-      await db
-        .update(agentSession)
-        .set({ status: "ended", endedAt, updatedAt: endedAt })
-        .where(eq(agentSession.id, row.sessionId));
-    }
-
-    eventCollectors.abandon(row.address);
-    instanceKeyCache.delete(instanceId);
-
-    sidecarRouter.dispatchAgentEvent(row.address, {
-      type: "session.ended",
-    });
-
-    return c.body(null, 204);
-  },
-);
-
-app.get(
-  "/:instanceId/events",
-  requireGrant(idResource("instance", "instanceId"), "read"),
-  describeRoute({
-    tags: ["Instances"],
-    summary: "SSE event stream",
-    description:
-      "Server-Sent Events stream for agent events. Use POST .../messages for client-to-server messaging.",
-    responses: {
-      200: {
-        description: "SSE event stream",
-        content: {
-          "text/event-stream": {},
-        },
-      },
-      404: {
-        description: "Instance not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      410: {
-        description: "Instance stopped",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
-    const sidecarRouter = c.get("sidecarRouter");
-    const eventCollectors = c.get("eventCollectors");
-    const instanceId = c.req.param("instanceId");
-
-    const row = await db.query.agentInstance.findFirst({
-      where: and(
-        eq(agentInstance.id, instanceId),
-        eq(agentInstance.tenantId, tenantCtx.id),
-      ),
-    });
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Instance not found" } },
-        404,
-      );
-    }
-
-    if (row.status === "stopped") {
-      return c.json(
-        { error: { code: "gone", message: "Instance has stopped" } },
-        410,
-      );
-    }
-
-    return streamSSE(c, async (stream) => {
-      const noop = () => undefined;
-
-      // Emit the replay before subscribing to live events so that a
-      // delta arriving between subscribe() and the replay write cannot
-      // beat the catch-up text onto the stream.
-      const status = eventCollectors.getStatus(row.address);
-      if (status?.status === "busy") {
-        await stream.writeSSE({
-          event: "agent.event",
-          data: JSON.stringify({
-            type: "inference.start",
-            seq: 0,
-            data: { model: "unknown" },
-          }),
-        });
-      }
-      const accumulatedText = eventCollectors.getAccumulatedText(row.address);
-      if (accumulatedText !== undefined && accumulatedText !== "") {
-        const turnId = eventCollectors.getLastTurnId(row.address);
-        await stream.writeSSE({
-          event: "agent.event",
-          data: JSON.stringify({
-            type: "inference.text.replay",
-            data: { turnId, text: accumulatedText },
-          }),
-        });
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Instance not found" } },
+          404,
+        );
       }
 
-      const unsubscribe = sidecarRouter.subscribeAgent(row.address, (event) => {
-        stream
-          .writeSSE({
-            event: "agent.event",
-            data: JSON.stringify(event),
-          })
-          .catch(noop);
-      });
-
-      const keepalive = setInterval(() => {
-        stream.write(": keepalive\n\n").catch(noop);
-      }, 30_000);
-
-      stream.onAbort(() => {
-        clearInterval(keepalive);
-        unsubscribe();
-      });
-
-      // Keep the stream open until the client disconnects.
-      await new Promise<void>(noop);
-    });
-  },
-);
-
-app.post(
-  "/:instanceId/abort",
-  requireGrant(idResource("instance", "instanceId"), "manage"),
-  describeRoute({
-    tags: ["Instances"],
-    summary: "Abort current operation",
-    description: "Aborts the agent's current inference or tool execution.",
-    responses: {
-      204: {
-        description: "Abort signal sent",
-      },
-      404: {
-        description: "Instance not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      409: {
-        description: "Instance not running",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      502: {
-        description: "Sidecar unavailable",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", AbortBody),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
-    const sidecarRouter = c.get("sidecarRouter");
-    const instanceId = c.req.param("instanceId");
-    const body = c.req.valid("json");
-
-    const row = await db.query.agentInstance.findFirst({
-      where: and(
-        eq(agentInstance.id, instanceId),
-        eq(agentInstance.tenantId, tenantCtx.id),
-      ),
-    });
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Instance not found" } },
-        404,
-      );
-    }
-
-    if (row.status !== "running") {
-      return c.json(
-        {
-          error: {
-            code: "conflict",
-            message: `Instance is not running (status: ${row.status})`,
+      if (row.status !== "running") {
+        return c.json(
+          {
+            error: {
+              code: "conflict",
+              message: `Instance is not running (status: ${row.status})`,
+            },
           },
-        },
-        409,
-      );
-    }
+          409,
+        );
+      }
 
-    try {
-      await sidecarRouter.sendSessionAbort(
-        row.address,
-        body.reason ?? "user_disconnect",
-      );
-    } catch (err) {
-      return c.json(
-        {
-          error: {
-            code: "sidecar_unavailable",
-            message:
-              err instanceof Error
-                ? err.message
-                : "Failed to reach sidecar for abort",
+      if (!row.sessionId) {
+        return c.json(
+          {
+            error: {
+              code: "conflict",
+              message: "Instance has no active session",
+            },
           },
-        },
-        502,
-      );
-    }
+          409,
+        );
+      }
 
-    return c.body(null, 204);
-  },
-);
+      const mailId = generateId("sessionMail");
+      const now = new Date();
 
-// Crypto providers for signing outbound messages, keyed by instance ID.
-// Evicted when an instance is stopped.
-const instanceKeyCache = new Map<string, Promise<CryptoProvider>>();
+      const user = c.get("user");
+      const fromAddr = `${principal.refId}@${tenant.domain}`;
+      const from = user?.name ? `"${user.name}" <${fromAddr}>` : fromAddr;
+      const mimeMessageId = `<${mailId}@${tenant.domain}>`;
 
-function getInstanceCryptoProvider(
-  instanceId: string,
-): Promise<CryptoProvider> {
-  let pending = instanceKeyCache.get(instanceId);
-  if (pending !== undefined) return pending;
-  pending = generateKeyPair().then((kp) => createNodeCrypto(kp));
-  instanceKeyCache.set(instanceId, pending);
-  return pending;
-}
+      // Fetch recent delivered inbound mail for the MIME References chain.
+      const priorMail = await db
+        .select({ id: sessionMail.id })
+        .from(sessionMail)
+        .where(
+          and(
+            eq(sessionMail.instanceId, instanceId),
+            eq(sessionMail.direction, "inbound"),
+            eq(sessionMail.status, "delivered"),
+          ),
+        )
+        .orderBy(asc(sessionMail.createdAt), asc(sessionMail.id))
+        .limit(100);
 
-app.post(
-  "/:instanceId/mail",
-  requireGrant(idResource("instance", "instanceId"), "write"),
-  describeRoute({
-    tags: ["Instances"],
-    summary: "Send mail to the agent",
-    description:
-      "Persists the user message as a mail record and dispatches it to the running agent. Returns JMAP Email-shaped response.",
-    responses: {
-      201: {
-        description: "Mail sent",
-        content: {
-          "application/json": { schema: resolver(MailResponse) },
-        },
-      },
-      400: {
-        description: "Validation error",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      404: {
-        description: "Instance not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      409: {
-        description: "Instance not running",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      502: {
-        description: "Sidecar unavailable",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", SendMessage),
-  async (c) => {
-    const tenant = c.get("tenant");
-    const db = c.get("db");
-    const sessionService = c.get("sessionService");
-    const sidecarRouter = c.get("sidecarRouter");
-    const principal = c.get("principal");
-    const instanceId = c.req.param("instanceId");
-    const body = c.req.valid("json");
+      const priorIds = priorMail.map((m) => `<${m.id}@${tenant.domain}>`);
+      const lastId = priorIds[priorIds.length - 1];
 
-    const row = await db.query.agentInstance.findFirst({
-      where: and(
-        eq(agentInstance.id, instanceId),
-        eq(agentInstance.tenantId, tenant.id),
-      ),
-    });
+      const cryptoProvider = await getInstanceCryptoProvider(instanceId);
 
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Instance not found" } },
-        404,
-      );
-    }
-
-    if (row.status !== "running") {
-      return c.json(
-        {
-          error: {
-            code: "conflict",
-            message: `Instance is not running (status: ${row.status})`,
+      let rawMIME: Uint8Array;
+      try {
+        rawMIME = await sessionService.sendUserMessage({
+          agentAddress: row.address,
+          from,
+          messageId: mimeMessageId,
+          date: now,
+          content: body.content,
+          ...(lastId !== undefined ? { inReplyTo: lastId } : {}),
+          ...(priorIds.length > 0 ? { references: priorIds } : {}),
+          sessionId: row.sessionId,
+          tenantId: tenant.id,
+          cryptoProvider,
+        });
+      } catch (err) {
+        return c.json(
+          {
+            error: {
+              code: "sidecar_unavailable",
+              message:
+                err instanceof Error
+                  ? err.message
+                  : "Failed to deliver message to sidecar",
+            },
           },
-        },
-        409,
-      );
-    }
+          502,
+        );
+      }
 
-    if (!row.sessionId) {
-      return c.json(
-        {
-          error: {
-            code: "conflict",
-            message: "Instance has no active session",
-          },
-        },
-        409,
-      );
-    }
+      const mailCreatedAt = new Date();
 
-    const mailId = generateId("sessionMail");
-    const now = new Date();
-
-    const user = c.get("user");
-    const fromAddr = `${principal.refId}@${tenant.domain}`;
-    const from = user?.name ? `"${user.name}" <${fromAddr}>` : fromAddr;
-    const mimeMessageId = `<${mailId}@${tenant.domain}>`;
-
-    // Fetch recent delivered inbound mail for the MIME References chain.
-    const priorMail = await db
-      .select({ id: sessionMail.id })
-      .from(sessionMail)
-      .where(
-        and(
-          eq(sessionMail.instanceId, instanceId),
-          eq(sessionMail.direction, "inbound"),
-          eq(sessionMail.status, "delivered"),
-        ),
-      )
-      .orderBy(asc(sessionMail.createdAt), asc(sessionMail.id))
-      .limit(100);
-
-    const priorIds = priorMail.map((m) => `<${m.id}@${tenant.domain}>`);
-    const lastId = priorIds[priorIds.length - 1];
-
-    const cryptoProvider = await getInstanceCryptoProvider(instanceId);
-
-    let rawMIME: Uint8Array;
-    try {
-      rawMIME = await sessionService.sendUserMessage({
-        agentAddress: row.address,
-        from,
-        messageId: mimeMessageId,
-        date: now,
-        content: body.content,
-        ...(lastId !== undefined ? { inReplyTo: lastId } : {}),
-        ...(priorIds.length > 0 ? { references: priorIds } : {}),
-        sessionId: row.sessionId,
-        tenantId: tenant.id,
-        cryptoProvider,
-      });
-    } catch (err) {
-      return c.json(
-        {
-          error: {
-            code: "sidecar_unavailable",
-            message:
-              err instanceof Error
-                ? err.message
-                : "Failed to deliver message to sidecar",
-          },
-        },
-        502,
-      );
-    }
-
-    const mailCreatedAt = new Date();
-
-    await db.insert(sessionMail).values({
-      id: mailId,
-      sessionId: row.sessionId,
-      instanceId,
-      tenantId: tenant.id,
-      direction: "inbound",
-      status: "delivered",
-      raw: rawMIME,
-      createdAt: mailCreatedAt,
-    });
-
-    const parsed = parseMailToEmail(rawMIME, mailId);
-    sidecarRouter.dispatchAgentEvent(row.address, {
-      type: "mail.delivered",
-      data: {
-        ...parsed,
-        id: mailId,
-        direction: "inbound" as const,
-        receivedAt: mailCreatedAt.toISOString(),
-      },
-    });
-
-    return c.json(
-      {
+      await db.insert(sessionMail).values({
         id: mailId,
         sessionId: row.sessionId,
         instanceId,
-        direction: "inbound" as const,
-        status: "delivered" as const,
-        receivedAt: mailCreatedAt.toISOString(),
-        ...parsed,
-      },
-      201,
-    );
-  },
-);
+        tenantId: tenant.id,
+        direction: "inbound",
+        status: "delivered",
+        raw: rawMIME,
+        createdAt: mailCreatedAt,
+      });
 
-app.get(
-  "/:instanceId/mail",
-  requireGrant(idResource("instance", "instanceId"), "read"),
-  describeRoute({
-    tags: ["Instances"],
-    summary: "List mail for an instance",
-    description:
-      "Returns parsed JMAP Email objects in reverse chronological order. Cursor-paginated.",
-    parameters: [...pageParameters],
-    responses: {
-      200: {
-        description: "List of mail",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(MailResponse)),
+      const parsed = parseMailToEmail(rawMIME, mailId);
+      sidecarRouter.dispatchAgentEvent(row.address, {
+        type: "mail.delivered",
+        data: {
+          ...parsed,
+          id: mailId,
+          direction: "inbound" as const,
+          receivedAt: mailCreatedAt.toISOString(),
+        },
+      });
+
+      return c.json(
+        {
+          id: mailId,
+          sessionId: row.sessionId,
+          instanceId,
+          direction: "inbound" as const,
+          status: "delivered" as const,
+          receivedAt: mailCreatedAt.toISOString(),
+          ...parsed,
+        },
+        201,
+      );
+    },
+  );
+
+  app.get(
+    "/:instanceId/mail",
+    requireGrant(idResource("instance", "instanceId"), "read"),
+    describeRoute({
+      tags: ["Instances"],
+      summary: "List mail for an instance",
+      description:
+        "Returns parsed JMAP Email objects in reverse chronological order. Cursor-paginated.",
+      parameters: [...pageParameters],
+      responses: {
+        200: {
+          description: "List of mail",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(MailResponse)),
+            },
+          },
+        },
+        404: {
+          description: "Instance not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
           },
         },
       },
-      404: {
-        description: "Instance not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenant = c.get("tenant");
-    const db = c.get("db");
-    const instanceId = c.req.param("instanceId");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
+    }),
+    async (c) => {
+      const tenant = c.get("tenant");
+      const instanceId = c.req.param("instanceId");
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
 
-    const row = await db.query.agentInstance.findFirst({
-      where: and(
-        eq(agentInstance.id, instanceId),
-        eq(agentInstance.tenantId, tenant.id),
-      ),
-    });
+      const row = await db.query.agentInstance.findFirst({
+        where: and(
+          eq(agentInstance.id, instanceId),
+          eq(agentInstance.tenantId, tenant.id),
+        ),
+      });
 
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Instance not found" } },
-        404,
-      );
-    }
-
-    const conditions = [eq(sessionMail.instanceId, instanceId)];
-    if (cursor) {
-      conditions.push(
-        cursorCondition(sessionMail.createdAt, sessionMail.id, cursor),
-      );
-    }
-
-    const rows = await db
-      .select()
-      .from(sessionMail)
-      .where(and(...conditions))
-      .orderBy(...pageOrder(sessionMail.createdAt, sessionMail.id))
-      .limit(limit);
-
-    const items = rows.map((m) => {
-      const parsed = parseMailToEmail(m.raw, m.id);
-      return {
-        id: m.id,
-        sessionId: m.sessionId,
-        instanceId: m.instanceId ?? null,
-        direction: m.direction,
-        status: m.status,
-        receivedAt: m.createdAt.toISOString(),
-        ...parsed,
-      };
-    });
-
-    return c.json(paginatedResponse(items, rows, limit));
-  },
-);
-
-app.get(
-  "/:instanceId/turns",
-  requireGrant(idResource("instance", "instanceId"), "read"),
-  describeRoute({
-    tags: ["Instances"],
-    summary: "List inference turns for an instance",
-    description:
-      "Returns inference turns with their parts in reverse chronological order. Cursor-paginated.",
-    parameters: [...pageParameters],
-    responses: {
-      200: {
-        description: "List of inference turns",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(InferenceTurnResponse)),
-          },
-        },
-      },
-      404: {
-        description: "Instance not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenant = c.get("tenant");
-    const db = c.get("db");
-    const instanceId = c.req.param("instanceId");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
-
-    const row = await db.query.agentInstance.findFirst({
-      where: and(
-        eq(agentInstance.id, instanceId),
-        eq(agentInstance.tenantId, tenant.id),
-      ),
-    });
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Instance not found" } },
-        404,
-      );
-    }
-
-    const conditions = [eq(inferenceTurn.instanceId, instanceId)];
-    if (cursor) {
-      conditions.push(
-        cursorCondition(inferenceTurn.startedAt, inferenceTurn.id, cursor),
-      );
-    }
-
-    const turns = await db
-      .select()
-      .from(inferenceTurn)
-      .where(and(...conditions))
-      .orderBy(...pageOrder(inferenceTurn.startedAt, inferenceTurn.id))
-      .limit(limit);
-
-    const turnIds = turns.map((t) => t.id);
-
-    const parts =
-      turnIds.length > 0
-        ? await db
-            .select()
-            .from(turnPart)
-            .where(inArray(turnPart.turnId, turnIds))
-            .orderBy(asc(turnPart.ordinal))
-        : [];
-
-    const partsByTurn = new Map<string, typeof parts>();
-    for (const part of parts) {
-      let list = partsByTurn.get(part.turnId);
-      if (list === undefined) {
-        list = [];
-        partsByTurn.set(part.turnId, list);
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Instance not found" } },
+          404,
+        );
       }
-      list.push(part);
-    }
 
-    const items = turns.map((t) => ({
-      id: t.id,
-      sessionId: t.sessionId,
-      instanceId: t.instanceId,
-      model: t.model,
-      status: t.status,
-      startedAt: t.startedAt.toISOString(),
-      endedAt: t.endedAt ? t.endedAt.toISOString() : null,
-      parts: (partsByTurn.get(t.id) ?? []).map((p) => ({
-        id: p.id,
-        type: p.type,
-        content: p.content ?? null,
-        metadata: p.metadata ?? null,
-        ordinal: p.ordinal,
-      })),
-    }));
+      const conditions = [eq(sessionMail.instanceId, instanceId)];
+      if (cursor) {
+        conditions.push(
+          cursorCondition(sessionMail.createdAt, sessionMail.id, cursor),
+        );
+      }
 
-    return c.json(
-      paginatedResponse(
-        items,
-        turns.map((t) => ({ createdAt: t.startedAt, id: t.id })),
-        limit,
-      ),
-    );
-  },
-);
+      const rows = await db
+        .select()
+        .from(sessionMail)
+        .where(and(...conditions))
+        .orderBy(...pageOrder(sessionMail.createdAt, sessionMail.id))
+        .limit(limit);
 
-export { app as instanceRoutes };
+      const items = rows.map((m) => {
+        const parsed = parseMailToEmail(m.raw, m.id);
+        return {
+          id: m.id,
+          sessionId: m.sessionId,
+          instanceId: m.instanceId ?? null,
+          direction: m.direction,
+          status: m.status,
+          receivedAt: m.createdAt.toISOString(),
+          ...parsed,
+        };
+      });
+
+      return c.json(paginatedResponse(items, rows, limit));
+    },
+  );
+
+  app.get(
+    "/:instanceId/turns",
+    requireGrant(idResource("instance", "instanceId"), "read"),
+    describeRoute({
+      tags: ["Instances"],
+      summary: "List inference turns for an instance",
+      description:
+        "Returns inference turns with their parts in reverse chronological order. Cursor-paginated.",
+      parameters: [...pageParameters],
+      responses: {
+        200: {
+          description: "List of inference turns",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(InferenceTurnResponse)),
+            },
+          },
+        },
+        404: {
+          description: "Instance not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenant = c.get("tenant");
+      const instanceId = c.req.param("instanceId");
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
+
+      const row = await db.query.agentInstance.findFirst({
+        where: and(
+          eq(agentInstance.id, instanceId),
+          eq(agentInstance.tenantId, tenant.id),
+        ),
+      });
+
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Instance not found" } },
+          404,
+        );
+      }
+
+      const conditions = [eq(inferenceTurn.instanceId, instanceId)];
+      if (cursor) {
+        conditions.push(
+          cursorCondition(inferenceTurn.startedAt, inferenceTurn.id, cursor),
+        );
+      }
+
+      const turns = await db
+        .select()
+        .from(inferenceTurn)
+        .where(and(...conditions))
+        .orderBy(...pageOrder(inferenceTurn.startedAt, inferenceTurn.id))
+        .limit(limit);
+
+      const turnIds = turns.map((t) => t.id);
+
+      const parts =
+        turnIds.length > 0
+          ? await db
+              .select()
+              .from(turnPart)
+              .where(inArray(turnPart.turnId, turnIds))
+              .orderBy(asc(turnPart.ordinal))
+          : [];
+
+      const partsByTurn = new Map<string, typeof parts>();
+      for (const part of parts) {
+        let list = partsByTurn.get(part.turnId);
+        if (list === undefined) {
+          list = [];
+          partsByTurn.set(part.turnId, list);
+        }
+        list.push(part);
+      }
+
+      const items = turns.map((t) => ({
+        id: t.id,
+        sessionId: t.sessionId,
+        instanceId: t.instanceId,
+        model: t.model,
+        status: t.status,
+        startedAt: t.startedAt.toISOString(),
+        endedAt: t.endedAt ? t.endedAt.toISOString() : null,
+        parts: (partsByTurn.get(t.id) ?? []).map((p) => ({
+          id: p.id,
+          type: p.type,
+          content: p.content ?? null,
+          metadata: p.metadata ?? null,
+          ordinal: p.ordinal,
+        })),
+      }));
+
+      return c.json(
+        paginatedResponse(
+          items,
+          turns.map((t) => ({ createdAt: t.startedAt, id: t.id })),
+          limit,
+        ),
+      );
+    },
+  );
+
+  return app;
+}

--- a/packages/hub/src/routes/instances.ts
+++ b/packages/hub/src/routes/instances.ts
@@ -55,7 +55,8 @@ import type { EventCollectorRegistry } from "../event-collector-registry";
 import { formatOffering } from "./offerings";
 
 import type { TenantEnv } from "../context";
-import { requireGrant, idResource } from "../middleware/grant";
+import { idResource } from "../middleware/grant";
+import type { RequireGrant } from "../middleware/grant";
 import { generateId } from "../ids";
 import { first, ts } from "../format";
 import {
@@ -105,6 +106,7 @@ export type CreateInstanceRoutesDeps = {
   eventCollectors: EventCollectorRegistry;
   grantStore: GrantStore;
   conditionRegistry: ConditionRegistry;
+  requireGrant: RequireGrant;
 };
 
 export function createInstanceRoutes({
@@ -114,6 +116,7 @@ export function createInstanceRoutes({
   eventCollectors,
   grantStore,
   conditionRegistry,
+  requireGrant,
 }: CreateInstanceRoutesDeps): Hono<TenantEnv> {
   const app = new Hono<TenantEnv>();
 

--- a/packages/hub/src/routes/me.ts
+++ b/packages/hub/src/routes/me.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { describeRoute, resolver } from "hono-openapi";
 
 import { agent, agentInstance, principal } from "@interchange/db/schema";
+import type { DB } from "@interchange/db";
 import {
   UserProfile,
   PrincipalSummary,
@@ -24,366 +25,381 @@ import {
   pageParameters,
 } from "../pagination";
 
-const app = new Hono<AppEnv>();
+export type CreateMeRoutesDeps = {
+  db: DB["db"];
+};
 
-app.get(
-  "/",
-  describeRoute({
-    tags: ["User"],
-    summary: "Get current user profile",
-    responses: {
-      200: {
-        description: "User profile",
-        content: {
-          "application/json": { schema: resolver(UserProfile) },
-        },
-      },
-      401: {
-        description: "Not authenticated",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  (c) => {
-    const user = c.get("user");
-    if (!user) {
-      return c.json(
-        { error: { code: "unauthorized", message: "Authentication required" } },
-        401,
-      );
-    }
-    return c.json({
-      id: user.id,
-      name: user.name,
-      email: user.email,
-      emailVerified: user.emailVerified,
-      image: user.image ?? null,
-      createdAt: ts(user.createdAt),
-      updatedAt: ts(user.updatedAt),
-    });
-  },
-);
+export function createMeRoutes({ db }: CreateMeRoutesDeps): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
 
-app.get(
-  "/principals",
-  describeRoute({
-    tags: ["User"],
-    summary: "List principals across all tenants",
-    description:
-      "Returns all of the authenticated user's principals across tenants, with tenant name, roles, and status in each.",
-    parameters: [...pageParameters],
-    responses: {
-      200: {
-        description: "List of principals across tenants",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(PrincipalSummary)),
+  app.get(
+    "/",
+    describeRoute({
+      tags: ["User"],
+      summary: "Get current user profile",
+      responses: {
+        200: {
+          description: "User profile",
+          content: {
+            "application/json": { schema: resolver(UserProfile) },
+          },
+        },
+        401: {
+          description: "Not authenticated",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
           },
         },
       },
-      401: {
-        description: "Not authenticated",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
+    }),
+    (c) => {
+      const user = c.get("user");
+      if (!user) {
+        return c.json(
+          {
+            error: { code: "unauthorized", message: "Authentication required" },
+          },
+          401,
+        );
+      }
+      return c.json({
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        emailVerified: user.emailVerified,
+        image: user.image ?? null,
+        createdAt: ts(user.createdAt),
+        updatedAt: ts(user.updatedAt),
+      });
     },
-  }),
-  async (c) => {
-    const user = c.get("user");
-    if (!user) {
-      return c.json(
-        { error: { code: "unauthorized", message: "Authentication required" } },
-        401,
-      );
-    }
-    const db = c.get("db");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
+  );
 
-    const conditions = [
-      eq(principal.kind, "user"),
-      eq(principal.refId, user.id),
-    ];
-    if (cursor) {
-      conditions.push(
-        cursorCondition(principal.createdAt, principal.id, cursor),
-      );
-    }
-
-    const rows = await db.query.principal.findMany({
-      where: and(...conditions),
-      orderBy: pageOrder(principal.createdAt, principal.id),
-      limit,
-    });
-
-    const tenantIds = rows.map((p) => p.tenantId);
-    const tenants =
-      tenantIds.length > 0
-        ? await db.query.tenant.findMany({
-            where: (t, { inArray }) => inArray(t.id, tenantIds),
-          })
-        : [];
-    const tenantMap = new Map(tenants.map((t) => [t.id, t]));
-
-    const principalIds = rows.map((p) => p.id);
-    const assignments =
-      principalIds.length > 0
-        ? await db.query.principalRole.findMany({
-            where: (pr, { inArray }) => inArray(pr.principalId, principalIds),
-          })
-        : [];
-
-    const roleIds = [...new Set(assignments.map((a) => a.roleId))];
-    const roles =
-      roleIds.length > 0
-        ? await db.query.role.findMany({
-            where: (r, { inArray }) => inArray(r.id, roleIds),
-          })
-        : [];
-    const roleMap = new Map(roles.map((r) => [r.id, r]));
-
-    const assignmentsByPrincipal = new Map<
-      string,
-      { id: string; name: string }[]
-    >();
-    for (const a of assignments) {
-      const r = roleMap.get(a.roleId);
-      if (!r) continue;
-      const list = assignmentsByPrincipal.get(a.principalId) ?? [];
-      list.push({ id: r.id, name: r.name });
-      assignmentsByPrincipal.set(a.principalId, list);
-    }
-
-    const items = rows.map((p) => {
-      const t = tenantMap.get(p.tenantId);
-      return {
-        principalId: p.id,
-        tenantId: p.tenantId,
-        tenantName: t?.name ?? "Unknown",
-        tenantSlug: t?.slug ?? "unknown",
-        kind: p.kind as "user" | "agent",
-        status: p.status as "active" | "suspended" | "invited" | "deactivated",
-        roles: assignmentsByPrincipal.get(p.id) ?? [],
-      };
-    });
-
-    return c.json(paginatedResponse(items, rows, limit));
-  },
-);
-
-app.get(
-  "/agents",
-  describeRoute({
-    tags: ["User"],
-    summary: "List agents across all tenants",
-    description:
-      "Aggregates agents from all tenants the user belongs to. Each result is tagged with tenantId.",
-    parameters: [...pageParameters],
-    responses: {
-      200: {
-        description: "Agents across tenants",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(AgentSummary)),
+  app.get(
+    "/principals",
+    describeRoute({
+      tags: ["User"],
+      summary: "List principals across all tenants",
+      description:
+        "Returns all of the authenticated user's principals across tenants, with tenant name, roles, and status in each.",
+      parameters: [...pageParameters],
+      responses: {
+        200: {
+          description: "List of principals across tenants",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(PrincipalSummary)),
+            },
+          },
+        },
+        401: {
+          description: "Not authenticated",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
           },
         },
       },
+    }),
+    async (c) => {
+      const user = c.get("user");
+      if (!user) {
+        return c.json(
+          {
+            error: { code: "unauthorized", message: "Authentication required" },
+          },
+          401,
+        );
+      }
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
+
+      const conditions = [
+        eq(principal.kind, "user"),
+        eq(principal.refId, user.id),
+      ];
+      if (cursor) {
+        conditions.push(
+          cursorCondition(principal.createdAt, principal.id, cursor),
+        );
+      }
+
+      const rows = await db.query.principal.findMany({
+        where: and(...conditions),
+        orderBy: pageOrder(principal.createdAt, principal.id),
+        limit,
+      });
+
+      const tenantIds = rows.map((p) => p.tenantId);
+      const tenants =
+        tenantIds.length > 0
+          ? await db.query.tenant.findMany({
+              where: (t, { inArray }) => inArray(t.id, tenantIds),
+            })
+          : [];
+      const tenantMap = new Map(tenants.map((t) => [t.id, t]));
+
+      const principalIds = rows.map((p) => p.id);
+      const assignments =
+        principalIds.length > 0
+          ? await db.query.principalRole.findMany({
+              where: (pr, { inArray }) => inArray(pr.principalId, principalIds),
+            })
+          : [];
+
+      const roleIds = [...new Set(assignments.map((a) => a.roleId))];
+      const roles =
+        roleIds.length > 0
+          ? await db.query.role.findMany({
+              where: (r, { inArray }) => inArray(r.id, roleIds),
+            })
+          : [];
+      const roleMap = new Map(roles.map((r) => [r.id, r]));
+
+      const assignmentsByPrincipal = new Map<
+        string,
+        { id: string; name: string }[]
+      >();
+      for (const a of assignments) {
+        const r = roleMap.get(a.roleId);
+        if (!r) continue;
+        const list = assignmentsByPrincipal.get(a.principalId) ?? [];
+        list.push({ id: r.id, name: r.name });
+        assignmentsByPrincipal.set(a.principalId, list);
+      }
+
+      const items = rows.map((p) => {
+        const t = tenantMap.get(p.tenantId);
+        return {
+          principalId: p.id,
+          tenantId: p.tenantId,
+          tenantName: t?.name ?? "Unknown",
+          tenantSlug: t?.slug ?? "unknown",
+          kind: p.kind as "user" | "agent",
+          status: p.status as
+            | "active"
+            | "suspended"
+            | "invited"
+            | "deactivated",
+          roles: assignmentsByPrincipal.get(p.id) ?? [],
+        };
+      });
+
+      return c.json(paginatedResponse(items, rows, limit));
     },
-  }),
-  async (c) => {
-    const user = c.get("user");
-    if (!user) {
-      return c.json(
-        { error: { code: "unauthorized", message: "Authentication required" } },
-        401,
-      );
-    }
-    const db = c.get("db");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
+  );
 
-    const principals = await db.query.principal.findMany({
-      where: and(eq(principal.kind, "user"), eq(principal.refId, user.id)),
-    });
-
-    const tenantIds = principals.map((p) => p.tenantId);
-    if (tenantIds.length === 0) {
-      return c.json({ data: [], nextCursor: null });
-    }
-
-    const tenants = await db.query.tenant.findMany({
-      where: (t, { inArray }) => inArray(t.id, tenantIds),
-    });
-    const tenantMap = new Map(tenants.map((t) => [t.id, t]));
-
-    const conditions: SQL[] = [];
-    if (cursor) {
-      conditions.push(cursorCondition(agent.createdAt, agent.id, cursor));
-    }
-
-    const rows = await db.query.agent.findMany({
-      where: (a, { inArray }) =>
-        and(inArray(a.tenantId, tenantIds), ...conditions),
-      orderBy: pageOrder(agent.createdAt, agent.id),
-      limit,
-    });
-
-    const items = rows.map((a) => ({
-      id: a.id,
-      tenantId: a.tenantId,
-      tenantName: tenantMap.get(a.tenantId)?.name ?? "Unknown",
-      name: a.name,
-      description: a.description ?? null,
-      status: a.status as "deployed" | "stopped" | "updating" | "error",
-    }));
-
-    return c.json(paginatedResponse(items, rows, limit));
-  },
-);
-
-app.get(
-  "/instances",
-  describeRoute({
-    tags: ["User"],
-    summary: "List running agent instances across all tenants",
-    description:
-      "Aggregates running agent instances from all tenants the user belongs to. Each result is tagged with tenantId.",
-    parameters: [...pageParameters],
-    responses: {
-      200: {
-        description: "Instances across tenants",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(InstanceSummary)),
+  app.get(
+    "/agents",
+    describeRoute({
+      tags: ["User"],
+      summary: "List agents across all tenants",
+      description:
+        "Aggregates agents from all tenants the user belongs to. Each result is tagged with tenantId.",
+      parameters: [...pageParameters],
+      responses: {
+        200: {
+          description: "Agents across tenants",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(AgentSummary)),
+            },
           },
         },
       },
+    }),
+    async (c) => {
+      const user = c.get("user");
+      if (!user) {
+        return c.json(
+          {
+            error: { code: "unauthorized", message: "Authentication required" },
+          },
+          401,
+        );
+      }
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
+
+      const principals = await db.query.principal.findMany({
+        where: and(eq(principal.kind, "user"), eq(principal.refId, user.id)),
+      });
+
+      const tenantIds = principals.map((p) => p.tenantId);
+      if (tenantIds.length === 0) {
+        return c.json({ data: [], nextCursor: null });
+      }
+
+      const tenants = await db.query.tenant.findMany({
+        where: (t, { inArray }) => inArray(t.id, tenantIds),
+      });
+      const tenantMap = new Map(tenants.map((t) => [t.id, t]));
+
+      const conditions: SQL[] = [];
+      if (cursor) {
+        conditions.push(cursorCondition(agent.createdAt, agent.id, cursor));
+      }
+
+      const rows = await db.query.agent.findMany({
+        where: (a, { inArray }) =>
+          and(inArray(a.tenantId, tenantIds), ...conditions),
+        orderBy: pageOrder(agent.createdAt, agent.id),
+        limit,
+      });
+
+      const items = rows.map((a) => ({
+        id: a.id,
+        tenantId: a.tenantId,
+        tenantName: tenantMap.get(a.tenantId)?.name ?? "Unknown",
+        name: a.name,
+        description: a.description ?? null,
+        status: a.status as "deployed" | "stopped" | "updating" | "error",
+      }));
+
+      return c.json(paginatedResponse(items, rows, limit));
     },
-  }),
-  async (c) => {
-    const user = c.get("user");
-    if (!user) {
-      return c.json(
-        { error: { code: "unauthorized", message: "Authentication required" } },
-        401,
-      );
-    }
-    const db = c.get("db");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
+  );
 
-    const principals = await db.query.principal.findMany({
-      where: and(eq(principal.kind, "user"), eq(principal.refId, user.id)),
-    });
-
-    const tenantIds = principals.map((p) => p.tenantId);
-    if (tenantIds.length === 0) {
-      return c.json({ data: [], nextCursor: null });
-    }
-
-    const tenants = await db.query.tenant.findMany({
-      where: (t, { inArray }) => inArray(t.id, tenantIds),
-    });
-    const tenantMap = new Map(tenants.map((t) => [t.id, t]));
-
-    const conditions: SQL[] = [eq(agentInstance.status, "running")];
-    if (cursor) {
-      conditions.push(
-        cursorCondition(agentInstance.createdAt, agentInstance.id, cursor),
-      );
-    }
-
-    const rows = await db.query.agentInstance.findMany({
-      where: (ai, { inArray }) =>
-        and(inArray(ai.tenantId, tenantIds), ...conditions),
-      orderBy: pageOrder(agentInstance.createdAt, agentInstance.id),
-      limit,
-    });
-
-    const agentIds = [...new Set(rows.map((r) => r.agentId))];
-    const agents =
-      agentIds.length > 0
-        ? await db.query.agent.findMany({
-            where: (a, { inArray }) => inArray(a.id, agentIds),
-          })
-        : [];
-    const agentMap = new Map(agents.map((a) => [a.id, a]));
-
-    const items = rows.map((r) => ({
-      id: r.id,
-      tenantId: r.tenantId,
-      tenantName: tenantMap.get(r.tenantId)?.name ?? "Unknown",
-      agentId: r.agentId,
-      agentName: agentMap.get(r.agentId)?.name ?? "Unknown",
-      address: r.address,
-      status: r.status as
-        | "deployed"
-        | "running"
-        | "updating"
-        | "error"
-        | "stopped",
-      createdAt: ts(r.createdAt),
-    }));
-
-    return c.json(paginatedResponse(items, rows, limit));
-  },
-);
-
-app.get(
-  "/sessions",
-  describeRoute({
-    tags: ["User"],
-    summary: "List sessions across all tenants",
-    description:
-      "Aggregates active sessions from all tenants the user belongs to. Each result is tagged with tenantId.",
-    responses: {
-      200: {
-        description: "Sessions across tenants",
-        content: {
-          "application/json": {
-            schema: resolver(SessionSummary.array()),
+  app.get(
+    "/instances",
+    describeRoute({
+      tags: ["User"],
+      summary: "List running agent instances across all tenants",
+      description:
+        "Aggregates running agent instances from all tenants the user belongs to. Each result is tagged with tenantId.",
+      parameters: [...pageParameters],
+      responses: {
+        200: {
+          description: "Instances across tenants",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(InstanceSummary)),
+            },
           },
         },
       },
-    },
-  }),
-  (_c) => {
-    // Sessions deferred to later phase
-    return _c.json([]);
-  },
-);
+    }),
+    async (c) => {
+      const user = c.get("user");
+      if (!user) {
+        return c.json(
+          {
+            error: { code: "unauthorized", message: "Authentication required" },
+          },
+          401,
+        );
+      }
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
 
-app.get(
-  "/approvals",
-  describeRoute({
-    tags: ["User"],
-    summary: "List pending approvals across all tenants",
-    description:
-      "Aggregates pending approval requests from all tenants the user belongs to. Each result is tagged with tenantId.",
-    responses: {
-      200: {
-        description: "Approvals across tenants",
-        content: {
-          "application/json": {
-            schema: resolver(ApprovalSummary.array()),
+      const principals = await db.query.principal.findMany({
+        where: and(eq(principal.kind, "user"), eq(principal.refId, user.id)),
+      });
+
+      const tenantIds = principals.map((p) => p.tenantId);
+      if (tenantIds.length === 0) {
+        return c.json({ data: [], nextCursor: null });
+      }
+
+      const tenants = await db.query.tenant.findMany({
+        where: (t, { inArray }) => inArray(t.id, tenantIds),
+      });
+      const tenantMap = new Map(tenants.map((t) => [t.id, t]));
+
+      const conditions: SQL[] = [eq(agentInstance.status, "running")];
+      if (cursor) {
+        conditions.push(
+          cursorCondition(agentInstance.createdAt, agentInstance.id, cursor),
+        );
+      }
+
+      const rows = await db.query.agentInstance.findMany({
+        where: (ai, { inArray }) =>
+          and(inArray(ai.tenantId, tenantIds), ...conditions),
+        orderBy: pageOrder(agentInstance.createdAt, agentInstance.id),
+        limit,
+      });
+
+      const agentIds = [...new Set(rows.map((r) => r.agentId))];
+      const agents =
+        agentIds.length > 0
+          ? await db.query.agent.findMany({
+              where: (a, { inArray }) => inArray(a.id, agentIds),
+            })
+          : [];
+      const agentMap = new Map(agents.map((a) => [a.id, a]));
+
+      const items = rows.map((r) => ({
+        id: r.id,
+        tenantId: r.tenantId,
+        tenantName: tenantMap.get(r.tenantId)?.name ?? "Unknown",
+        agentId: r.agentId,
+        agentName: agentMap.get(r.agentId)?.name ?? "Unknown",
+        address: r.address,
+        status: r.status as
+          | "deployed"
+          | "running"
+          | "updating"
+          | "error"
+          | "stopped",
+        createdAt: ts(r.createdAt),
+      }));
+
+      return c.json(paginatedResponse(items, rows, limit));
+    },
+  );
+
+  app.get(
+    "/sessions",
+    describeRoute({
+      tags: ["User"],
+      summary: "List sessions across all tenants",
+      description:
+        "Aggregates active sessions from all tenants the user belongs to. Each result is tagged with tenantId.",
+      responses: {
+        200: {
+          description: "Sessions across tenants",
+          content: {
+            "application/json": {
+              schema: resolver(SessionSummary.array()),
+            },
           },
         },
       },
+    }),
+    (_c) => {
+      // Sessions deferred to later phase
+      return _c.json([]);
     },
-  }),
-  (_c) => {
-    // Approvals deferred to later phase
-    return _c.json([]);
-  },
-);
+  );
 
-export { app as meRoutes };
+  app.get(
+    "/approvals",
+    describeRoute({
+      tags: ["User"],
+      summary: "List pending approvals across all tenants",
+      description:
+        "Aggregates pending approval requests from all tenants the user belongs to. Each result is tagged with tenantId.",
+      responses: {
+        200: {
+          description: "Approvals across tenants",
+          content: {
+            "application/json": {
+              schema: resolver(ApprovalSummary.array()),
+            },
+          },
+        },
+      },
+    }),
+    (_c) => {
+      // Approvals deferred to later phase
+      return _c.json([]);
+    },
+  );
+
+  return app;
+}

--- a/packages/hub/src/routes/oauth-clients.ts
+++ b/packages/hub/src/routes/oauth-clients.ts
@@ -16,7 +16,8 @@ import {
 import type { TenantEnv } from "../context";
 import { first, ts } from "../format";
 import { generateId } from "../ids";
-import { requireGrant, idResource } from "../middleware/grant";
+import { idResource } from "../middleware/grant";
+import type { RequireGrant } from "../middleware/grant";
 import {
   parsePageParams,
   cursorCondition,
@@ -42,10 +43,12 @@ function formatOAuthClient(row: typeof oauthClient.$inferSelect) {
 
 export type CreateOAuthClientRoutesDeps = {
   db: DB["db"];
+  requireGrant: RequireGrant;
 };
 
 export function createOAuthClientRoutes({
   db,
+  requireGrant,
 }: CreateOAuthClientRoutesDeps): Hono<TenantEnv> {
   const app = new Hono<TenantEnv>();
 

--- a/packages/hub/src/routes/oauth-clients.ts
+++ b/packages/hub/src/routes/oauth-clients.ts
@@ -4,6 +4,7 @@ import { describeRoute, resolver, validator } from "hono-openapi";
 
 import { oauthClient, provider } from "@interchange/db/schema";
 import { getAncestorChain, parseOAuthClientRow } from "@interchange/db";
+import type { DB } from "@interchange/db";
 import {
   CreateOAuthClient,
   UpdateOAuthClient,
@@ -39,302 +40,307 @@ function formatOAuthClient(row: typeof oauthClient.$inferSelect) {
   };
 }
 
-const app = new Hono<TenantEnv>();
+export type CreateOAuthClientRoutesDeps = {
+  db: DB["db"];
+};
 
-app.get(
-  "/",
-  requireGrant("oauth_client:*", "read"),
-  describeRoute({
-    tags: ["OAuth Clients"],
-    summary: "List OAuth client registrations",
-    description:
-      "Lists OAuth client registrations for the tenant. Secrets are never returned.",
-    parameters: [...pageParameters],
-    responses: {
-      200: {
-        description: "List of OAuth clients",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(OAuthClientResponse)),
+export function createOAuthClientRoutes({
+  db,
+}: CreateOAuthClientRoutesDeps): Hono<TenantEnv> {
+  const app = new Hono<TenantEnv>();
+
+  app.get(
+    "/",
+    requireGrant("oauth_client:*", "read"),
+    describeRoute({
+      tags: ["OAuth Clients"],
+      summary: "List OAuth client registrations",
+      description:
+        "Lists OAuth client registrations for the tenant. Secrets are never returned.",
+      parameters: [...pageParameters],
+      responses: {
+        200: {
+          description: "List of OAuth clients",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(OAuthClientResponse)),
+            },
           },
         },
       },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
+
+      const conditions = [eq(oauthClient.tenantId, tenantCtx.id)];
+      if (cursor) {
+        conditions.push(
+          cursorCondition(oauthClient.createdAt, oauthClient.id, cursor),
+        );
+      }
+
+      const rows = await db.query.oauthClient.findMany({
+        where: and(...conditions),
+        orderBy: pageOrder(oauthClient.createdAt, oauthClient.id),
+        limit,
+      });
+
+      return c.json(
+        paginatedResponse(rows.map(formatOAuthClient), rows, limit),
+      );
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
+  );
 
-    const conditions = [eq(oauthClient.tenantId, tenantCtx.id)];
-    if (cursor) {
-      conditions.push(
-        cursorCondition(oauthClient.createdAt, oauthClient.id, cursor),
-      );
-    }
-
-    const rows = await db.query.oauthClient.findMany({
-      where: and(...conditions),
-      orderBy: pageOrder(oauthClient.createdAt, oauthClient.id),
-      limit,
-    });
-
-    return c.json(paginatedResponse(rows.map(formatOAuthClient), rows, limit));
-  },
-);
-
-app.post(
-  "/",
-  requireGrant("oauth_client:*", "create"),
-  describeRoute({
-    tags: ["OAuth Clients"],
-    summary: "Register an OAuth client",
-    description:
-      "Registers an OAuth client (client_id/client_secret) for a provider. The provider must exist in the tenant or its ancestors.",
-    responses: {
-      201: {
-        description: "OAuth client registered",
-        content: {
-          "application/json": { schema: resolver(OAuthClientResponse) },
-        },
-      },
-      400: {
-        description: "Validation error",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      404: {
-        description: "Provider not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      409: {
-        description:
-          "OAuth client already exists for this provider in this tenant",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", CreateOAuthClient),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const body = c.req.valid("json");
-    const db = c.get("db");
-
-    const providerRow = await db.query.provider.findFirst({
-      where: eq(provider.id, body.providerId),
-    });
-    if (!providerRow) {
-      return c.json(
-        { error: { code: "not_found", message: "Provider not found" } },
-        404,
-      );
-    }
-
-    const chain = await getAncestorChain(db, tenantCtx.id);
-    if (!chain.includes(providerRow.tenantId)) {
-      return c.json(
-        { error: { code: "not_found", message: "Provider not found" } },
-        404,
-      );
-    }
-
-    const existing = await db.query.oauthClient.findFirst({
-      where: and(
-        eq(oauthClient.tenantId, tenantCtx.id),
-        eq(oauthClient.providerId, body.providerId),
-      ),
-    });
-    if (existing) {
-      return c.json(
-        {
-          error: {
-            code: "conflict",
-            message:
-              "OAuth client already exists for this provider in this tenant",
+  app.post(
+    "/",
+    requireGrant("oauth_client:*", "create"),
+    describeRoute({
+      tags: ["OAuth Clients"],
+      summary: "Register an OAuth client",
+      description:
+        "Registers an OAuth client (client_id/client_secret) for a provider. The provider must exist in the tenant or its ancestors.",
+      responses: {
+        201: {
+          description: "OAuth client registered",
+          content: {
+            "application/json": { schema: resolver(OAuthClientResponse) },
           },
         },
-        409,
+        400: {
+          description: "Validation error",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        404: {
+          description: "Provider not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        409: {
+          description:
+            "OAuth client already exists for this provider in this tenant",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    validator("json", CreateOAuthClient),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const body = c.req.valid("json");
+
+      const providerRow = await db.query.provider.findFirst({
+        where: eq(provider.id, body.providerId),
+      });
+      if (!providerRow) {
+        return c.json(
+          { error: { code: "not_found", message: "Provider not found" } },
+          404,
+        );
+      }
+
+      const chain = await getAncestorChain(db, tenantCtx.id);
+      if (!chain.includes(providerRow.tenantId)) {
+        return c.json(
+          { error: { code: "not_found", message: "Provider not found" } },
+          404,
+        );
+      }
+
+      const existing = await db.query.oauthClient.findFirst({
+        where: and(
+          eq(oauthClient.tenantId, tenantCtx.id),
+          eq(oauthClient.providerId, body.providerId),
+        ),
+      });
+      if (existing) {
+        return c.json(
+          {
+            error: {
+              code: "conflict",
+              message:
+                "OAuth client already exists for this provider in this tenant",
+            },
+          },
+          409,
+        );
+      }
+
+      const now = new Date();
+      const row = first(
+        await db
+          .insert(oauthClient)
+          .values({
+            id: generateId("oauthClient"),
+            tenantId: tenantCtx.id,
+            providerId: body.providerId,
+            name: body.name,
+            clientId: body.clientId,
+            clientSecret: body.clientSecret,
+            redirectUris: body.redirectUris ?? null,
+            defaultScopes: body.defaultScopes ?? null,
+            metadata: body.metadata ?? null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning(),
       );
-    }
 
-    const now = new Date();
-    const row = first(
-      await db
-        .insert(oauthClient)
-        .values({
-          id: generateId("oauthClient"),
-          tenantId: tenantCtx.id,
-          providerId: body.providerId,
-          name: body.name,
-          clientId: body.clientId,
-          clientSecret: body.clientSecret,
-          redirectUris: body.redirectUris ?? null,
-          defaultScopes: body.defaultScopes ?? null,
-          metadata: body.metadata ?? null,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning(),
-    );
-
-    return c.json(formatOAuthClient(row), 201);
-  },
-);
-
-app.get(
-  "/:oauthClientId",
-  requireGrant(idResource("oauth_client", "oauthClientId"), "read"),
-  describeRoute({
-    tags: ["OAuth Clients"],
-    summary: "Get OAuth client details",
-    description: "Returns OAuth client metadata. Secrets are never included.",
-    responses: {
-      200: {
-        description: "OAuth client details",
-        content: {
-          "application/json": { schema: resolver(OAuthClientResponse) },
-        },
-      },
-      404: {
-        description: "OAuth client not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
+      return c.json(formatOAuthClient(row), 201);
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const oauthClientId = c.req.param("oauthClientId");
-    const db = c.get("db");
+  );
 
-    const row = await db.query.oauthClient.findFirst({
-      where: and(
-        eq(oauthClient.id, oauthClientId),
-        eq(oauthClient.tenantId, tenantCtx.id),
-      ),
-    });
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "OAuth client not found" } },
-        404,
-      );
-    }
-
-    return c.json(formatOAuthClient(row));
-  },
-);
-
-app.patch(
-  "/:oauthClientId",
-  requireGrant(idResource("oauth_client", "oauthClientId"), "manage"),
-  describeRoute({
-    tags: ["OAuth Clients"],
-    summary: "Update an OAuth client registration",
-    responses: {
-      200: {
-        description: "OAuth client updated",
-        content: {
-          "application/json": { schema: resolver(OAuthClientResponse) },
+  app.get(
+    "/:oauthClientId",
+    requireGrant(idResource("oauth_client", "oauthClientId"), "read"),
+    describeRoute({
+      tags: ["OAuth Clients"],
+      summary: "Get OAuth client details",
+      description: "Returns OAuth client metadata. Secrets are never included.",
+      responses: {
+        200: {
+          description: "OAuth client details",
+          content: {
+            "application/json": { schema: resolver(OAuthClientResponse) },
+          },
+        },
+        404: {
+          description: "OAuth client not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-      404: {
-        description: "OAuth client not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", UpdateOAuthClient),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const oauthClientId = c.req.param("oauthClientId");
-    const body = c.req.valid("json");
-    const db = c.get("db");
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const oauthClientId = c.req.param("oauthClientId");
 
-    const updates: Record<string, unknown> = { updatedAt: new Date() };
-    if (body.name !== undefined) updates["name"] = body.name;
-    if (body.clientId !== undefined) updates["clientId"] = body.clientId;
-    if (body.clientSecret !== undefined)
-      updates["clientSecret"] = body.clientSecret;
-    if (body.redirectUris !== undefined)
-      updates["redirectUris"] = body.redirectUris;
-    if (body.defaultScopes !== undefined)
-      updates["defaultScopes"] = body.defaultScopes;
-    if (body.metadata !== undefined) updates["metadata"] = body.metadata;
-
-    const [updated] = await db
-      .update(oauthClient)
-      .set(updates)
-      .where(
-        and(
+      const row = await db.query.oauthClient.findFirst({
+        where: and(
           eq(oauthClient.id, oauthClientId),
           eq(oauthClient.tenantId, tenantCtx.id),
         ),
-      )
-      .returning();
+      });
 
-    if (!updated) {
-      return c.json(
-        { error: { code: "not_found", message: "OAuth client not found" } },
-        404,
-      );
-    }
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "OAuth client not found" } },
+          404,
+        );
+      }
 
-    return c.json(formatOAuthClient(updated));
-  },
-);
+      return c.json(formatOAuthClient(row));
+    },
+  );
 
-app.delete(
-  "/:oauthClientId",
-  requireGrant(idResource("oauth_client", "oauthClientId"), "manage"),
-  describeRoute({
-    tags: ["OAuth Clients"],
-    summary: "Remove an OAuth client registration",
-    responses: {
-      204: { description: "OAuth client removed" },
-      404: {
-        description: "OAuth client not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
+  app.patch(
+    "/:oauthClientId",
+    requireGrant(idResource("oauth_client", "oauthClientId"), "manage"),
+    describeRoute({
+      tags: ["OAuth Clients"],
+      summary: "Update an OAuth client registration",
+      responses: {
+        200: {
+          description: "OAuth client updated",
+          content: {
+            "application/json": { schema: resolver(OAuthClientResponse) },
+          },
+        },
+        404: {
+          description: "OAuth client not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
+    }),
+    validator("json", UpdateOAuthClient),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const oauthClientId = c.req.param("oauthClientId");
+      const body = c.req.valid("json");
+
+      const updates: Record<string, unknown> = { updatedAt: new Date() };
+      if (body.name !== undefined) updates["name"] = body.name;
+      if (body.clientId !== undefined) updates["clientId"] = body.clientId;
+      if (body.clientSecret !== undefined)
+        updates["clientSecret"] = body.clientSecret;
+      if (body.redirectUris !== undefined)
+        updates["redirectUris"] = body.redirectUris;
+      if (body.defaultScopes !== undefined)
+        updates["defaultScopes"] = body.defaultScopes;
+      if (body.metadata !== undefined) updates["metadata"] = body.metadata;
+
+      const [updated] = await db
+        .update(oauthClient)
+        .set(updates)
+        .where(
+          and(
+            eq(oauthClient.id, oauthClientId),
+            eq(oauthClient.tenantId, tenantCtx.id),
+          ),
+        )
+        .returning();
+
+      if (!updated) {
+        return c.json(
+          { error: { code: "not_found", message: "OAuth client not found" } },
+          404,
+        );
+      }
+
+      return c.json(formatOAuthClient(updated));
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const oauthClientId = c.req.param("oauthClientId");
-    const db = c.get("db");
+  );
 
-    const deleted = await db
-      .delete(oauthClient)
-      .where(
-        and(
-          eq(oauthClient.id, oauthClientId),
-          eq(oauthClient.tenantId, tenantCtx.id),
-        ),
-      )
-      .returning();
+  app.delete(
+    "/:oauthClientId",
+    requireGrant(idResource("oauth_client", "oauthClientId"), "manage"),
+    describeRoute({
+      tags: ["OAuth Clients"],
+      summary: "Remove an OAuth client registration",
+      responses: {
+        204: { description: "OAuth client removed" },
+        404: {
+          description: "OAuth client not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const oauthClientId = c.req.param("oauthClientId");
 
-    if (deleted.length === 0) {
-      return c.json(
-        { error: { code: "not_found", message: "OAuth client not found" } },
-        404,
-      );
-    }
+      const deleted = await db
+        .delete(oauthClient)
+        .where(
+          and(
+            eq(oauthClient.id, oauthClientId),
+            eq(oauthClient.tenantId, tenantCtx.id),
+          ),
+        )
+        .returning();
 
-    return c.body(null, 204);
-  },
-);
+      if (deleted.length === 0) {
+        return c.json(
+          { error: { code: "not_found", message: "OAuth client not found" } },
+          404,
+        );
+      }
 
-export { app as oauthClientRoutes };
+      return c.body(null, 204);
+    },
+  );
+
+  return app;
+}

--- a/packages/hub/src/routes/observability.ts
+++ b/packages/hub/src/routes/observability.ts
@@ -10,135 +10,137 @@ import {
 
 import type { AppEnv } from "../context";
 
-const app = new Hono<AppEnv>();
+export function createObservabilityRoutes(): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
 
-app.get(
-  "/agents/:agentId/logs",
-  describeRoute({
-    tags: ["Observability"],
-    summary: "Get agent logs",
-    description:
-      "Structured logs for an agent. Filterable by level and time range.",
-    parameters: [
-      {
-        name: "level",
-        in: "query",
-        schema: { type: "string", enum: ["debug", "info", "warn", "error"] },
-      },
-      { name: "startTime", in: "query", schema: { type: "string" } },
-      { name: "endTime", in: "query", schema: { type: "string" } },
-    ],
-    responses: {
-      200: {
-        description: "Log entries",
-        content: {
-          "application/json": {
-            schema: resolver(LogEntry.array()),
+  app.get(
+    "/agents/:agentId/logs",
+    describeRoute({
+      tags: ["Observability"],
+      summary: "Get agent logs",
+      description:
+        "Structured logs for an agent. Filterable by level and time range.",
+      parameters: [
+        {
+          name: "level",
+          in: "query",
+          schema: { type: "string", enum: ["debug", "info", "warn", "error"] },
+        },
+        { name: "startTime", in: "query", schema: { type: "string" } },
+        { name: "endTime", in: "query", schema: { type: "string" } },
+      ],
+      responses: {
+        200: {
+          description: "Log entries",
+          content: {
+            "application/json": {
+              schema: resolver(LogEntry.array()),
+            },
+          },
+        },
+        404: {
+          description: "Agent not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
           },
         },
       },
-      404: {
-        description: "Agent not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  (c) =>
-    c.json(
-      { error: { code: "not_implemented", message: "Not implemented" } },
-      501,
-    ),
-);
+    }),
+    (c) =>
+      c.json(
+        { error: { code: "not_implemented", message: "Not implemented" } },
+        501,
+      ),
+  );
 
-app.get(
-  "/agents/:agentId/metrics",
-  describeRoute({
-    tags: ["Observability"],
-    summary: "Get agent metrics",
-    description:
-      "Returns throughput, latency, error rates, token usage, and cost metrics.",
-    responses: {
-      200: {
-        description: "Agent metrics",
-        content: {
-          "application/json": { schema: resolver(MetricsResponse) },
+  app.get(
+    "/agents/:agentId/metrics",
+    describeRoute({
+      tags: ["Observability"],
+      summary: "Get agent metrics",
+      description:
+        "Returns throughput, latency, error rates, token usage, and cost metrics.",
+      responses: {
+        200: {
+          description: "Agent metrics",
+          content: {
+            "application/json": { schema: resolver(MetricsResponse) },
+          },
         },
-      },
-      404: {
-        description: "Agent not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  (c) =>
-    c.json(
-      { error: { code: "not_implemented", message: "Not implemented" } },
-      501,
-    ),
-);
-
-app.get(
-  "/traces",
-  describeRoute({
-    tags: ["Observability"],
-    summary: "Query distributed traces",
-    description:
-      "Searches traces within the tenant. Filterable by agent, session, time range, and trace ID.",
-    parameters: [
-      { name: "agentId", in: "query", schema: { type: "string" } },
-      { name: "sessionId", in: "query", schema: { type: "string" } },
-      { name: "traceId", in: "query", schema: { type: "string" } },
-      { name: "startTime", in: "query", schema: { type: "string" } },
-      { name: "endTime", in: "query", schema: { type: "string" } },
-    ],
-    responses: {
-      200: {
-        description: "List of traces",
-        content: {
-          "application/json": {
-            schema: resolver(SpanResponse.array()),
+        404: {
+          description: "Agent not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
           },
         },
       },
-    },
-  }),
-  (c) =>
-    c.json(
-      { error: { code: "not_implemented", message: "Not implemented" } },
-      501,
-    ),
-);
+    }),
+    (c) =>
+      c.json(
+        { error: { code: "not_implemented", message: "Not implemented" } },
+        501,
+      ),
+  );
 
-app.get(
-  "/traces/:traceId",
-  describeRoute({
-    tags: ["Observability"],
-    summary: "Get a full trace",
-    description: "Returns all spans in a trace across agent boundaries.",
-    responses: {
-      200: {
-        description: "Trace with spans",
-        content: {
-          "application/json": { schema: resolver(TraceResponse) },
+  app.get(
+    "/traces",
+    describeRoute({
+      tags: ["Observability"],
+      summary: "Query distributed traces",
+      description:
+        "Searches traces within the tenant. Filterable by agent, session, time range, and trace ID.",
+      parameters: [
+        { name: "agentId", in: "query", schema: { type: "string" } },
+        { name: "sessionId", in: "query", schema: { type: "string" } },
+        { name: "traceId", in: "query", schema: { type: "string" } },
+        { name: "startTime", in: "query", schema: { type: "string" } },
+        { name: "endTime", in: "query", schema: { type: "string" } },
+      ],
+      responses: {
+        200: {
+          description: "List of traces",
+          content: {
+            "application/json": {
+              schema: resolver(SpanResponse.array()),
+            },
+          },
         },
       },
-      404: {
-        description: "Trace not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
+    }),
+    (c) =>
+      c.json(
+        { error: { code: "not_implemented", message: "Not implemented" } },
+        501,
+      ),
+  );
+
+  app.get(
+    "/traces/:traceId",
+    describeRoute({
+      tags: ["Observability"],
+      summary: "Get a full trace",
+      description: "Returns all spans in a trace across agent boundaries.",
+      responses: {
+        200: {
+          description: "Trace with spans",
+          content: {
+            "application/json": { schema: resolver(TraceResponse) },
+          },
+        },
+        404: {
+          description: "Trace not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-    },
-  }),
-  (c) =>
-    c.json(
-      { error: { code: "not_implemented", message: "Not implemented" } },
-      501,
-    ),
-);
+    }),
+    (c) =>
+      c.json(
+        { error: { code: "not_implemented", message: "Not implemented" } },
+        501,
+      ),
+  );
 
-export { app as observabilityRoutes };
+  return app;
+}

--- a/packages/hub/src/routes/offerings.ts
+++ b/packages/hub/src/routes/offerings.ts
@@ -4,6 +4,7 @@ import { describeRoute, resolver, validator } from "hono-openapi";
 
 import { agent, offering } from "@interchange/db/schema";
 import { parseOfferingRow } from "@interchange/db";
+import type { DB } from "@interchange/db";
 import {
   CreateOffering,
   UpdateOffering,
@@ -42,327 +43,337 @@ export function formatOffering(
   };
 }
 
-const app = new Hono<TenantEnv>();
+export type CreateOfferingRoutesDeps = {
+  db: DB["db"];
+};
 
-app.get(
-  "/",
-  requireGrant("offering:*", "read"),
-  describeRoute({
-    tags: ["Discovery"],
-    summary: "Search offerings",
-    description:
-      "Searches offerings across discoverable agents in the tenant and federated tenants. Filterable by offering name, pricing range, and payment method.",
-    parameters: [
-      { name: "name", in: "query", schema: { type: "string" } },
-      { name: "minPrice", in: "query", schema: { type: "string" } },
-      { name: "maxPrice", in: "query", schema: { type: "string" } },
-      { name: "paymentMethod", in: "query", schema: { type: "string" } },
-      ...pageParameters,
-    ],
-    responses: {
-      200: {
-        description: "List of offerings",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(OfferingDetail)),
+export function createOfferingRoutes({
+  db,
+}: CreateOfferingRoutesDeps): Hono<TenantEnv> {
+  const app = new Hono<TenantEnv>();
+
+  app.get(
+    "/",
+    requireGrant("offering:*", "read"),
+    describeRoute({
+      tags: ["Discovery"],
+      summary: "Search offerings",
+      description:
+        "Searches offerings across discoverable agents in the tenant and federated tenants. Filterable by offering name, pricing range, and payment method.",
+      parameters: [
+        { name: "name", in: "query", schema: { type: "string" } },
+        { name: "minPrice", in: "query", schema: { type: "string" } },
+        { name: "maxPrice", in: "query", schema: { type: "string" } },
+        { name: "paymentMethod", in: "query", schema: { type: "string" } },
+        ...pageParameters,
+      ],
+      responses: {
+        200: {
+          description: "List of offerings",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(OfferingDetail)),
+            },
           },
         },
       },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
-    const name = c.req.query("name");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
-
-    const conditions = [eq(offering.tenantId, tenantCtx.id)];
-    if (name) {
-      conditions.push(ilike(offering.name, `%${name}%`));
-    }
-    if (cursor) {
-      conditions.push(cursorCondition(offering.createdAt, offering.id, cursor));
-    }
-
-    const rows = await db.query.offering.findMany({
-      where: and(...conditions),
-      orderBy: pageOrder(offering.createdAt, offering.id),
-      limit,
-    });
-
-    const agentIds = [...new Set(rows.map((r) => r.agentId))];
-    const agentNames = new Map<string, string>();
-    if (agentIds.length > 0) {
-      const agents = await db.query.agent.findMany({
-        where: (a, { inArray }) => inArray(a.id, agentIds),
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const name = c.req.query("name");
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
       });
-      for (const a of agents) {
-        agentNames.set(a.id, a.name);
+
+      const conditions = [eq(offering.tenantId, tenantCtx.id)];
+      if (name) {
+        conditions.push(ilike(offering.name, `%${name}%`));
       }
-    }
+      if (cursor) {
+        conditions.push(
+          cursorCondition(offering.createdAt, offering.id, cursor),
+        );
+      }
 
-    const items = rows.map((r) =>
-      formatOffering(r, agentNames.get(r.agentId) ?? r.agentId),
-    );
+      const rows = await db.query.offering.findMany({
+        where: and(...conditions),
+        orderBy: pageOrder(offering.createdAt, offering.id),
+        limit,
+      });
 
-    return c.json(paginatedResponse(items, rows, limit));
-  },
-);
+      const agentIds = [...new Set(rows.map((r) => r.agentId))];
+      const agentNames = new Map<string, string>();
+      if (agentIds.length > 0) {
+        const agents = await db.query.agent.findMany({
+          where: (a, { inArray }) => inArray(a.id, agentIds),
+        });
+        for (const a of agents) {
+          agentNames.set(a.id, a.name);
+        }
+      }
 
-app.post(
-  "/",
-  requireGrant("offering:*", "create"),
-  describeRoute({
-    tags: ["Discovery"],
-    summary: "Register an offering",
-    description:
-      "Registers an offering for an agent. The agent must belong to the tenant.",
-    responses: {
-      201: {
-        description: "Offering registered",
-        content: {
-          "application/json": { schema: resolver(OfferingDetail) },
-        },
-      },
-      400: {
-        description: "Validation error",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      404: {
-        description: "Agent not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
+      const items = rows.map((r) =>
+        formatOffering(r, agentNames.get(r.agentId) ?? r.agentId),
+      );
+
+      return c.json(paginatedResponse(items, rows, limit));
     },
-  }),
-  validator("json", CreateOffering),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const body = c.req.valid("json");
-    const db = c.get("db");
+  );
 
-    const agentRow = await db.query.agent.findFirst({
-      where: and(eq(agent.id, body.agentId), eq(agent.tenantId, tenantCtx.id)),
-    });
-
-    if (!agentRow) {
-      return c.json(
-        {
-          error: {
-            code: "not_found",
-            message: "Agent not found in this tenant",
+  app.post(
+    "/",
+    requireGrant("offering:*", "create"),
+    describeRoute({
+      tags: ["Discovery"],
+      summary: "Register an offering",
+      description:
+        "Registers an offering for an agent. The agent must belong to the tenant.",
+      responses: {
+        201: {
+          description: "Offering registered",
+          content: {
+            "application/json": { schema: resolver(OfferingDetail) },
           },
         },
-        404,
+        400: {
+          description: "Validation error",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        404: {
+          description: "Agent not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    validator("json", CreateOffering),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const body = c.req.valid("json");
+
+      const agentRow = await db.query.agent.findFirst({
+        where: and(
+          eq(agent.id, body.agentId),
+          eq(agent.tenantId, tenantCtx.id),
+        ),
+      });
+
+      if (!agentRow) {
+        return c.json(
+          {
+            error: {
+              code: "not_found",
+              message: "Agent not found in this tenant",
+            },
+          },
+          404,
+        );
+      }
+
+      const now = new Date();
+      const row = first(
+        await db
+          .insert(offering)
+          .values({
+            id: generateId("offering"),
+            agentId: body.agentId,
+            tenantId: tenantCtx.id,
+            name: body.name,
+            description: body.description ?? null,
+            pricing: body.pricing ?? null,
+            schema: body.schema ?? null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning(),
       );
-    }
 
-    const now = new Date();
-    const row = first(
-      await db
-        .insert(offering)
-        .values({
-          id: generateId("offering"),
-          agentId: body.agentId,
-          tenantId: tenantCtx.id,
-          name: body.name,
-          description: body.description ?? null,
-          pricing: body.pricing ?? null,
-          schema: body.schema ?? null,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning(),
-    );
-
-    return c.json(formatOffering(row, agentRow.name), 201);
-  },
-);
-
-app.get(
-  "/:offeringId",
-  requireGrant(idResource("offering", "offeringId"), "read"),
-  describeRoute({
-    tags: ["Discovery"],
-    summary: "Get offering details",
-    description:
-      "Returns pricing, agent info, and request/response type information.",
-    responses: {
-      200: {
-        description: "Offering details",
-        content: {
-          "application/json": { schema: resolver(OfferingDetail) },
-        },
-      },
-      404: {
-        description: "Offering not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
+      return c.json(formatOffering(row, agentRow.name), 201);
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const offeringId = c.req.param("offeringId");
-    const db = c.get("db");
+  );
 
-    const row = await db.query.offering.findFirst({
-      where: and(
-        eq(offering.id, offeringId),
-        eq(offering.tenantId, tenantCtx.id),
-      ),
-    });
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Offering not found" } },
-        404,
-      );
-    }
-
-    const agentRow = await db.query.agent.findFirst({
-      where: eq(agent.id, row.agentId),
-    });
-
-    return c.json(formatOffering(row, agentRow?.name ?? row.agentId));
-  },
-);
-
-app.patch(
-  "/:offeringId",
-  requireGrant(idResource("offering", "offeringId"), "manage"),
-  describeRoute({
-    tags: ["Discovery"],
-    summary: "Update an offering",
-    responses: {
-      200: {
-        description: "Offering updated",
-        content: {
-          "application/json": { schema: resolver(OfferingDetail) },
+  app.get(
+    "/:offeringId",
+    requireGrant(idResource("offering", "offeringId"), "read"),
+    describeRoute({
+      tags: ["Discovery"],
+      summary: "Get offering details",
+      description:
+        "Returns pricing, agent info, and request/response type information.",
+      responses: {
+        200: {
+          description: "Offering details",
+          content: {
+            "application/json": { schema: resolver(OfferingDetail) },
+          },
+        },
+        404: {
+          description: "Offering not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-      404: {
-        description: "Offering not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const offeringId = c.req.param("offeringId");
+
+      const row = await db.query.offering.findFirst({
+        where: and(
+          eq(offering.id, offeringId),
+          eq(offering.tenantId, tenantCtx.id),
+        ),
+      });
+
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Offering not found" } },
+          404,
+        );
+      }
+
+      const agentRow = await db.query.agent.findFirst({
+        where: eq(agent.id, row.agentId),
+      });
+
+      return c.json(formatOffering(row, agentRow?.name ?? row.agentId));
     },
-  }),
-  validator("json", UpdateOffering),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const offeringId = c.req.param("offeringId");
-    const body = c.req.valid("json");
-    const db = c.get("db");
+  );
 
-    const updates: Record<string, unknown> = { updatedAt: new Date() };
-    if (body.name !== undefined) updates["name"] = body.name;
-    if (body.description !== undefined)
-      updates["description"] = body.description;
-    if (body.pricing !== undefined) updates["pricing"] = body.pricing;
-    if (body.schema !== undefined) updates["schema"] = body.schema;
-
-    const [updated] = await db
-      .update(offering)
-      .set(updates)
-      .where(
-        and(eq(offering.id, offeringId), eq(offering.tenantId, tenantCtx.id)),
-      )
-      .returning();
-
-    if (!updated) {
-      return c.json(
-        { error: { code: "not_found", message: "Offering not found" } },
-        404,
-      );
-    }
-
-    const agentRow = await db.query.agent.findFirst({
-      where: eq(agent.id, updated.agentId),
-    });
-
-    return c.json(formatOffering(updated, agentRow?.name ?? updated.agentId));
-  },
-);
-
-app.delete(
-  "/:offeringId",
-  requireGrant(idResource("offering", "offeringId"), "manage"),
-  describeRoute({
-    tags: ["Discovery"],
-    summary: "Remove an offering",
-    responses: {
-      204: {
-        description: "Offering removed",
-      },
-      404: {
-        description: "Offering not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
+  app.patch(
+    "/:offeringId",
+    requireGrant(idResource("offering", "offeringId"), "manage"),
+    describeRoute({
+      tags: ["Discovery"],
+      summary: "Update an offering",
+      responses: {
+        200: {
+          description: "Offering updated",
+          content: {
+            "application/json": { schema: resolver(OfferingDetail) },
+          },
+        },
+        404: {
+          description: "Offering not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
+    }),
+    validator("json", UpdateOffering),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const offeringId = c.req.param("offeringId");
+      const body = c.req.valid("json");
+
+      const updates: Record<string, unknown> = { updatedAt: new Date() };
+      if (body.name !== undefined) updates["name"] = body.name;
+      if (body.description !== undefined)
+        updates["description"] = body.description;
+      if (body.pricing !== undefined) updates["pricing"] = body.pricing;
+      if (body.schema !== undefined) updates["schema"] = body.schema;
+
+      const [updated] = await db
+        .update(offering)
+        .set(updates)
+        .where(
+          and(eq(offering.id, offeringId), eq(offering.tenantId, tenantCtx.id)),
+        )
+        .returning();
+
+      if (!updated) {
+        return c.json(
+          { error: { code: "not_found", message: "Offering not found" } },
+          404,
+        );
+      }
+
+      const agentRow = await db.query.agent.findFirst({
+        where: eq(agent.id, updated.agentId),
+      });
+
+      return c.json(formatOffering(updated, agentRow?.name ?? updated.agentId));
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const offeringId = c.req.param("offeringId");
-    const db = c.get("db");
+  );
 
-    const deleted = await db
-      .delete(offering)
-      .where(
-        and(eq(offering.id, offeringId), eq(offering.tenantId, tenantCtx.id)),
-      )
-      .returning();
+  app.delete(
+    "/:offeringId",
+    requireGrant(idResource("offering", "offeringId"), "manage"),
+    describeRoute({
+      tags: ["Discovery"],
+      summary: "Remove an offering",
+      responses: {
+        204: {
+          description: "Offering removed",
+        },
+        404: {
+          description: "Offering not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const offeringId = c.req.param("offeringId");
 
-    if (deleted.length === 0) {
-      return c.json(
-        { error: { code: "not_found", message: "Offering not found" } },
-        404,
-      );
-    }
+      const deleted = await db
+        .delete(offering)
+        .where(
+          and(eq(offering.id, offeringId), eq(offering.tenantId, tenantCtx.id)),
+        )
+        .returning();
 
-    return c.body(null, 204);
-  },
-);
+      if (deleted.length === 0) {
+        return c.json(
+          { error: { code: "not_found", message: "Offering not found" } },
+          404,
+        );
+      }
 
-export { app as offeringRoutes };
+      return c.body(null, 204);
+    },
+  );
+
+  return app;
+}
 
 // Models endpoint is global (not tenant-scoped) -- remains a stub for now
 // since model discovery requires external provider integration
-const modelsApp = new Hono<AppEnv>();
+export function createModelRoutes(): Hono<AppEnv> {
+  const modelsApp = new Hono<AppEnv>();
 
-modelsApp.get(
-  "/",
-  describeRoute({
-    tags: ["Discovery"],
-    summary: "List available models",
-    description:
-      "Lists available models across configured providers with capabilities, pricing, and limits.",
-    responses: {
-      200: {
-        description: "List of models",
-        content: {
-          "application/json": {
-            schema: resolver(ModelInfo.array()),
+  modelsApp.get(
+    "/",
+    describeRoute({
+      tags: ["Discovery"],
+      summary: "List available models",
+      description:
+        "Lists available models across configured providers with capabilities, pricing, and limits.",
+      responses: {
+        200: {
+          description: "List of models",
+          content: {
+            "application/json": {
+              schema: resolver(ModelInfo.array()),
+            },
           },
         },
       },
-    },
-  }),
-  (c) =>
-    c.json(
-      { error: { code: "not_implemented", message: "Not implemented" } },
-      501,
-    ),
-);
+    }),
+    (c) =>
+      c.json(
+        { error: { code: "not_implemented", message: "Not implemented" } },
+        501,
+      ),
+  );
 
-export { modelsApp as modelRoutes };
+  return modelsApp;
+}

--- a/packages/hub/src/routes/offerings.ts
+++ b/packages/hub/src/routes/offerings.ts
@@ -17,7 +17,8 @@ import {
 import type { TenantEnv, AppEnv } from "../context";
 import { first } from "../format";
 import { generateId } from "../ids";
-import { requireGrant, idResource } from "../middleware/grant";
+import { idResource } from "../middleware/grant";
+import type { RequireGrant } from "../middleware/grant";
 import {
   parsePageParams,
   cursorCondition,
@@ -45,10 +46,12 @@ export function formatOffering(
 
 export type CreateOfferingRoutesDeps = {
   db: DB["db"];
+  requireGrant: RequireGrant;
 };
 
 export function createOfferingRoutes({
   db,
+  requireGrant,
 }: CreateOfferingRoutesDeps): Hono<TenantEnv> {
   const app = new Hono<TenantEnv>();
 

--- a/packages/hub/src/routes/principals.ts
+++ b/packages/hub/src/routes/principals.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
 
 import { principal, principalRole, role, user } from "@interchange/db/schema";
+import type { DB } from "@interchange/db";
 import {
   PrincipalResponse,
   UpdatePrincipal,
@@ -117,382 +118,396 @@ async function loadRolesForPrincipal(
   return roles.map((r) => ({ id: r.id, name: r.name }));
 }
 
-const app = new Hono<TenantEnv>();
+export type CreatePrincipalRoutesDeps = {
+  db: DB["db"];
+};
 
-app.get(
-  "/",
-  requireGrant("principal:*", "read"),
-  describeRoute({
-    tags: ["Principals"],
-    summary: "List principals in the tenant",
-    description:
-      "Lists all principals (users and agents) in the tenant. Filterable by kind and status.",
-    parameters: [
-      {
-        name: "kind",
-        in: "query",
-        schema: { type: "string", enum: ["user", "agent"] },
-      },
-      {
-        name: "status",
-        in: "query",
-        schema: {
-          type: "string",
-          enum: ["active", "suspended", "invited", "deactivated"],
+export function createPrincipalRoutes({
+  db,
+}: CreatePrincipalRoutesDeps): Hono<TenantEnv> {
+  const app = new Hono<TenantEnv>();
+
+  app.get(
+    "/",
+    requireGrant("principal:*", "read"),
+    describeRoute({
+      tags: ["Principals"],
+      summary: "List principals in the tenant",
+      description:
+        "Lists all principals (users and agents) in the tenant. Filterable by kind and status.",
+      parameters: [
+        {
+          name: "kind",
+          in: "query",
+          schema: { type: "string", enum: ["user", "agent"] },
         },
-      },
-      ...pageParameters,
-    ],
-    responses: {
-      200: {
-        description: "List of principals",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(PrincipalResponse)),
+        {
+          name: "status",
+          in: "query",
+          schema: {
+            type: "string",
+            enum: ["active", "suspended", "invited", "deactivated"],
+          },
+        },
+        ...pageParameters,
+      ],
+      responses: {
+        200: {
+          description: "List of principals",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(PrincipalResponse)),
+            },
           },
         },
       },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
-    const kind = c.req.query("kind");
-    const status = c.req.query("status");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const kind = c.req.query("kind");
+      const status = c.req.query("status");
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
 
-    const conditions = [eq(principal.tenantId, tenantCtx.id)];
-    if (kind === "user" || kind === "agent") {
-      conditions.push(eq(principal.kind, kind));
-    }
-    if (
-      status === "active" ||
-      status === "suspended" ||
-      status === "invited" ||
-      status === "deactivated"
-    ) {
-      conditions.push(eq(principal.status, status));
-    } else {
-      // Exclude deactivated principals by default
-      conditions.push(ne(principal.status, "deactivated"));
-    }
-    if (cursor) {
-      conditions.push(
-        cursorCondition(principal.createdAt, principal.id, cursor),
+      const conditions = [eq(principal.tenantId, tenantCtx.id)];
+      if (kind === "user" || kind === "agent") {
+        conditions.push(eq(principal.kind, kind));
+      }
+      if (
+        status === "active" ||
+        status === "suspended" ||
+        status === "invited" ||
+        status === "deactivated"
+      ) {
+        conditions.push(eq(principal.status, status));
+      } else {
+        // Exclude deactivated principals by default
+        conditions.push(ne(principal.status, "deactivated"));
+      }
+      if (cursor) {
+        conditions.push(
+          cursorCondition(principal.createdAt, principal.id, cursor),
+        );
+      }
+
+      const rows = await db.query.principal.findMany({
+        where: and(...conditions),
+        orderBy: pageOrder(principal.createdAt, principal.id),
+        limit,
+      });
+
+      const allAssignments =
+        rows.length > 0
+          ? await db.query.principalRole.findMany({
+              where: (pr, { inArray }) =>
+                inArray(
+                  pr.principalId,
+                  rows.map((p) => p.id),
+                ),
+            })
+          : [];
+
+      const roleIds = [...new Set(allAssignments.map((a) => a.roleId))];
+      const roles =
+        roleIds.length > 0
+          ? await db.query.role.findMany({
+              where: (r, { inArray }) => inArray(r.id, roleIds),
+            })
+          : [];
+      const roleMap = new Map(roles.map((r) => [r.id, r]));
+
+      const rolesByPrincipal = new Map<
+        string,
+        { id: string; name: string }[]
+      >();
+      for (const a of allAssignments) {
+        const r = roleMap.get(a.roleId);
+        if (!r) continue;
+        const list = rolesByPrincipal.get(a.principalId) ?? [];
+        list.push({ id: r.id, name: r.name });
+        rolesByPrincipal.set(a.principalId, list);
+      }
+
+      const identities = await resolveIdentities(db, rows);
+
+      const items = rows.map((p) =>
+        formatPrincipal(
+          p,
+          rolesByPrincipal.get(p.id) ?? [],
+          identities.get(p.refId),
+        ),
       );
-    }
 
-    const rows = await db.query.principal.findMany({
-      where: and(...conditions),
-      orderBy: pageOrder(principal.createdAt, principal.id),
-      limit,
-    });
-
-    const allAssignments =
-      rows.length > 0
-        ? await db.query.principalRole.findMany({
-            where: (pr, { inArray }) =>
-              inArray(
-                pr.principalId,
-                rows.map((p) => p.id),
-              ),
-          })
-        : [];
-
-    const roleIds = [...new Set(allAssignments.map((a) => a.roleId))];
-    const roles =
-      roleIds.length > 0
-        ? await db.query.role.findMany({
-            where: (r, { inArray }) => inArray(r.id, roleIds),
-          })
-        : [];
-    const roleMap = new Map(roles.map((r) => [r.id, r]));
-
-    const rolesByPrincipal = new Map<string, { id: string; name: string }[]>();
-    for (const a of allAssignments) {
-      const r = roleMap.get(a.roleId);
-      if (!r) continue;
-      const list = rolesByPrincipal.get(a.principalId) ?? [];
-      list.push({ id: r.id, name: r.name });
-      rolesByPrincipal.set(a.principalId, list);
-    }
-
-    const identities = await resolveIdentities(db, rows);
-
-    const items = rows.map((p) =>
-      formatPrincipal(
-        p,
-        rolesByPrincipal.get(p.id) ?? [],
-        identities.get(p.refId),
-      ),
-    );
-
-    return c.json(paginatedResponse(items, rows, limit));
-  },
-);
-
-app.get(
-  "/:principalId",
-  requireGrant(idResource("principal", "principalId"), "read"),
-  describeRoute({
-    tags: ["Principals"],
-    summary: "Get principal details",
-    description:
-      "Returns principal details including kind, status, assigned roles, and effective grants.",
-    responses: {
-      200: {
-        description: "Principal details",
-        content: {
-          "application/json": { schema: resolver(PrincipalResponse) },
-        },
-      },
-      404: {
-        description: "Principal not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
+      return c.json(paginatedResponse(items, rows, limit));
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const principalId = c.req.param("principalId");
-    const db = c.get("db");
+  );
 
-    const row = await db.query.principal.findFirst({
-      where: and(
-        eq(principal.id, principalId),
-        eq(principal.tenantId, tenantCtx.id),
-      ),
-    });
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Principal not found" } },
-        404,
-      );
-    }
-
-    const roles = await loadRolesForPrincipal(db, principalId);
-    const identities = await resolveIdentities(db, [row]);
-    return c.json(formatPrincipal(row, roles, identities.get(row.refId)));
-  },
-);
-
-app.patch(
-  "/:principalId",
-  requireGrant(idResource("principal", "principalId"), "manage"),
-  describeRoute({
-    tags: ["Principals"],
-    summary: "Update principal status",
-    description: "Activate, suspend, or deactivate a principal.",
-    responses: {
-      200: {
-        description: "Principal updated",
-        content: {
-          "application/json": { schema: resolver(PrincipalResponse) },
+  app.get(
+    "/:principalId",
+    requireGrant(idResource("principal", "principalId"), "read"),
+    describeRoute({
+      tags: ["Principals"],
+      summary: "Get principal details",
+      description:
+        "Returns principal details including kind, status, assigned roles, and effective grants.",
+      responses: {
+        200: {
+          description: "Principal details",
+          content: {
+            "application/json": { schema: resolver(PrincipalResponse) },
+          },
+        },
+        404: {
+          description: "Principal not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-      403: {
-        description: "Insufficient grants",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", UpdatePrincipal),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const principalId = c.req.param("principalId");
-    const body = c.req.valid("json");
-    const db = c.get("db");
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const principalId = c.req.param("principalId");
 
-    const [updated] = await db
-      .update(principal)
-      .set({ status: body.status, updatedAt: new Date() })
-      .where(
-        and(
+      const row = await db.query.principal.findFirst({
+        where: and(
           eq(principal.id, principalId),
           eq(principal.tenantId, tenantCtx.id),
         ),
-      )
-      .returning();
+      });
 
-    if (!updated) {
-      return c.json(
-        { error: { code: "not_found", message: "Principal not found" } },
-        404,
-      );
-    }
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Principal not found" } },
+          404,
+        );
+      }
 
-    const roles = await loadRolesForPrincipal(db, principalId);
-    const identities = await resolveIdentities(db, [updated]);
-    return c.json(
-      formatPrincipal(updated, roles, identities.get(updated.refId)),
-    );
-  },
-);
+      const roles = await loadRolesForPrincipal(db, principalId);
+      const identities = await resolveIdentities(db, [row]);
+      return c.json(formatPrincipal(row, roles, identities.get(row.refId)));
+    },
+  );
 
-app.delete(
-  "/:principalId",
-  requireGrant(idResource("principal", "principalId"), "manage"),
-  describeRoute({
-    tags: ["Principals"],
-    summary: "Remove principal from tenant",
-    description:
-      "Removes a user or agent principal from the tenant. For agents, use agent deletion instead.",
-    responses: {
-      204: {
-        description: "Principal removed",
-      },
-      403: {
-        description: "Insufficient grants",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
+  app.patch(
+    "/:principalId",
+    requireGrant(idResource("principal", "principalId"), "manage"),
+    describeRoute({
+      tags: ["Principals"],
+      summary: "Update principal status",
+      description: "Activate, suspend, or deactivate a principal.",
+      responses: {
+        200: {
+          description: "Principal updated",
+          content: {
+            "application/json": { schema: resolver(PrincipalResponse) },
+          },
+        },
+        403: {
+          description: "Insufficient grants",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const principalId = c.req.param("principalId");
-    const db = c.get("db");
+    }),
+    validator("json", UpdatePrincipal),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const principalId = c.req.param("principalId");
+      const body = c.req.valid("json");
 
-    const deleted = await db
-      .delete(principal)
-      .where(
-        and(
-          eq(principal.id, principalId),
-          eq(principal.tenantId, tenantCtx.id),
-        ),
-      )
-      .returning();
+      const [updated] = await db
+        .update(principal)
+        .set({ status: body.status, updatedAt: new Date() })
+        .where(
+          and(
+            eq(principal.id, principalId),
+            eq(principal.tenantId, tenantCtx.id),
+          ),
+        )
+        .returning();
 
-    if (deleted.length === 0) {
+      if (!updated) {
+        return c.json(
+          { error: { code: "not_found", message: "Principal not found" } },
+          404,
+        );
+      }
+
+      const roles = await loadRolesForPrincipal(db, principalId);
+      const identities = await resolveIdentities(db, [updated]);
       return c.json(
-        { error: { code: "not_found", message: "Principal not found" } },
-        404,
+        formatPrincipal(updated, roles, identities.get(updated.refId)),
       );
-    }
+    },
+  );
 
-    return c.body(null, 204);
-  },
-);
+  app.delete(
+    "/:principalId",
+    requireGrant(idResource("principal", "principalId"), "manage"),
+    describeRoute({
+      tags: ["Principals"],
+      summary: "Remove principal from tenant",
+      description:
+        "Removes a user or agent principal from the tenant. For agents, use agent deletion instead.",
+      responses: {
+        204: {
+          description: "Principal removed",
+        },
+        403: {
+          description: "Insufficient grants",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const principalId = c.req.param("principalId");
 
-export { app as principalRoutes };
+      const deleted = await db
+        .delete(principal)
+        .where(
+          and(
+            eq(principal.id, principalId),
+            eq(principal.tenantId, tenantCtx.id),
+          ),
+        )
+        .returning();
+
+      if (deleted.length === 0) {
+        return c.json(
+          { error: { code: "not_found", message: "Principal not found" } },
+          404,
+        );
+      }
+
+      return c.body(null, 204);
+    },
+  );
+
+  return app;
+}
 
 // Invite is mounted separately at ../members/invite in app.ts
-const inviteApp = new Hono<TenantEnv>();
+export type CreateInviteRoutesDeps = {
+  db: DB["db"];
+};
 
-inviteApp.post(
-  "/",
-  requireGrant("principal:*", "create"),
-  describeRoute({
-    tags: ["Principals"],
-    summary: "Invite a user to the tenant",
-    description:
-      "Invites a user by email. Creates a principal with invited status and optionally assigns a role.",
-    responses: {
-      201: {
-        description: "Invitation sent",
-        content: {
-          "application/json": { schema: resolver(PrincipalResponse) },
-        },
-      },
-      400: {
-        description: "Validation error",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", InviteMember),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const body = c.req.valid("json");
-    const db = c.get("db");
+export function createInviteRoutes({
+  db,
+}: CreateInviteRoutesDeps): Hono<TenantEnv> {
+  const inviteApp = new Hono<TenantEnv>();
 
-    const invitedUser = await db.query.user.findFirst({
-      where: eq(user.email, body.email),
-    });
-
-    if (!invitedUser) {
-      return c.json(
-        {
-          error: {
-            code: "not_found",
-            message: "No user found with that email",
+  inviteApp.post(
+    "/",
+    requireGrant("principal:*", "create"),
+    describeRoute({
+      tags: ["Principals"],
+      summary: "Invite a user to the tenant",
+      description:
+        "Invites a user by email. Creates a principal with invited status and optionally assigns a role.",
+      responses: {
+        201: {
+          description: "Invitation sent",
+          content: {
+            "application/json": { schema: resolver(PrincipalResponse) },
           },
         },
-        404,
-      );
-    }
-
-    const existing = await db.query.principal.findFirst({
-      where: and(
-        eq(principal.tenantId, tenantCtx.id),
-        eq(principal.kind, "user"),
-        eq(principal.refId, invitedUser.id),
-      ),
-    });
-
-    if (existing) {
-      return c.json(
-        {
-          error: {
-            code: "conflict",
-            message: "User is already a member of this tenant",
+        400: {
+          description: "Validation error",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
           },
         },
-        409,
-      );
-    }
+      },
+    }),
+    validator("json", InviteMember),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const body = c.req.valid("json");
 
-    const now = new Date();
-    const principalId = generateId("principal");
-
-    const row = first(
-      await db
-        .insert(principal)
-        .values({
-          id: principalId,
-          tenantId: tenantCtx.id,
-          kind: "user",
-          refId: invitedUser.id,
-          status: "invited",
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning(),
-    );
-
-    let roles: { id: string; name: string }[] = [];
-
-    if (body.roleId) {
-      const roleRow = await db.query.role.findFirst({
-        where: and(eq(role.id, body.roleId), eq(role.tenantId, tenantCtx.id)),
+      const invitedUser = await db.query.user.findFirst({
+        where: eq(user.email, body.email),
       });
-      if (roleRow) {
-        await db.insert(principalRole).values({
-          principalId,
-          roleId: roleRow.id,
-          createdAt: now,
-        });
-        roles = [{ id: roleRow.id, name: roleRow.name }];
+
+      if (!invitedUser) {
+        return c.json(
+          {
+            error: {
+              code: "not_found",
+              message: "No user found with that email",
+            },
+          },
+          404,
+        );
       }
-    }
 
-    const identity: ResolvedIdentity = {
-      displayName: invitedUser.name,
-      email: invitedUser.email,
-    };
-    return c.json(formatPrincipal(row, roles, identity), 201);
-  },
-);
+      const existing = await db.query.principal.findFirst({
+        where: and(
+          eq(principal.tenantId, tenantCtx.id),
+          eq(principal.kind, "user"),
+          eq(principal.refId, invitedUser.id),
+        ),
+      });
 
-export { inviteApp as inviteRoutes };
+      if (existing) {
+        return c.json(
+          {
+            error: {
+              code: "conflict",
+              message: "User is already a member of this tenant",
+            },
+          },
+          409,
+        );
+      }
+
+      const now = new Date();
+      const principalId = generateId("principal");
+
+      const row = first(
+        await db
+          .insert(principal)
+          .values({
+            id: principalId,
+            tenantId: tenantCtx.id,
+            kind: "user",
+            refId: invitedUser.id,
+            status: "invited",
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning(),
+      );
+
+      let roles: { id: string; name: string }[] = [];
+
+      if (body.roleId) {
+        const roleRow = await db.query.role.findFirst({
+          where: and(eq(role.id, body.roleId), eq(role.tenantId, tenantCtx.id)),
+        });
+        if (roleRow) {
+          await db.insert(principalRole).values({
+            principalId,
+            roleId: roleRow.id,
+            createdAt: now,
+          });
+          roles = [{ id: roleRow.id, name: roleRow.name }];
+        }
+      }
+
+      const identity: ResolvedIdentity = {
+        displayName: invitedUser.name,
+        email: invitedUser.email,
+      };
+      return c.json(formatPrincipal(row, roles, identity), 201);
+    },
+  );
+
+  return inviteApp;
+}

--- a/packages/hub/src/routes/principals.ts
+++ b/packages/hub/src/routes/principals.ts
@@ -15,7 +15,8 @@ import {
 import type { TenantEnv } from "../context";
 import { first, ts } from "../format";
 import { generateId } from "../ids";
-import { requireGrant, idResource } from "../middleware/grant";
+import { idResource } from "../middleware/grant";
+import type { RequireGrant } from "../middleware/grant";
 import {
   parsePageParams,
   cursorCondition,
@@ -46,7 +47,7 @@ function formatPrincipal(
 }
 
 async function resolveIdentities(
-  db: TenantEnv["Variables"]["db"],
+  db: DB["db"],
   principals: (typeof principal.$inferSelect)[],
 ): Promise<Map<string, ResolvedIdentity>> {
   const identities = new Map<string, ResolvedIdentity>();
@@ -102,10 +103,7 @@ async function resolveIdentities(
   return identities;
 }
 
-async function loadRolesForPrincipal(
-  db: TenantEnv["Variables"]["db"],
-  principalId: string,
-) {
+async function loadRolesForPrincipal(db: DB["db"], principalId: string) {
   const assignments = await db.query.principalRole.findMany({
     where: eq(principalRole.principalId, principalId),
   });
@@ -120,10 +118,12 @@ async function loadRolesForPrincipal(
 
 export type CreatePrincipalRoutesDeps = {
   db: DB["db"];
+  requireGrant: RequireGrant;
 };
 
 export function createPrincipalRoutes({
   db,
+  requireGrant,
 }: CreatePrincipalRoutesDeps): Hono<TenantEnv> {
   const app = new Hono<TenantEnv>();
 
@@ -396,10 +396,12 @@ export function createPrincipalRoutes({
 // Invite is mounted separately at ../members/invite in app.ts
 export type CreateInviteRoutesDeps = {
   db: DB["db"];
+  requireGrant: RequireGrant;
 };
 
 export function createInviteRoutes({
   db,
+  requireGrant,
 }: CreateInviteRoutesDeps): Hono<TenantEnv> {
   const inviteApp = new Hono<TenantEnv>();
 

--- a/packages/hub/src/routes/providers.ts
+++ b/packages/hub/src/routes/providers.ts
@@ -4,6 +4,7 @@ import { describeRoute, resolver, validator } from "hono-openapi";
 
 import { provider } from "@interchange/db/schema";
 import { getAncestorChain, parseProviderRow } from "@interchange/db";
+import type { DB } from "@interchange/db";
 import {
   CreateProvider,
   UpdateProvider,
@@ -41,302 +42,307 @@ function formatProvider(row: typeof provider.$inferSelect) {
   };
 }
 
-const app = new Hono<TenantEnv>();
+export type CreateProviderRoutesDeps = {
+  db: DB["db"];
+};
 
-app.get(
-  "/",
-  requireGrant("provider:*", "read"),
-  describeRoute({
-    tags: ["Providers"],
-    summary: "List providers",
-    description:
-      "Lists provider definitions for the tenant, including those inherited from ancestor tenants.",
-    parameters: [
-      {
-        name: "inherited",
-        in: "query",
-        schema: { type: "string", enum: ["true", "false"] },
-      },
-      ...pageParameters,
-    ],
-    responses: {
-      200: {
-        description: "List of providers",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(ProviderResponse)),
+export function createProviderRoutes({
+  db,
+}: CreateProviderRoutesDeps): Hono<TenantEnv> {
+  const app = new Hono<TenantEnv>();
+
+  app.get(
+    "/",
+    requireGrant("provider:*", "read"),
+    describeRoute({
+      tags: ["Providers"],
+      summary: "List providers",
+      description:
+        "Lists provider definitions for the tenant, including those inherited from ancestor tenants.",
+      parameters: [
+        {
+          name: "inherited",
+          in: "query",
+          schema: { type: "string", enum: ["true", "false"] },
+        },
+        ...pageParameters,
+      ],
+      responses: {
+        200: {
+          description: "List of providers",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(ProviderResponse)),
+            },
           },
         },
       },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
-    const inherited = c.req.query("inherited") !== "false";
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const inherited = c.req.query("inherited") !== "false";
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
 
-    if (inherited) {
-      const chain = await getAncestorChain(db, tenantCtx.id);
-      const seen = new Set<string>();
-      const items: ReturnType<typeof formatProvider>[] = [];
+      if (inherited) {
+        const chain = await getAncestorChain(db, tenantCtx.id);
+        const seen = new Set<string>();
+        const items: ReturnType<typeof formatProvider>[] = [];
 
-      for (const tid of chain) {
-        const rows = await db.query.provider.findMany({
-          where: eq(provider.tenantId, tid),
-        });
-        for (const row of rows) {
-          if (!seen.has(row.name)) {
-            seen.add(row.name);
-            items.push(formatProvider(row));
+        for (const tid of chain) {
+          const rows = await db.query.provider.findMany({
+            where: eq(provider.tenantId, tid),
+          });
+          for (const row of rows) {
+            if (!seen.has(row.name)) {
+              seen.add(row.name);
+              items.push(formatProvider(row));
+            }
           }
         }
+
+        return c.json({ data: items, nextCursor: null });
       }
 
-      return c.json({ data: items, nextCursor: null });
-    }
+      const conditions = [eq(provider.tenantId, tenantCtx.id)];
+      if (cursor) {
+        conditions.push(
+          cursorCondition(provider.createdAt, provider.id, cursor),
+        );
+      }
 
-    const conditions = [eq(provider.tenantId, tenantCtx.id)];
-    if (cursor) {
-      conditions.push(cursorCondition(provider.createdAt, provider.id, cursor));
-    }
+      const rows = await db.query.provider.findMany({
+        where: and(...conditions),
+        orderBy: pageOrder(provider.createdAt, provider.id),
+        limit,
+      });
 
-    const rows = await db.query.provider.findMany({
-      where: and(...conditions),
-      orderBy: pageOrder(provider.createdAt, provider.id),
-      limit,
-    });
-
-    return c.json(paginatedResponse(rows.map(formatProvider), rows, limit));
-  },
-);
-
-app.post(
-  "/",
-  requireGrant("provider:*", "create"),
-  describeRoute({
-    tags: ["Providers"],
-    summary: "Create a provider definition",
-    description:
-      "Defines a new service provider for the tenant. The plugin field determines how Interchange integrates with the service.",
-    responses: {
-      201: {
-        description: "Provider created",
-        content: {
-          "application/json": { schema: resolver(ProviderResponse) },
-        },
-      },
-      400: {
-        description: "Validation error",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      409: {
-        description: "Provider name already exists in this tenant",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
+      return c.json(paginatedResponse(rows.map(formatProvider), rows, limit));
     },
-  }),
-  validator("json", CreateProvider),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const body = c.req.valid("json");
-    const db = c.get("db");
+  );
 
-    const existing = await db.query.provider.findFirst({
-      where: and(
-        eq(provider.tenantId, tenantCtx.id),
-        eq(provider.name, body.name),
-      ),
-    });
-    if (existing) {
-      return c.json(
-        {
-          error: {
-            code: "conflict",
-            message: "Provider name already exists in this tenant",
+  app.post(
+    "/",
+    requireGrant("provider:*", "create"),
+    describeRoute({
+      tags: ["Providers"],
+      summary: "Create a provider definition",
+      description:
+        "Defines a new service provider for the tenant. The plugin field determines how Interchange integrates with the service.",
+      responses: {
+        201: {
+          description: "Provider created",
+          content: {
+            "application/json": { schema: resolver(ProviderResponse) },
           },
         },
-        409,
+        400: {
+          description: "Validation error",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        409: {
+          description: "Provider name already exists in this tenant",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    validator("json", CreateProvider),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const body = c.req.valid("json");
+
+      const existing = await db.query.provider.findFirst({
+        where: and(
+          eq(provider.tenantId, tenantCtx.id),
+          eq(provider.name, body.name),
+        ),
+      });
+      if (existing) {
+        return c.json(
+          {
+            error: {
+              code: "conflict",
+              message: "Provider name already exists in this tenant",
+            },
+          },
+          409,
+        );
+      }
+
+      const now = new Date();
+      const row = first(
+        await db
+          .insert(provider)
+          .values({
+            id: generateId("provider"),
+            tenantId: tenantCtx.id,
+            name: body.name,
+            plugin: body.plugin,
+            authorizationUrl: body.authorizationUrl ?? null,
+            tokenUrl: body.tokenUrl ?? null,
+            userInfoUrl: body.userInfoUrl ?? null,
+            scopes: body.scopes ?? null,
+            metadata: body.metadata ?? null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning(),
       );
-    }
 
-    const now = new Date();
-    const row = first(
-      await db
-        .insert(provider)
-        .values({
-          id: generateId("provider"),
-          tenantId: tenantCtx.id,
-          name: body.name,
-          plugin: body.plugin,
-          authorizationUrl: body.authorizationUrl ?? null,
-          tokenUrl: body.tokenUrl ?? null,
-          userInfoUrl: body.userInfoUrl ?? null,
-          scopes: body.scopes ?? null,
-          metadata: body.metadata ?? null,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning(),
-    );
-
-    return c.json(formatProvider(row), 201);
-  },
-);
-
-app.get(
-  "/:providerId",
-  requireGrant(idResource("provider", "providerId"), "read"),
-  describeRoute({
-    tags: ["Providers"],
-    summary: "Get provider details",
-    responses: {
-      200: {
-        description: "Provider details",
-        content: {
-          "application/json": { schema: resolver(ProviderResponse) },
-        },
-      },
-      404: {
-        description: "Provider not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
+      return c.json(formatProvider(row), 201);
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const providerId = c.req.param("providerId");
-    const db = c.get("db");
+  );
 
-    const row = await db.query.provider.findFirst({
-      where: eq(provider.id, providerId),
-    });
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Provider not found" } },
-        404,
-      );
-    }
-
-    const chain = await getAncestorChain(db, tenantCtx.id);
-    if (!chain.includes(row.tenantId)) {
-      return c.json(
-        { error: { code: "not_found", message: "Provider not found" } },
-        404,
-      );
-    }
-
-    return c.json(formatProvider(row));
-  },
-);
-
-app.patch(
-  "/:providerId",
-  requireGrant(idResource("provider", "providerId"), "manage"),
-  describeRoute({
-    tags: ["Providers"],
-    summary: "Update a provider definition",
-    description: "Only providers owned by this tenant can be updated.",
-    responses: {
-      200: {
-        description: "Provider updated",
-        content: {
-          "application/json": { schema: resolver(ProviderResponse) },
+  app.get(
+    "/:providerId",
+    requireGrant(idResource("provider", "providerId"), "read"),
+    describeRoute({
+      tags: ["Providers"],
+      summary: "Get provider details",
+      responses: {
+        200: {
+          description: "Provider details",
+          content: {
+            "application/json": { schema: resolver(ProviderResponse) },
+          },
+        },
+        404: {
+          description: "Provider not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-      404: {
-        description: "Provider not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const providerId = c.req.param("providerId");
+
+      const row = await db.query.provider.findFirst({
+        where: eq(provider.id, providerId),
+      });
+
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Provider not found" } },
+          404,
+        );
+      }
+
+      const chain = await getAncestorChain(db, tenantCtx.id);
+      if (!chain.includes(row.tenantId)) {
+        return c.json(
+          { error: { code: "not_found", message: "Provider not found" } },
+          404,
+        );
+      }
+
+      return c.json(formatProvider(row));
     },
-  }),
-  validator("json", UpdateProvider),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const providerId = c.req.param("providerId");
-    const body = c.req.valid("json");
-    const db = c.get("db");
+  );
 
-    const updates: Record<string, unknown> = { updatedAt: new Date() };
-    if (body.name !== undefined) updates["name"] = body.name;
-    if (body.plugin !== undefined) updates["plugin"] = body.plugin;
-    if (body.authorizationUrl !== undefined)
-      updates["authorizationUrl"] = body.authorizationUrl;
-    if (body.tokenUrl !== undefined) updates["tokenUrl"] = body.tokenUrl;
-    if (body.userInfoUrl !== undefined)
-      updates["userInfoUrl"] = body.userInfoUrl;
-    if (body.scopes !== undefined) updates["scopes"] = body.scopes;
-    if (body.metadata !== undefined) updates["metadata"] = body.metadata;
-
-    const [updated] = await db
-      .update(provider)
-      .set(updates)
-      .where(
-        and(eq(provider.id, providerId), eq(provider.tenantId, tenantCtx.id)),
-      )
-      .returning();
-
-    if (!updated) {
-      return c.json(
-        { error: { code: "not_found", message: "Provider not found" } },
-        404,
-      );
-    }
-
-    return c.json(formatProvider(updated));
-  },
-);
-
-app.delete(
-  "/:providerId",
-  requireGrant(idResource("provider", "providerId"), "manage"),
-  describeRoute({
-    tags: ["Providers"],
-    summary: "Remove a provider definition",
-    description: "Only providers owned by this tenant can be removed.",
-    responses: {
-      204: { description: "Provider removed" },
-      404: {
-        description: "Provider not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
+  app.patch(
+    "/:providerId",
+    requireGrant(idResource("provider", "providerId"), "manage"),
+    describeRoute({
+      tags: ["Providers"],
+      summary: "Update a provider definition",
+      description: "Only providers owned by this tenant can be updated.",
+      responses: {
+        200: {
+          description: "Provider updated",
+          content: {
+            "application/json": { schema: resolver(ProviderResponse) },
+          },
+        },
+        404: {
+          description: "Provider not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
+    }),
+    validator("json", UpdateProvider),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const providerId = c.req.param("providerId");
+      const body = c.req.valid("json");
+
+      const updates: Record<string, unknown> = { updatedAt: new Date() };
+      if (body.name !== undefined) updates["name"] = body.name;
+      if (body.plugin !== undefined) updates["plugin"] = body.plugin;
+      if (body.authorizationUrl !== undefined)
+        updates["authorizationUrl"] = body.authorizationUrl;
+      if (body.tokenUrl !== undefined) updates["tokenUrl"] = body.tokenUrl;
+      if (body.userInfoUrl !== undefined)
+        updates["userInfoUrl"] = body.userInfoUrl;
+      if (body.scopes !== undefined) updates["scopes"] = body.scopes;
+      if (body.metadata !== undefined) updates["metadata"] = body.metadata;
+
+      const [updated] = await db
+        .update(provider)
+        .set(updates)
+        .where(
+          and(eq(provider.id, providerId), eq(provider.tenantId, tenantCtx.id)),
+        )
+        .returning();
+
+      if (!updated) {
+        return c.json(
+          { error: { code: "not_found", message: "Provider not found" } },
+          404,
+        );
+      }
+
+      return c.json(formatProvider(updated));
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const providerId = c.req.param("providerId");
-    const db = c.get("db");
+  );
 
-    const deleted = await db
-      .delete(provider)
-      .where(
-        and(eq(provider.id, providerId), eq(provider.tenantId, tenantCtx.id)),
-      )
-      .returning();
+  app.delete(
+    "/:providerId",
+    requireGrant(idResource("provider", "providerId"), "manage"),
+    describeRoute({
+      tags: ["Providers"],
+      summary: "Remove a provider definition",
+      description: "Only providers owned by this tenant can be removed.",
+      responses: {
+        204: { description: "Provider removed" },
+        404: {
+          description: "Provider not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const providerId = c.req.param("providerId");
 
-    if (deleted.length === 0) {
-      return c.json(
-        { error: { code: "not_found", message: "Provider not found" } },
-        404,
-      );
-    }
+      const deleted = await db
+        .delete(provider)
+        .where(
+          and(eq(provider.id, providerId), eq(provider.tenantId, tenantCtx.id)),
+        )
+        .returning();
 
-    return c.body(null, 204);
-  },
-);
+      if (deleted.length === 0) {
+        return c.json(
+          { error: { code: "not_found", message: "Provider not found" } },
+          404,
+        );
+      }
 
-export { app as providerRoutes };
+      return c.body(null, 204);
+    },
+  );
+
+  return app;
+}

--- a/packages/hub/src/routes/providers.ts
+++ b/packages/hub/src/routes/providers.ts
@@ -16,7 +16,8 @@ import {
 import type { TenantEnv } from "../context";
 import { first, ts } from "../format";
 import { generateId } from "../ids";
-import { requireGrant, idResource } from "../middleware/grant";
+import { idResource } from "../middleware/grant";
+import type { RequireGrant } from "../middleware/grant";
 import {
   parsePageParams,
   cursorCondition,
@@ -44,10 +45,12 @@ function formatProvider(row: typeof provider.$inferSelect) {
 
 export type CreateProviderRoutesDeps = {
   db: DB["db"];
+  requireGrant: RequireGrant;
 };
 
 export function createProviderRoutes({
   db,
+  requireGrant,
 }: CreateProviderRoutesDeps): Hono<TenantEnv> {
   const app = new Hono<TenantEnv>();
 

--- a/packages/hub/src/routes/roles.ts
+++ b/packages/hub/src/routes/roles.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
 
 import { role, principalRole, principal } from "@interchange/db/schema";
+import type { DB } from "@interchange/db";
 import {
   CreateRole,
   UpdateRole,
@@ -35,398 +36,412 @@ function formatRole(row: typeof role.$inferSelect) {
   };
 }
 
-const app = new Hono<TenantEnv>();
+export type CreateRoleRoutesDeps = {
+  db: DB["db"];
+};
 
-app.get(
-  "/",
-  requireGrant("role:*", "read"),
-  describeRoute({
-    tags: ["Roles"],
-    summary: "List roles in the tenant",
-    description:
-      "Lists both system roles (owner, admin, member) and custom roles.",
-    parameters: [...pageParameters],
-    responses: {
-      200: {
-        description: "List of roles",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(RoleResponse)),
+export function createRoleRoutes({
+  db,
+}: CreateRoleRoutesDeps): Hono<TenantEnv> {
+  const app = new Hono<TenantEnv>();
+
+  app.get(
+    "/",
+    requireGrant("role:*", "read"),
+    describeRoute({
+      tags: ["Roles"],
+      summary: "List roles in the tenant",
+      description:
+        "Lists both system roles (owner, admin, member) and custom roles.",
+      parameters: [...pageParameters],
+      responses: {
+        200: {
+          description: "List of roles",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(RoleResponse)),
+            },
           },
         },
       },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
+
+      const conditions = [eq(role.tenantId, tenantCtx.id)];
+      if (cursor) {
+        conditions.push(cursorCondition(role.createdAt, role.id, cursor));
+      }
+
+      const rows = await db.query.role.findMany({
+        where: and(...conditions),
+        orderBy: pageOrder(role.createdAt, role.id),
+        limit,
+      });
+
+      return c.json(paginatedResponse(rows.map(formatRole), rows, limit));
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
+  );
 
-    const conditions = [eq(role.tenantId, tenantCtx.id)];
-    if (cursor) {
-      conditions.push(cursorCondition(role.createdAt, role.id, cursor));
-    }
-
-    const rows = await db.query.role.findMany({
-      where: and(...conditions),
-      orderBy: pageOrder(role.createdAt, role.id),
-      limit,
-    });
-
-    return c.json(paginatedResponse(rows.map(formatRole), rows, limit));
-  },
-);
-
-app.post(
-  "/",
-  requireGrant("role:*", "create"),
-  describeRoute({
-    tags: ["Roles"],
-    summary: "Create a custom role",
-    responses: {
-      201: {
-        description: "Role created",
-        content: {
-          "application/json": { schema: resolver(RoleResponse) },
-        },
-      },
-      400: {
-        description: "Validation error",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", CreateRole),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const body = c.req.valid("json");
-    const db = c.get("db");
-
-    const now = new Date();
-    const row = first(
-      await db
-        .insert(role)
-        .values({
-          id: generateId("role"),
-          tenantId: tenantCtx.id,
-          name: body.name,
-          description: body.description ?? null,
-          isSystem: false,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning(),
-    );
-
-    return c.json(formatRole(row), 201);
-  },
-);
-
-app.get(
-  "/:roleId",
-  requireGrant(idResource("role", "roleId"), "read"),
-  describeRoute({
-    tags: ["Roles"],
-    summary: "Get role details",
-    description: "Returns role details including attached grants.",
-    responses: {
-      200: {
-        description: "Role details",
-        content: {
-          "application/json": { schema: resolver(RoleResponse) },
-        },
-      },
-      404: {
-        description: "Role not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const roleId = c.req.param("roleId");
-    const db = c.get("db");
-
-    const row = await db.query.role.findFirst({
-      where: and(eq(role.id, roleId), eq(role.tenantId, tenantCtx.id)),
-    });
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Role not found" } },
-        404,
-      );
-    }
-
-    return c.json(formatRole(row));
-  },
-);
-
-app.patch(
-  "/:roleId",
-  requireGrant(idResource("role", "roleId"), "manage"),
-  describeRoute({
-    tags: ["Roles"],
-    summary: "Update a role",
-    description: "Update name or description. System roles cannot be modified.",
-    responses: {
-      200: {
-        description: "Role updated",
-        content: {
-          "application/json": { schema: resolver(RoleResponse) },
-        },
-      },
-      403: {
-        description: "Cannot modify system role",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", UpdateRole),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const roleId = c.req.param("roleId");
-    const body = c.req.valid("json");
-    const db = c.get("db");
-
-    const existing = await db.query.role.findFirst({
-      where: and(eq(role.id, roleId), eq(role.tenantId, tenantCtx.id)),
-    });
-
-    if (!existing) {
-      return c.json(
-        { error: { code: "not_found", message: "Role not found" } },
-        404,
-      );
-    }
-
-    if (existing.isSystem) {
-      return c.json(
-        {
-          error: {
-            code: "forbidden",
-            message: "Cannot modify system roles",
+  app.post(
+    "/",
+    requireGrant("role:*", "create"),
+    describeRoute({
+      tags: ["Roles"],
+      summary: "Create a custom role",
+      responses: {
+        201: {
+          description: "Role created",
+          content: {
+            "application/json": { schema: resolver(RoleResponse) },
           },
         },
-        403,
+        400: {
+          description: "Validation error",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    validator("json", CreateRole),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const body = c.req.valid("json");
+
+      const now = new Date();
+      const row = first(
+        await db
+          .insert(role)
+          .values({
+            id: generateId("role"),
+            tenantId: tenantCtx.id,
+            name: body.name,
+            description: body.description ?? null,
+            isSystem: false,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning(),
       );
-    }
 
-    const updates: Record<string, unknown> = { updatedAt: new Date() };
-    if (body.name !== undefined) updates["name"] = body.name;
-    if (body.description !== undefined)
-      updates["description"] = body.description;
-
-    const updated = first(
-      await db.update(role).set(updates).where(eq(role.id, roleId)).returning(),
-    );
-
-    return c.json(formatRole(updated));
-  },
-);
-
-app.delete(
-  "/:roleId",
-  requireGrant(idResource("role", "roleId"), "manage"),
-  describeRoute({
-    tags: ["Roles"],
-    summary: "Delete a custom role",
-    description:
-      "Deletes a custom role. Fails if principals are currently assigned to it. System roles cannot be deleted.",
-    responses: {
-      204: {
-        description: "Role deleted",
-      },
-      400: {
-        description: "Role still assigned to principals",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      403: {
-        description: "Cannot delete system role",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
+      return c.json(formatRole(row), 201);
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const roleId = c.req.param("roleId");
-    const db = c.get("db");
+  );
 
-    const existing = await db.query.role.findFirst({
-      where: and(eq(role.id, roleId), eq(role.tenantId, tenantCtx.id)),
-    });
-
-    if (!existing) {
-      return c.json(
-        { error: { code: "not_found", message: "Role not found" } },
-        404,
-      );
-    }
-
-    if (existing.isSystem) {
-      return c.json(
-        {
-          error: {
-            code: "forbidden",
-            message: "Cannot delete system roles",
+  app.get(
+    "/:roleId",
+    requireGrant(idResource("role", "roleId"), "read"),
+    describeRoute({
+      tags: ["Roles"],
+      summary: "Get role details",
+      description: "Returns role details including attached grants.",
+      responses: {
+        200: {
+          description: "Role details",
+          content: {
+            "application/json": { schema: resolver(RoleResponse) },
           },
         },
-        403,
-      );
-    }
-
-    const assignments = await db.query.principalRole.findMany({
-      where: eq(principalRole.roleId, roleId),
-    });
-
-    if (assignments.length > 0) {
-      return c.json(
-        {
-          error: {
-            code: "bad_request",
-            message: `Role is still assigned to ${assignments.length} principal(s)`,
+        404: {
+          description: "Role not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
           },
         },
-        400,
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const roleId = c.req.param("roleId");
+
+      const row = await db.query.role.findFirst({
+        where: and(eq(role.id, roleId), eq(role.tenantId, tenantCtx.id)),
+      });
+
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Role not found" } },
+          404,
+        );
+      }
+
+      return c.json(formatRole(row));
+    },
+  );
+
+  app.patch(
+    "/:roleId",
+    requireGrant(idResource("role", "roleId"), "manage"),
+    describeRoute({
+      tags: ["Roles"],
+      summary: "Update a role",
+      description:
+        "Update name or description. System roles cannot be modified.",
+      responses: {
+        200: {
+          description: "Role updated",
+          content: {
+            "application/json": { schema: resolver(RoleResponse) },
+          },
+        },
+        403: {
+          description: "Cannot modify system role",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    validator("json", UpdateRole),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const roleId = c.req.param("roleId");
+      const body = c.req.valid("json");
+
+      const existing = await db.query.role.findFirst({
+        where: and(eq(role.id, roleId), eq(role.tenantId, tenantCtx.id)),
+      });
+
+      if (!existing) {
+        return c.json(
+          { error: { code: "not_found", message: "Role not found" } },
+          404,
+        );
+      }
+
+      if (existing.isSystem) {
+        return c.json(
+          {
+            error: {
+              code: "forbidden",
+              message: "Cannot modify system roles",
+            },
+          },
+          403,
+        );
+      }
+
+      const updates: Record<string, unknown> = { updatedAt: new Date() };
+      if (body.name !== undefined) updates["name"] = body.name;
+      if (body.description !== undefined)
+        updates["description"] = body.description;
+
+      const updated = first(
+        await db
+          .update(role)
+          .set(updates)
+          .where(eq(role.id, roleId))
+          .returning(),
       );
-    }
 
-    await db.delete(role).where(eq(role.id, roleId));
+      return c.json(formatRole(updated));
+    },
+  );
 
-    return c.body(null, 204);
-  },
-);
+  app.delete(
+    "/:roleId",
+    requireGrant(idResource("role", "roleId"), "manage"),
+    describeRoute({
+      tags: ["Roles"],
+      summary: "Delete a custom role",
+      description:
+        "Deletes a custom role. Fails if principals are currently assigned to it. System roles cannot be deleted.",
+      responses: {
+        204: {
+          description: "Role deleted",
+        },
+        400: {
+          description: "Role still assigned to principals",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        403: {
+          description: "Cannot delete system role",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const roleId = c.req.param("roleId");
 
-export { app as roleRoutes };
+      const existing = await db.query.role.findFirst({
+        where: and(eq(role.id, roleId), eq(role.tenantId, tenantCtx.id)),
+      });
+
+      if (!existing) {
+        return c.json(
+          { error: { code: "not_found", message: "Role not found" } },
+          404,
+        );
+      }
+
+      if (existing.isSystem) {
+        return c.json(
+          {
+            error: {
+              code: "forbidden",
+              message: "Cannot delete system roles",
+            },
+          },
+          403,
+        );
+      }
+
+      const assignments = await db.query.principalRole.findMany({
+        where: eq(principalRole.roleId, roleId),
+      });
+
+      if (assignments.length > 0) {
+        return c.json(
+          {
+            error: {
+              code: "bad_request",
+              message: `Role is still assigned to ${assignments.length} principal(s)`,
+            },
+          },
+          400,
+        );
+      }
+
+      await db.delete(role).where(eq(role.id, roleId));
+
+      return c.body(null, 204);
+    },
+  );
+
+  return app;
+}
 
 // Role assignment routes are mounted under principals
-const assignApp = new Hono<TenantEnv>();
+export type CreateRoleAssignRoutesDeps = {
+  db: DB["db"];
+};
 
-assignApp.post(
-  "/:roleId",
-  requireGrant("role:*", "manage"),
-  describeRoute({
-    tags: ["Roles"],
-    summary: "Assign a role to a principal",
-    description:
-      "Assigns a role to a user or agent principal within the tenant.",
-    responses: {
-      204: {
-        description: "Role assigned",
-      },
-      404: {
-        description: "Principal or role not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
+export function createRoleAssignRoutes({
+  db,
+}: CreateRoleAssignRoutesDeps): Hono<TenantEnv> {
+  const assignApp = new Hono<TenantEnv>();
+
+  assignApp.post(
+    "/:roleId",
+    requireGrant("role:*", "manage"),
+    describeRoute({
+      tags: ["Roles"],
+      summary: "Assign a role to a principal",
+      description:
+        "Assigns a role to a user or agent principal within the tenant.",
+      responses: {
+        204: {
+          description: "Role assigned",
+        },
+        404: {
+          description: "Principal or role not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const principalId = c.req.param("principalId") ?? "";
-    const roleId = c.req.param("roleId") ?? "";
-    const db = c.get("db");
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const principalId = c.req.param("principalId") ?? "";
+      const roleId = c.req.param("roleId") ?? "";
 
-    const principalRow = await db.query.principal.findFirst({
-      where: and(
-        eq(principal.id, principalId),
-        eq(principal.tenantId, tenantCtx.id),
-      ),
-    });
-    if (!principalRow) {
-      return c.json(
-        { error: { code: "not_found", message: "Principal not found" } },
-        404,
-      );
-    }
-
-    const roleRow = await db.query.role.findFirst({
-      where: and(eq(role.id, roleId), eq(role.tenantId, tenantCtx.id)),
-    });
-    if (!roleRow) {
-      return c.json(
-        { error: { code: "not_found", message: "Role not found" } },
-        404,
-      );
-    }
-
-    const existing = await db.query.principalRole.findFirst({
-      where: and(
-        eq(principalRole.principalId, principalId),
-        eq(principalRole.roleId, roleId),
-      ),
-    });
-
-    if (!existing) {
-      await db.insert(principalRole).values({
-        principalId,
-        roleId,
-        createdAt: new Date(),
+      const principalRow = await db.query.principal.findFirst({
+        where: and(
+          eq(principal.id, principalId),
+          eq(principal.tenantId, tenantCtx.id),
+        ),
       });
-    }
+      if (!principalRow) {
+        return c.json(
+          { error: { code: "not_found", message: "Principal not found" } },
+          404,
+        );
+      }
 
-    return c.body(null, 204);
-  },
-);
+      const roleRow = await db.query.role.findFirst({
+        where: and(eq(role.id, roleId), eq(role.tenantId, tenantCtx.id)),
+      });
+      if (!roleRow) {
+        return c.json(
+          { error: { code: "not_found", message: "Role not found" } },
+          404,
+        );
+      }
 
-assignApp.delete(
-  "/:roleId",
-  requireGrant("role:*", "manage"),
-  describeRoute({
-    tags: ["Roles"],
-    summary: "Remove a role from a principal",
-    responses: {
-      204: {
-        description: "Role removed",
-      },
-      404: {
-        description: "Assignment not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const principalId = c.req.param("principalId") ?? "";
-    const roleId = c.req.param("roleId") ?? "";
-    const db = c.get("db");
-
-    const deleted = await db
-      .delete(principalRole)
-      .where(
-        and(
+      const existing = await db.query.principalRole.findFirst({
+        where: and(
           eq(principalRole.principalId, principalId),
           eq(principalRole.roleId, roleId),
         ),
-      )
-      .returning();
+      });
 
-    if (deleted.length === 0) {
-      return c.json(
-        {
-          error: { code: "not_found", message: "Assignment not found" },
+      if (!existing) {
+        await db.insert(principalRole).values({
+          principalId,
+          roleId,
+          createdAt: new Date(),
+        });
+      }
+
+      return c.body(null, 204);
+    },
+  );
+
+  assignApp.delete(
+    "/:roleId",
+    requireGrant("role:*", "manage"),
+    describeRoute({
+      tags: ["Roles"],
+      summary: "Remove a role from a principal",
+      responses: {
+        204: {
+          description: "Role removed",
         },
-        404,
-      );
-    }
+        404: {
+          description: "Assignment not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const principalId = c.req.param("principalId") ?? "";
+      const roleId = c.req.param("roleId") ?? "";
 
-    return c.body(null, 204);
-  },
-);
+      const deleted = await db
+        .delete(principalRole)
+        .where(
+          and(
+            eq(principalRole.principalId, principalId),
+            eq(principalRole.roleId, roleId),
+          ),
+        )
+        .returning();
 
-export { assignApp as roleAssignRoutes };
+      if (deleted.length === 0) {
+        return c.json(
+          {
+            error: { code: "not_found", message: "Assignment not found" },
+          },
+          404,
+        );
+      }
+
+      return c.body(null, 204);
+    },
+  );
+
+  return assignApp;
+}

--- a/packages/hub/src/routes/roles.ts
+++ b/packages/hub/src/routes/roles.ts
@@ -15,7 +15,8 @@ import {
 import type { TenantEnv } from "../context";
 import { first, ts } from "../format";
 import { generateId } from "../ids";
-import { requireGrant, idResource } from "../middleware/grant";
+import { idResource } from "../middleware/grant";
+import type { RequireGrant } from "../middleware/grant";
 import {
   parsePageParams,
   cursorCondition,
@@ -38,10 +39,12 @@ function formatRole(row: typeof role.$inferSelect) {
 
 export type CreateRoleRoutesDeps = {
   db: DB["db"];
+  requireGrant: RequireGrant;
 };
 
 export function createRoleRoutes({
   db,
+  requireGrant,
 }: CreateRoleRoutesDeps): Hono<TenantEnv> {
   const app = new Hono<TenantEnv>();
 
@@ -324,10 +327,12 @@ export function createRoleRoutes({
 // Role assignment routes are mounted under principals
 export type CreateRoleAssignRoutesDeps = {
   db: DB["db"];
+  requireGrant: RequireGrant;
 };
 
 export function createRoleAssignRoutes({
   db,
+  requireGrant,
 }: CreateRoleAssignRoutesDeps): Hono<TenantEnv> {
   const assignApp = new Hono<TenantEnv>();
 

--- a/packages/hub/src/routes/sidecars.ts
+++ b/packages/hub/src/routes/sidecars.ts
@@ -5,6 +5,7 @@ import type { Handler } from "hono";
 
 import { sidecar } from "@interchange/db/schema";
 import { parseSidecarStatus } from "@interchange/db";
+import type { DB } from "@interchange/db";
 import {
   CreateSidecar,
   SidecarResponse,
@@ -25,11 +26,19 @@ function formatSidecar(row: typeof sidecar.$inferSelect) {
   };
 }
 
+export type CreateSidecarRoutesDeps = {
+  db: DB["db"];
+  wsHandler?: Handler<AppEnv>;
+};
+
 // Sidecar management routes are system-level (not tenant-scoped) and
 // authenticated by the sidecar's registration token over the WebSocket
 // channel. The REST endpoints here are for internal tooling and are not
 // exposed through tenant authorization grants.
-export function createSidecarRoutes(wsHandler?: Handler<AppEnv>) {
+export function createSidecarRoutes({
+  db,
+  wsHandler,
+}: CreateSidecarRoutesDeps): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
 
   if (wsHandler) {
@@ -54,7 +63,6 @@ export function createSidecarRoutes(wsHandler?: Handler<AppEnv>) {
     }),
     validator("json", CreateSidecar),
     async (c) => {
-      const db = c.get("db");
       const body = c.req.valid("json");
 
       const resolvedStatus = body.status ?? "online";
@@ -100,7 +108,6 @@ export function createSidecarRoutes(wsHandler?: Handler<AppEnv>) {
       },
     }),
     async (c) => {
-      const db = c.get("db");
       const sidecars = await db.select().from(sidecar);
       return c.json(sidecars.map(formatSidecar));
     },
@@ -127,7 +134,6 @@ export function createSidecarRoutes(wsHandler?: Handler<AppEnv>) {
       },
     }),
     async (c) => {
-      const db = c.get("db");
       const id = c.req.param("id");
       const [sc] = await db.select().from(sidecar).where(eq(sidecar.id, id));
 
@@ -158,7 +164,6 @@ export function createSidecarRoutes(wsHandler?: Handler<AppEnv>) {
       },
     }),
     async (c) => {
-      const db = c.get("db");
       const id = c.req.param("id");
       const deleted = await db
         .delete(sidecar)
@@ -194,7 +199,6 @@ export function createSidecarRoutes(wsHandler?: Handler<AppEnv>) {
       },
     }),
     async (c) => {
-      const db = c.get("db");
       const id = c.req.param("id");
       const updated = await db
         .update(sidecar)

--- a/packages/hub/src/routes/tenant-federation.ts
+++ b/packages/hub/src/routes/tenant-federation.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
 
 import { federationTrust, tenant } from "@interchange/db/schema";
+import type { DB } from "@interchange/db";
 import {
   FederationTrust,
   CreateFederationTrust,
@@ -21,195 +22,204 @@ import {
   pageParameters,
 } from "../pagination";
 
-const app = new Hono<TenantEnv>();
+export type CreateTenantFederationRoutesDeps = {
+  db: DB["db"];
+};
 
-app.get(
-  "/",
-  describeRoute({
-    tags: ["Tenants"],
-    summary: "List federation trust relationships",
-    parameters: [...pageParameters],
-    responses: {
-      200: {
-        description: "Federation trusts",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(FederationTrust)),
+export function createTenantFederationRoutes({
+  db,
+}: CreateTenantFederationRoutesDeps): Hono<TenantEnv> {
+  const app = new Hono<TenantEnv>();
+
+  app.get(
+    "/",
+    describeRoute({
+      tags: ["Tenants"],
+      summary: "List federation trust relationships",
+      parameters: [...pageParameters],
+      responses: {
+        200: {
+          description: "Federation trusts",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(FederationTrust)),
+            },
           },
         },
       },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
+
+      const conditions = [eq(federationTrust.tenantId, tenantCtx.id)];
+      if (cursor) {
+        conditions.push(
+          cursorCondition(
+            federationTrust.createdAt,
+            federationTrust.id,
+            cursor,
+          ),
+        );
+      }
+
+      const rows = await db.query.federationTrust.findMany({
+        where: and(...conditions),
+        orderBy: pageOrder(federationTrust.createdAt, federationTrust.id),
+        limit,
+      });
+
+      const targetIds = rows.map((t) => t.targetTenantId);
+      const tenants =
+        targetIds.length > 0
+          ? await db.query.tenant.findMany({
+              where: (t, { inArray }) => inArray(t.id, targetIds),
+            })
+          : [];
+      const tenantMap = new Map(tenants.map((t) => [t.id, t]));
+
+      const items = rows.map((trust) => {
+        const target = tenantMap.get(trust.targetTenantId);
+        return {
+          tenantId: trust.targetTenantId,
+          tenantName: target?.name ?? "Unknown",
+          tenantDomain: target?.domain ?? "unknown",
+          direction: trust.direction,
+          createdAt: ts(trust.createdAt),
+        };
+      });
+
+      return c.json(paginatedResponse(items, rows, limit));
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
+  );
 
-    const conditions = [eq(federationTrust.tenantId, tenantCtx.id)];
-    if (cursor) {
-      conditions.push(
-        cursorCondition(federationTrust.createdAt, federationTrust.id, cursor),
-      );
-    }
-
-    const rows = await db.query.federationTrust.findMany({
-      where: and(...conditions),
-      orderBy: pageOrder(federationTrust.createdAt, federationTrust.id),
-      limit,
-    });
-
-    const targetIds = rows.map((t) => t.targetTenantId);
-    const tenants =
-      targetIds.length > 0
-        ? await db.query.tenant.findMany({
-            where: (t, { inArray }) => inArray(t.id, targetIds),
-          })
-        : [];
-    const tenantMap = new Map(tenants.map((t) => [t.id, t]));
-
-    const items = rows.map((trust) => {
-      const target = tenantMap.get(trust.targetTenantId);
-      return {
-        tenantId: trust.targetTenantId,
-        tenantName: target?.name ?? "Unknown",
-        tenantDomain: target?.domain ?? "unknown",
-        direction: trust.direction,
-        createdAt: ts(trust.createdAt),
-      };
-    });
-
-    return c.json(paginatedResponse(items, rows, limit));
-  },
-);
-
-app.post(
-  "/",
-  describeRoute({
-    tags: ["Tenants"],
-    summary: "Establish federation trust",
-    description:
-      "Creates a trust relationship with another tenant for cross-tenant agent discovery and interaction.",
-    responses: {
-      201: {
-        description: "Trust established",
-        content: {
-          "application/json": { schema: resolver(FederationTrust) },
-        },
-      },
-      400: {
-        description: "Validation error",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", CreateFederationTrust),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const body = c.req.valid("json");
-    const db = c.get("db");
-
-    const target = await db.query.tenant.findFirst({
-      where: eq(tenant.id, body.targetTenantId),
-    });
-    if (!target) {
-      return c.json(
-        {
-          error: {
-            code: "not_found",
-            message: "Target tenant not found",
+  app.post(
+    "/",
+    describeRoute({
+      tags: ["Tenants"],
+      summary: "Establish federation trust",
+      description:
+        "Creates a trust relationship with another tenant for cross-tenant agent discovery and interaction.",
+      responses: {
+        201: {
+          description: "Trust established",
+          content: {
+            "application/json": { schema: resolver(FederationTrust) },
           },
         },
-        404,
-      );
-    }
-
-    const existing = await db.query.federationTrust.findFirst({
-      where: and(
-        eq(federationTrust.tenantId, tenantCtx.id),
-        eq(federationTrust.targetTenantId, body.targetTenantId),
-      ),
-    });
-    if (existing) {
-      return c.json(
-        {
-          error: {
-            code: "conflict",
-            message: "Trust relationship already exists",
+        400: {
+          description: "Validation error",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
           },
         },
-        409,
-      );
-    }
-
-    await db.insert(federationTrust).values({
-      id: generateId("federationTrust"),
-      tenantId: tenantCtx.id,
-      targetTenantId: body.targetTenantId,
-      direction: body.direction,
-      createdAt: new Date(),
-    });
-
-    return c.json(
-      {
-        tenantId: body.targetTenantId,
-        tenantName: target.name,
-        tenantDomain: target.domain,
-        direction: body.direction,
-        createdAt: ts(new Date()),
       },
-      201,
-    );
-  },
-);
+    }),
+    validator("json", CreateFederationTrust),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const body = c.req.valid("json");
 
-app.delete(
-  "/:targetTenantId",
-  describeRoute({
-    tags: ["Tenants"],
-    summary: "Revoke federation trust",
-    responses: {
-      204: {
-        description: "Trust revoked",
-      },
-      404: {
-        description: "Trust not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const targetTenantId = c.req.param("targetTenantId");
-    const db = c.get("db");
+      const target = await db.query.tenant.findFirst({
+        where: eq(tenant.id, body.targetTenantId),
+      });
+      if (!target) {
+        return c.json(
+          {
+            error: {
+              code: "not_found",
+              message: "Target tenant not found",
+            },
+          },
+          404,
+        );
+      }
 
-    const deleted = await db
-      .delete(federationTrust)
-      .where(
-        and(
+      const existing = await db.query.federationTrust.findFirst({
+        where: and(
           eq(federationTrust.tenantId, tenantCtx.id),
-          eq(federationTrust.targetTenantId, targetTenantId),
+          eq(federationTrust.targetTenantId, body.targetTenantId),
         ),
-      )
-      .returning();
+      });
+      if (existing) {
+        return c.json(
+          {
+            error: {
+              code: "conflict",
+              message: "Trust relationship already exists",
+            },
+          },
+          409,
+        );
+      }
 
-    if (deleted.length === 0) {
+      await db.insert(federationTrust).values({
+        id: generateId("federationTrust"),
+        tenantId: tenantCtx.id,
+        targetTenantId: body.targetTenantId,
+        direction: body.direction,
+        createdAt: new Date(),
+      });
+
       return c.json(
         {
-          error: { code: "not_found", message: "Trust not found" },
+          tenantId: body.targetTenantId,
+          tenantName: target.name,
+          tenantDomain: target.domain,
+          direction: body.direction,
+          createdAt: ts(new Date()),
         },
-        404,
+        201,
       );
-    }
+    },
+  );
 
-    return c.body(null, 204);
-  },
-);
+  app.delete(
+    "/:targetTenantId",
+    describeRoute({
+      tags: ["Tenants"],
+      summary: "Revoke federation trust",
+      responses: {
+        204: {
+          description: "Trust revoked",
+        },
+        404: {
+          description: "Trust not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const targetTenantId = c.req.param("targetTenantId");
 
-export { app as tenantFederationRoutes };
+      const deleted = await db
+        .delete(federationTrust)
+        .where(
+          and(
+            eq(federationTrust.tenantId, tenantCtx.id),
+            eq(federationTrust.targetTenantId, targetTenantId),
+          ),
+        )
+        .returning();
+
+      if (deleted.length === 0) {
+        return c.json(
+          {
+            error: { code: "not_found", message: "Trust not found" },
+          },
+          404,
+        );
+      }
+
+      return c.body(null, 204);
+    },
+  );
+
+  return app;
+}

--- a/packages/hub/src/routes/tenants.ts
+++ b/packages/hub/src/routes/tenants.ts
@@ -10,6 +10,7 @@ import {
   grant,
 } from "@interchange/db/schema";
 import { parseTenantRow } from "@interchange/db";
+import type { DB } from "@interchange/db";
 import {
   CreateTenant,
   UpdateTenant,
@@ -37,333 +38,338 @@ function formatTenant(row: typeof tenant.$inferSelect) {
   };
 }
 
-const app = new Hono<AppEnv>();
+export type CreateTenantRoutesDeps = {
+  db: DB["db"];
+};
 
-app.post(
-  "/",
-  describeRoute({
-    tags: ["Tenants"],
-    summary: "Create a tenant",
-    description:
-      "Creates a new tenant. The authenticated user becomes the owner with a principal and default owner role.",
-    responses: {
-      201: {
-        description: "Tenant created",
-        content: {
-          "application/json": { schema: resolver(TenantResponse) },
+export function createTenantRoutes({
+  db,
+}: CreateTenantRoutesDeps): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+
+  app.post(
+    "/",
+    describeRoute({
+      tags: ["Tenants"],
+      summary: "Create a tenant",
+      description:
+        "Creates a new tenant. The authenticated user becomes the owner with a principal and default owner role.",
+      responses: {
+        201: {
+          description: "Tenant created",
+          content: {
+            "application/json": { schema: resolver(TenantResponse) },
+          },
+        },
+        400: {
+          description: "Validation error",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
         },
       },
-      400: {
-        description: "Validation error",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", CreateTenant),
-  async (c) => {
-    const user = c.get("user");
-    if (!user) {
-      return c.json(
-        {
-          error: { code: "unauthorized", message: "Authentication required" },
-        },
-        401,
+    }),
+    validator("json", CreateTenant),
+    async (c) => {
+      const user = c.get("user");
+      if (!user) {
+        return c.json(
+          {
+            error: { code: "unauthorized", message: "Authentication required" },
+          },
+          401,
+        );
+      }
+
+      const body = c.req.valid("json");
+
+      const tenantId = generateId("tenant");
+      const domain = `${body.slug}.localhost`;
+
+      const existing = await db.query.tenant.findFirst({
+        where: eq(tenant.slug, body.slug),
+      });
+      if (existing) {
+        return c.json(
+          {
+            error: { code: "conflict", message: "Slug already taken" },
+          },
+          409,
+        );
+      }
+
+      const now = new Date();
+
+      const tenantRow = first(
+        await db
+          .insert(tenant)
+          .values({
+            id: tenantId,
+            name: body.name,
+            slug: body.slug,
+            domain,
+            parentId: body.parentId ?? null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning(),
       );
-    }
 
-    const body = c.req.valid("json");
-    const db = c.get("db");
-
-    const tenantId = generateId("tenant");
-    const domain = `${body.slug}.localhost`;
-
-    const existing = await db.query.tenant.findFirst({
-      where: eq(tenant.slug, body.slug),
-    });
-    if (existing) {
-      return c.json(
-        {
-          error: { code: "conflict", message: "Slug already taken" },
-        },
-        409,
-      );
-    }
-
-    const now = new Date();
-
-    const tenantRow = first(
-      await db
-        .insert(tenant)
-        .values({
-          id: tenantId,
-          name: body.name,
-          slug: body.slug,
-          domain,
-          parentId: body.parentId ?? null,
+      const roleIds: Record<string, string> = {};
+      for (const roleName of SYSTEM_ROLES) {
+        const roleId = generateId("role");
+        roleIds[roleName] = roleId;
+        await db.insert(role).values({
+          id: roleId,
+          tenantId,
+          name: roleName,
+          description: `System ${roleName} role`,
+          isSystem: true,
           createdAt: now,
           updatedAt: now,
-        })
-        .returning(),
-    );
+        });
+      }
 
-    const roleIds: Record<string, string> = {};
-    for (const roleName of SYSTEM_ROLES) {
-      const roleId = generateId("role");
-      roleIds[roleName] = roleId;
-      await db.insert(role).values({
-        id: roleId,
+      const ownerRoleId = roleIds["owner"];
+      if (!ownerRoleId) throw new Error("Owner role was not created");
+
+      const principalId = generateId("principal");
+      await db.insert(principal).values({
+        id: principalId,
         tenantId,
-        name: roleName,
-        description: `System ${roleName} role`,
-        isSystem: true,
+        kind: "user",
+        refId: user.id,
+        status: "active",
         createdAt: now,
         updatedAt: now,
       });
-    }
 
-    const ownerRoleId = roleIds["owner"];
-    if (!ownerRoleId) throw new Error("Owner role was not created");
+      await db.insert(principalRole).values({
+        principalId,
+        roleId: ownerRoleId,
+        createdAt: now,
+      });
 
-    const principalId = generateId("principal");
-    await db.insert(principal).values({
-      id: principalId,
-      tenantId,
-      kind: "user",
-      refId: user.id,
-      status: "active",
-      createdAt: now,
-      updatedAt: now,
-    });
+      // Grant owner role full access
+      await db.insert(grant).values({
+        id: generateId("grant"),
+        tenantId,
+        roleId: ownerRoleId,
+        resource: "*",
+        action: "*",
+        effect: "allow",
+        origin: "system",
+        createdAt: now,
+        updatedAt: now,
+      });
 
-    await db.insert(principalRole).values({
-      principalId,
-      roleId: ownerRoleId,
-      createdAt: now,
-    });
+      // Grant admin role broad management access
+      const adminRoleId = roleIds["admin"];
+      if (adminRoleId) {
+        await db.insert(grant).values([
+          {
+            id: generateId("grant"),
+            tenantId,
+            roleId: adminRoleId,
+            resource: "*",
+            action: "read",
+            effect: "allow",
+            origin: "system",
+            createdAt: now,
+            updatedAt: now,
+          },
+          {
+            id: generateId("grant"),
+            tenantId,
+            roleId: adminRoleId,
+            resource: "*",
+            action: "create",
+            effect: "allow",
+            origin: "system",
+            createdAt: now,
+            updatedAt: now,
+          },
+          {
+            id: generateId("grant"),
+            tenantId,
+            roleId: adminRoleId,
+            resource: "*",
+            action: "manage",
+            effect: "allow",
+            origin: "system",
+            createdAt: now,
+            updatedAt: now,
+          },
+        ]);
+      }
 
-    // Grant owner role full access
-    await db.insert(grant).values({
-      id: generateId("grant"),
-      tenantId,
-      roleId: ownerRoleId,
-      resource: "*",
-      action: "*",
-      effect: "allow",
-      origin: "system",
-      createdAt: now,
-      updatedAt: now,
-    });
-
-    // Grant admin role broad management access
-    const adminRoleId = roleIds["admin"];
-    if (adminRoleId) {
-      await db.insert(grant).values([
-        {
+      // Grant member role read-only access
+      const memberRoleId = roleIds["member"];
+      if (memberRoleId) {
+        await db.insert(grant).values({
           id: generateId("grant"),
           tenantId,
-          roleId: adminRoleId,
+          roleId: memberRoleId,
           resource: "*",
           action: "read",
           effect: "allow",
           origin: "system",
           createdAt: now,
           updatedAt: now,
-        },
-        {
-          id: generateId("grant"),
-          tenantId,
-          roleId: adminRoleId,
-          resource: "*",
-          action: "create",
-          effect: "allow",
-          origin: "system",
-          createdAt: now,
-          updatedAt: now,
-        },
-        {
-          id: generateId("grant"),
-          tenantId,
-          roleId: adminRoleId,
-          resource: "*",
-          action: "manage",
-          effect: "allow",
-          origin: "system",
-          createdAt: now,
-          updatedAt: now,
-        },
-      ]);
-    }
+        });
+      }
 
-    // Grant member role read-only access
-    const memberRoleId = roleIds["member"];
-    if (memberRoleId) {
-      await db.insert(grant).values({
-        id: generateId("grant"),
-        tenantId,
-        roleId: memberRoleId,
-        resource: "*",
-        action: "read",
-        effect: "allow",
-        origin: "system",
-        createdAt: now,
-        updatedAt: now,
+      return c.json(formatTenant(tenantRow), 201);
+    },
+  );
+
+  app.get(
+    "/:tenantId",
+    describeRoute({
+      tags: ["Tenants"],
+      summary: "Get tenant details",
+      responses: {
+        200: {
+          description: "Tenant details",
+          content: {
+            "application/json": { schema: resolver(TenantResponse) },
+          },
+        },
+        403: {
+          description: "Not a member of this tenant",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        404: {
+          description: "Tenant not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const user = c.get("user");
+      if (!user) {
+        return c.json(
+          {
+            error: { code: "unauthorized", message: "Authentication required" },
+          },
+          401,
+        );
+      }
+
+      const tenantId = c.req.param("tenantId");
+
+      const tenantRow = await db.query.tenant.findFirst({
+        where: eq(tenant.id, tenantId),
       });
-    }
+      if (!tenantRow) {
+        return c.json(
+          { error: { code: "not_found", message: "Tenant not found" } },
+          404,
+        );
+      }
 
-    return c.json(formatTenant(tenantRow), 201);
-  },
-);
+      const membership = await db.query.principal.findFirst({
+        where: and(
+          eq(principal.tenantId, tenantId),
+          eq(principal.kind, "user"),
+          eq(principal.refId, user.id),
+        ),
+      });
+      if (!membership) {
+        return c.json(
+          {
+            error: {
+              code: "forbidden",
+              message: "Not a member of this tenant",
+            },
+          },
+          403,
+        );
+      }
 
-app.get(
-  "/:tenantId",
-  describeRoute({
-    tags: ["Tenants"],
-    summary: "Get tenant details",
-    responses: {
-      200: {
-        description: "Tenant details",
-        content: {
-          "application/json": { schema: resolver(TenantResponse) },
-        },
-      },
-      403: {
-        description: "Not a member of this tenant",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-      404: {
-        description: "Tenant not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
+      return c.json(formatTenant(tenantRow));
     },
-  }),
-  async (c) => {
-    const user = c.get("user");
-    if (!user) {
-      return c.json(
-        {
-          error: { code: "unauthorized", message: "Authentication required" },
-        },
-        401,
-      );
-    }
+  );
 
-    const tenantId = c.req.param("tenantId");
-    const db = c.get("db");
-
-    const tenantRow = await db.query.tenant.findFirst({
-      where: eq(tenant.id, tenantId),
-    });
-    if (!tenantRow) {
-      return c.json(
-        { error: { code: "not_found", message: "Tenant not found" } },
-        404,
-      );
-    }
-
-    const membership = await db.query.principal.findFirst({
-      where: and(
-        eq(principal.tenantId, tenantId),
-        eq(principal.kind, "user"),
-        eq(principal.refId, user.id),
-      ),
-    });
-    if (!membership) {
-      return c.json(
-        {
-          error: {
-            code: "forbidden",
-            message: "Not a member of this tenant",
+  app.patch(
+    "/:tenantId",
+    describeRoute({
+      tags: ["Tenants"],
+      summary: "Update tenant config",
+      description: "Requires admin or higher grant within the tenant.",
+      responses: {
+        200: {
+          description: "Tenant updated",
+          content: {
+            "application/json": { schema: resolver(TenantResponse) },
           },
         },
-        403,
-      );
-    }
-
-    return c.json(formatTenant(tenantRow));
-  },
-);
-
-app.patch(
-  "/:tenantId",
-  describeRoute({
-    tags: ["Tenants"],
-    summary: "Update tenant config",
-    description: "Requires admin or higher grant within the tenant.",
-    responses: {
-      200: {
-        description: "Tenant updated",
-        content: {
-          "application/json": { schema: resolver(TenantResponse) },
-        },
-      },
-      403: {
-        description: "Insufficient grants",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", UpdateTenant),
-  async (c) => {
-    const user = c.get("user");
-    if (!user) {
-      return c.json(
-        {
-          error: { code: "unauthorized", message: "Authentication required" },
-        },
-        401,
-      );
-    }
-
-    const tenantId = c.req.param("tenantId");
-    const body = c.req.valid("json");
-    const db = c.get("db");
-
-    const membership = await db.query.principal.findFirst({
-      where: and(
-        eq(principal.tenantId, tenantId),
-        eq(principal.kind, "user"),
-        eq(principal.refId, user.id),
-      ),
-    });
-    if (!membership) {
-      return c.json(
-        {
-          error: {
-            code: "forbidden",
-            message: "Not a member of this tenant",
+        403: {
+          description: "Insufficient grants",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
           },
         },
-        403,
-      );
-    }
+      },
+    }),
+    validator("json", UpdateTenant),
+    async (c) => {
+      const user = c.get("user");
+      if (!user) {
+        return c.json(
+          {
+            error: { code: "unauthorized", message: "Authentication required" },
+          },
+          401,
+        );
+      }
 
-    const updates: Record<string, unknown> = { updatedAt: new Date() };
-    if (body.name !== undefined) updates["name"] = body.name;
-    if (body.config !== undefined) updates["config"] = body.config;
+      const tenantId = c.req.param("tenantId");
+      const body = c.req.valid("json");
 
-    const [updated] = await db
-      .update(tenant)
-      .set(updates)
-      .where(eq(tenant.id, tenantId))
-      .returning();
+      const membership = await db.query.principal.findFirst({
+        where: and(
+          eq(principal.tenantId, tenantId),
+          eq(principal.kind, "user"),
+          eq(principal.refId, user.id),
+        ),
+      });
+      if (!membership) {
+        return c.json(
+          {
+            error: {
+              code: "forbidden",
+              message: "Not a member of this tenant",
+            },
+          },
+          403,
+        );
+      }
 
-    if (!updated) {
-      return c.json(
-        { error: { code: "not_found", message: "Tenant not found" } },
-        404,
-      );
-    }
+      const updates: Record<string, unknown> = { updatedAt: new Date() };
+      if (body.name !== undefined) updates["name"] = body.name;
+      if (body.config !== undefined) updates["config"] = body.config;
 
-    return c.json(formatTenant(updated));
-  },
-);
+      const [updated] = await db
+        .update(tenant)
+        .set(updates)
+        .where(eq(tenant.id, tenantId))
+        .returning();
 
-export { app as tenantRoutes };
+      if (!updated) {
+        return c.json(
+          { error: { code: "not_found", message: "Tenant not found" } },
+          404,
+        );
+      }
+
+      return c.json(formatTenant(updated));
+    },
+  );
+
+  return app;
+}

--- a/packages/hub/src/routes/wallets.ts
+++ b/packages/hub/src/routes/wallets.ts
@@ -4,6 +4,7 @@ import { describeRoute, resolver, validator } from "hono-openapi";
 
 import { wallet, transaction } from "@interchange/db/schema";
 import { parseWalletRow, parseTransactionRow } from "@interchange/db";
+import type { DB } from "@interchange/db";
 import {
   CreateWallet,
   UpdateWallet,
@@ -57,302 +58,310 @@ function formatTransaction(row: typeof transaction.$inferSelect) {
   };
 }
 
-const app = new Hono<TenantEnv>();
+export type CreateWalletRoutesDeps = {
+  db: DB["db"];
+};
 
-app.get(
-  "/",
-  requireGrant("wallet:*", "read"),
-  describeRoute({
-    tags: ["Wallets"],
-    summary: "List wallets in the tenant",
-    parameters: [...pageParameters],
-    responses: {
-      200: {
-        description: "List of wallets",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(WalletResponse)),
+export function createWalletRoutes({
+  db,
+}: CreateWalletRoutesDeps): Hono<TenantEnv> {
+  const app = new Hono<TenantEnv>();
+
+  app.get(
+    "/",
+    requireGrant("wallet:*", "read"),
+    describeRoute({
+      tags: ["Wallets"],
+      summary: "List wallets in the tenant",
+      parameters: [...pageParameters],
+      responses: {
+        200: {
+          description: "List of wallets",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(WalletResponse)),
+            },
           },
         },
       },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
+
+      const conditions = [eq(wallet.tenantId, tenantCtx.id)];
+      if (cursor) {
+        conditions.push(cursorCondition(wallet.createdAt, wallet.id, cursor));
+      }
+
+      const rows = await db.query.wallet.findMany({
+        where: and(...conditions),
+        orderBy: pageOrder(wallet.createdAt, wallet.id),
+        limit,
+      });
+
+      return c.json(paginatedResponse(rows.map(formatWallet), rows, limit));
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const db = c.get("db");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
+  );
 
-    const conditions = [eq(wallet.tenantId, tenantCtx.id)];
-    if (cursor) {
-      conditions.push(cursorCondition(wallet.createdAt, wallet.id, cursor));
-    }
-
-    const rows = await db.query.wallet.findMany({
-      where: and(...conditions),
-      orderBy: pageOrder(wallet.createdAt, wallet.id),
-      limit,
-    });
-
-    return c.json(paginatedResponse(rows.map(formatWallet), rows, limit));
-  },
-);
-
-app.post(
-  "/",
-  requireGrant("wallet:*", "create"),
-  describeRoute({
-    tags: ["Wallets"],
-    summary: "Create a wallet",
-    description:
-      "Creates a wallet with the specified payment backend and currency. Access for agents is managed through grants.",
-    responses: {
-      201: {
-        description: "Wallet created",
-        content: {
-          "application/json": { schema: resolver(WalletResponse) },
+  app.post(
+    "/",
+    requireGrant("wallet:*", "create"),
+    describeRoute({
+      tags: ["Wallets"],
+      summary: "Create a wallet",
+      description:
+        "Creates a wallet with the specified payment backend and currency. Access for agents is managed through grants.",
+      responses: {
+        201: {
+          description: "Wallet created",
+          content: {
+            "application/json": { schema: resolver(WalletResponse) },
+          },
         },
-      },
-      400: {
-        description: "Validation error",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", CreateWallet),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const body = c.req.valid("json");
-    const db = c.get("db");
-
-    const now = new Date();
-    const row = first(
-      await db
-        .insert(wallet)
-        .values({
-          id: generateId("wallet"),
-          tenantId: tenantCtx.id,
-          name: body.name,
-          backendType: body.backendType,
-          currency: body.currency,
-          balance: "0",
-          config: body.config ?? null,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning(),
-    );
-
-    return c.json(formatWallet(row), 201);
-  },
-);
-
-app.get(
-  "/:walletId",
-  requireGrant(idResource("wallet", "walletId"), "read"),
-  describeRoute({
-    tags: ["Wallets"],
-    summary: "Get wallet details",
-    description: "Returns wallet details including current balance.",
-    responses: {
-      200: {
-        description: "Wallet details",
-        content: {
-          "application/json": { schema: resolver(WalletResponse) },
-        },
-      },
-      404: {
-        description: "Wallet not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const walletId = c.req.param("walletId");
-    const db = c.get("db");
-
-    const row = await db.query.wallet.findFirst({
-      where: and(eq(wallet.id, walletId), eq(wallet.tenantId, tenantCtx.id)),
-    });
-
-    if (!row) {
-      return c.json(
-        { error: { code: "not_found", message: "Wallet not found" } },
-        404,
-      );
-    }
-
-    return c.json(formatWallet(row));
-  },
-);
-
-app.patch(
-  "/:walletId",
-  requireGrant(idResource("wallet", "walletId"), "manage"),
-  describeRoute({
-    tags: ["Wallets"],
-    summary: "Update wallet config",
-    responses: {
-      200: {
-        description: "Wallet updated",
-        content: {
-          "application/json": { schema: resolver(WalletResponse) },
-        },
-      },
-      404: {
-        description: "Wallet not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  validator("json", UpdateWallet),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const walletId = c.req.param("walletId");
-    const body = c.req.valid("json");
-    const db = c.get("db");
-
-    const updates: Record<string, unknown> = { updatedAt: new Date() };
-    if (body.name !== undefined) updates["name"] = body.name;
-    if (body.config !== undefined) updates["config"] = body.config;
-
-    const [updated] = await db
-      .update(wallet)
-      .set(updates)
-      .where(and(eq(wallet.id, walletId), eq(wallet.tenantId, tenantCtx.id)))
-      .returning();
-
-    if (!updated) {
-      return c.json(
-        { error: { code: "not_found", message: "Wallet not found" } },
-        404,
-      );
-    }
-
-    return c.json(formatWallet(updated));
-  },
-);
-
-app.delete(
-  "/:walletId",
-  requireGrant(idResource("wallet", "walletId"), "manage"),
-  describeRoute({
-    tags: ["Wallets"],
-    summary: "Deactivate a wallet",
-    responses: {
-      204: {
-        description: "Wallet deactivated",
-      },
-      404: {
-        description: "Wallet not found",
-        content: {
-          "application/json": { schema: resolver(ErrorResponse) },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const walletId = c.req.param("walletId");
-    const db = c.get("db");
-
-    const deleted = await db
-      .delete(wallet)
-      .where(and(eq(wallet.id, walletId), eq(wallet.tenantId, tenantCtx.id)))
-      .returning();
-
-    if (deleted.length === 0) {
-      return c.json(
-        { error: { code: "not_found", message: "Wallet not found" } },
-        404,
-      );
-    }
-
-    return c.body(null, 204);
-  },
-);
-
-app.get(
-  "/:walletId/transactions",
-  requireGrant(idResource("wallet", "walletId"), "read"),
-  describeRoute({
-    tags: ["Wallets"],
-    summary: "List transactions",
-    description:
-      "Transaction history for a wallet. Filterable by agent, date range, and status.",
-    parameters: [
-      { name: "agentId", in: "query", schema: { type: "string" } },
-      { name: "startTime", in: "query", schema: { type: "string" } },
-      { name: "endTime", in: "query", schema: { type: "string" } },
-      {
-        name: "status",
-        in: "query",
-        schema: { type: "string", enum: ["pending", "completed", "failed"] },
-      },
-      ...pageParameters,
-    ],
-    responses: {
-      200: {
-        description: "List of transactions",
-        content: {
-          "application/json": {
-            schema: resolver(paginatedSchema(TransactionResponse)),
+        400: {
+          description: "Validation error",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
           },
         },
       },
+    }),
+    validator("json", CreateWallet),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const body = c.req.valid("json");
+
+      const now = new Date();
+      const row = first(
+        await db
+          .insert(wallet)
+          .values({
+            id: generateId("wallet"),
+            tenantId: tenantCtx.id,
+            name: body.name,
+            backendType: body.backendType,
+            currency: body.currency,
+            balance: "0",
+            config: body.config ?? null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning(),
+      );
+
+      return c.json(formatWallet(row), 201);
     },
-  }),
-  async (c) => {
-    const tenantCtx = c.get("tenant");
-    const walletId = c.req.param("walletId");
-    const db = c.get("db");
+  );
 
-    const walletRow = await db.query.wallet.findFirst({
-      where: and(eq(wallet.id, walletId), eq(wallet.tenantId, tenantCtx.id)),
-    });
+  app.get(
+    "/:walletId",
+    requireGrant(idResource("wallet", "walletId"), "read"),
+    describeRoute({
+      tags: ["Wallets"],
+      summary: "Get wallet details",
+      description: "Returns wallet details including current balance.",
+      responses: {
+        200: {
+          description: "Wallet details",
+          content: {
+            "application/json": { schema: resolver(WalletResponse) },
+          },
+        },
+        404: {
+          description: "Wallet not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const walletId = c.req.param("walletId");
 
-    if (!walletRow) {
+      const row = await db.query.wallet.findFirst({
+        where: and(eq(wallet.id, walletId), eq(wallet.tenantId, tenantCtx.id)),
+      });
+
+      if (!row) {
+        return c.json(
+          { error: { code: "not_found", message: "Wallet not found" } },
+          404,
+        );
+      }
+
+      return c.json(formatWallet(row));
+    },
+  );
+
+  app.patch(
+    "/:walletId",
+    requireGrant(idResource("wallet", "walletId"), "manage"),
+    describeRoute({
+      tags: ["Wallets"],
+      summary: "Update wallet config",
+      responses: {
+        200: {
+          description: "Wallet updated",
+          content: {
+            "application/json": { schema: resolver(WalletResponse) },
+          },
+        },
+        404: {
+          description: "Wallet not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    validator("json", UpdateWallet),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const walletId = c.req.param("walletId");
+      const body = c.req.valid("json");
+
+      const updates: Record<string, unknown> = { updatedAt: new Date() };
+      if (body.name !== undefined) updates["name"] = body.name;
+      if (body.config !== undefined) updates["config"] = body.config;
+
+      const [updated] = await db
+        .update(wallet)
+        .set(updates)
+        .where(and(eq(wallet.id, walletId), eq(wallet.tenantId, tenantCtx.id)))
+        .returning();
+
+      if (!updated) {
+        return c.json(
+          { error: { code: "not_found", message: "Wallet not found" } },
+          404,
+        );
+      }
+
+      return c.json(formatWallet(updated));
+    },
+  );
+
+  app.delete(
+    "/:walletId",
+    requireGrant(idResource("wallet", "walletId"), "manage"),
+    describeRoute({
+      tags: ["Wallets"],
+      summary: "Deactivate a wallet",
+      responses: {
+        204: {
+          description: "Wallet deactivated",
+        },
+        404: {
+          description: "Wallet not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const walletId = c.req.param("walletId");
+
+      const deleted = await db
+        .delete(wallet)
+        .where(and(eq(wallet.id, walletId), eq(wallet.tenantId, tenantCtx.id)))
+        .returning();
+
+      if (deleted.length === 0) {
+        return c.json(
+          { error: { code: "not_found", message: "Wallet not found" } },
+          404,
+        );
+      }
+
+      return c.body(null, 204);
+    },
+  );
+
+  app.get(
+    "/:walletId/transactions",
+    requireGrant(idResource("wallet", "walletId"), "read"),
+    describeRoute({
+      tags: ["Wallets"],
+      summary: "List transactions",
+      description:
+        "Transaction history for a wallet. Filterable by agent, date range, and status.",
+      parameters: [
+        { name: "agentId", in: "query", schema: { type: "string" } },
+        { name: "startTime", in: "query", schema: { type: "string" } },
+        { name: "endTime", in: "query", schema: { type: "string" } },
+        {
+          name: "status",
+          in: "query",
+          schema: { type: "string", enum: ["pending", "completed", "failed"] },
+        },
+        ...pageParameters,
+      ],
+      responses: {
+        200: {
+          description: "List of transactions",
+          content: {
+            "application/json": {
+              schema: resolver(paginatedSchema(TransactionResponse)),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const walletId = c.req.param("walletId");
+
+      const walletRow = await db.query.wallet.findFirst({
+        where: and(eq(wallet.id, walletId), eq(wallet.tenantId, tenantCtx.id)),
+      });
+
+      if (!walletRow) {
+        return c.json(
+          { error: { code: "not_found", message: "Wallet not found" } },
+          404,
+        );
+      }
+
+      const agentId = c.req.query("agentId");
+      const status = c.req.query("status");
+      const { limit, cursor } = parsePageParams({
+        cursor: c.req.query("cursor"),
+        limit: c.req.query("limit"),
+      });
+
+      const conditions = [eq(transaction.walletId, walletId)];
+      if (agentId) conditions.push(eq(transaction.agentId, agentId));
+      if (
+        status === "pending" ||
+        status === "completed" ||
+        status === "failed"
+      ) {
+        conditions.push(eq(transaction.status, status));
+      }
+      if (cursor) {
+        conditions.push(
+          cursorCondition(transaction.createdAt, transaction.id, cursor),
+        );
+      }
+
+      const rows = await db.query.transaction.findMany({
+        where: and(...conditions),
+        orderBy: pageOrder(transaction.createdAt, transaction.id),
+        limit,
+      });
+
       return c.json(
-        { error: { code: "not_found", message: "Wallet not found" } },
-        404,
+        paginatedResponse(rows.map(formatTransaction), rows, limit),
       );
-    }
+    },
+  );
 
-    const agentId = c.req.query("agentId");
-    const status = c.req.query("status");
-    const { limit, cursor } = parsePageParams({
-      cursor: c.req.query("cursor"),
-      limit: c.req.query("limit"),
-    });
-
-    const conditions = [eq(transaction.walletId, walletId)];
-    if (agentId) conditions.push(eq(transaction.agentId, agentId));
-    if (status === "pending" || status === "completed" || status === "failed") {
-      conditions.push(eq(transaction.status, status));
-    }
-    if (cursor) {
-      conditions.push(
-        cursorCondition(transaction.createdAt, transaction.id, cursor),
-      );
-    }
-
-    const rows = await db.query.transaction.findMany({
-      where: and(...conditions),
-      orderBy: pageOrder(transaction.createdAt, transaction.id),
-      limit,
-    });
-
-    return c.json(paginatedResponse(rows.map(formatTransaction), rows, limit));
-  },
-);
-
-export { app as walletRoutes };
+  return app;
+}

--- a/packages/hub/src/routes/wallets.ts
+++ b/packages/hub/src/routes/wallets.ts
@@ -17,7 +17,8 @@ import {
 import type { TenantEnv } from "../context";
 import { first, ts } from "../format";
 import { generateId } from "../ids";
-import { requireGrant, idResource } from "../middleware/grant";
+import { idResource } from "../middleware/grant";
+import type { RequireGrant } from "../middleware/grant";
 import {
   parsePageParams,
   cursorCondition,
@@ -60,10 +61,12 @@ function formatTransaction(row: typeof transaction.$inferSelect) {
 
 export type CreateWalletRoutesDeps = {
   db: DB["db"];
+  requireGrant: RequireGrant;
 };
 
 export function createWalletRoutes({
   db,
+  requireGrant,
 }: CreateWalletRoutesDeps): Hono<TenantEnv> {
   const app = new Hono<TenantEnv>();
 


### PR DESCRIPTION
## Summary

- Every hub route group is now exported as a dependency-injected factory (`createXRoutes(deps)`). Per-request middleware that consumed app-lifetime services (`resolveTenant`, `requireGrant`) becomes a factory of the same shape.
- The session-layer variables (db, grantStore, conditionRegistry, sessionService, sidecarRouter, eventCollectors) are gone from `AppEnv.Variables`; the setter middleware that populated them is deleted. The request context now carries only per-request facts.
- `createHubContextMiddleware` and `mountHubRoutes` are exported from the hub package. Third parties can stand up their own Hono application, mount the request logger and context middleware on their own terms, and bring in hub routes via `mountHubRoutes`. `createApp` is rebuilt as a thin convenience over the two helpers with an unchanged first-party signature.

## Test plan

- [x] \`make all\` (lint + \`tsc -b\` + tests) passes locally on a clean rebase from \`origin/main\`.
- [x] \`packages/hub/src/app.test.ts\` and \`packages/hub/src/routes/instances.test.ts\` continue to pass through the public \`createApp\` path.
- [x] A grep of \`c.get(\` across \`packages/hub/src\` returns only \`tenant\`, \`principal\`, and \`user\` — no consumer still reaches into the request context for app-lifetime services.

Closes INTR-66