### PR TITLE
Add per-call inactivity and total timeouts to inference harness

### DIFF
--- a/docs/INFERENCE.md
+++ b/docs/INFERENCE.md
@@ -656,12 +656,28 @@ Provider errors are classified into categories that determine the reactor's resp
 - **Quota exhausted** — Provider-level usage limit hit (distinct from transient rate limits). Response: fail or switch model, depending on director policy.
 - **Fatal** — Invalid request, unsupported model, malformed content. Response: fail immediately with diagnostic information.
 - **Aborted** — Caller cancelled via AbortSignal. Response: clean termination.
+- **Timeout** — Per-call inactivity or total wall-clock cap fired (see Per-Call Timeouts). The call produced no usable response. Response: treat as transient infrastructure failure and retry per director policy rather than as a model decision.
 
 The classifier inspects HTTP status codes, error response bodies, and provider-specific error message patterns. The classified error is delivered to the director as an `inference.error` event, and the director decides the response — retry, compact, switch model, suspend, or fail. The error categories inform the director's decision but do not hardcode the response.
 
 ### Retry Behavior
 
 Retryable errors use exponential backoff: `baseDelay * 2^attempt`. The director controls maximum attempts and total budget. Failed attempts are removed from the message history before retrying — the model should not see its own error responses.
+
+## Per-Call Timeouts
+
+Every `runInference` call arms two timers: an inactivity timer reset on every chunk the harness receives from the wire, and a total wall-clock cap that starts at `fetch()`. When either timer fires, the harness aborts the underlying fetch's combined `AbortController` and emits an `inference.error` with category `"timeout"` and a message naming which timer fired and its threshold value. The combined controller wires together the caller-supplied signal (if any) and the harness's internal timeout signal, so a fetch implementation that respects `AbortSignal` sees both.
+
+"Wire chunk" means any SSE data line the harness reads, not strictly the events the harness yields downstream — heartbeat frames, sentinel-only chunks (e.g. `[DONE]`), and trailing usage events all count as activity. This is the more permissive of the two natural rules: it treats any sign of provider liveness as defeat of the inactivity timer, which is what "stalled SSE stream" intuitively means and what the safety property actually guards against.
+
+The defaults are conservative:
+
+- `inactivityTimeoutMs: 120_000` (2 min). Reasoning-heavy models emit tokens regularly when actually thinking; two minutes of pure silence is real stall, not legitimate reasoning. Tune higher for models with extended pure-silence thinking stretches — the `interchange-demo-dispatch` planner agent was observed reasoning for roughly seven minutes between tool calls during early benchmarking, which would require a higher inactivity threshold.
+- `totalTimeoutMs: 600_000` (10 min). Matches Anthropic's documented per-call recommendation and fits within typical CI budgets. Backstop for streams that keep emitting forever without terminating.
+
+Both can be overridden per call via `InferenceOptions.inactivityTimeoutMs` and `InferenceOptions.totalTimeoutMs`. Set to a smaller number to fail fast; set to a larger number to accommodate slower model behaviour.
+
+A timeout always classifies as `"timeout"`, never as `"aborted"` — even though the underlying mechanism is an `AbortController` firing. Distinguishing the two at the category level lets directors apply different policies: a caller-initiated abort is the user's decision and should not be retried, while a timeout is an infrastructure failure and may be retried.
 
 ## Abort Handling
 

--- a/packages/inference-testing/README.md
+++ b/packages/inference-testing/README.md
@@ -165,6 +165,45 @@ harness.scenario.abortAfter(
 stream and errors its controller — useful for modelling network failures
 mid-response.
 
+### Stall scenarios
+
+`scenario.stall` wires up a parked-stream fixture for tests that exercise
+the inference layer's per-call timeouts. The matched fetch is bound to a
+stream the helper never feeds, so the SSE iterator parks on its first
+read; in virtual time the test advances past the timeout threshold and
+the inactivity (or total) timer in `runInference` aborts the underlying
+fetch. The returned `StallHandle` exposes live abort telemetry so tests
+can assert on `AbortController` propagation directly, not only on the
+downstream `inference.error` event the abort produces.
+
+```ts
+const harness = setupHarness({ enableInferenceTimers: true });
+const stall = harness.scenario.stall();
+
+const events = runInference({
+  /* ... */
+  inferenceOptions: { inactivityTimeoutMs: 50, totalTimeoutMs: 10_000 },
+  deps: harness.deps,
+});
+
+await harness.run();
+await stall.awaitAbort;
+
+expect(stall.aborted).toBe(true);
+```
+
+`stall.stream` is the underlying `SimulatedStream` in case a test wants
+to release the stall by enqueueing chunks before the timeout fires.
+`stall.aborted` flips `true` the moment the matched fetch's signal
+fires (timeout, caller signal, or `dispose()`). `stall.awaitAbort`
+resolves at the same moment for tests that need to sequence
+assertions after abort propagation.
+
+Pair `stall` with `setupHarness({ enableInferenceTimers: true })` — the
+default no-op scheduler leaves the inference layer's timers inert so
+that other test suites don't have to advance virtual time through the
+ten-minute default total timeout on every call.
+
 ### Multi-turn
 
 Compose multiple matchers and call `runInference` once per turn. The

--- a/packages/inference-testing/README.md
+++ b/packages/inference-testing/README.md
@@ -194,10 +194,17 @@ expect(stall.aborted).toBe(true);
 
 `stall.stream` is the underlying `SimulatedStream` in case a test wants
 to release the stall by enqueueing chunks before the timeout fires.
-`stall.aborted` flips `true` the moment the matched fetch's signal
-fires (timeout, caller signal, or `dispose()`). `stall.awaitAbort`
-resolves at the same moment for tests that need to sequence
-assertions after abort propagation.
+`stall.aborted` flips `true` the moment the matched fetch's
+`AbortSignal` fires (the inference layer's per-call timeout firing,
+or a caller-supplied signal aborting). `dispose()` does not flip
+`aborted` — it rejects the underlying fetch with an `Error` rather
+than aborting its signal — but it does resolve `awaitAbort` so tests
+that awaited the promise past dispose do not hang the test runner.
+
+The harness has no special-case knowledge of stalls. The matcher
+settles the fetch with a `Response` as soon as it fires; what parks
+indefinitely is the response body's SSE iterator. `checkQuiescence`
+therefore does not see an unmatched fetch and does not raise.
 
 Pair `stall` with `setupHarness({ enableInferenceTimers: true })` — the
 default no-op scheduler leaves the inference layer's timers inert so

--- a/packages/inference-testing/src/harness.ts
+++ b/packages/inference-testing/src/harness.ts
@@ -26,6 +26,8 @@ import {
   type ReplyOnceOpts,
   type RequestPredicate,
   type Scenario,
+  type StallHandle,
+  type StallOpts,
   type WaitingFetch,
   type WhenRequestMatchesOpts,
   type WireEventPredicate,
@@ -186,6 +188,13 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
   const matcherTable = createMatcherTable();
   let disposed = false;
 
+  type StallRegistration = {
+    readonly stream: SimulatedStream;
+    readonly aborted: { value: boolean };
+    readonly resolveAwaitAbort: () => void;
+  };
+  const stallRegistrations: StallRegistration[] = [];
+
   const streamIdToHandle = new Map<StreamId, SimulatedStreamHandle>();
   const streamToHandle = new WeakMap<SimulatedStream, SimulatedStreamHandle>();
 
@@ -267,6 +276,33 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
           handle.forceError(new DOMException("aborted", "AbortError"));
         };
         signal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+    // Stall telemetry: if this stream was minted by `scenario.stall`,
+    // record when its bound fetch's signal aborts so the test can
+    // assert directly on AbortController propagation rather than only
+    // on the downstream `inference.error` event the abort produces.
+    const stallReg = stallRegistrations.find((r) => r.stream === stream);
+    if (stallReg !== undefined) {
+      if (signal === undefined) {
+        // No signal means no abort can ever fire on this fetch. The
+        // stall handle's `aborted` stays false and `awaitAbort` never
+        // resolves; that's the honest read of the situation. A test
+        // that called stall() without a signal-bearing call is using
+        // the helper outside its intended purpose, and we will not
+        // fabricate a resolution.
+      } else if (signal.aborted) {
+        stallReg.aborted.value = true;
+        stallReg.resolveAwaitAbort();
+      } else {
+        signal.addEventListener(
+          "abort",
+          () => {
+            stallReg.aborted.value = true;
+            stallReg.resolveAwaitAbort();
+          },
+          { once: true },
+        );
       }
     }
     const status = opts?.status ?? 200;
@@ -453,6 +489,35 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     return stream;
   };
 
+  const stall = (opts: StallOpts = {}): StallHandle => {
+    if (disposed) {
+      throw new Error("Harness.scenario.stall: harness has been disposed");
+    }
+    const stream = createStream();
+    const aborted = { value: false };
+    let resolveAwaitAbort: () => void = () => {
+      throw new Error(
+        "Harness.scenario.stall: awaitAbort resolver invoked before Promise constructor ran (internal bug)",
+      );
+    };
+    const awaitAbort = new Promise<void>((resolve) => {
+      resolveAwaitAbort = resolve;
+    });
+    stallRegistrations.push({ stream, aborted, resolveAwaitAbort });
+    whenRequestMatches(
+      opts.predicate ?? (() => true),
+      stream,
+      opts.responseOpts,
+    );
+    return {
+      stream,
+      get aborted() {
+        return aborted.value;
+      },
+      awaitAbort,
+    };
+  };
+
   const scenario: Scenario = {
     createStream,
     whenRequestMatches,
@@ -461,6 +526,7 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     lastToolDispatch,
     lastRequest,
     replyOnce,
+    stall,
     abortAt,
     abortAfter,
   };
@@ -825,6 +891,12 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     inFlightToolHandlers.clear();
     inFlightErrors.length = 0;
     abortAfterRegistrations.length = 0;
+    // Resolve any still-pending stall awaits so test code that awaited
+    // `stall.awaitAbort` past dispose does not deadlock the test runner.
+    for (const reg of stallRegistrations) {
+      reg.resolveAwaitAbort();
+    }
+    stallRegistrations.length = 0;
     lastToolDispatchByName.clear();
   };
 

--- a/packages/inference-testing/src/harness.ts
+++ b/packages/inference-testing/src/harness.ts
@@ -3,6 +3,7 @@ import {
   runInference,
   type Dependencies,
   type InferenceHarnessOptions,
+  type Scheduler,
 } from "@intx/inference";
 import type { InferenceEvent } from "@intx/types/runtime";
 
