### PR TITLE
Drop opsh as a contributor prerequisite

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,6 +1,7 @@
-#!/usr/bin/env opsh
+#!/usr/bin/env bash
 # shellcheck shell=bash
 
+source "$(dirname -- "${BASH_SOURCE[0]}")/../bin/opsh"
 source "$SCRIPTDIR/lib.opsh"
 
 MSGFILE=$1

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,5 +1,7 @@
-#!/usr/bin/env opsh
+#!/usr/bin/env bash
 # shellcheck shell=bash
+
+source "$(dirname -- "${BASH_SOURCE[0]}")/../bin/opsh"
 
 PREV_HEAD=$1
 shift

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,7 @@
-#!/usr/bin/env opsh
+#!/usr/bin/env bash
 # shellcheck shell=bash
 
+source "$(dirname -- "${BASH_SOURCE[0]}")/../bin/opsh"
 source "$SCRIPTDIR/lib.opsh"
 
 step::000::checkout-staging() {

--- a/DEV.md
+++ b/DEV.md
@@ -3,7 +3,6 @@
 ## Prerequisites
 
 - [Bun](https://bun.sh/) (1.2+)
-- [opsh](https://github.com/alexanderguy/opsh) (v0.7+) -- for the shell scripts in `bin/`
 - PostgreSQL (15+)
 - Git hooks configured: `git config core.hooksPath .githooks`
 
@@ -135,7 +134,7 @@ is validated.
 
 ## Bin Scripts
 
-All scripts live in `bin/`. Shell scripts that start with `#!/usr/bin/env opsh` use the bundled `opsh` shell framework (`bin/opsh`).
+All scripts live in `bin/`. The bash scripts source the bundled [opsh](https://github.com/alexanderguy/opsh) framework as a library from `bin/opsh`, so opsh does not need to be installed separately.
 
 | Script                | Usage                                            | Description                                                                                             |
 | --------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -38,11 +38,10 @@ bin/db-reset && bun bin/dev.ts --seed
 Starts the hub, sidecar, and UI — entry points in
 [`apps/`](./apps).
 
-Requires [Bun](https://bun.sh/) 1.2+,
-[opsh](https://github.com/alexanderguy/opsh) 0.7+, and PostgreSQL
-15+. See [`DEV.md`](./DEV.md) for everything else — environment
-files, role setup, default ports, seed credentials, partial-stack
-variants, reset recipes.
+Requires [Bun](https://bun.sh/) 1.2+ and PostgreSQL 15+. See
+[`DEV.md`](./DEV.md) for everything else — environment files, role
+setup, default ports, seed credentials, partial-stack variants,
+reset recipes.
 
 ## Build verbs
 

--- a/bin/add-package
+++ b/bin/add-package
@@ -1,7 +1,8 @@
-#!/usr/bin/env opsh
+#!/usr/bin/env bash
 # shellcheck shell=bash
 
-opsh::version::require v0.7.0
+source "$(dirname -- "${BASH_SOURCE[0]}")/opsh"
+opsh::version::require v0.9.0
 
 REPODIR=$(git rev-parse --show-toplevel)
 

--- a/bin/check-env
+++ b/bin/check-env
@@ -1,6 +1,19 @@
-#!/usr/bin/env opsh
+#!/usr/bin/env bash
 # shellcheck shell=bash disable=SC2164
-opsh::version::require v0.7.0
+
+# This script is the environment-validation gate. Every other shell
+# script in the repo just sources bin/opsh and accepts bash's generic
+# error if the file is missing; here we explicitly check first so a
+# missing vendored opsh fails with a clear diagnostic rather than a
+# bash "no such file" message.
+OPSH_VENDORED="$(dirname -- "${BASH_SOURCE[0]}")/opsh"
+if [[ ! -f $OPSH_VENDORED ]]; then
+	echo "FATAL: vendored opsh not found at $OPSH_VENDORED" >&2
+	exit 1
+fi
+source "$OPSH_VENDORED"
+
+opsh::version::require v0.9.0
 lib::import step-runner
 
 REQUIRED_BUN_VERSION=1.2.0

--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -1,7 +1,8 @@
-#!/usr/bin/env opsh
+#!/usr/bin/env bash
 # shellcheck shell=bash
 
-opsh::version::require v0.7.0
+source "$(dirname -- "${BASH_SOURCE[0]}")/opsh"
+opsh::version::require v0.9.0
 lib::import step-runner
 
 REPODIR=$(git rev-parse --show-toplevel)

--- a/bin/db-reset
+++ b/bin/db-reset
@@ -1,7 +1,8 @@
-#!/usr/bin/env opsh
+#!/usr/bin/env bash
 # shellcheck shell=bash
 
-opsh::version::require v0.7.0
+source "$(dirname -- "${BASH_SOURCE[0]}")/opsh"
+opsh::version::require v0.9.0
 lib::import step-runner
 
 REPODIR=$(git rev-parse --show-toplevel)

--- a/bin/hub
+++ b/bin/hub
@@ -1,7 +1,8 @@
-#!/usr/bin/env opsh
+#!/usr/bin/env bash
 # shellcheck shell=bash
 
-opsh::version::require v0.7.0
+source "$(dirname -- "${BASH_SOURCE[0]}")/opsh"
+opsh::version::require v0.9.0
 
 REPODIR=$(git rev-parse --show-toplevel)
 

--- a/bin/opsh
+++ b/bin/opsh
@@ -19,7 +19,7 @@ set -o errtrace
 
 OPSHROOTDIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/.. &>/dev/null && pwd)
 
-_OPSH_VERSION="0.7.0"
+_OPSH_VERSION="0.9.0"
 _OPSH_LIB_IMPORTED=()
 EXIT_FUNCS=()
 
@@ -172,6 +172,7 @@ opsh::version::require() {
 _OPSH_LIB_IMPORTED+=(cloud-init)
 _OPSH_LIB_IMPORTED+=(command)
 _OPSH_LIB_IMPORTED+=(git)
+_OPSH_LIB_IMPORTED+=(path)
 _OPSH_LIB_IMPORTED+=(semver)
 _OPSH_LIB_IMPORTED+=(ssh)
 _OPSH_LIB_IMPORTED+=(step-runner)
@@ -244,6 +245,18 @@ git::tag::lookup::remote() {
 
     awk '{ print $1;}' <"$tagfile"
     rm "$tagfile"
+}
+path::env::add() {
+    PATH=$(array::join : "$@"):$PATH
+}
+
+path::env::remove() {
+    local dir
+    dir=$1
+    shift
+
+    # XXX - This is not as sophisticated as it could be, but that's probably alright.
+    PATH=$(echo -n "$PATH" | awk -v RS=: -v ORS=: "\$0 == \"$dir\" {next} {print}" | sed 's/:$//;')
 }
 _OPSH_SEMVER_NUM='0|[1-9][0-9]*'
 _OPSH_SEMVER_REGEX="^[vV]?($_OPSH_SEMVER_NUM)\\.($_OPSH_SEMVER_NUM)\\.($_OPSH_SEMVER_NUM)((\+|-).+)?\$"
@@ -365,22 +378,43 @@ semver::bump() {
 
     echo "$prefix"
 }
+lib::import path
+
 export _OPSH_SSH_CONTEXT
 
 ssh::end() {
     [[ -v _OPSH_SSH_CONTEXT ]] || return 0
-    eval "$(cat "$_OPSH_SSH_CONTEXT/env")"
+    path::env::remove "$_OPSH_SSH_CONTEXT/bin"
+
+    # shellcheck disable=SC1091 # we assume this is well formed at runtime
+    source "$_OPSH_SSH_CONTEXT/env"
     eval "$(ssh-agent -k | grep -v echo)"
     unset _OPSH_SSH_CONTEXT
 }
 
 ssh::begin() {
+    local realssh
+
+    # shellcheck disable=SC2034 # it's used in the proxy below
+    realssh=$(command -v ssh)
+
     _OPSH_SSH_CONTEXT=$(temp::dir)
     chmod 700 "$_OPSH_SSH_CONTEXT"
 
     log::debug "launching local SSH agent..."
     ssh-agent | grep -v echo >"$_OPSH_SSH_CONTEXT/env" 2>/dev/null
-    eval "$(cat "$_OPSH_SSH_CONTEXT/env")"
+    # shellcheck disable=SC1091 # we assume this is well formed at runtime
+    source "$_OPSH_SSH_CONTEXT/env"
+
+    mkdir -p "$_OPSH_SSH_CONTEXT/bin"
+    cat >"$_OPSH_SSH_CONTEXT/bin/ssh" <<EOF
+#!/usr/bin/env opsh
+[[ -v _OPSH_SSH_CONTEXT ]] || log::fatal "proxied ssh being run outside of opsh ssh context; this is a bug"
+
+exec $realssh -F "\$_OPSH_SSH_CONTEXT/config" "\$@"
+EOF
+    chmod 755 "$_OPSH_SSH_CONTEXT/bin/ssh"
+    path::env::add "$_OPSH_SSH_CONTEXT/bin"
 
     exit::trigger ssh::end
 }
@@ -464,6 +498,40 @@ testing::register() {
     fi
 }
 
+testing::_should-bail() {
+    local code=$1
+    shift
+    local next=$1
+    shift
+
+    if [[ $code -eq 0 ]]; then
+        return 1
+    fi
+
+    # In the case where the previous next was the function we just entered,
+    # ignore failures, since nothing has gotten the chance to run yet.
+    if [[ $_OPSH_TESTING_PREV_NEXT == ${FUNCNAME[1]}* ]]; then
+        return 1
+    fi
+
+    _OPSH_TESTING_PREV_NEXT="$next"
+
+    case "$next" in
+    ret=\$?)
+        return 1
+        ;;
+    return*)
+        return 1
+        ;;
+    testing::fail\ *)
+        return 1
+        ;;
+    *)
+        return 0
+        ;;
+    esac
+}
+
 testing::run() {
     echo "TAP version 13"
     echo "1..${#_TESTING_REGISTERED_FUNCS[@]}"
@@ -475,7 +543,18 @@ testing::run() {
     n=1
     for func in "${_TESTING_REGISTERED_FUNCS[@]}"; do
         res=0
-        ("$func") >"$outfile" 2>&1 || res=$?
+        (
+            _OPSH_TESTING_PREV_NEXT=""
+            set -o functrace
+            # shellcheck disable=SC2154
+            trap '{
+                local code=$?
+                if testing::_should-bail "$code" "$BASH_COMMAND" ; then
+                    [[ $FUNCNAME ]] && return $code || exit $code
+                fi
+            }' DEBUG
+            "$func"
+        ) >"$outfile" 2>&1 || res=$?
 
         if [[ $res -ne 0 ]]; then
             echo -n "not "
@@ -507,18 +586,25 @@ testing::fail() {
     log::fatal "${BASH_SOURCE[1]}:${BASH_LINENO[0]} inside ${FUNCNAME[1]}${msg}"
 }
 #- SECTION 20-command
-if [[ $# -lt 1 ]]; then
-    log::fatal "$0 requires a single argument of the script to run!"
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    SCRIPTFILE="$BASH_ARGV0"
+    # shellcheck disable=SC2034
+    SCRIPTDIR=$(dirname -- "$SCRIPTFILE")
+else
+    if [[ $# -lt 1 ]]; then
+        log::fatal "$0 requires a single argument of the script to run!"
+    fi
+
+    SCRIPTFILE="$1"
+    shift
+    [[ -f $SCRIPTFILE ]] || log::fatal "$0 can only run normal files that exist!"
+
+    # shellcheck disable=SC2034
+    SCRIPTDIR=$(dirname -- "$SCRIPTFILE")
+
+    BASH_ARGV0=$SCRIPTFILE
+    # shellcheck disable=SC1090
+    source "$SCRIPTFILE"
 fi
-
-SCRIPTFILE="$1"
-shift
-[[ -f $SCRIPTFILE ]] || log::fatal "$0 can only run normal files that exist!"
-
-# shellcheck disable=SC2034
-SCRIPTDIR=$(dirname -- "$SCRIPTFILE")
-
-BASH_ARGV0=$SCRIPTFILE
-# shellcheck disable=SC1090
-source "$SCRIPTFILE"
 #- SECTION 30-end


### PR DESCRIPTION
## Summary

- Vendored opsh bumped to 0.9.0, which supports a source-mode dispatch (`BASH_SOURCE[0] != $0` exposes `SCRIPTDIR` without re-executing).
- Every `#!/usr/bin/env opsh` script in `.githooks/` and `bin/` switches to `#!/usr/bin/env bash` and sources the vendored `bin/opsh` as its first line, so opsh no longer needs to be on PATH.
- `bin/check-env` additionally verifies the vendored copy exists before sourcing it, so the env-validation gate fails with a clear diagnostic rather than a bash "no such file" error.
- README and `DEV.md` prerequisite lists drop the opsh entry; `DEV.md`'s "Bin Scripts" intro is rewritten to describe the new convention.

## Scope note

The issue called out three hooks plus `bin/check-env`. The wider scope here also migrates `bin/hub`, `bin/db-migrate`, `bin/db-reset`, and `bin/add-package` — confirmed with the issue author before implementing. Without those four, the README's quick-start (`bin/db-reset && bun bin/dev.ts --seed`) would still require opsh on PATH even though the prerequisite list no longer says so.

## Changes

- `bin/opsh`: replaced wholesale with the upstream 0.9.0 single-file release (GPL-3.0, attribution in the commit message).
- `.githooks/{commit-msg,post-checkout,pre-commit}`, `bin/{check-env,hub,db-migrate,db-reset,add-package}`: shebang -> `bash`, source the vendored opsh, `opsh::version::require` bumped to `v0.9.0`.
- `bin/check-env`: explicit pre-source existence check for `bin/opsh`, with a comment explaining why this script is the only one with the guard.
- `README.md`, `DEV.md`: drop opsh prerequisite; rewrite the bin-scripts intro.

## Testing

- `make all` succeeded with opsh deliberately stripped from PATH (verified via `env -i PATH=<no-opsh-dir> bash -c 'make all'`).
- `git commit` and `git commit --allow-empty` both succeeded under the same stripped PATH; the `commit-msg` and `pre-commit` hooks fired and validated under the new mechanism.
- The three real commits on this branch passed both hooks during their own commit, exercising the new code paths end-to-end.

## Known latent issue (not addressed)

`bin/opsh:411` -- `ssh::begin` writes a proxy `ssh` shim with `#!/usr/bin/env opsh`. The path is unreachable in this repo (no caller of `ssh::begin`/`ssh::end`), so it does not regress the goal of this PR. Vendored unmodified per attribution discipline; worth a follow-up upstream.

Closes INTR-71