### PR TITLE
Throw ProtocolMismatchError instead of silently dropping malformed SSE chunks

### DIFF
--- a/docs/INFERENCE.md
+++ b/docs/INFERENCE.md
@@ -657,6 +657,7 @@ Provider errors are classified into categories that determine the reactor's resp
 - **Fatal** — Invalid request, unsupported model, malformed content. Response: fail immediately with diagnostic information.
 - **Aborted** — Caller cancelled via AbortSignal. Response: clean termination.
 - **Timeout** — Per-call inactivity or total wall-clock cap fired (see Per-Call Timeouts). The call produced no usable response. Response: treat as transient infrastructure failure and retry per director policy rather than as a model decision.
+- **Protocol mismatch** — Upstream emitted a chunk that violates the provider's streaming protocol: malformed JSON, schema validation failure, or an out-of-order event sequence; the offending chunk is preserved in `error.raw`. Response: fail rather than retry — retrying the same request won't fix the bytes.
 
 The classifier inspects HTTP status codes, error response bodies, and provider-specific error message patterns. The classified error is delivered to the director as an `inference.error` event, and the director decides the response — retry, compact, switch model, suspend, or fail. The error categories inform the director's decision but do not hardcode the response.
 

--- a/packages/inference/src/adapter.ts
+++ b/packages/inference/src/adapter.ts
@@ -26,8 +26,15 @@ export type RequestBuilder = (
 // requests.
 //
 // The parser may return an empty array for events it doesn't care about
-// (e.g., Anthropic's ping events). It must not throw; errors should be
-// returned as inference.error events.
+// (e.g., Anthropic's ping events). It MAY throw `ProtocolMismatchError`
+// when the upstream chunk violates the provider's protocol (malformed
+// JSON, schema validation failure, out-of-order events); the harness's
+// stream-error catch converts that into an `inference.error` with
+// category `"protocol_mismatch"` via `classifyStreamError`. No other
+// throw type is permitted, and adapter-returned `inference.error` or
+// `inference.done` events are silently dropped — the harness owns
+// emission of those terminal types and the only path through which
+// adapter-detected failures can surface is `ProtocolMismatchError`.
 export type ResponseParser = (sseData: string) => InferenceEvent[];
 
 // An adapter pairs a request builder with a response parser. Registration

--- a/packages/inference/src/errors.test.ts
+++ b/packages/inference/src/errors.test.ts
@@ -4,6 +4,8 @@ import {
   classifyNetworkError,
   classifyAbortError,
   classifyStreamError,
+  classifyProtocolMismatch,
+  ProtocolMismatchError,
 } from "./errors";
 
 describe("classifyHTTPError", () => {
@@ -98,5 +100,34 @@ describe("classifyStreamError", () => {
     const err = classifyStreamError(new Error("stream corrupted"));
     expect(err.category).toBe("retryable");
     expect(err.message).toBe("stream corrupted");
+  });
+
+  test("ProtocolMismatchError → protocol_mismatch with raw passed through", () => {
+    const raw = { choices: [{ delta: { role: 42 } }] };
+    const cause = new ProtocolMismatchError(
+      "delta.role must be a string (was number)",
+      raw,
+    );
+    const err = classifyStreamError(cause);
+    expect(err.category).toBe("protocol_mismatch");
+    expect(err.message).toBe("delta.role must be a string (was number)");
+    expect(err.raw).toBe(raw);
+  });
+});
+
+describe("classifyProtocolMismatch", () => {
+  test("constructs a protocol_mismatch error with the given detail and raw", () => {
+    const raw = { malformed: true };
+    const err = classifyProtocolMismatch("bad chunk", raw);
+    expect(err.category).toBe("protocol_mismatch");
+    expect(err.message).toBe("bad chunk");
+    expect(err.raw).toBe(raw);
+  });
+
+  test("omits raw when none is supplied", () => {
+    const err = classifyProtocolMismatch("bad chunk");
+    expect(err.category).toBe("protocol_mismatch");
+    expect(err.message).toBe("bad chunk");
+    expect("raw" in err).toBe(false);
   });
 });

--- a/packages/inference/src/errors.ts
+++ b/packages/inference/src/errors.ts
@@ -58,9 +58,38 @@ export function classifyTimeoutError(
   return { category: "timeout", message };
 }
 
+/**
+ * The one throw type a response parser is permitted to raise. See the
+ * `ResponseParser` contract on `adapter.ts` for full semantics. `raw`
+ * carries the offending bytes or parsed object so operators can
+ * inspect what came over the wire.
+ */
+export class ProtocolMismatchError extends Error {
+  readonly raw: unknown;
+  constructor(detail: string, raw?: unknown) {
+    super(detail);
+    this.name = "ProtocolMismatchError";
+    this.raw = raw;
+  }
+}
+
+export function classifyProtocolMismatch(
+  detail: string,
+  raw?: unknown,
+): InferenceError {
+  return {
+    category: "protocol_mismatch",
+    message: detail,
+    ...(raw !== undefined ? { raw } : {}),
+  };
+}
+
 export function classifyStreamError(cause: unknown): InferenceError {
   if (isAbortError(cause)) {
     return classifyAbortError();
+  }
+  if (cause instanceof ProtocolMismatchError) {
+    return classifyProtocolMismatch(cause.message, cause.raw);
   }
   const message = cause instanceof Error ? cause.message : String(cause);
   return { category: "retryable", message, raw: cause };

--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -26,6 +26,8 @@ export {
   classifyNetworkError,
   classifyAbortError,
   classifyStreamError,
+  classifyProtocolMismatch,
+  ProtocolMismatchError,
 } from "./errors";
 export { transformMessages, createIDNormalizer } from "./transform";
 export type { TransformOptions, IDNormalizer } from "./transform";

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -1,6 +1,5 @@
 import { type } from "arktype";
 
-import { getLogger } from "@intx/log";
 import type {
   ConversationTurn,
   ContentBlock,
@@ -10,8 +9,7 @@ import type {
   TokenUsage,
 } from "@intx/types/runtime";
 import type { ProviderAdapter, BuiltRequest } from "../adapter";
-
-const logger = getLogger(["interchange", "inference", "anthropic"]);
+import { ProtocolMismatchError } from "../errors";
 
 // ---------------------------------------------------------------------------
 // Request building
@@ -254,17 +252,30 @@ function parseResponse(
   sseData: string,
   blockIndexToCallId: Map<number, string>,
 ): InferenceEvent[] {
+  // Same protocol-mismatch posture as the openai adapter: a JSON parse
+  // failure or arktype rejection means the upstream emitted bytes that
+  // violate the Anthropic streaming protocol. Surface through
+  // ProtocolMismatchError so the harness's stream-error catch emits
+  // an inference.error with category "protocol_mismatch" carrying the
+  // offending data in error.raw, rather than dropping the chunk
+  // silently.
   let parsed: unknown;
   try {
     parsed = JSON.parse(sseData);
-  } catch {
-    return [];
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    throw new ProtocolMismatchError(
+      `anthropic parseResponse: malformed JSON in SSE data payload: ${message}`,
+      sseData,
+    );
   }
 
   const event = AnthropicSSEEvent(parsed);
   if (event instanceof type.errors) {
-    logger.warn`Unexpected SSE event shape: ${event.summary}`;
-    return [];
+    throw new ProtocolMismatchError(
+      `anthropic parseResponse: SSE event failed schema validation: ${event.summary}`,
+      parsed,
+    );
   }
 
   // The seq field is a placeholder 0 — the harness assigns real sequence numbers.
@@ -300,8 +311,9 @@ function parseResponse(
         const index = event.index ?? 0;
         const callId = blockIndexToCallId.get(index);
         if (callId === undefined) {
-          throw new Error(
-            `input_json_delta for content block ${index} with no preceding tool_use start`,
+          throw new ProtocolMismatchError(
+            `anthropic parseResponse: input_json_delta for content block ${index} with no preceding tool_use start`,
+            event,
           );
         }
         const fragment = delta.partial_json ?? "";

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -1,6 +1,5 @@
 import { type } from "arktype";
 
-import { getLogger } from "@intx/log";
 import type {
   ConversationTurn,
   ContentBlock,
@@ -10,8 +9,7 @@ import type {
   TokenUsage,
 } from "@intx/types/runtime";
 import type { ProviderAdapter, BuiltRequest } from "../adapter";
-
-const logger = getLogger(["interchange", "inference", "openai"]);
+import { ProtocolMismatchError } from "../errors";
 
 // ---------------------------------------------------------------------------
 // Request building
@@ -221,17 +219,33 @@ const OpenAIChunk = type({
 });
 
 function parseResponse(sseData: string): InferenceEvent[] {
+  // parseSSE strips the `[DONE]` sentinel before yielding payloads, so
+  // anything that reaches us here is supposed to be a JSON chunk. A
+  // JSON.parse failure or an arktype rejection means the upstream
+  // emitted bytes that violate the OpenAI streaming protocol — a
+  // protocol mismatch, not a transport flake. Surface it through the
+  // harness's stream-error catch via ProtocolMismatchError so the
+  // resulting inference.error carries category "protocol_mismatch"
+  // and the offending data in error.raw, instead of silently dropping
+  // the chunk and leaving the agent to guess why a tool call arrived
+  // with empty arguments.
   let parsed: unknown;
   try {
     parsed = JSON.parse(sseData);
-  } catch {
-    return [];
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    throw new ProtocolMismatchError(
+      `openai parseResponse: malformed JSON in SSE data payload: ${message}`,
+      sseData,
+    );
   }
 
   const chunk = OpenAIChunk(parsed);
   if (chunk instanceof type.errors) {
-    logger.warn`Unexpected SSE chunk shape: ${chunk.summary}`;
-    return [];
+    throw new ProtocolMismatchError(
+      `openai parseResponse: SSE chunk failed schema validation: ${chunk.summary}`,
+      parsed,
+    );
   }
 
   const seq = 0;

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -176,10 +176,19 @@ function toOpenAIContentPart(block: ContentBlock): unknown {
 
 const EMPTY_PARTIAL: PartialMessage = { text: "" };
 
+// Fireworks (and likely other OpenAI-compatible deployments) emits
+// `name: null` and `arguments: null` on tool-call delta fragments AFTER
+// the start delta. arktype rejects `null` against `"string"` and would
+// drop the whole chunk silently — taking the argument fragments with
+// it. Accept `string | null` here and treat null the same as the field
+// being absent at the consumer site.
 const OpenAIToolCallDelta = type({
   "index?": "number",
-  "id?": "string",
-  "function?": { "name?": "string", "arguments?": "string" },
+  "id?": "string | null",
+  "function?": {
+    "name?": "string | null",
+    "arguments?": "string | null",
+  },
 });
 
 const OpenAIChunkDelta = type({
@@ -277,21 +286,36 @@ function parseResponse(sseData: string): InferenceEvent[] {
   if (toolCallDeltas !== undefined) {
     for (const tcDelta of toolCallDeltas) {
       const index = tcDelta.index ?? 0;
-      const { id } = tcDelta;
+      // Normalize null → undefined: Fireworks emits literal null on every
+      // delta after the first; we treat that the same as the field being
+      // absent so the start / fragment branches below remain simple.
+      const id = tcDelta.id ?? undefined;
       const fn = tcDelta.function;
-      const name = fn?.name;
-      const argFragment = fn?.arguments;
+      const name = fn?.name ?? undefined;
+      const argFragment = fn?.arguments ?? undefined;
 
+      // Different providers shape these deltas differently:
+      //   - OpenAI emits id + name + empty arguments in the first delta,
+      //     then arguments-only deltas (no id, no name) for the body.
+      //   - Fireworks (kimi-k2.6) emits id + index on EVERY delta, with
+      //     name populated only on the first and arguments fragments on
+      //     subsequent deltas. The non-first deltas carry name: null
+      //     (normalized to undefined above) rather than omitting the
+      //     field outright.
+      // Treat the two signals independently. A single delta may legitimately
+      // carry both a start signal (id + non-null name) and an argument
+      // fragment; both must be emitted.
       if (id !== undefined && name !== undefined) {
-        // First delta for this tool call — emit start.
         events.push({
           type: "inference.tool_call.start",
           seq,
           data: { callId: id, name, partial: EMPTY_PARTIAL },
         });
-      } else if (argFragment !== undefined && argFragment.length > 0) {
+      }
+      if (argFragment !== undefined && argFragment.length > 0) {
         // Argument fragment. We use the index as a temporary callId placeholder
-        // since we may not have the real ID yet — the harness resolves this.
+        // since the upstream harness merges fragments by index — the real id is
+        // resolved at finalize time.
         events.push({
           type: "inference.tool_call.delta",
           seq,

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -686,6 +686,7 @@ export const InferenceError = type({
     "fatal",
     "aborted",
     "timeout",
+    "protocol_mismatch",
   ),
   message: "string",
   "statusCode?": "number",

--- a/tests/inference/protocol-mismatch.test.ts
+++ b/tests/inference/protocol-mismatch.test.ts
@@ -1,0 +1,132 @@
+// End-to-end coverage of the protocol_mismatch failure path: when an
+// upstream emits a chunk whose JSON is malformed or whose shape rejects
+// against the adapter's arktype schema, `runInference` must surface
+// the failure as an `inference.error` event with category
+// `"protocol_mismatch"` carrying the offending bytes in `error.raw` —
+// not silently drop the chunk and let the agent guess.
+//
+// The unit tests in `tests/inference/providers/{openai,anthropic}.test.ts`
+// pin the throw shape at the adapter layer; the test in
+// `packages/inference/src/errors.test.ts` pins `classifyStreamError`'s
+// dispatch. This file pins the harness-level integration: a real
+// `runInference` call against a stub fetch sees the failure category
+// at the event boundary the way every downstream consumer (default
+// director's reply, hub event collector, audit store) will see it.
+
+import { describe, test, expect } from "bun:test";
+
+import { runInference } from "@intx/inference";
+import type { Dependencies, Scheduler } from "@intx/inference";
+import type {
+  InferenceEvent,
+  InferenceError,
+  ConversationTurn,
+  ProviderConfig,
+} from "@intx/types/runtime";
+
+const inertScheduler: Scheduler = {
+  setTimeout: () => () => {
+    /* tests do not exercise timer firing */
+  },
+};
+
+function makeTurns(): ConversationTurn[] {
+  return [
+    { role: "user", content: [{ type: "text", text: "hi" }], timestamp: 0 },
+  ];
+}
+
+async function drain(
+  stream: AsyncIterable<InferenceEvent>,
+): Promise<InferenceEvent[]> {
+  const out: InferenceEvent[] = [];
+  for await (const event of stream) {
+    out.push(event);
+  }
+  return out;
+}
+
+function findError(events: InferenceEvent[]): InferenceError | undefined {
+  const errorEvent = events.find((e) => e.type === "inference.error");
+  if (errorEvent?.type !== "inference.error") return undefined;
+  return errorEvent.data.error;
+}
+
+function streamingFetch(sseBody: string): Dependencies["fetch"] {
+  return () => {
+    const enc = new TextEncoder();
+    return Promise.resolve(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(enc.encode(sseBody));
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+  };
+}
+
+async function runAgainst(
+  provider: "openai" | "anthropic",
+  sseBody: string,
+): Promise<InferenceError | undefined> {
+  const config: ProviderConfig = {
+    provider,
+    baseURL: "https://test.invalid/v1",
+    apiKey: "test",
+    model: "test-model",
+  };
+  const deps: Dependencies = {
+    fetch: streamingFetch(sseBody),
+    scheduler: inertScheduler,
+  };
+  let seq = 0;
+  const events = await drain(
+    runInference({
+      turns: makeTurns(),
+      model: "test-model",
+      providerConfig: config,
+      nextSeq: () => seq++,
+      deps,
+    }),
+  );
+  return findError(events);
+}
+
+describe("runInference — protocol_mismatch surfacing", () => {
+  test("openai: malformed JSON chunk produces inference.error protocol_mismatch", async () => {
+    const err = await runAgainst("openai", "data: not json {\n\n");
+    expect(err).toBeDefined();
+    expect(err?.category).toBe("protocol_mismatch");
+    expect(err?.message).toContain("malformed JSON");
+    expect(err?.raw).toBe("not json {");
+  });
+
+  test("openai: schema-mismatched chunk produces inference.error protocol_mismatch", async () => {
+    const malformed = '{"choices":[{"delta":{"role":42}}]}';
+    const err = await runAgainst("openai", `data: ${malformed}\n\n`);
+    expect(err).toBeDefined();
+    expect(err?.category).toBe("protocol_mismatch");
+    expect(err?.message).toContain("schema validation");
+    expect(err?.raw).toEqual({ choices: [{ delta: { role: 42 } }] });
+  });
+
+  test("anthropic: malformed JSON chunk produces inference.error protocol_mismatch", async () => {
+    const err = await runAgainst("anthropic", "event: x\ndata: not json {\n\n");
+    expect(err).toBeDefined();
+    expect(err?.category).toBe("protocol_mismatch");
+    expect(err?.message).toContain("malformed JSON");
+    expect(err?.raw).toBe("not json {");
+  });
+
+  test("anthropic: schema-mismatched event produces inference.error protocol_mismatch", async () => {
+    const err = await runAgainst("anthropic", 'data: {"type":42}\n\n');
+    expect(err).toBeDefined();
+    expect(err?.category).toBe("protocol_mismatch");
+    expect(err?.message).toContain("schema validation");
+    expect(err?.raw).toEqual({ type: 42 });
+  });
+});

--- a/tests/inference/providers/anthropic.test.ts
+++ b/tests/inference/providers/anthropic.test.ts
@@ -4,6 +4,7 @@ import { wire } from "@intx/inference-testing";
 import {
   parseSSE,
   createAnthropicAdapter,
+  ProtocolMismatchError,
   type ProviderAdapter,
 } from "@intx/inference";
 import type { ConversationTurn, InferenceEvent } from "@intx/types/runtime";
@@ -288,13 +289,71 @@ describe("Anthropic adapter: buildRequest", () => {
 });
 
 describe("Anthropic adapter: parseResponse", () => {
-  test("returns empty array for non-JSON input", async () => {
-    // Non-JSON data payload — the structured DSL helpers serialize JSON, so
-    // `wire.anthropic.raw` is the right tool for genuinely-adversarial bytes.
-    const events = await parseWire(adapter, [
-      wire.anthropic.raw("event: x\ndata: not json\n\n"),
-    ]);
-    expect(events).toEqual([]);
+  test("throws ProtocolMismatchError on malformed JSON in SSE payload", () => {
+    // The harness's stream-error catch maps this to inference.error with
+    // category "protocol_mismatch" via classifyStreamError. The raw
+    // payload is carried in error.raw for operator inspection.
+    expect(() => adapter.parseResponse("not json {")).toThrow(
+      ProtocolMismatchError,
+    );
+
+    try {
+      adapter.parseResponse("not json {");
+      throw new Error("expected ProtocolMismatchError to be thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProtocolMismatchError);
+      if (err instanceof ProtocolMismatchError) {
+        expect(err.message).toContain("malformed JSON");
+        expect(err.raw).toBe("not json {");
+      }
+    }
+  });
+
+  test("throws ProtocolMismatchError on schema-mismatched event", () => {
+    // `{"type":42}` is well-formed JSON but rejects against the
+    // AnthropicSSEEvent schema (type must be a string). The thrown
+    // error carries the parsed object in raw and the arktype summary
+    // in message.
+    const malformed = '{"type":42}';
+
+    expect(() => adapter.parseResponse(malformed)).toThrow(
+      ProtocolMismatchError,
+    );
+
+    try {
+      adapter.parseResponse(malformed);
+      throw new Error("expected ProtocolMismatchError to be thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProtocolMismatchError);
+      if (err instanceof ProtocolMismatchError) {
+        expect(err.message).toContain("schema validation");
+        expect(err.raw).toEqual({ type: 42 });
+      }
+    }
+  });
+
+  test("throws ProtocolMismatchError on input_json_delta with no preceding tool_use start", () => {
+    // The adapter tracks tool_use content-block IDs by index so that
+    // subsequent input_json_delta events can resolve to the right
+    // tool call. A delta for an unknown index means the upstream
+    // emitted events out of order — a protocol violation, not a
+    // transport flake.
+    const malformed =
+      '{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"x\\":1}"}}';
+
+    expect(() => adapter.parseResponse(malformed)).toThrow(
+      ProtocolMismatchError,
+    );
+
+    try {
+      adapter.parseResponse(malformed);
+      throw new Error("expected ProtocolMismatchError to be thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProtocolMismatchError);
+      if (err instanceof ProtocolMismatchError) {
+        expect(err.message).toContain("no preceding tool_use start");
+      }
+    }
   });
 
   test("parses text_delta", async () => {

--- a/tests/inference/providers/openai.test.ts
+++ b/tests/inference/providers/openai.test.ts
@@ -4,6 +4,7 @@ import { wire } from "@intx/inference-testing";
 import {
   parseSSE,
   createOpenAIAdapter,
+  ProtocolMismatchError,
   type ProviderAdapter,
 } from "@intx/inference";
 import type { ConversationTurn, InferenceEvent } from "@intx/types/runtime";
@@ -262,15 +263,6 @@ describe("OpenAI adapter: buildRequest", () => {
 });
 
 describe("OpenAI adapter: parseResponse", () => {
-  test("returns empty array for non-JSON input", async () => {
-    // Non-JSON data payload — the structured DSL helpers serialize JSON, so
-    // `wire.openai.raw` is the right tool for genuinely-adversarial bytes.
-    const events = await parseWire(adapter, [
-      wire.openai.raw("data: not json\n\n"),
-    ]);
-    expect(events).toEqual([]);
-  });
-
   test("parses text delta from choices", async () => {
     const events = await parseWire(adapter, [
       wire.openai.chunk({ content: "Hello" }),
@@ -407,5 +399,51 @@ describe("OpenAI adapter: parseResponse", () => {
       wire.openai.raw('data: {"choices":[]}\n\n'),
     ]);
     expect(events).toEqual([]);
+  });
+
+  test("throws ProtocolMismatchError on malformed JSON in SSE payload", () => {
+    // The harness's stream-error catch maps this throw to an
+    // inference.error event with category "protocol_mismatch" via
+    // classifyStreamError. The raw payload is carried in error.raw so
+    // operators can inspect the bytes that failed to parse.
+    expect(() => adapter.parseResponse("not json {")).toThrow(
+      ProtocolMismatchError,
+    );
+
+    try {
+      adapter.parseResponse("not json {");
+      throw new Error("expected ProtocolMismatchError to be thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProtocolMismatchError);
+      if (err instanceof ProtocolMismatchError) {
+        expect(err.message).toContain("malformed JSON");
+        expect(err.raw).toBe("not json {");
+      }
+    }
+  });
+
+  test("throws ProtocolMismatchError on schema-mismatched chunk", () => {
+    // `delta.role: 42` is well-formed JSON but rejects against the
+    // OpenAIChunkDelta schema (role must be string when present).
+    // The thrown error carries the parsed object in `raw` and the
+    // arktype summary in `message` so operators reading audit logs see
+    // exactly where the wire violated the contract.
+    const malformed = '{"choices":[{"delta":{"role":42}}]}';
+
+    expect(() => adapter.parseResponse(malformed)).toThrow(
+      ProtocolMismatchError,
+    );
+
+    try {
+      adapter.parseResponse(malformed);
+      throw new Error("expected ProtocolMismatchError to be thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProtocolMismatchError);
+      if (err instanceof ProtocolMismatchError) {
+        expect(err.message).toContain("schema validation");
+        // The raw field carries the parsed object, not the original string.
+        expect(err.raw).toEqual({ choices: [{ delta: { role: 42 } }] });
+      }
+    }
   });
 });

--- a/tests/inference/providers/openai.test.ts
+++ b/tests/inference/providers/openai.test.ts
@@ -324,6 +324,81 @@ describe("OpenAI adapter: parseResponse", () => {
     }
   });
 
+  test("parses Fireworks-shaped tool-call deltas with null name/id on follow-up fragments", async () => {
+    // Fireworks (and other OpenAI-compatible deployments routing through
+    // opencode-zen) emits `id: null` and `function.name: null` on every
+    // tool-call delta AFTER the start delta — semantically equivalent to
+    // omitting the field, but lexically a different JSON value.
+    // The schema must accept `null` and the consumer site must normalise
+    // it to undefined, otherwise every fragment chunk fails validation
+    // and `argsBuffer` never accumulates — the exact failure mode that
+    // produced `arguments: {}` tool calls in kimi-k2.6 runs of
+    // interchange-demo-dispatch.
+    //
+    // Hand-rolled via `wire.openai.raw()` because the wire DSL's typed
+    // helpers (`toolCallStart`, `toolCallArgumentsDelta`) always emit
+    // the canonical OpenAI shape, never the Fireworks variant.
+    const events = await parseWire(adapter, [
+      wire.openai.raw(
+        'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_abc","function":{"name":"read_file","arguments":""}}]}}]}\n\n',
+      ),
+      wire.openai.raw(
+        'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":null,"function":{"name":null,"arguments":"{\\"path\\":\\""}}]}}]}\n\n',
+      ),
+      wire.openai.raw(
+        'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":null,"function":{"name":null,"arguments":"foo.ts\\"}"}}]}}]}\n\n',
+      ),
+    ]);
+
+    // One start (from chunk 1) plus two fragments (from chunks 2 and 3).
+    // Chunk 1's empty `arguments: ""` does not produce a fragment event
+    // because the consumer-site length check skips zero-length fragments.
+    const starts = events.filter((e) => e.type === "inference.tool_call.start");
+    const fragments = events.filter(
+      (e) => e.type === "inference.tool_call.delta",
+    );
+    expect(starts).toHaveLength(1);
+    expect(fragments).toHaveLength(2);
+
+    const start = starts[0];
+    if (start?.type === "inference.tool_call.start") {
+      expect(start.data.callId).toBe("call_abc");
+      expect(start.data.name).toBe("read_file");
+    }
+
+    const accumulated = fragments
+      .map((e) =>
+        e.type === "inference.tool_call.delta" ? e.data.argumentFragment : "",
+      )
+      .join("");
+    expect(accumulated).toBe('{"path":"foo.ts"}');
+  });
+
+  test("emits both start and fragment from a single Fireworks first-fragment delta", async () => {
+    // Locks the dual-emission claim in the consumer-site comment: when
+    // one chunk carries BOTH a start signal (id + non-null name) and
+    // a non-empty argument fragment, both events must come out. This
+    // is what Fireworks does on the first fragment delta following the
+    // bare start — without this independent treatment, accepting null
+    // name on the second-and-later deltas alone wouldn't be enough.
+    const events = await parseWire(adapter, [
+      wire.openai.raw(
+        'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_xyz","function":{"name":"search","arguments":"{\\"q\\":\\"foo\\"}"}}]}}]}\n\n',
+      ),
+    ]);
+
+    expect(events).toHaveLength(2);
+    expect(events[0]?.type).toBe("inference.tool_call.start");
+    expect(events[1]?.type).toBe("inference.tool_call.delta");
+    if (events[0]?.type === "inference.tool_call.start") {
+      expect(events[0].data.callId).toBe("call_xyz");
+      expect(events[0].data.name).toBe("search");
+    }
+    if (events[1]?.type === "inference.tool_call.delta") {
+      expect(events[1].data.argumentFragment).toBe('{"q":"foo"}');
+    }
+  });
+
   test("returns empty for empty choices array with no usage", async () => {
     // The `chunk()` helper always emits a non-empty choices entry unless a
     // usage block is supplied (in which case it also adds a usage object).


### PR DESCRIPTION
## Summary

- OpenAI and Anthropic SSE adapters now throw `ProtocolMismatchError` when `JSON.parse` fails or an arktype validator rejects the chunk, instead of logging a warning and returning `[]`. The harness's existing stream-error catch maps that throw to an `inference.error` event with the new `"protocol_mismatch"` category, carrying the offending bytes or parsed object in `error.raw` and the JSON parse error or schema summary in `error.message`.
- Closes the Fireworks symptom that motivated INTR-84: `OpenAIToolCallDelta` now accepts `string | null` on `id`, `function.name`, and `function.arguments`, with `null → undefined` normalisation at the consumer site. Start and fragment branches are independent so a single delta can emit both a `tool_call.start` and a `tool_call.delta` (which is what Fireworks does on the first fragment delta).
- The pre-existing `input_json_delta`-without-`tool_use_start` throw in the Anthropic adapter (previously a bare `Error` classified as `retryable`) becomes a `ProtocolMismatchError` too — out-of-order events are a protocol violation, not a transport flake.

## Changes

- `packages/types/src/runtime.ts`: `"protocol_mismatch"` added to `InferenceError.category` union.
- `packages/inference/src/adapter.ts`: `ResponseParser` contract docstring amended to permit `ProtocolMismatchError` throws and explicitly note that adapter-emitted `inference.error` / `inference.done` events are silently dropped by the harness.
- `packages/inference/src/errors.ts`: new `ProtocolMismatchError` class with a `raw` field; new `classifyProtocolMismatch(detail, raw?)` helper; `classifyStreamError` dispatches `ProtocolMismatchError` to the new category.
- `packages/inference/src/index.ts`: exports `ProtocolMismatchError` and `classifyProtocolMismatch`.
- `packages/inference/src/providers/openai.ts`: schema relaxation (Fireworks-shape `null`-on-inner-fields), `null → undefined` normalisation, independent start and fragment emission branches, `ProtocolMismatchError` throws on JSON parse and schema rejection paths. Now-unused LogTape import dropped.
- `packages/inference/src/providers/anthropic.ts`: `ProtocolMismatchError` throws on JSON parse, schema rejection, AND the `input_json_delta`-without-preceding-`tool_use_start` path. Now-unused LogTape import dropped.
- `docs/INFERENCE.md`: new `"Protocol mismatch"` entry in the Error Categories list.

## Testing

- [x] `make all` green: lint + `tsc -b --noEmit` + 1514 main tests + 9 sequential tests passing.
- [x] Fireworks regression test in `tests/inference/providers/openai.test.ts` — hand-rolls the three-chunk sequence (start delta with `name`, two fragment deltas with `id: null` / `name: null`) and asserts the start event plus accumulated argument fragments.
- [x] Dual-emission test in the same file — pins the consumer-site claim that one chunk can carry both a start signal and a non-empty argument fragment.
- [x] Adapter-level unit tests for `ProtocolMismatchError` throws across both providers (JSON parse path, schema rejection path, and for Anthropic the `input_json_delta`-without-tool_use_start path).
- [x] End-to-end test (`tests/inference/protocol-mismatch.test.ts`) drives `runInference` against a stub fetch returning malformed SSE bytes and asserts the emitted `inference.error` has the right category, message, and raw payload for both providers.
- [x] `classifyStreamError` unit tests cover the new `ProtocolMismatchError → protocol_mismatch` dispatch.
- [x] Self-review via the `code-review` skill: three rounds (initial via critique subagent, follow-up after fixup-and-rebase pass, final after a second rebase-with-edits pass). Final pass clean.

## Out of scope

The third checklist item on INTR-84 (logger silent-init defensive observability) is **deferred to INTR-91** by user decision. The `@intx/inference` adapters no longer rely on the logger to surface schema-rejection diagnostics — those flow through typed `inference.error` events instead — so the logger fallback is now genuinely secondary.

Closes INTR-84