@@ -152,6 +153,20 @@ export type SetupHarnessOpts = {
    * should let `setupHarness()` create its own clock.
    */
   clock?: Clock;
+  /**
+   * When true, the `Scheduler` exposed via `harness.deps.scheduler` is
+   * backed by the virtual clock so production inactivity / total timeouts
+   * in `@intx/inference`'s `runInference` fire at virtual time. When
+   * false (default), the scheduler is a no-op — production timers are
+   * inert during tests, which is what almost every test wants (otherwise
+   * `harness.run()` would have to advance virtual time through the 600s
+   * default total-timeout horizon on every call).
+   *
+   * Tests that specifically assert on timeout behaviour set this to
+   * true and pass explicit short thresholds via
+   * `InferenceOptions.inactivityTimeoutMs` / `totalTimeoutMs`.
+   */
+  enableInferenceTimers?: boolean;
 };
 
 /**
@@ -525,8 +540,45 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     });
   };
 
+  // Scheduler exposed via deps. Behaviour depends on opts.enableInferenceTimers:
+  //
+  //   - false (default): a no-op — every `setTimeout` returns a no-op
+  //     canceller without scheduling anything. Production timers in
+  //     `runInference` are inert, which is what every test that isn't
+  //     specifically asserting timeout behaviour wants (otherwise
+  //     `harness.run()` would have to advance virtual time through the
+  //     600s default total-timeout horizon on every call).
+  //   - true: backed by the virtual clock, so the inference layer's
+  //     inactivity / total timers fire at virtual time exactly when
+  //     they would in production. Tests that exercise timeout
+  //     behaviour set this and pass explicit short thresholds.
+  // The inert scheduler's no-op canceller has nothing to cancel because
+  // its `setTimeout` never scheduled anything in the first place.
+  const noopCanceller = (): void => {
+    /* no scheduled work to cancel */
+  };
+  const inertScheduler: Scheduler = {
+    setTimeout: () => noopCanceller,
+  };
+  const scheduler: Scheduler =
+    opts.enableInferenceTimers === true
+      ? {
+          setTimeout(callback, delayMs) {
+            let cancelled = false;
+            clock.schedule(clock.now() + delayMs, () => {
+              if (cancelled) return;
+              callback();
+            });
+            return () => {
+              cancelled = true;
+            };
+          },
+        }
+      : inertScheduler;
+
   const deps: Dependencies = {
     fetch: stubFetch,
+    scheduler,
     [HarnessId]: harnessSymbol,
   };
 

--- a/packages/inference-testing/src/index.ts
+++ b/packages/inference-testing/src/index.ts
@@ -22,6 +22,8 @@ export type {
   Scenario,
   ReplyOnceOpts,
   RequestPredicate,
+  StallHandle,
+  StallOpts,
   WhenRequestMatchesOpts,
   WireEventPredicate,
 } from "./scenario";

--- a/packages/inference-testing/src/scenario.ts
+++ b/packages/inference-testing/src/scenario.ts
@@ -74,6 +74,39 @@ export type WhenRequestMatchesOpts = {
 };
 
 /**
+ * Options for `scenario.stall`. `predicate` narrows which fetch the
+ * stalled stream routes to (defaults to match-any). `responseOpts`
+ * shapes the HTTP envelope of the `Response` the matcher produces.
+ */
+export type StallOpts = {
+  readonly predicate?: RequestPredicate;
+  readonly responseOpts?: WhenRequestMatchesOpts;
+};
+
+/**
+ * Handle returned by `scenario.stall`. Exposes the underlying
+ * `SimulatedStream` (in case a test wants to enqueue something into it
+ * later, e.g. to release the stall after the assertions run) plus abort
+ * telemetry covering the matched fetch's `AbortSignal`.
+ *
+ * `aborted` flips to `true` as soon as the matched fetch's signal fires
+ * — either because the inference layer's per-call timeout aborted it,
+ * because a caller-supplied `signal` aborted, or because `dispose()`
+ * rejected the still-waiting fetch. Reading `aborted` before the
+ * matcher fires returns `false`. Reading it after the matcher fires
+ * but before any abort returns `false`.
+ *
+ * `awaitAbort` resolves the first time the matched fetch's signal
+ * fires. Tests use it when they need to sequence assertions after the
+ * abort propagated rather than after `harness.run()` returned.
+ */
+export type StallHandle = {
+  readonly stream: SimulatedStream;
+  readonly aborted: boolean;
+  readonly awaitAbort: Promise<void>;
+};
+
+/**
  * The public scenario seam exposed by the harness. `createStream()` mints a
  * `SimulatedStream` registered with the harness for `dispose()` teardown.
  * `whenRequestMatches(predicate, responseStream, opts?)` registers a
@@ -192,6 +225,27 @@ export type Scenario = {
    * tool calls), use `createStream` + `whenRequestMatches` directly.
    */
   replyOnce(provider: Provider, opts: ReplyOnceOpts): SimulatedStream;
+  /**
+   * Convenience helper for timeout/abort tests. Creates a stream,
+   * registers a single-use matcher that routes the next fetch to it,
+   * and never enqueues anything — the matched stream parks forever.
+   *
+   * The returned `StallHandle` exposes the underlying stream (in case
+   * the test wants to release the stall by enqueueing chunks later)
+   * and live abort telemetry: `aborted` flips true when the matched
+   * fetch's `AbortSignal` fires, and `awaitAbort` resolves at the
+   * same moment.
+   *
+   * The harness recognises the stall as intentional pending state and
+   * does NOT raise `UnmatchedFetchError` during the quiescence check
+   * *as long as the fetch eventually settles* — i.e., either an abort
+   * fires (timeout, caller signal, dispose) or the test enqueues the
+   * terminating chunks. Tests that exercise per-call timeout
+   * behaviour should pair `stall` with short `inactivityTimeoutMs` or
+   * `totalTimeoutMs` values and `setupHarness({ enableInferenceTimers:
+   * true })` so the inference layer's timers fire at virtual time.
+   */
+  stall(opts?: StallOpts): StallHandle;
   /**
    * Schedules `controller.abort()` to fire at the supplied virtual time.
    * The caller supplies the `AbortController` they want aborted —

--- a/packages/inference-testing/src/scenario.ts
+++ b/packages/inference-testing/src/scenario.ts
@@ -89,16 +89,19 @@ export type StallOpts = {
  * later, e.g. to release the stall after the assertions run) plus abort
  * telemetry covering the matched fetch's `AbortSignal`.
  *
- * `aborted` flips to `true` as soon as the matched fetch's signal fires
- * — either because the inference layer's per-call timeout aborted it,
- * because a caller-supplied `signal` aborted, or because `dispose()`
- * rejected the still-waiting fetch. Reading `aborted` before the
- * matcher fires returns `false`. Reading it after the matcher fires
- * but before any abort returns `false`.
+ * `aborted` flips to `true` as soon as the matched fetch's signal
+ * fires — typically because the inference layer's per-call timeout
+ * aborted it, but a caller-supplied `signal` aborting also counts.
+ * Reading `aborted` before the matcher fires or before any abort
+ * returns `false`. `dispose()` does NOT flip `aborted` (it rejects
+ * the underlying fetch with an `Error` rather than aborting its
+ * `AbortSignal`); it does, however, resolve `awaitAbort` so tests
+ * that awaited it past dispose do not hang the test runner.
  *
  * `awaitAbort` resolves the first time the matched fetch's signal
- * fires. Tests use it when they need to sequence assertions after the
- * abort propagated rather than after `harness.run()` returned.
+ * fires, or when `dispose()` runs — whichever happens first. Tests
+ * use it when they need to sequence assertions after the abort
+ * propagated rather than after `harness.run()` returned.
  */
 export type StallHandle = {
   readonly stream: SimulatedStream;
@@ -236,14 +239,17 @@ export type Scenario = {
    * fetch's `AbortSignal` fires, and `awaitAbort` resolves at the
    * same moment.
    *
-   * The harness recognises the stall as intentional pending state and
-   * does NOT raise `UnmatchedFetchError` during the quiescence check
-   * *as long as the fetch eventually settles* — i.e., either an abort
-   * fires (timeout, caller signal, dispose) or the test enqueues the
-   * terminating chunks. Tests that exercise per-call timeout
-   * behaviour should pair `stall` with short `inactivityTimeoutMs` or
-   * `totalTimeoutMs` values and `setupHarness({ enableInferenceTimers:
-   * true })` so the inference layer's timers fire at virtual time.
+   * Quiescence interaction: the harness has no special-case knowledge
+   * of stalls. The matched fetch's `Response` is delivered as soon as
+   * the matcher fires (the WaitingFetch is settled at that moment);
+   * what parks indefinitely is the response body's SSE iterator, not
+   * the fetch itself. `checkQuiescence` therefore does not see an
+   * unmatched fetch and does not raise `UnmatchedFetchError`. Tests
+   * that exercise per-call timeout behaviour should pair `stall` with
+   * short `inactivityTimeoutMs` or `totalTimeoutMs` values and
+   * `setupHarness({ enableInferenceTimers: true })` so the inference
+   * layer's timers fire at virtual time and surface a `"timeout"`
+   * `inference.error` before the test's `harness.run()` returns.
    */
   stall(opts?: StallOpts): StallHandle;
   /**

--- a/packages/inference/src/errors.ts
+++ b/packages/inference/src/errors.ts
@@ -47,6 +47,17 @@ export function classifyAbortError(): InferenceError {
   return { category: "aborted", message: "inference aborted" };
 }
 
+export function classifyTimeoutError(
+  kind: "inactivity" | "total",
+  thresholdMs: number,
+): InferenceError {
+  const message =
+    kind === "inactivity"
+      ? `inference call exceeded inactivity timeout (${String(thresholdMs)} ms with no events from the provider)`
+      : `inference call exceeded total timeout (${String(thresholdMs)} ms wall-clock)`;
+  return { category: "timeout", message };
+}
+
 export function classifyStreamError(cause: unknown): InferenceError {
   if (isAbortError(cause)) {
     return classifyAbortError();

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -782,6 +782,26 @@ const ParsedToolArgs = type("Record<string, unknown>");
 const ErrorBody = type({ error: { message: "string" } });
 const DirectMessageBody = type({ message: "string" });
 
+/**
+ * Upper bound on the length of a plain-text error body that gets
+ * promoted to `InferenceError.message`. Bodies longer than this are
+ * truncated with a marker pointing operators at `error.raw`, which
+ * always retains the untruncated body. Structured JSON envelopes are
+ * not subject to this cap — their `message` fields are server-curated
+ * and concise in practice.
+ *
+ * 500 characters covers a multi-line stack trace or a paragraph of
+ * diagnostic text without blowing up the default director's
+ * user-facing reply (which concatenates the message into a chat-style
+ * string) or the timeline part stored by the hub event collector.
+ */
+const MAX_PLAIN_TEXT_MESSAGE_CHARS = 500;
+
+function truncatePlainTextMessage(text: string): string {
+  if (text.length <= MAX_PLAIN_TEXT_MESSAGE_CHARS) return text;
+  return `${text.slice(0, MAX_PLAIN_TEXT_MESSAGE_CHARS)}… (truncated; full body in error.raw)`;
+}
+
 function extractErrorMessage(body: unknown): string | null {
   // Anthropic/OpenAI: { error: { message: "..." } }
   const errorBody = ErrorBody(body);
@@ -793,6 +813,18 @@ function extractErrorMessage(body: unknown): string | null {
   const directBody = DirectMessageBody(body);
   if (!(directBody instanceof type.errors)) {
     return directBody.message;
+  }
+
+  // Plain-text error bodies (HTML error pages, raw exception strings,
+  // load-balancer diagnostics). The body reaches us via the
+  // text-then-parse path in the `!response.ok` branch: when
+  // JSON.parse failed, the raw string is stored as errorBody.
+  // Surfacing it here means the operator-visible message contains
+  // the server's actual diagnostic rather than just `statusText`.
+  // `error.raw` always holds the untruncated body for audit-time
+  // inspection.
+  if (typeof body === "string" && body.length > 0) {
+    return truncatePlainTextMessage(body);
   }
 
   return null;

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -309,21 +309,27 @@ export async function* runInference(
     }
 
     if (!response.ok) {
-      // Bind both body reads to the combined fetch signal. The fetch's
-      // response body is supposed to inherit the signal, but in practice
-      // some runtimes leave it parked even after the signal aborts — a
-      // hostile server returning a 4xx/5xx with a body that never
-      // terminates would otherwise hang the call indefinitely, defeating
-      // the total-timeout safety property.
+      // Read the body as text once and then try to parse it as JSON.
+      // Calling `.json()` first and falling back to `.text()` on the
+      // same response does not work — per WHATWG fetch the body stream
+      // is locked/disturbed by the first read attempt, so the fallback
+      // throws `TypeError: body already consumed` and `errorBody` ends
+      // up `undefined`. Reading text-then-parsing covers both JSON and
+      // plain-text error bodies in a single pass.
+      //
+      // The read is bound to the combined fetch signal so a hostile
+      // server returning a 4xx/5xx with a body that never terminates
+      // cannot hang the call past the total-timeout horizon.
       let errorBody: unknown;
       try {
-        errorBody = await awaitWithSignal(response.json(), fetchSignal);
-      } catch {
+        const text = await awaitWithSignal(response.text(), fetchSignal);
         try {
-          errorBody = await awaitWithSignal(response.text(), fetchSignal);
+          errorBody = JSON.parse(text);
         } catch {
-          errorBody = undefined;
+          errorBody = text;
         }
+      } catch {
+        errorBody = undefined;
       }
       const errorMessage =
         extractErrorMessage(errorBody) ?? response.statusText;

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -33,7 +33,24 @@ import {
   classifyNetworkError,
   classifyAbortError,
   classifyStreamError,
+  classifyTimeoutError,
 } from "./errors";
+
+/**
+ * Default per-call inactivity timeout (ms). Two minutes is conservative
+ * for reasoning-heavy models that emit `inference.thinking.delta` tokens
+ * regularly when actually working — sustained silence past this means
+ * the provider stream has genuinely stalled, not that the model is
+ * thinking. Operators can tune via `InferenceOptions.inactivityTimeoutMs`.
+ */
+export const DEFAULT_INACTIVITY_TIMEOUT_MS = 120_000;
+
+/**
+ * Default per-call total wall-clock cap (ms). Matches Anthropic's
+ * documented per-call recommendation and fits within typical CI
+ * timeouts. Operators can tune via `InferenceOptions.totalTimeoutMs`.
+ */
+export const DEFAULT_TOTAL_TIMEOUT_MS = 600_000;
 
 export const HarnessId: unique symbol = Symbol("HarnessId");
 
@@ -58,11 +75,45 @@ export type Dependencies = {
     input: string | URL | Request,
     init?: RequestInit,
   ) => Promise<Response>;
+  /**
+   * Time-based scheduler used by the harness's per-call timeouts (see
+   * `InferenceOptions.inactivityTimeoutMs` / `totalTimeoutMs`). Production
+   * passes the default wrapper around `setTimeout` / `clearTimeout`; the
+   * deterministic test harness injects a scheduler that wraps its virtual
+   * clock so timeout tests fire at virtual-time-N without sleeping real
+   * wall-clock. Optional for backward compatibility — when omitted the
+   * harness substitutes the production default.
+   */
+  readonly scheduler?: Scheduler;
   readonly [HarnessId]?: symbol;
 };
 
+/**
+ * Minimal scheduling abstraction. `setTimeout` returns a canceller; the
+ * canceller is idempotent (multiple calls are safe). The harness uses
+ * this for both the inactivity timer (which is re-armed on every event)
+ * and the total wall-clock cap.
+ */
+export type Scheduler = {
+  setTimeout(callback: () => void, delayMs: number): () => void;
+};
+
+export function createDefaultScheduler(): Scheduler {
+  return {
+    setTimeout(callback, delayMs) {
+      const handle = setTimeout(callback, delayMs);
+      return () => {
+        clearTimeout(handle);
+      };
+    },
+  };
+}
+
 export function createDefaultDependencies(): Dependencies {
-  return { fetch: globalThis.fetch.bind(globalThis) };
+  return {
+    fetch: globalThis.fetch.bind(globalThis),
+    scheduler: createDefaultScheduler(),
+  };
 }
 
 export type InferenceHarnessOptions = {
@@ -167,15 +218,63 @@ export async function* runInference(
   const url = resolveURL(builtRequest.url, providerConfig.baseURL);
   const headers = injectCredentials(builtRequest.headers, providerConfig);
 
+  // Per-call timeouts. The inactivity timer fires when the harness
+  // hasn't yielded an event for `inactivityTimeoutMs`; the total timer
+  // is a wall-clock cap from fetch onwards. We own one AbortController,
+  // combine its signal with the caller's, and attribute the abort to
+  // whichever timer fired by checking `timeoutReason` at the catch site.
+  const inactivityTimeoutMs =
+    inferenceOptions.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
+  const totalTimeoutMs =
+    inferenceOptions.totalTimeoutMs ?? DEFAULT_TOTAL_TIMEOUT_MS;
+  const scheduler = deps.scheduler ?? createDefaultScheduler();
+  const timeoutAbort = new AbortController();
+  let timeoutReason: "inactivity" | "total" | null = null;
+  let cancelInactivity: (() => void) | null = null;
+  const armInactivity = () => {
+    cancelInactivity?.();
+    cancelInactivity = scheduler.setTimeout(() => {
+      timeoutReason = "inactivity";
+      timeoutAbort.abort();
+    }, inactivityTimeoutMs);
+  };
+  const cancelTotal = scheduler.setTimeout(() => {
+    timeoutReason = "total";
+    timeoutAbort.abort();
+  }, totalTimeoutMs);
+  const cleanupTimers = () => {
+    cancelTotal();
+    cancelInactivity?.();
+    cancelInactivity = null;
+  };
+  // Combined signal: the production code's existing caller-signal +
+  // our timeout controller, so a fetch implementation that respects
+  // AbortSignal sees both.
+  const fetchSignal = combineSignals(signal, timeoutAbort.signal);
+
   let response: Response;
   try {
     response = await deps.fetch(url, {
       method: "POST",
       headers,
       body: builtRequest.body,
-      ...(signal !== undefined ? { signal } : {}),
+      signal: fetchSignal,
     });
   } catch (cause) {
+    cleanupTimers();
+    if (timeoutReason !== null) {
+      const thresholdMs =
+        timeoutReason === "inactivity" ? inactivityTimeoutMs : totalTimeoutMs;
+      yield {
+        type: "inference.error",
+        seq: nextSeq(),
+        data: {
+          error: classifyTimeoutError(timeoutReason, thresholdMs),
+          partial: snapshotPartial(partial),
+        },
+      };
+      return;
+    }
     if (signal?.aborted) {
       yield {
         type: "inference.error",
@@ -239,8 +338,31 @@ export async function* runInference(
     return;
   }
 
+  // Arm the inactivity timer now that the SSE stream is open. Every
+  // event we yield below resets it; sustained silence past
+  // `inactivityTimeoutMs` aborts the controller and the loop's catch
+  // surfaces the timeout error.
+  armInactivity();
+
   try {
     for await (const sseData of parseSSE(response.body)) {
+      if (timeoutReason !== null) {
+        // The timeout aborted the stream; bubble up the right error
+        // shape rather than letting the abort masquerade as a
+        // caller-initiated cancellation.
+        const thresholdMs =
+          timeoutReason === "inactivity" ? inactivityTimeoutMs : totalTimeoutMs;
+        yield {
+          type: "inference.error",
+          seq: nextSeq(),
+          data: {
+            error: classifyTimeoutError(timeoutReason, thresholdMs),
+            partial: snapshotPartial(partial),
+          },
+        };
+        cleanupTimers();
+        return;
+      }
       if (signal?.aborted) {
         yield {
           type: "inference.error",
@@ -250,8 +372,12 @@ export async function* runInference(
             partial: snapshotPartial(partial),
           },
         };
+        cleanupTimers();
         return;
       }
+
+      // Reset inactivity timer — we just got something from the wire.
+      armInactivity();
 
       const rawEvents = adapter.parseResponse(sseData);
 
@@ -357,6 +483,20 @@ export async function* runInference(
       }
     }
   } catch (cause) {
+    if (timeoutReason !== null) {
+      const thresholdMs =
+        timeoutReason === "inactivity" ? inactivityTimeoutMs : totalTimeoutMs;
+      yield {
+        type: "inference.error",
+        seq: nextSeq(),
+        data: {
+          error: classifyTimeoutError(timeoutReason, thresholdMs),
+          partial: snapshotPartial(partial),
+        },
+      };
+      cleanupTimers();
+      return;
+    }
     if (signal?.aborted) {
       yield {
         type: "inference.error",
@@ -366,6 +506,7 @@ export async function* runInference(
           partial: snapshotPartial(partial),
         },
       };
+      cleanupTimers();
       return;
     }
     yield {
@@ -376,8 +517,15 @@ export async function* runInference(
         partial: snapshotPartial(partial),
       },
     };
+    cleanupTimers();
     return;
   }
+
+  // SSE loop exited normally — disarm timers before the finalization
+  // path emits any further events. (Both timers are no-op-safe after
+  // cleanup, but stopping them avoids spurious firings during a slow
+  // finalization step.)
+  cleanupTimers();
 
   // Finalize any open tool calls that never received an explicit end event.
   const completedToolCalls: ContentBlock[] = [];
@@ -458,6 +606,32 @@ export async function* runInference(
         : {}),
     },
   };
+}
+
+/**
+ * Combine an optional caller-supplied `AbortSignal` with the harness's
+ * internal timeout-driven controller into a single signal the fetch
+ * implementation can observe. Returns the internal controller's signal
+ * alone if no caller signal exists; otherwise wires both so that either
+ * one firing aborts the combined signal.
+ */
+function combineSignals(
+  caller: AbortSignal | undefined,
+  internal: AbortSignal,
+): AbortSignal {
+  if (caller === undefined) return internal;
+  const composite = new AbortController();
+  if (caller.aborted) composite.abort(caller.reason);
+  else
+    caller.addEventListener("abort", () => composite.abort(caller.reason), {
+      once: true,
+    });
+  if (internal.aborted) composite.abort(internal.reason);
+  else
+    internal.addEventListener("abort", () => composite.abort(internal.reason), {
+      once: true,
+    });
+  return composite.signal;
 }
 
 function snapshotPartial(partial: PartialMessage): PartialMessage {

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -242,114 +242,38 @@ export async function* runInference(
     timeoutReason = "total";
     timeoutAbort.abort();
   }, totalTimeoutMs);
-  const cleanupTimers = () => {
+  // Per-timer cancellers are idempotent (the production scheduler's
+  // canceller wraps `clearTimeout`, which no-ops on a fired timer; the
+  // test scheduler's canceller flips a `cancelled` flag). Callers may
+  // invoke `cleanupTimers` exactly once; the `try/finally` around the
+  // generator body below is the single owner of that lifecycle.
+  const cleanupTimers = (): void => {
     cancelTotal();
     cancelInactivity?.();
     cancelInactivity = null;
   };
   // Combined signal: the production code's existing caller-signal +
   // our timeout controller, so a fetch implementation that respects
-  // AbortSignal sees both.
-  const fetchSignal = combineSignals(signal, timeoutAbort.signal);
+  // AbortSignal sees both. `cleanupSignal` removes the abort listeners
+  // `combineSignals` installs on the caller signal so a long-lived
+  // caller signal (e.g., a session-scoped controller) does not
+  // accumulate one un-removed listener per call.
+  const { signal: fetchSignal, cleanup: cleanupSignal } = combineSignals(
+    signal,
+    timeoutAbort.signal,
+  );
 
-  let response: Response;
   try {
-    response = await deps.fetch(url, {
-      method: "POST",
-      headers,
-      body: builtRequest.body,
-      signal: fetchSignal,
-    });
-  } catch (cause) {
-    cleanupTimers();
-    if (timeoutReason !== null) {
-      const thresholdMs =
-        timeoutReason === "inactivity" ? inactivityTimeoutMs : totalTimeoutMs;
-      yield {
-        type: "inference.error",
-        seq: nextSeq(),
-        data: {
-          error: classifyTimeoutError(timeoutReason, thresholdMs),
-          partial: snapshotPartial(partial),
-        },
-      };
-      return;
-    }
-    if (signal?.aborted) {
-      yield {
-        type: "inference.error",
-        seq: nextSeq(),
-        data: {
-          error: classifyAbortError(),
-          partial: snapshotPartial(partial),
-        },
-      };
-      return;
-    }
-    yield {
-      type: "inference.error",
-      seq: nextSeq(),
-      data: {
-        error: classifyNetworkError(cause),
-        partial: snapshotPartial(partial),
-      },
-    };
-    return;
-  }
-
-  if (!response.ok) {
-    let errorBody: unknown;
+    let response: Response;
     try {
-      errorBody = await response.json();
-    } catch {
-      try {
-        errorBody = await response.text();
-      } catch {
-        errorBody = undefined;
-      }
-    }
-    const errorMessage = extractErrorMessage(errorBody) ?? response.statusText;
-    const retryAfterMs = adapter.extractRetryAfterMs?.(response.headers);
-    yield {
-      type: "inference.error",
-      seq: nextSeq(),
-      data: {
-        error: classifyHTTPError(
-          response.status,
-          errorMessage,
-          errorBody,
-          retryAfterMs,
-        ),
-        partial: snapshotPartial(partial),
-      },
-    };
-    return;
-  }
-
-  if (response.body === null) {
-    yield {
-      type: "inference.error",
-      seq: nextSeq(),
-      data: {
-        error: classifyNetworkError(new Error("Response body is null")),
-        partial: snapshotPartial(partial),
-      },
-    };
-    return;
-  }
-
-  // Arm the inactivity timer now that the SSE stream is open. Every
-  // event we yield below resets it; sustained silence past
-  // `inactivityTimeoutMs` aborts the controller and the loop's catch
-  // surfaces the timeout error.
-  armInactivity();
-
-  try {
-    for await (const sseData of parseSSE(response.body)) {
+      response = await deps.fetch(url, {
+        method: "POST",
+        headers,
+        body: builtRequest.body,
+        signal: fetchSignal,
+      });
+    } catch (cause) {
       if (timeoutReason !== null) {
-        // The timeout aborted the stream; bubble up the right error
-        // shape rather than letting the abort masquerade as a
-        // caller-initiated cancellation.
         const thresholdMs =
           timeoutReason === "inactivity" ? inactivityTimeoutMs : totalTimeoutMs;
         yield {
@@ -360,7 +284,6 @@ export async function* runInference(
             partial: snapshotPartial(partial),
           },
         };
-        cleanupTimers();
         return;
       }
       if (signal?.aborted) {
@@ -372,240 +295,335 @@ export async function* runInference(
             partial: snapshotPartial(partial),
           },
         };
-        cleanupTimers();
         return;
       }
+      yield {
+        type: "inference.error",
+        seq: nextSeq(),
+        data: {
+          error: classifyNetworkError(cause),
+          partial: snapshotPartial(partial),
+        },
+      };
+      return;
+    }
 
-      // Reset inactivity timer — we just got something from the wire.
-      armInactivity();
+    if (!response.ok) {
+      // Bind both body reads to the combined fetch signal. The fetch's
+      // response body is supposed to inherit the signal, but in practice
+      // some runtimes leave it parked even after the signal aborts — a
+      // hostile server returning a 4xx/5xx with a body that never
+      // terminates would otherwise hang the call indefinitely, defeating
+      // the total-timeout safety property.
+      let errorBody: unknown;
+      try {
+        errorBody = await awaitWithSignal(response.json(), fetchSignal);
+      } catch {
+        try {
+          errorBody = await awaitWithSignal(response.text(), fetchSignal);
+        } catch {
+          errorBody = undefined;
+        }
+      }
+      const errorMessage =
+        extractErrorMessage(errorBody) ?? response.statusText;
+      const retryAfterMs = adapter.extractRetryAfterMs?.(response.headers);
+      yield {
+        type: "inference.error",
+        seq: nextSeq(),
+        data: {
+          error: classifyHTTPError(
+            response.status,
+            errorMessage,
+            errorBody,
+            retryAfterMs,
+          ),
+          partial: snapshotPartial(partial),
+        },
+      };
+      return;
+    }
 
-      const rawEvents = adapter.parseResponse(sseData);
+    if (response.body === null) {
+      yield {
+        type: "inference.error",
+        seq: nextSeq(),
+        data: {
+          error: classifyNetworkError(new Error("Response body is null")),
+          partial: snapshotPartial(partial),
+        },
+      };
+      return;
+    }
 
-      for (const raw of rawEvents) {
-        switch (raw.type) {
-          case "inference.text.delta": {
-            partial.text += raw.data.token;
-            yield {
-              type: "inference.text.delta",
-              seq: nextSeq(),
-              data: {
-                token: raw.data.token,
-                partial: snapshotPartial(partial),
-              },
-            };
-            break;
-          }
+    // Arm the inactivity timer now that the SSE stream is open. Every
+    // event we yield below resets it; sustained silence past
+    // `inactivityTimeoutMs` aborts the controller and the loop's catch
+    // surfaces the timeout error.
+    armInactivity();
 
-          case "inference.thinking.delta": {
-            thinkingBuffer += raw.data.token;
-            partial.thinking = thinkingBuffer;
-            yield {
-              type: "inference.thinking.delta",
-              seq: nextSeq(),
-              data: {
-                token: raw.data.token,
-                partial: snapshotPartial(partial),
-              },
-            };
-            break;
-          }
+    try {
+      for await (const sseData of parseSSE(response.body)) {
+        if (timeoutReason !== null) {
+          // The timeout aborted the stream; bubble up the right error
+          // shape rather than letting the abort masquerade as a
+          // caller-initiated cancellation.
+          const thresholdMs =
+            timeoutReason === "inactivity"
+              ? inactivityTimeoutMs
+              : totalTimeoutMs;
+          yield {
+            type: "inference.error",
+            seq: nextSeq(),
+            data: {
+              error: classifyTimeoutError(timeoutReason, thresholdMs),
+              partial: snapshotPartial(partial),
+            },
+          };
+          return;
+        }
+        if (signal?.aborted) {
+          yield {
+            type: "inference.error",
+            seq: nextSeq(),
+            data: {
+              error: classifyAbortError(),
+              partial: snapshotPartial(partial),
+            },
+          };
+          return;
+        }
 
-          case "inference.tool_call.start": {
-            const { callId, name } = raw.data;
-            openToolCalls.set(callId, { callId, name, argsBuffer: "" });
-            // OpenAI sends deltas with a string index ("0", "1", ...) as the
-            // callId. Map each index to the real callId so deltas resolve.
-            // The index is the position of this tool call in the current batch.
-            indexToCallId.set(String(openToolCalls.size - 1), callId);
-            partial.toolCalls = [
-              ...(partial.toolCalls ?? []),
-              {
-                id: callId,
-                name,
-                partialArguments: "",
-              },
-            ];
-            yield {
-              type: "inference.tool_call.start",
-              seq: nextSeq(),
-              data: { callId, name, partial: snapshotPartial(partial) },
-            };
-            break;
-          }
+        // Reset inactivity timer — we just got something from the wire.
+        armInactivity();
 
-          case "inference.tool_call.delta": {
-            const { callId, argumentFragment } = raw.data;
+        const rawEvents = adapter.parseResponse(sseData);
 
-            // Resolve index-based callId to real callId if we have a mapping.
-            const resolvedId = indexToCallId.get(callId) ?? callId;
-            const tc = openToolCalls.get(resolvedId);
-            if (tc !== undefined) {
-              tc.argsBuffer += argumentFragment;
-              // Update partial.toolCalls entry.
-              if (partial.toolCalls !== undefined) {
-                for (const ptc of partial.toolCalls) {
-                  if (ptc.id === resolvedId) {
-                    ptc.partialArguments = tc.argsBuffer;
-                    break;
-                  }
-                }
-              }
+        for (const raw of rawEvents) {
+          switch (raw.type) {
+            case "inference.text.delta": {
+              partial.text += raw.data.token;
               yield {
-                type: "inference.tool_call.delta",
+                type: "inference.text.delta",
                 seq: nextSeq(),
                 data: {
-                  callId: resolvedId,
-                  argumentFragment,
+                  token: raw.data.token,
                   partial: snapshotPartial(partial),
                 },
               };
+              break;
             }
-            break;
-          }
 
-          case "inference.usage": {
-            // Accumulate usage — providers may send multiple usage events
-            // (e.g., Anthropic sends one at message_start, one at message_delta).
-            usageSeen = mergeUsage(usageSeen, raw.data.usage);
-            yield {
-              type: "inference.usage",
-              seq: nextSeq(),
-              data: { usage: raw.data.usage },
-            };
-            break;
-          }
+            case "inference.thinking.delta": {
+              thinkingBuffer += raw.data.token;
+              partial.thinking = thinkingBuffer;
+              yield {
+                type: "inference.thinking.delta",
+                seq: nextSeq(),
+                data: {
+                  token: raw.data.token,
+                  partial: snapshotPartial(partial),
+                },
+              };
+              break;
+            }
 
-          // inference.done and inference.error from adapters are unexpected —
-          // the harness emits those itself. Ignore them.
-          default:
-            break;
+            case "inference.tool_call.start": {
+              const { callId, name } = raw.data;
+              openToolCalls.set(callId, { callId, name, argsBuffer: "" });
+              // OpenAI sends deltas with a string index ("0", "1", ...) as the
+              // callId. Map each index to the real callId so deltas resolve.
+              // The index is the position of this tool call in the current batch.
+              indexToCallId.set(String(openToolCalls.size - 1), callId);
+              partial.toolCalls = [
+                ...(partial.toolCalls ?? []),
+                {
+                  id: callId,
+                  name,
+                  partialArguments: "",
+                },
+              ];
+              yield {
+                type: "inference.tool_call.start",
+                seq: nextSeq(),
+                data: { callId, name, partial: snapshotPartial(partial) },
+              };
+              break;
+            }
+
+            case "inference.tool_call.delta": {
+              const { callId, argumentFragment } = raw.data;
+
+              // Resolve index-based callId to real callId if we have a mapping.
+              const resolvedId = indexToCallId.get(callId) ?? callId;
+              const tc = openToolCalls.get(resolvedId);
+              if (tc !== undefined) {
+                tc.argsBuffer += argumentFragment;
+                // Update partial.toolCalls entry.
+                if (partial.toolCalls !== undefined) {
+                  for (const ptc of partial.toolCalls) {
+                    if (ptc.id === resolvedId) {
+                      ptc.partialArguments = tc.argsBuffer;
+                      break;
+                    }
+                  }
+                }
+                yield {
+                  type: "inference.tool_call.delta",
+                  seq: nextSeq(),
+                  data: {
+                    callId: resolvedId,
+                    argumentFragment,
+                    partial: snapshotPartial(partial),
+                  },
+                };
+              }
+              break;
+            }
+
+            case "inference.usage": {
+              // Accumulate usage — providers may send multiple usage events
+              // (e.g., Anthropic sends one at message_start, one at message_delta).
+              usageSeen = mergeUsage(usageSeen, raw.data.usage);
+              yield {
+                type: "inference.usage",
+                seq: nextSeq(),
+                data: { usage: raw.data.usage },
+              };
+              break;
+            }
+
+            // inference.done and inference.error from adapters are unexpected —
+            // the harness emits those itself. Ignore them.
+            default:
+              break;
+          }
         }
       }
-    }
-  } catch (cause) {
-    if (timeoutReason !== null) {
-      const thresholdMs =
-        timeoutReason === "inactivity" ? inactivityTimeoutMs : totalTimeoutMs;
+    } catch (cause) {
+      if (timeoutReason !== null) {
+        const thresholdMs =
+          timeoutReason === "inactivity" ? inactivityTimeoutMs : totalTimeoutMs;
+        yield {
+          type: "inference.error",
+          seq: nextSeq(),
+          data: {
+            error: classifyTimeoutError(timeoutReason, thresholdMs),
+            partial: snapshotPartial(partial),
+          },
+        };
+        return;
+      }
+      if (signal?.aborted) {
+        yield {
+          type: "inference.error",
+          seq: nextSeq(),
+          data: {
+            error: classifyAbortError(),
+            partial: snapshotPartial(partial),
+          },
+        };
+        return;
+      }
       yield {
         type: "inference.error",
         seq: nextSeq(),
         data: {
-          error: classifyTimeoutError(timeoutReason, thresholdMs),
+          error: classifyStreamError(cause),
           partial: snapshotPartial(partial),
         },
       };
-      cleanupTimers();
       return;
     }
-    if (signal?.aborted) {
-      yield {
-        type: "inference.error",
-        seq: nextSeq(),
-        data: {
-          error: classifyAbortError(),
-          partial: snapshotPartial(partial),
-        },
-      };
-      cleanupTimers();
-      return;
-    }
-    yield {
-      type: "inference.error",
-      seq: nextSeq(),
-      data: {
-        error: classifyStreamError(cause),
-        partial: snapshotPartial(partial),
-      },
-    };
-    cleanupTimers();
-    return;
-  }
 
-  // SSE loop exited normally — disarm timers before the finalization
-  // path emits any further events. (Both timers are no-op-safe after
-  // cleanup, but stopping them avoids spurious firings during a slow
-  // finalization step.)
-  cleanupTimers();
+    // Finalize any open tool calls that never received an explicit end event.
+    const completedToolCalls: ContentBlock[] = [];
+    for (const tc of openToolCalls.values()) {
+      let parsedArgs: Record<string, unknown>;
+      try {
+        const raw = tc.argsBuffer.trim() === "" ? "{}" : tc.argsBuffer;
+        const parsed = JSON.parse(raw);
+        const validated = ParsedToolArgs(parsed);
+        parsedArgs = validated instanceof type.errors ? {} : validated;
+      } catch {
+        parsedArgs = { _raw: tc.argsBuffer };
+      }
 
-  // Finalize any open tool calls that never received an explicit end event.
-  const completedToolCalls: ContentBlock[] = [];
-  for (const tc of openToolCalls.values()) {
-    let parsedArgs: Record<string, unknown>;
-    try {
-      const raw = tc.argsBuffer.trim() === "" ? "{}" : tc.argsBuffer;
-      const parsed = JSON.parse(raw);
-      const validated = ParsedToolArgs(parsed);
-      parsedArgs = validated instanceof type.errors ? {} : validated;
-    } catch {
-      parsedArgs = { _raw: tc.argsBuffer };
-    }
-
-    completedToolCalls.push({
-      type: "tool_call",
-      id: tc.callId,
-      name: tc.name,
-      arguments: parsedArgs,
-    });
-
-    yield {
-      type: "inference.tool_call.end",
-      seq: nextSeq(),
-      data: {
-        callId: tc.callId,
+      completedToolCalls.push({
+        type: "tool_call",
+        id: tc.callId,
         name: tc.name,
         arguments: parsedArgs,
-        partial: snapshotPartial(partial),
+      });
+
+      yield {
+        type: "inference.tool_call.end",
+        seq: nextSeq(),
+        data: {
+          callId: tc.callId,
+          name: tc.name,
+          arguments: parsedArgs,
+          partial: snapshotPartial(partial),
+        },
+      };
+    }
+
+    const finalUsage: TokenUsage = usageSeen ?? {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      thinking: 0,
+    };
+
+    // Emit inference.usage before inference.done per the protocol spec.
+    if (usageSeen === null) {
+      yield {
+        type: "inference.usage",
+        seq: nextSeq(),
+        data: { usage: finalUsage },
+      };
+    }
+
+    // Build the final assistant message.
+    const contentBlocks: ContentBlock[] = [];
+    if (thinkingBuffer.length > 0) {
+      contentBlocks.push({ type: "thinking", thinking: thinkingBuffer });
+    }
+    if (partial.text.length > 0) {
+      contentBlocks.push({ type: "text", text: partial.text });
+    }
+    contentBlocks.push(...completedToolCalls);
+
+    const finalTurn: AssistantTurn = {
+      role: "assistant",
+      content: contentBlocks,
+      model,
+      timestamp: Date.now(),
+    };
+
+    const pacingDelayMs = adapter.extractPacingDelayMs?.(response.headers);
+
+    yield {
+      type: "inference.done",
+      seq: nextSeq(),
+      data: {
+        turn: finalTurn,
+        usage: finalUsage,
+        ...(pacingDelayMs !== undefined && pacingDelayMs > 0
+          ? { pacingDelayMs }
+          : {}),
       },
     };
+  } finally {
+    // Single owner of the timer + signal-listener lifecycle. Runs on
+    // every exit including normal completion, early `return`, thrown
+    // errors, and consumer abandonment via `for await` `break`
+    // (which invokes the generator's `return()` and triggers the
+    // finally). Both cleanups are idempotent.
+    cleanupTimers();
+    cleanupSignal();
   }
-
-  const finalUsage: TokenUsage = usageSeen ?? {
-    input: 0,
-    output: 0,
-    cacheRead: 0,
-    cacheWrite: 0,
-    thinking: 0,
-  };
-
-  // Emit inference.usage before inference.done per the protocol spec.
-  if (usageSeen === null) {
-    yield {
-      type: "inference.usage",
-      seq: nextSeq(),
-      data: { usage: finalUsage },
-    };
-  }
-
-  // Build the final assistant message.
-  const contentBlocks: ContentBlock[] = [];
-  if (thinkingBuffer.length > 0) {
-    contentBlocks.push({ type: "thinking", thinking: thinkingBuffer });
-  }
-  if (partial.text.length > 0) {
-    contentBlocks.push({ type: "text", text: partial.text });
-  }
-  contentBlocks.push(...completedToolCalls);
-
-  const finalTurn: AssistantTurn = {
-    role: "assistant",
-    content: contentBlocks,
-    model,
-    timestamp: Date.now(),
-  };
-
-  const pacingDelayMs = adapter.extractPacingDelayMs?.(response.headers);
-
-  yield {
-    type: "inference.done",
-    seq: nextSeq(),
-    data: {
-      turn: finalTurn,
-      usage: finalUsage,
-      ...(pacingDelayMs !== undefined && pacingDelayMs > 0
-        ? { pacingDelayMs }
-        : {}),
-    },
-  };
 }
 
 /**
@@ -614,24 +632,88 @@ export async function* runInference(
  * implementation can observe. Returns the internal controller's signal
  * alone if no caller signal exists; otherwise wires both so that either
  * one firing aborts the combined signal.
+ *
+ * Returns a bundle containing the signal AND an explicit cleanup
+ * function. `{ once: true }` on the abort listeners only auto-removes
+ * after firing, so on the happy path (no abort) the listeners would
+ * accumulate against a long-lived caller signal — one un-removed
+ * listener per `runInference` call. The caller MUST invoke
+ * `cleanup()` exactly once when the call's interest in the signal
+ * ends (whether by completion, error, or abandonment); the harness
+ * does this from its `try/finally` block. `cleanup()` is idempotent.
  */
+type CombinedSignal = {
+  readonly signal: AbortSignal;
+  readonly cleanup: () => void;
+};
+
 function combineSignals(
   caller: AbortSignal | undefined,
   internal: AbortSignal,
-): AbortSignal {
-  if (caller === undefined) return internal;
+): CombinedSignal {
+  if (caller === undefined) {
+    const noopCleanup = (): void => {
+      /* no listener was attached */
+    };
+    return { signal: internal, cleanup: noopCleanup };
+  }
   const composite = new AbortController();
-  if (caller.aborted) composite.abort(caller.reason);
-  else
-    caller.addEventListener("abort", () => composite.abort(caller.reason), {
-      once: true,
-    });
-  if (internal.aborted) composite.abort(internal.reason);
-  else
-    internal.addEventListener("abort", () => composite.abort(internal.reason), {
-      once: true,
-    });
-  return composite.signal;
+  const onCallerAbort = (): void => {
+    composite.abort(caller.reason);
+  };
+  const onInternalAbort = (): void => {
+    composite.abort(internal.reason);
+  };
+  let cleanedUp = false;
+  const cleanup = (): void => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    caller.removeEventListener("abort", onCallerAbort);
+    internal.removeEventListener("abort", onInternalAbort);
+  };
+  if (caller.aborted) {
+    composite.abort(caller.reason);
+  } else {
+    caller.addEventListener("abort", onCallerAbort, { once: true });
+  }
+  if (internal.aborted) {
+    composite.abort(internal.reason);
+  } else {
+    internal.addEventListener("abort", onInternalAbort, { once: true });
+  }
+  return { signal: composite.signal, cleanup };
+}
+
+/**
+ * Await `promise` but reject early if `signal` aborts in the meantime.
+ * Used for non-streaming reads of the error response body so a hostile
+ * server cannot hang the call by returning a 4xx/5xx with a body that
+ * never terminates. The signal's listener is always removed before
+ * settlement so this helper does not itself leak listeners.
+ */
+async function awaitWithSignal<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) {
+    throw new DOMException("aborted", "AbortError");
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => {
+      reject(new DOMException("aborted", "AbortError"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (err: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      },
+    );
+  });
 }
 
 function snapshotPartial(partial: PartialMessage): PartialMessage {

--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -1,6 +1,15 @@
 export { parseSSE } from "./sse";
-export { runInference, createDefaultDependencies, HarnessId } from "./harness";
-export type { Dependencies, InferenceHarnessOptions } from "./harness";
+export {
+  runInference,
+  createDefaultDependencies,
+  createDefaultScheduler,
+  HarnessId,
+} from "./harness";
+export type {
+  Dependencies,
+  InferenceHarnessOptions,
+  Scheduler,
+} from "./harness";
 export {
   hasProvider,
   lookupProvider,

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -685,6 +685,7 @@ export const InferenceError = type({
     "quota_exhausted",
     "fatal",
     "aborted",
+    "timeout",
   ),
   message: "string",
   "statusCode?": "number",
@@ -1472,6 +1473,21 @@ export type InferenceOptions = {
   thinking?: { enabled: boolean; budgetTokens?: number };
   systemPrompt?: string;
   tools?: ToolDefinition[];
+  /**
+   * Per-call inactivity timeout in milliseconds. If the harness yields no
+   * event (other than `inference.start`) for this many ms, the underlying
+   * fetch is aborted and the call ends with `inference.error` of category
+   * `"timeout"`. Default 120_000 (2 min). Tune higher for reasoning models
+   * that exhibit long silent-thinking stretches between token bursts; tune
+   * lower to fail fast.
+   */
+  inactivityTimeoutMs?: number;
+  /**
+   * Per-call total wall-clock cap in milliseconds. Starts at fetch.
+   * Default 600_000 (10 min). Backstop for streams that keep emitting
+   * forever without terminating. Same error category as `inactivityTimeoutMs`.
+   */
+  totalTimeoutMs?: number;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -1479,13 +1479,15 @@ export type InferenceOptions = {
    * fetch is aborted and the call ends with `inference.error` of category
    * `"timeout"`. Default 120_000 (2 min). Tune higher for reasoning models
    * that exhibit long silent-thinking stretches between token bursts; tune
-   * lower to fail fast.
+   * lower to fail fast. `0` arms the timer to fire on the next tick (a
+   * "fail-fast even if the fetch is instant" mode useful in tests).
    */
   inactivityTimeoutMs?: number;
   /**
    * Per-call total wall-clock cap in milliseconds. Starts at fetch.
    * Default 600_000 (10 min). Backstop for streams that keep emitting
    * forever without terminating. Same error category as `inactivityTimeoutMs`.
+   * `0` arms the timer to fire on the next tick.
    */
   totalTimeoutMs?: number;
 };

--- a/tests/inference/error-body.test.ts
+++ b/tests/inference/error-body.test.ts
@@ -1,0 +1,141 @@
+// Behaviour of `InferenceError.message` and `InferenceError.raw` when
+// the upstream returns a non-OK HTTP response with various body shapes.
+//
+// Three consumers read `error.message` in production: the default
+// director synthesises it into the user-facing reply, the hub event
+// collector stores it as the timeline error part, and the reactor
+// harness writes it into the audit store. A meaningful message is the
+// difference between an actionable diagnostic and a generic
+// `statusText` echo, so the extraction path needs explicit coverage —
+// especially for plain-text bodies (HTML error pages, raw exception
+// strings, load-balancer diagnostics) which were previously dropped on
+// the floor.
+
+import { describe, test, expect } from "bun:test";
+
+import { runInference } from "@intx/inference";
+import type { Dependencies, Scheduler } from "@intx/inference";
+import type {
+  InferenceEvent,
+  InferenceError,
+  ConversationTurn,
+  ProviderConfig,
+} from "@intx/types/runtime";
+
+const PROVIDER: ProviderConfig = {
+  provider: "openai",
+  baseURL: "https://test.invalid/v1",
+  apiKey: "test",
+  model: "test-model",
+};
+
+function makeTurns(): ConversationTurn[] {
+  return [
+    { role: "user", content: [{ type: "text", text: "hi" }], timestamp: 0 },
+  ];
+}
+
+const inertScheduler: Scheduler = {
+  setTimeout: () => () => {
+    /* tests do not exercise timer firing */
+  },
+};
+
+async function drain(
+  stream: AsyncIterable<InferenceEvent>,
+): Promise<InferenceEvent[]> {
+  const out: InferenceEvent[] = [];
+  for await (const event of stream) {
+    out.push(event);
+  }
+  return out;
+}
+
+async function runAgainstFetch(
+  fetchStub: Dependencies["fetch"],
+): Promise<InferenceError> {
+  const deps: Dependencies = { fetch: fetchStub, scheduler: inertScheduler };
+  let seq = 0;
+  const events = await drain(
+    runInference({
+      turns: makeTurns(),
+      model: "test-model",
+      providerConfig: PROVIDER,
+      nextSeq: () => seq++,
+      deps,
+    }),
+  );
+  const errorEvent = events.find((e) => e.type === "inference.error");
+  if (errorEvent === undefined || errorEvent.type !== "inference.error") {
+    throw new Error("expected an inference.error event");
+  }
+  return errorEvent.data.error;
+}
+
+function plainTextResponse(status: number, body: string): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/plain" },
+  });
+}
+
+describe("inference.error.message extraction from non-OK responses", () => {
+  test("structured JSON envelope: message is the nested error.message", async () => {
+    // Sanity check that the prior behaviour for { error: { message } }
+    // is preserved.
+    const err = await runAgainstFetch(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ error: { message: "rate limit reached" } }),
+          { status: 429, headers: { "content-type": "application/json" } },
+        ),
+      ),
+    );
+    expect(err.message).toBe("rate limit reached");
+    expect(err.statusCode).toBe(429);
+  });
+
+  test("plain-text body: message surfaces the body content", async () => {
+    // Previously: error.message fell back to statusText because the
+    // body wasn't valid JSON. Now: the diagnostic text reaches the
+    // operator/user-facing message.
+    const body = "Database connection pool exhausted at db-replica-3:5432";
+    const err = await runAgainstFetch(() =>
+      Promise.resolve(plainTextResponse(503, body)),
+    );
+    expect(err.message).toBe(body);
+    expect(err.statusCode).toBe(503);
+    expect(err.raw).toBe(body);
+  });
+
+  test("long plain-text body: message is truncated with a marker; raw retains the full body", async () => {
+    // HTML error pages and stack traces can easily exceed a chat-reply's
+    // practical budget. The truncation keeps `error.message` bounded
+    // while preserving the full payload in `error.raw` for audit-time
+    // inspection.
+    const longBody = "x".repeat(2000);
+    const err = await runAgainstFetch(() =>
+      Promise.resolve(plainTextResponse(500, longBody)),
+    );
+    expect(typeof err.message).toBe("string");
+    expect(err.message.length).toBeLessThan(longBody.length);
+    expect(err.message).toContain("truncated");
+    expect(err.message).toContain("error.raw");
+    expect(err.raw).toBe(longBody);
+  });
+
+  test("empty body: message falls back to statusText", async () => {
+    // No body, no content. The pre-existing statusText fallback is
+    // still the right behaviour — nothing else is available.
+    // `statusText` is set explicitly because runtime defaults
+    // (Bun returns "" rather than the IANA reason phrase) are not
+    // portable across the engines runInference may execute under.
+    const err = await runAgainstFetch(() =>
+      Promise.resolve(
+        new Response(null, { status: 502, statusText: "Bad Gateway" }),
+      ),
+    );
+    expect(err.message).toBe("Bad Gateway");
+    expect(err.statusCode).toBe(502);
+  });
+});

--- a/tests/inference/lifecycle.test.ts
+++ b/tests/inference/lifecycle.test.ts
@@ -1,0 +1,246 @@
+// Inference harness lifecycle hygiene: timers cancelled on every exit
+// path; AbortSignal listeners on the caller's signal do not accumulate
+// across calls. These tests pin the invariants the timeout work in
+// INTR-87 added to `runInference` — they were originally written to
+// demonstrate three concrete leaks in the first draft of that work and
+// are kept here as regression coverage so future edits to the error
+// paths or the signal-combining logic cannot quietly reintroduce them.
+//
+// Drive `runInference` with synthetic Dependencies (recording scheduler,
+// counting signal, stub fetch) rather than the inference-testing harness
+// — these tests scrutinise the harness's plumbing, not the wire
+// behaviour, so going through `setupHarness` would only obscure the
+// assertions.
+
+import { describe, test, expect } from "bun:test";
+
+import { runInference } from "@intx/inference";
+import type { Dependencies, Scheduler } from "@intx/inference";
+import type {
+  ConversationTurn,
+  InferenceEvent,
+  ProviderConfig,
+} from "@intx/types/runtime";
+
+const PROVIDER: ProviderConfig = {
+  provider: "openai",
+  baseURL: "https://test.invalid/v1",
+  apiKey: "test",
+  model: "test-model",
+};
+
+function makeTurns(): ConversationTurn[] {
+  return [
+    { role: "user", content: [{ type: "text", text: "hi" }], timestamp: 0 },
+  ];
+}
+
+type ScheduledEntry = {
+  callback: () => void;
+  delayMs: number;
+  cancelled: boolean;
+};
+
+function recordingScheduler(): {
+  scheduler: Scheduler;
+  entries: ScheduledEntry[];
+} {
+  const entries: ScheduledEntry[] = [];
+  const scheduler: Scheduler = {
+    setTimeout(callback, delayMs) {
+      const entry: ScheduledEntry = { callback, delayMs, cancelled: false };
+      entries.push(entry);
+      return () => {
+        entry.cancelled = true;
+      };
+    },
+  };
+  return { scheduler, entries };
+}
+
+async function drain(
+  stream: AsyncIterable<InferenceEvent>,
+): Promise<InferenceEvent[]> {
+  const out: InferenceEvent[] = [];
+  for await (const event of stream) {
+    out.push(event);
+  }
+  return out;
+}
+
+describe("runInference — timer cancellation on non-streaming exit paths", () => {
+  test("non-OK HTTP response cancels the total timer", async () => {
+    const { scheduler, entries } = recordingScheduler();
+    const fetchStub: Dependencies["fetch"] = () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: { message: "boom" } }), {
+          status: 500,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    const deps: Dependencies = { fetch: fetchStub, scheduler };
+
+    let seq = 0;
+    const events = await drain(
+      runInference({
+        turns: makeTurns(),
+        model: "test-model",
+        providerConfig: PROVIDER,
+        nextSeq: () => seq++,
+        deps,
+      }),
+    );
+
+    expect(events.some((e) => e.type === "inference.error")).toBe(true);
+    expect(entries.length).toBeGreaterThan(0);
+    const totalTimer = entries[0];
+    if (totalTimer === undefined) throw new Error("no timer registered");
+    expect(totalTimer.cancelled).toBe(true);
+  });
+
+  test("204 response with null body cancels the total timer", async () => {
+    const { scheduler, entries } = recordingScheduler();
+    const fetchStub: Dependencies["fetch"] = () =>
+      Promise.resolve(new Response(null, { status: 204 }));
+    const deps: Dependencies = { fetch: fetchStub, scheduler };
+
+    let seq = 0;
+    const events = await drain(
+      runInference({
+        turns: makeTurns(),
+        model: "test-model",
+        providerConfig: PROVIDER,
+        nextSeq: () => seq++,
+        deps,
+      }),
+    );
+
+    expect(events.some((e) => e.type === "inference.error")).toBe(true);
+    expect(entries.length).toBeGreaterThan(0);
+    const totalTimer = entries[0];
+    if (totalTimer === undefined) throw new Error("no timer registered");
+    expect(totalTimer.cancelled).toBe(true);
+  });
+});
+
+describe("runInference — timer cancellation on consumer abandonment", () => {
+  test("consumer abandoning the iterator mid-stream cancels every timer", async () => {
+    const { scheduler, entries } = recordingScheduler();
+    const fetchStub: Dependencies["fetch"] = () => {
+      const enc = new TextEncoder();
+      return Promise.resolve(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(
+                enc.encode(
+                  'data: {"choices":[{"index":0,"delta":{"content":"a"}}]}\n\n',
+                ),
+              );
+              // Stream never closes. The consumer is expected to `break`
+              // out below; without the generator's `finally`, the
+              // timers stay armed.
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        ),
+      );
+    };
+    const deps: Dependencies = { fetch: fetchStub, scheduler };
+
+    let seq = 0;
+    const iter = runInference({
+      turns: makeTurns(),
+      model: "test-model",
+      providerConfig: PROVIDER,
+      nextSeq: () => seq++,
+      deps,
+    });
+
+    for await (const ev of iter) {
+      if (ev.type === "inference.text.delta") break;
+    }
+
+    const armed = entries.filter((e) => !e.cancelled).length;
+    expect(armed).toBe(0);
+  });
+});
+
+describe("runInference — caller-signal listener accounting", () => {
+  test("a successful call does not leak abort listeners on the caller signal", async () => {
+    // The DOM-shaped EventListener types are not in the project's
+    // `lib` (ESNext only), but `Parameters<EventTarget["addEventListener"]>`
+    // recovers the right tuple structurally without naming the missing
+    // types directly.
+    class CountingSignal extends EventTarget {
+      added = 0;
+      removed = 0;
+      readonly aborted = false;
+      readonly reason: unknown = undefined;
+      override addEventListener(
+        ...args: Parameters<EventTarget["addEventListener"]>
+      ): void {
+        if (args[0] === "abort") this.added += 1;
+        super.addEventListener(...args);
+      }
+      override removeEventListener(
+        ...args: Parameters<EventTarget["removeEventListener"]>
+      ): void {
+        if (args[0] === "abort") this.removed += 1;
+        super.removeEventListener(...args);
+      }
+    }
+
+    const inertScheduler: Scheduler = {
+      setTimeout: () => () => {
+        /* no-op: tests do not exercise the timer firing */
+      },
+    };
+    const successfulFetch: Dependencies["fetch"] = () => {
+      const enc = new TextEncoder();
+      return Promise.resolve(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(
+                enc.encode(
+                  'data: {"choices":[{"index":0,"delta":{"content":"hi"}}]}\n\n',
+                ),
+              );
+              controller.enqueue(enc.encode("data: [DONE]\n\n"));
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        ),
+      );
+    };
+
+    const counter = new CountingSignal();
+    // The Signal-typed view of the counter is intentional: runInference
+    // requires an AbortSignal at the parameter level, and the counter
+    // satisfies the structural shape EventTarget exposes for that use.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- CountingSignal extends EventTarget and exposes the AbortSignal shape runInference relies on (addEventListener/removeEventListener + aborted + reason).
+    const fakeSignal = counter as unknown as AbortSignal;
+
+    const deps: Dependencies = {
+      fetch: successfulFetch,
+      scheduler: inertScheduler,
+    };
+
+    let seq = 0;
+    await drain(
+      runInference({
+        turns: makeTurns(),
+        model: "test-model",
+        providerConfig: PROVIDER,
+        nextSeq: () => seq++,
+        deps,
+        signal: fakeSignal,
+      }),
+    );
+
+    expect(counter.added).toBeGreaterThan(0);
+    expect(counter.added - counter.removed).toBe(0);
+  });
+});

--- a/tests/inference/timeout.test.ts
+++ b/tests/inference/timeout.test.ts
@@ -120,9 +120,9 @@ describe("runInference — per-call timeouts (virtual clock)", () => {
       const stream = harness.scenario.createStream();
       harness.scenario.whenRequestMatches(() => true, stream);
 
-      // Five chunks at 60ms apart — under a 100ms inactivity timeout,
-      // each chunk resets the timer well before it can fire. Total
-      // virtual time elapsed: 5 * 60 = 300ms.
+      // wire.completeResponse for openai produces two chunks (one
+      // content delta + the `[DONE]` sentinel). Spaced 60ms apart,
+      // each resets the 100ms inactivity timer well before it fires.
       const chunks = wire.completeResponse("openai", { text: "hello" });
       stream.enqueueAll(chunks, { startAt: 60, stepMs: 60 });
 

--- a/tests/inference/timeout.test.ts
+++ b/tests/inference/timeout.test.ts
@@ -1,0 +1,339 @@
+// Per-call inactivity + total timeouts for the inference harness.
+// See INTR-87 — without these timeouts, a provider that stops emitting
+// SSE chunks (or never sends `[DONE]`) deadlocks every downstream
+// consumer of `runInference` because the iterator never terminates.
+//
+// Driven against the deterministic test harness's virtual clock — the
+// production code uses real `setTimeout` only when no scheduler is
+// injected via `Dependencies.scheduler`; the harness substitutes a
+// scheduler backed by `clock.schedule`, so these tests fire the
+// timeouts at virtual time without sleeping real wall-clock. We are
+// not testing `setTimeout` itself; we are testing the timeout LOGIC
+// (which timer fired, which error category surfaces, that the
+// AbortController propagated to the fetch).
+
+import { describe, test, expect } from "bun:test";
+
+import { runInference } from "@intx/inference";
+import type {
+  InferenceEvent,
+  InferenceError,
+  ConversationTurn,
+  ProviderConfig,
+} from "@intx/types/runtime";
+import { setupHarness, wire } from "@intx/inference-testing";
+import type { Harness } from "@intx/inference-testing";
+
+async function withHarness<T>(body: (h: Harness) => Promise<T>): Promise<T> {
+  // `enableInferenceTimers: true` wires the harness's virtual clock to
+  // the inference layer's per-call timeout scheduler. Every other test
+  // suite leaves this off so the 600s default total-timeout doesn't
+  // force `harness.run()` to advance virtual time through ten minutes
+  // of empty heap.
+  const harness = setupHarness({ enableInferenceTimers: true });
+  try {
+    return await body(harness);
+  } finally {
+    harness.dispose();
+  }
+}
+
+const PROVIDER: ProviderConfig = {
+  provider: "openai",
+  baseURL: "https://test.invalid/v1",
+  apiKey: "test",
+  model: "test-model",
+};
+
+function makeTurns(): ConversationTurn[] {
+  return [
+    {
+      role: "user",
+      content: [{ type: "text", text: "hi" }],
+      timestamp: 0,
+    },
+  ];
+}
+
+async function collect(
+  stream: AsyncIterable<InferenceEvent>,
+): Promise<InferenceEvent[]> {
+  const out: InferenceEvent[] = [];
+  for await (const event of stream) {
+    out.push(event);
+  }
+  return out;
+}
+
+function findError(events: InferenceEvent[]): InferenceError | undefined {
+  const errorEvent = events.find((e) => e.type === "inference.error");
+  if (errorEvent?.type !== "inference.error") return undefined;
+  return errorEvent.data.error;
+}
+
+function startConsumer(events: AsyncIterable<InferenceEvent>): {
+  done: Promise<InferenceEvent[]>;
+} {
+  return { done: collect(events) };
+}
+
+describe("runInference — per-call timeouts (virtual clock)", () => {
+  test("inactivity timeout fires when SSE stream goes silent past the threshold", async () => {
+    await withHarness(async (harness) => {
+      // `scenario.stall()` routes the fetch to a stream that never
+      // emits anything. The SSE iterator's first read parks forever in
+      // real time; in virtual time we advance past the inactivity
+      // threshold and the timer aborts the fetch.
+      harness.scenario.stall();
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          model: "test-model",
+          providerConfig: PROVIDER,
+          inferenceOptions: {
+            inactivityTimeoutMs: 100,
+            totalTimeoutMs: 10_000,
+          },
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+
+      // Advance virtual clock past the inactivity threshold. Drains
+      // every scheduled callback (including the timeout), settles
+      // microtasks, returns when the heap is empty + quiescent.
+      await harness.run();
+
+      const events = await consumer.done;
+      const err = findError(events);
+      expect(err).toBeDefined();
+      expect(err?.category).toBe("timeout");
+      expect(err?.message).toMatch(/inactivity/i);
+      expect(err?.message).toMatch(/100/);
+    });
+  });
+
+  test("inactivity timer is reset by each yielded event — slow but steady stream finishes", async () => {
+    await withHarness(async (harness) => {
+      const stream = harness.scenario.createStream();
+      harness.scenario.whenRequestMatches(() => true, stream);
+
+      // Five chunks at 60ms apart — under a 100ms inactivity timeout,
+      // each chunk resets the timer well before it can fire. Total
+      // virtual time elapsed: 5 * 60 = 300ms.
+      const chunks = wire.completeResponse("openai", { text: "hello" });
+      stream.enqueueAll(chunks, { startAt: 60, stepMs: 60 });
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          model: "test-model",
+          providerConfig: PROVIDER,
+          inferenceOptions: {
+            inactivityTimeoutMs: 100,
+            totalTimeoutMs: 10_000,
+          },
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+
+      await harness.run();
+
+      const events = await consumer.done;
+      expect(findError(events)).toBeUndefined();
+      // Sanity: the stream actually produced something.
+      expect(events.some((e) => e.type === "inference.done")).toBe(true);
+    });
+  });
+
+  test("total timeout fires even when the stream is active enough to keep inactivity from firing", async () => {
+    await withHarness(async (harness) => {
+      const stream = harness.scenario.createStream();
+      harness.scenario.whenRequestMatches(() => true, stream);
+
+      // 100 chunks at 10ms apart — total virtual span 1000ms. The
+      // inactivity timer (5000ms) never trips; the total cap (200ms)
+      // does.
+      const longTrickle: Uint8Array[] = [];
+      const encoder = new TextEncoder();
+      for (let i = 0; i < 100; i++) {
+        longTrickle.push(
+          encoder.encode('data: {"choices":[{"index":0,"delta":{}}]}\n\n'),
+        );
+      }
+      stream.enqueueAll(longTrickle, { startAt: 10, stepMs: 10 });
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          model: "test-model",
+          providerConfig: PROVIDER,
+          inferenceOptions: {
+            inactivityTimeoutMs: 5_000,
+            totalTimeoutMs: 200,
+          },
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+
+      await harness.run();
+
+      const events = await consumer.done;
+      const err = findError(events);
+      expect(err).toBeDefined();
+      expect(err?.category).toBe("timeout");
+      expect(err?.message).toMatch(/total/i);
+      expect(err?.message).toMatch(/200/);
+    });
+  });
+
+  test("a healthy short call completes well inside both default timeouts", async () => {
+    await withHarness(async (harness) => {
+      // No timeout options — defaults of 120000 / 600000 ms apply.
+      // The reply lands at virtual time ~1ms and the call wraps.
+      harness.scenario.replyOnce("openai", { text: "ok" });
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          model: "test-model",
+          providerConfig: PROVIDER,
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+
+      await harness.run();
+      const events = await consumer.done;
+      expect(findError(events)).toBeUndefined();
+    });
+  });
+
+  test("underlying fetch AbortController fires on timeout", async () => {
+    await withHarness(async (harness) => {
+      // Direct assertion on abort propagation: `stall.aborted` flips
+      // and `stall.awaitAbort` resolves the moment the matched fetch's
+      // AbortSignal fires. This is the assertion INTR-87's checklist
+      // names explicitly — the downstream `inference.error` event the
+      // other tests look at is downstream of the abort, but this test
+      // proves the abort actually fired at the fetch boundary.
+      const stall = harness.scenario.stall();
+      expect(stall.aborted).toBe(false);
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          model: "test-model",
+          providerConfig: PROVIDER,
+          inferenceOptions: {
+            inactivityTimeoutMs: 50,
+            totalTimeoutMs: 10_000,
+          },
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+
+      await harness.run();
+      await stall.awaitAbort;
+      expect(stall.aborted).toBe(true);
+
+      // Sanity: the run also surfaced a timeout error, so this is a
+      // genuine timeout-driven abort and not some other path.
+      const events = await consumer.done;
+      const err = findError(events);
+      expect(err?.category).toBe("timeout");
+      expect(err?.message).toMatch(/inactivity/i);
+    });
+  });
+
+  describe("per-call override on the same scripted wire", () => {
+    // Shared wire script: one event at virtual t=1ms, then a 1000ms
+    // silence, then the remainder of a complete reply starting at
+    // t=1001ms. With a 50ms inactivity threshold the silence trips
+    // the timer; with a 5000ms inactivity threshold the silence is
+    // well under the budget and the reply lands cleanly.
+    function scriptOneSecondGap(
+      stream: ReturnType<Harness["scenario"]["createStream"]>,
+    ): void {
+      const chunks = wire.completeResponse("openai", { text: "hi" });
+      if (chunks.length < 2) {
+        throw new Error(
+          `scriptOneSecondGap: wire.completeResponse returned ${String(chunks.length)} chunks; needs at least 2 to model an inter-chunk gap`,
+        );
+      }
+      const [first, ...rest] = chunks;
+      if (first === undefined) {
+        throw new Error("scriptOneSecondGap: first chunk unexpectedly missing");
+      }
+      stream.enqueueAt(1, first);
+      stream.enqueueAll(rest, { startAt: 1001, stepMs: 1 });
+    }
+
+    test("short inactivity threshold trips on the 1s gap", async () => {
+      await withHarness(async (harness) => {
+        const stream = harness.scenario.createStream();
+        harness.scenario.whenRequestMatches(() => true, stream);
+        scriptOneSecondGap(stream);
+
+        let seq = 0;
+        const consumer = startConsumer(
+          runInference({
+            turns: makeTurns(),
+            model: "test-model",
+            providerConfig: PROVIDER,
+            inferenceOptions: {
+              inactivityTimeoutMs: 50,
+              totalTimeoutMs: 10_000,
+            },
+            nextSeq: () => seq++,
+            deps: harness.deps,
+          }),
+        );
+
+        await harness.run();
+        const events = await consumer.done;
+        const err = findError(events);
+        expect(err?.category).toBe("timeout");
+        expect(err?.message).toMatch(/inactivity/i);
+        expect(err?.message).toMatch(/\b50\b/);
+      });
+    });
+
+    test("long inactivity threshold passes through on the same gap", async () => {
+      await withHarness(async (harness) => {
+        const stream = harness.scenario.createStream();
+        harness.scenario.whenRequestMatches(() => true, stream);
+        scriptOneSecondGap(stream);
+
+        let seq = 0;
+        const consumer = startConsumer(
+          runInference({
+            turns: makeTurns(),
+            model: "test-model",
+            providerConfig: PROVIDER,
+            inferenceOptions: {
+              inactivityTimeoutMs: 5_000,
+              totalTimeoutMs: 10_000,
+            },
+            nextSeq: () => seq++,
+            deps: harness.deps,
+          }),
+        );
+
+        await harness.run();
+        const events = await consumer.done;
+        expect(findError(events)).toBeUndefined();
+        expect(events.some((e) => e.type === "inference.done")).toBe(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Inference harness arms an inactivity timer (reset on every wire chunk) and a total wall-clock cap per call; either firing aborts the fetch and produces an `inference.error` with the new `"timeout"` category naming which timer fired and its threshold.
- Adds a `scenario.stall()` helper to `@intx/inference-testing` with a `StallHandle` exposing `aborted` + `awaitAbort` telemetry, so timeout tests can assert directly on `AbortController` propagation rather than only on the downstream error event.
- Timer + signal-listener lifecycle is owned by a single `try/finally` around the generator body, so cleanup runs on every exit path including consumer abandonment, non-OK HTTP responses, and null-body responses.
- Error response bodies are now read once as text and then parsed (fixing a pre-existing WHATWG locked-body bug where the `.json()` → `.text()` fallback always threw), and plain-text bodies are surfaced as the `InferenceError.message` (bounded at 500 chars; full body retained in `error.raw`) so user-facing replies, timeline parts, and audit store rows carry actionable diagnostic content instead of a generic statusText echo.

## Changes

- `packages/types/src/runtime.ts`: `"timeout"` added to `InferenceError` category union; `inactivityTimeoutMs?` / `totalTimeoutMs?` added to `InferenceOptions` with 120k / 600k defaults.
- `packages/inference/src/errors.ts`: `classifyTimeoutError(kind, thresholdMs)` helper.
- `packages/inference/src/harness.ts`: two timers, `AbortController`, `combineSignals` returning `{ signal, cleanup }`, signal-bound `awaitWithSignal` for non-OK error-body reads, text-then-parse pattern for body extraction, plain-text fallback with truncation in `extractErrorMessage`, generator body wrapped in `try/finally` with single cleanup owner.
- `packages/inference/src/index.ts`: exports `Scheduler` + `createDefaultScheduler`.
- `packages/inference-testing/src/harness.ts`: `enableInferenceTimers` opt-in wires `deps.scheduler` to the virtual clock; default is an inert scheduler so other test suites are unaffected.
- `packages/inference-testing/src/scenario.ts`: `scenario.stall({ predicate? })` returning `StallHandle`; abort observer wired into `routeWaitingFetch`; `dispose()` resolves any pending `awaitAbort` promises.
- `tests/inference/timeout.test.ts`: six scenarios — inactivity fires on stall, slow-but-steady stream survives, total cap fires on active stream, healthy short call passes under defaults, AbortController fires on timeout, per-call override on a shared one-second-gap wire.
- `tests/inference/lifecycle.test.ts`: four regression tests across three describe blocks — non-streaming exit paths (non-OK HTTP, null body), consumer abandonment, caller-signal listener accounting.
- `tests/inference/error-body.test.ts`: four cases covering structured JSON envelope extraction, plain-text body passthrough, long-text truncation with marker + full `error.raw`, and empty-body `statusText` fallback.
- `docs/INFERENCE.md`: `"Timeout"` entry in Error Categories; new `Per-Call Timeouts` section with defaults, override mechanism, reasoning-model tuning guidance, and a clarification that the inactivity timer resets on every wire chunk rather than strictly on yielded events.
- `packages/inference-testing/README.md`: `Stall scenarios` subsection documenting `scenario.stall` and `StallHandle`.

## Testing

- [x] `make all` green: lint + `tsc -b --noEmit` + 1502 main tests + 9 sequential tests passing.
- [x] New timeout-behaviour tests in `tests/inference/timeout.test.ts` — six scenarios cover the issue's "tests first" checklist.
- [x] New lifecycle regression tests in `tests/inference/lifecycle.test.ts` — four invariants pinned across three describe blocks (timer cancellation on every exit path; no caller-signal listener accumulation).
- [x] New error-body extraction tests in `tests/inference/error-body.test.ts` — four cases pinning the public-facing shape of `InferenceError.message` and `error.raw` across the input shapes.
- [x] Existing `@intx/inference` and `@intx/inference-testing` suites continue to pass without modification.
- [x] Self-review via the `code-review` skill: four rounds. Round-one surfaced six findings (timer leaks, signal-listener leak, no-finally on generator, unbounded error-body read, two doc errors); all six resolved. Round-two clean. Round-three covered the body-read fix and a rebase that landed two doc/test refinements via `edit` (not fixups) so they live in the right commits — clean, with a single non-blocking observation (plain-text bodies captured in `error.raw` but not in `error.message`). Round-four covered the plain-text-message follow-up that closed that observation — clean.

Closes INTR-87