### PR TITLE
inference-testing: route by request body, friendlier replyOnce, matchedRequests

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -52,7 +52,6 @@ export default defineConfig(
             "bin/*.ts",
             "packages/db/drizzle.config.ts",
             "tests/sidecar/*.ts",
-            "tests/inference-testing/*.ts",
             "tests/inference/transform-cutover.test.ts",
             "tests/agent/*.ts",
             "tests/coding-agent/*.ts",

--- a/packages/inference-testing/README.md
+++ b/packages/inference-testing/README.md
@@ -347,6 +347,96 @@ expectToolCall("search").from(events).toHaveBeenCalledTimes(2);
 `toMatchSequence` allows gaps between expected entries — events not named
 in the partial are tolerated.
 
+### Per-agent scoping
+
+Multi-agent tests routinely want to assert "agent A made tool call X"
+independently of "agent B made tool call Y". The harness supports this
+without any special-purpose machinery: each call to
+`harness.runInference(...)` returns its own
+`AsyncIterable<InferenceEvent>`. Collect events per call into separate
+arrays, and every matcher (`expectToolCalls`, `expectToolCall(...).from(events)`)
+is automatically scoped to the agent whose events array it sees.
+
+```ts
+const harness = setupHarness();
+
+// Route each agent's fetch to its own response stream — either by URL,
+// or by body content via `whenRequestBodyMatches` (see below).
+harness.scenario.replyOnce("openai", {
+  toolCalls: [{ name: "agentATool", args: { value: "from-A" } }],
+  predicate: (req) => req.url.includes("/agent-a/"),
+});
+harness.scenario.replyOnce("openai", {
+  toolCalls: [{ name: "agentBTool", args: { value: "from-B" } }],
+  predicate: (req) => req.url.includes("/agent-b/"),
+});
+
+const eventsA: InferenceEvent[] = [];
+const eventsB: InferenceEvent[] = [];
+
+const collectA = (async () => {
+  for await (const ev of harness.runInference({
+    /* agent A's opts */
+  })) {
+    eventsA.push(ev);
+  }
+})();
+const collectB = (async () => {
+  for await (const ev of harness.runInference({
+    /* agent B's opts */
+  })) {
+    eventsB.push(ev);
+  }
+})();
+
+await harness.run();
+await Promise.all([collectA, collectB]);
+
+// Each assertion sees only the agent's own events.
+expectToolCall("agentATool").from(eventsA).toHaveBeenCalledTimes(1);
+expectToolCall("agentBTool").from(eventsA).toHaveBeenCalledTimes(0);
+expectToolCall("agentBTool").from(eventsB).toHaveBeenCalledTimes(1);
+expectToolCall("agentATool").from(eventsB).toHaveBeenCalledTimes(0);
+```
+
+The same pattern works when agents share a URL and only the body
+distinguishes them — see [body-aware predicates](#body-aware-predicates).
+`tests/inference-testing/per-agent-scoping.test.ts` pins this contract.
+
+### Body-aware predicates
+
+When the only distinguishing data between parallel fetches lives in the
+request body — for example, multiple agents POSTing to the same
+`/chat/completions` endpoint with the same headers and the same `model`
+field, distinguishable only by the task id in the seed message —
+register matchers via `scenario.whenRequestBodyMatches`. The predicate
+receives the buffered body text alongside the `Request`:
+
+```ts
+harness.scenario.whenRequestBodyMatches(
+  (body) => body.includes("1a-greet"),
+  greetImplementerStream,
+);
+harness.scenario.whenRequestBodyMatches(
+  (body) => body.includes("1b-format"),
+  formatImplementerStream,
+);
+```
+
+The harness buffers each fetch's body once before evaluating
+body-aware matchers; subsequent body-aware predicates see the cached
+text. URL/header-only matchers registered via `whenRequestMatches`
+never trigger a body read, so existing tests pay no extra cost.
+
+Scan ordering: sync `whenRequestMatches` predicates evaluate first.
+If none bind a fetch and at least one body-aware matcher exists, the
+harness buffers the bodies of every still-waiting fetch and runs a
+follow-up scan against body-aware matchers in their original
+registration order. Ambiguity (two fetches binding to the same
+body-aware matcher) is detected over a fully-buffered waiting set, so
+`AmbiguousRequestError` carries the same semantics it carries for sync
+matchers.
+
 ## Rules
 
 The harness's determinism rests on a small set of contracts test authors
@@ -369,20 +459,25 @@ count and the elapsed wall time so the offending site is easy to find.
 
 ### Matcher predicate purity rule
 
-A `RequestPredicate` passed to `scenario.whenRequestMatches` must be:
+A `RequestPredicate` passed to `scenario.whenRequestMatches` (and a
+`BodyAwareRequestPredicate` passed to `scenario.whenRequestBodyMatches`)
+must be:
 
-- **synchronous** — enforced by the `(req: Request) => boolean` type
-  signature; there is no place to `await`.
+- **synchronous** — enforced by the type signature; there is no place
+  to `await`. A body-aware predicate receives the body as a string
+  parameter, so the predicate itself never reads the body asynchronously.
 - **idempotent** — the harness scans the matcher table on every fetch,
-  every `whenRequestMatches` call, and at quiescence checkpoints. A
-  predicate may run any number of times against the same request.
+  every `whenRequestMatches` / `whenRequestBodyMatches` call, and at
+  quiescence checkpoints. A predicate may run any number of times
+  against the same request.
 - **side-effect-free** — predicates must not mutate harness state, mutate
   closed-over test state, or emit events.
 - **independent of harness state** — predicates must not read
   `clock.now()`, `scenario.invokeTool`-managed registries, the matcher
   table, or anything else that changes between scan passes. Reading
-  `req.url`, `req.method`, and `req.headers` is fine; everything else is
-  a bug class.
+  `req.url`, `req.method`, `req.headers`, and (for body-aware predicates)
+  the buffered body string passed as the first parameter is fine;
+  everything else is a bug class.
 
 A predicate that reads `clock.now()` to "only match the second fetch"
 will misbehave: the harness calls the predicate during scan-on-quiescence

--- a/packages/inference-testing/README.md
+++ b/packages/inference-testing/README.md
@@ -413,15 +413,34 @@ register matchers via `scenario.whenRequestBodyMatches`. The predicate
 receives the buffered body text alongside the `Request`:
 
 ```ts
+const greetStream = harness.scenario.createStream();
+greetStream.enqueueAll(
+  wire.completeResponse("openai", {
+    toolCalls: [{ name: "writeFile", args: { path: "greet.ts" } }],
+  }),
+  { startAt: harness.clock.now() + 1 },
+);
 harness.scenario.whenRequestBodyMatches(
   (body) => body.includes("1a-greet"),
-  greetImplementerStream,
+  greetStream,
+);
+
+const formatStream = harness.scenario.createStream();
+formatStream.enqueueAll(
+  wire.completeResponse("openai", {
+    toolCalls: [{ name: "writeFile", args: { path: "format.ts" } }],
+  }),
+  { startAt: harness.clock.now() + 1 },
 );
 harness.scenario.whenRequestBodyMatches(
   (body) => body.includes("1b-format"),
-  formatImplementerStream,
+  formatStream,
 );
 ```
+
+See `tests/inference-testing/per-agent-scoping.test.ts` for a runnable
+end-to-end shape that combines body-aware routing with per-agent
+assertion scoping.
 
 The harness buffers each fetch's body once before evaluating
 body-aware matchers; subsequent body-aware predicates see the cached

--- a/packages/inference-testing/src/body-predicate.test.ts
+++ b/packages/inference-testing/src/body-predicate.test.ts
@@ -1,0 +1,431 @@
+// Tests for `scenario.whenRequestBodyMatches`. Body-aware predicates
+// receive the buffered request body alongside the original `Request`,
+// letting tests route by content when URL/headers don't distinguish
+// parallel fetches.
+//
+// The scan-pass ordering contract these tests pin:
+//   1. Sync `whenRequestMatches` matchers always evaluate first.
+//   2. If a body-aware matcher is registered, the harness buffers the
+//      body of every still-waiting fetch and runs a follow-up scan
+//      against body-aware matchers.
+//   3. `AmbiguousRequestError` for body-aware matchers is detected over
+//      a fully-buffered waiting set, never as bodies arrive one at a
+//      time.
+
+import { describe, test, expect } from "bun:test";
+
+import { setupHarness } from "./harness";
+import { AmbiguousRequestError, UnmatchedFetchError } from "./errors";
+
+const utf8 = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+async function drainResponse(response: Response): Promise<string> {
+  const body = response.body;
+  if (body === null) throw new Error("response body is null");
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value !== undefined) out += decoder.decode(value, { stream: true });
+  }
+  out += decoder.decode();
+  return out;
+}
+
+describe("Scenario.whenRequestBodyMatches", () => {
+  test("routes two concurrent POSTs to different streams by body substring", async () => {
+    // This is the primary use case from INTR-83: N agents POST to the
+    // same URL with the same headers; only the seed message in the body
+    // (here, a task id) distinguishes them. Body-aware matchers route
+    // each fetch to its own response stream without needing the test to
+    // know about arrival order.
+    const harness = setupHarness();
+    try {
+      const sGreet = harness.scenario.createStream();
+      const sFormat = harness.scenario.createStream();
+
+      harness.scenario.whenRequestBodyMatches(
+        (body) => body.includes("1a-greet"),
+        sGreet,
+      );
+      harness.scenario.whenRequestBodyMatches(
+        (body) => body.includes("1b-format"),
+        sFormat,
+      );
+
+      sGreet.enqueueAt(10, utf8("greet-reply"));
+      sGreet.closeAt(20);
+      sFormat.enqueueAt(10, utf8("format-reply"));
+      sFormat.closeAt(20);
+
+      const fGreet = harness.deps.fetch("https://example/chat/completions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ task: "1a-greet", model: "x" }),
+      });
+      const fFormat = harness.deps.fetch("https://example/chat/completions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ task: "1b-format", model: "x" }),
+      });
+
+      await harness.run();
+      const [rGreet, rFormat] = await Promise.all([fGreet, fFormat]);
+      expect(await drainResponse(rGreet)).toBe("greet-reply");
+      expect(await drainResponse(rFormat)).toBe("format-reply");
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("body-aware predicate sees the same body via second argument as Request", async () => {
+    // Predicates receive the buffered body text AND the original Request.
+    // Sanity-check that the Request argument carries the same body the
+    // text argument was derived from.
+    const harness = setupHarness();
+    try {
+      const s = harness.scenario.createStream();
+      let seenBody: string | undefined;
+      let seenReqUrl: string | undefined;
+      harness.scenario.whenRequestBodyMatches((body, req) => {
+        seenBody = body;
+        seenReqUrl = req.url;
+        return body.includes("needle");
+      }, s);
+
+      s.enqueueAt(5, utf8("matched"));
+      s.closeAt(10);
+
+      const f = harness.deps.fetch("https://example/route", {
+        method: "POST",
+        body: "haystack-needle-haystack",
+      });
+      await harness.run();
+      const r = await f;
+      expect(await drainResponse(r)).toBe("matched");
+      expect(seenBody).toBe("haystack-needle-haystack");
+      expect(seenReqUrl).toBe("https://example/route");
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("sync matcher takes priority when registered before a body-aware matcher", async () => {
+    // The sync scan pass runs first. If a sync matcher's predicate
+    // accepts a fetch, the body-aware matcher never sees it — and the
+    // body is never read.
+    const harness = setupHarness();
+    try {
+      const sSync = harness.scenario.createStream();
+      const sBody = harness.scenario.createStream();
+
+      harness.scenario.whenRequestMatches(
+        (req) => req.url.endsWith("/sync"),
+        sSync,
+      );
+      let bodyAwareSawCall = false;
+      harness.scenario.whenRequestBodyMatches((_body) => {
+        bodyAwareSawCall = true;
+        return true;
+      }, sBody);
+
+      sSync.enqueueAt(5, utf8("sync-reply"));
+      sSync.closeAt(10);
+
+      const f = harness.deps.fetch("https://example/sync", {
+        method: "POST",
+        body: "anything",
+      });
+      await harness.run();
+      const r = await f;
+      expect(await drainResponse(r)).toBe("sync-reply");
+      expect(bodyAwareSawCall).toBe(false);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("body-aware matcher routes a fetch the sync matchers missed", async () => {
+    // Sync scan misses → body-aware scan kicks in → fetch is bound.
+    const harness = setupHarness();
+    try {
+      const sBody = harness.scenario.createStream();
+      // A sync matcher that never accepts this fetch.
+      const sSync = harness.scenario.createStream();
+      harness.scenario.whenRequestMatches(
+        (req) => req.url.endsWith("/sync-only"),
+        sSync,
+      );
+      harness.scenario.whenRequestBodyMatches(
+        (body) => body.includes("special-marker"),
+        sBody,
+      );
+
+      sBody.enqueueAt(5, utf8("body-aware-reply"));
+      sBody.closeAt(10);
+
+      const f = harness.deps.fetch("https://example/chat", {
+        method: "POST",
+        body: "carries the special-marker",
+      });
+      await harness.run();
+      const r = await f;
+      expect(await drainResponse(r)).toBe("body-aware-reply");
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("body-aware matcher that rejects the body leaves the fetch unmatched", async () => {
+    // A predicate that returns false for everything must leave the fetch
+    // parked; quiescence surfaces UnmatchedFetchError.
+    const harness = setupHarness();
+    try {
+      const s = harness.scenario.createStream();
+      harness.scenario.whenRequestBodyMatches(
+        (body) => body.includes("never-present"),
+        s,
+      );
+      s.enqueueAt(5, utf8("unused"));
+      s.closeAt(10);
+
+      const f = harness.deps.fetch("https://example/x", {
+        method: "POST",
+        body: "the marker is not here",
+      });
+      const fSettled = f.catch((err: unknown) => err);
+
+      let runErr: unknown;
+      try {
+        await harness.run();
+      } catch (err) {
+        runErr = err;
+      }
+      expect(runErr).toBeInstanceOf(UnmatchedFetchError);
+      const fErr = await fSettled;
+      expect(fErr).toBeInstanceOf(UnmatchedFetchError);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("AmbiguousRequestError fires when two body-aware fetches collide on one matcher", async () => {
+    // Two POSTs both contain the marker the matcher looks for. The
+    // body-aware scan binds the first to the matcher and reports the
+    // second as a same-matcher conflict, just like the sync scan does
+    // for URL-based matchers.
+    const harness = setupHarness();
+    try {
+      const s = harness.scenario.createStream();
+      s.enqueueAt(5, utf8("only-one"));
+      s.closeAt(10);
+
+      const f1 = harness.deps.fetch("https://example/a", {
+        method: "POST",
+        body: "carries marker-X",
+      });
+      const f2 = harness.deps.fetch("https://example/b", {
+        method: "POST",
+        body: "also carries marker-X",
+      });
+      const f1Settled = f1.catch((err: unknown) => err);
+      const f2Settled = f2.catch((err: unknown) => err);
+
+      // Register the body-aware matcher AFTER both fetches park, so a
+      // single scan sees both at once.
+      harness.scenario.whenRequestBodyMatches(
+        (body) => body.includes("marker-X"),
+        s,
+      );
+
+      // The ambiguity surfaces on the async body-aware scan. `run`
+      // awaits the scan promise via the drain loop and rethrows.
+      let runErr: unknown;
+      try {
+        await harness.run();
+      } catch (err) {
+        runErr = err;
+      }
+      expect(runErr).toBeInstanceOf(AmbiguousRequestError);
+      const f1Err = await f1Settled;
+      const f2Err = await f2Settled;
+      expect(f1Err).toBeInstanceOf(AmbiguousRequestError);
+      expect(f2Err).toBeInstanceOf(AmbiguousRequestError);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("GET request with no body: body-aware predicate sees an empty string", async () => {
+    // GETs (and other request shapes without a body) buffer to "".
+    // Predicates can still evaluate; they just won't find substring
+    // matches against an empty string. A predicate that accepts ""
+    // routes the GET; one that requires content rejects it.
+    const harness = setupHarness();
+    try {
+      const sEmpty = harness.scenario.createStream();
+      let seenBody: string | undefined;
+      harness.scenario.whenRequestBodyMatches((body) => {
+        seenBody = body;
+        return body === "";
+      }, sEmpty);
+
+      sEmpty.enqueueAt(5, utf8("got-the-get"));
+      sEmpty.closeAt(10);
+
+      const f = harness.deps.fetch("https://example/health");
+      await harness.run();
+      const r = await f;
+      expect(await drainResponse(r)).toBe("got-the-get");
+      expect(seenBody).toBe("");
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("abort during body buffering: fetch rejects with AbortError, scan does not throw", async () => {
+    // A fetch aborted between arrival and body-aware scan should reject
+    // cleanly. The body buffer reads through but the routing path
+    // checks `settled` and skips. `run()` returns without an error.
+    const harness = setupHarness();
+    try {
+      const s = harness.scenario.createStream();
+      harness.scenario.whenRequestBodyMatches(() => true, s);
+      s.enqueueAt(5, utf8("unused"));
+      s.closeAt(10);
+
+      const ac = new AbortController();
+      const f = harness.deps.fetch("https://example/abortme", {
+        method: "POST",
+        body: "anything",
+        signal: ac.signal,
+      });
+      ac.abort();
+
+      let caught: unknown;
+      try {
+        await f;
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(DOMException);
+      if (!(caught instanceof DOMException)) throw new Error("unreachable");
+      expect(caught.name).toBe("AbortError");
+
+      // Quiescence must NOT throw; the aborted fetch was removed from
+      // the waiting set and the body-aware matcher is still available
+      // for any future fetch (which there isn't, so the matcher just
+      // stays unconsumed).
+      await harness.run();
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("multiple body-aware matchers preserve registration-order priority", async () => {
+    // When two body-aware matchers could both accept a fetch, the
+    // first-registered wins — same rule as sync matchers.
+    const harness = setupHarness();
+    try {
+      const sFirst = harness.scenario.createStream();
+      const sSecond = harness.scenario.createStream();
+
+      harness.scenario.whenRequestBodyMatches(
+        (body) => body.includes("common"),
+        sFirst,
+      );
+      harness.scenario.whenRequestBodyMatches(
+        (body) => body.includes("common"),
+        sSecond,
+      );
+
+      sFirst.enqueueAt(5, utf8("first-wins"));
+      sFirst.closeAt(10);
+      sSecond.enqueueAt(5, utf8("second-fallback"));
+      sSecond.closeAt(10);
+
+      const f1 = harness.deps.fetch("https://example/a", {
+        method: "POST",
+        body: "common-1",
+      });
+      const f2 = harness.deps.fetch("https://example/b", {
+        method: "POST",
+        body: "common-2",
+      });
+      await harness.run();
+      const [r1, r2] = await Promise.all([f1, f2]);
+      expect(await drainResponse(r1)).toBe("first-wins");
+      expect(await drainResponse(r2)).toBe("second-fallback");
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("rejects non-function predicate at the registration site", () => {
+    const harness = setupHarness();
+    try {
+      const s = harness.scenario.createStream();
+      expect(() =>
+        harness.scenario.whenRequestBodyMatches(
+          // Intentionally pass a non-function value to verify the
+          // defensive type-system + runtime guard rejects it.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion -- runtime guard exercise
+          "not a function" as any,
+          s,
+        ),
+      ).toThrow(/predicate must be a function/);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("rejects a foreign response stream", () => {
+    const harnessA = setupHarness();
+    const harnessB = setupHarness();
+    try {
+      const foreign = harnessA.scenario.createStream();
+      expect(() =>
+        harnessB.scenario.whenRequestBodyMatches(() => true, foreign),
+      ).toThrow(/was not minted by this harness/);
+    } finally {
+      harnessA.dispose();
+      harnessB.dispose();
+    }
+  });
+
+  test("rejects registration after dispose", () => {
+    const harness = setupHarness();
+    const s = harness.scenario.createStream();
+    harness.dispose();
+    expect(() =>
+      harness.scenario.whenRequestBodyMatches(() => true, s),
+    ).toThrow(/has been disposed/);
+  });
+
+  test("body-aware scan does NOT fire when no body-aware matchers are registered", async () => {
+    // Confirms the cost-isolation property: existing tests that use only
+    // sync matchers continue to pay zero body-read cost. We can't observe
+    // the read directly, but we can confirm that a body-only fetch with
+    // a sync matcher works end-to-end without touching body machinery —
+    // the existing scenario.test.ts suite already pins this — and that a
+    // BodyText-reading predicate is never invoked against a fetch that
+    // bound on the sync pass (covered above).
+    const harness = setupHarness();
+    try {
+      const s = harness.scenario.createStream();
+      harness.scenario.whenRequestMatches(() => true, s);
+      s.enqueueAt(5, utf8("sync-only"));
+      s.closeAt(10);
+      const f = harness.deps.fetch("https://example/x", {
+        method: "POST",
+        body: "not-read",
+      });
+      await harness.run();
+      expect(await drainResponse(await f)).toBe("sync-only");
+    } finally {
+      harness.dispose();
+    }
+  });
+});

--- a/packages/inference-testing/src/body-predicate.test.ts
+++ b/packages/inference-testing/src/body-predicate.test.ts
@@ -34,6 +34,103 @@ async function drainResponse(response: Response): Promise<string> {
   return out;
 }
 
+describe("Scenario.matchedRequests", () => {
+  test("returns fresh clones every call so bodies can be read repeatedly", async () => {
+    // matchedRequests() is the post-match seam for asserting against
+    // request bodies. Tests sometimes call it more than once during a
+    // run (e.g., once to check the first agent's request, again after
+    // the second agent's request fires). Each call must return clones
+    // whose bodies are independently consumable — the route-time
+    // stored clone is only used as a source for further `.clone()`
+    // calls, never consumed itself.
+    const harness = setupHarness();
+    try {
+      const s = harness.scenario.createStream();
+      harness.scenario.whenRequestMatches(() => true, s);
+      s.enqueueAt(5, utf8("reply"));
+      s.closeAt(10);
+
+      const body = JSON.stringify({ marker: "abc" });
+      const f = harness.deps.fetch("https://example/x", {
+        method: "POST",
+        body,
+      });
+      await harness.run();
+      await f;
+
+      const first = harness.scenario.matchedRequests();
+      expect(first).toHaveLength(1);
+      const firstEntry = first[0];
+      if (firstEntry === undefined) throw new Error("unreachable");
+      expect(await firstEntry.text()).toBe(body);
+
+      // Second call must succeed even though the first call's clone
+      // had its body fully consumed.
+      const second = harness.scenario.matchedRequests();
+      expect(second).toHaveLength(1);
+      const secondEntry = second[0];
+      if (secondEntry === undefined) throw new Error("unreachable");
+      expect(await secondEntry.text()).toBe(body);
+
+      // And the two calls' clones must themselves be different
+      // objects — caller code that mutates one (e.g., reads headers
+      // case-insensitively, applies request rewriting in a test
+      // utility) must not see leakage into the next call's clones.
+      expect(firstEntry).not.toBe(secondEntry);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("captures matched requests in match order across multiple routings", async () => {
+    const harness = setupHarness();
+    try {
+      const sA = harness.scenario.createStream();
+      const sB = harness.scenario.createStream();
+      harness.scenario.whenRequestMatches((req) => req.url.endsWith("/a"), sA);
+      harness.scenario.whenRequestMatches((req) => req.url.endsWith("/b"), sB);
+      sA.enqueueAt(5, utf8("a"));
+      sA.closeAt(10);
+      sB.enqueueAt(5, utf8("b"));
+      sB.closeAt(10);
+
+      const fA = harness.deps.fetch("https://example/a", {
+        method: "POST",
+        body: "first",
+      });
+      const fB = harness.deps.fetch("https://example/b", {
+        method: "POST",
+        body: "second",
+      });
+      await harness.run();
+      await Promise.all([fA, fB]);
+
+      const all = harness.scenario.matchedRequests();
+      expect(all).toHaveLength(2);
+      // Match order is fetch arrival order — fA was the first to park.
+      const [first, second] = all;
+      if (first === undefined || second === undefined) {
+        throw new Error("unreachable");
+      }
+      expect(first.url).toBe("https://example/a");
+      expect(second.url).toBe("https://example/b");
+      expect(await first.text()).toBe("first");
+      expect(await second.text()).toBe("second");
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("returns an empty array when nothing has been matched yet", () => {
+    const harness = setupHarness();
+    try {
+      expect(harness.scenario.matchedRequests()).toEqual([]);
+    } finally {
+      harness.dispose();
+    }
+  });
+});
+
 describe("Scenario.whenRequestBodyMatches", () => {
   test("routes two concurrent POSTs to different streams by body substring", async () => {
     // This is the primary use case from INTR-83: N agents POST to the
@@ -285,10 +382,22 @@ describe("Scenario.whenRequestBodyMatches", () => {
     }
   });
 
-  test("abort during body buffering: fetch rejects with AbortError, scan does not throw", async () => {
-    // A fetch aborted between arrival and body-aware scan should reject
-    // cleanly. The body buffer reads through but the routing path
-    // checks `settled` and skips. `run()` returns without an error.
+  test("abort before run(): aborted fetch is removed from the waiting set before any body-aware scan runs", async () => {
+    // The abort fires synchronously, BEFORE `harness.run()` begins.
+    // `triggerBodyAwareScan` already ran (synchronously, from
+    // `stubFetch`) and queued an async scan whose `bufferUnreadBodies`
+    // call snapshots the entry into `needBuffer` before the first
+    // `await`. By the time `Promise.all` resumes, the pre-route abort
+    // listener in `stubFetch` has already set `settled = true` and
+    // removed the entry from `waiting`. The `if (wf.settled) return;`
+    // short-circuit at the head of the map callback (and the second
+    // guard around the `clone().text()` catch) is what then prevents
+    // a spurious read error from surfacing.
+    //
+    // This test pins that body-aware matchers tolerate a pre-run abort
+    // gracefully (the matcher stays unconsumed and is available for
+    // any future fetch) and that the settled-flag guards inside the
+    // buffer are the ones doing the work.
     const harness = setupHarness();
     try {
       const s = harness.scenario.createStream();
@@ -402,6 +511,60 @@ describe("Scenario.whenRequestBodyMatches", () => {
     expect(() =>
       harness.scenario.whenRequestBodyMatches(() => true, s),
     ).toThrow(/has been disposed/);
+  });
+
+  test("genuine body-read failure surfaces as the scan error, not as UnmatchedFetchError", async () => {
+    // The pre-INTR-83 buffer path used to map any body-read exception
+    // to `bodyText = ""`, hiding real failures behind a downstream
+    // "fetch was not matched" diagnostic. Per the CLAUDE.md defensive-
+    // coding rule, errors must surface — this test pins that contract.
+    //
+    // Synthesizing a real body-read failure on the Bun runtime is
+    // unreliable (Bun's `Request.clone().text()` is permissive about
+    // disturbed bodies and errored streams), so we override `clone`
+    // on the request instance to throw deterministically. The harness
+    // calls `wf.request.clone().text()` inside `bufferUnreadBodies`;
+    // the override turns that into a guaranteed rejection the harness
+    // must re-throw to the caller of `harness.run()` rather than
+    // silently coerce to an empty body.
+    const harness = setupHarness();
+    try {
+      const s = harness.scenario.createStream();
+      harness.scenario.whenRequestBodyMatches(() => true, s);
+      s.enqueueAt(5, utf8("unused"));
+      s.closeAt(10);
+
+      const SENTINEL = "intentional-clone-failure";
+      const req = new Request("https://example/x", {
+        method: "POST",
+        body: "payload",
+      });
+      Object.defineProperty(req, "clone", {
+        value: () => {
+          throw new Error(SENTINEL);
+        },
+      });
+
+      // Attach the rejection-catcher BEFORE driving run() so the
+      // parked fetch's eventual rejection (delivered by `dispose()` in
+      // the finally clause once `run()` has thrown) does not surface
+      // as an unhandled rejection inside the test runner.
+      const f = harness.deps.fetch(req);
+      f.catch(() => undefined);
+
+      let runErr: unknown;
+      try {
+        await harness.run();
+      } catch (err) {
+        runErr = err;
+      }
+      expect(runErr).toBeInstanceOf(Error);
+      expect(runErr).not.toBeInstanceOf(UnmatchedFetchError);
+      if (!(runErr instanceof Error)) throw new Error("unreachable");
+      expect(runErr.message).toBe(SENTINEL);
+    } finally {
+      harness.dispose();
+    }
   });
 
   test("body-aware scan does NOT fire when no body-aware matchers are registered", async () => {

--- a/packages/inference-testing/src/harness.ts
+++ b/packages/inference-testing/src/harness.ts
@@ -23,6 +23,7 @@ import {
   captureMatcherSource,
   createMatcherTable,
   scanWaitingSet,
+  type BodyAwareRequestPredicate,
   type ReplyOnceOpts,
   type RequestPredicate,
   type Scenario,
@@ -242,14 +243,15 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     return handle.stream;
   };
 
-  // Most-recently matched request, cloned so the test can consume its
-  // body without affecting the original. See `scenario.lastRequest`.
+  // Every matched request, captured in match order as a fresh clone the
+  // test can consume freely. The clones share no state with the original
+  // (which the production reactor reads via the `Response` returned
+  // through the stream) and no state with each other.
   // Type widened to satisfy the gap between Bun's global Request and
   // the undici Request the fetch stub builds; both have the methods
   // the public surface needs (clone, json, text, headers).
-  let lastMatchedRequest:
-    | ReturnType<WaitingFetch["request"]["clone"]>
-    | undefined;
+  const matchedRequestsList: ReturnType<WaitingFetch["request"]["clone"]>[] =
+    [];
 
   const routeWaitingFetch = (
     wf: WaitingFetch,
@@ -259,7 +261,7 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     wf.settled = true;
     const idx = waiting.indexOf(wf);
     if (idx >= 0) waiting.splice(idx, 1);
-    lastMatchedRequest = wf.request.clone();
+    matchedRequestsList.push(wf.request.clone());
     // Per-call abort isolation on the matched stream: once a fetch has
     // been bound to a stream, an abort on its signal must error ONLY
     // that stream's controller. We attach the listener here (the
@@ -319,15 +321,102 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     wf.resolve(new Response(stream.body, { status, headers }));
   };
 
-  const runScan = (): void => {
-    scanWaitingSet(waiting, matcherTable, routeWaitingFetch);
-    // Drop any fetches that were settled by scanWaitingSet (ambiguity case).
+  const sweepSettled = (): void => {
     for (let i = waiting.length - 1; i >= 0; i--) {
       const entry = waiting[i];
       if (entry !== undefined && entry.settled) {
         waiting.splice(i, 1);
       }
     }
+  };
+
+  const runScan = (): void => {
+    scanWaitingSet(waiting, matcherTable, routeWaitingFetch);
+    // Drop any fetches that were settled by scanWaitingSet (ambiguity case).
+    sweepSettled();
+  };
+
+  // Body-aware scan plumbing.
+  //
+  // The sync scan (above) considers only sync matchers. When body-aware
+  // matchers exist, the harness:
+  //
+  //   1. Buffers the body of every still-waiting fetch (in parallel, via
+  //      one `clone().text()` per fetch). The result is cached on the
+  //      `WaitingFetch.bodyText` field so subsequent passes don't re-read.
+  //   2. Runs a second `scanWaitingSet` pass with `includeBodyAware: true`,
+  //      which evaluates body-aware predicates over the buffered text.
+  //
+  // The buffer-then-scan ordering is deliberate: ambiguous body-aware
+  // matches are detected over a fully-buffered waiting set, not as
+  // bodies become available one at a time. That keeps the conflict
+  // semantics identical to the sync scan's "single pass over the
+  // waiting set at the trigger point" model.
+  //
+  // `run`/`advanceTo` drain in-flight body scans alongside in-flight
+  // tool handlers before checking quiescence; a body-aware match can
+  // route a fetch (which schedules clock work — the response stream's
+  // chunks fire on the virtual clock), so the outer loop re-enters
+  // `clock.run` after the scan completes.
+  const inFlightBodyScans = new Set<Promise<void>>();
+  const inFlightScanErrors: unknown[] = [];
+
+  const bufferUnreadBodies = async (): Promise<void> => {
+    // Loop until no unbuffered waiting fetches remain. The loop is
+    // necessary because new fetches can arrive (via `stubFetch`) while
+    // a body read is in flight — each `await` here yields the event
+    // loop and gives `stubFetch` a chance to push fresh entries onto
+    // `waiting`. Without the loop, scan-time would observe those
+    // new entries with `bodyText === undefined` and throw an internal
+    // invariant error.
+    for (;;) {
+      const needBuffer = waiting.filter(
+        (wf) => !wf.settled && wf.bodyText === undefined,
+      );
+      if (needBuffer.length === 0) return;
+      await Promise.all(
+        needBuffer.map(async (wf) => {
+          if (wf.settled) return;
+          // Re-check inside the awaited body too: another concurrent
+          // scan may have buffered this same fetch via a parallel
+          // `clone().text()` already.
+          if (wf.bodyText !== undefined) return;
+          try {
+            wf.bodyText = await wf.request.clone().text();
+          } catch {
+            // A request with no readable body (e.g., a GET with no
+            // payload) cannot be matched by body-aware predicates;
+            // treat as empty so body-aware predicates can still
+            // evaluate without throwing. If the body genuinely
+            // matters and the read failed, the body-aware predicate
+            // returns false on the empty string and the fetch
+            // surfaces later as UnmatchedFetchError, which is the
+            // correct diagnostic.
+            wf.bodyText = "";
+          }
+        }),
+      );
+    }
+  };
+
+  const triggerBodyAwareScan = (): void => {
+    if (!matcherTable.hasBodyAware()) return;
+    if (disposed) return;
+    const scanPromise: Promise<void> = (async () => {
+      await bufferUnreadBodies();
+      if (disposed) return;
+      // Re-check after the buffer await; entries can have been settled
+      // or removed in the interim.
+      scanWaitingSet(waiting, matcherTable, routeWaitingFetch, true);
+      sweepSettled();
+    })()
+      .catch((err: unknown) => {
+        inFlightScanErrors.push(err);
+      })
+      .finally(() => {
+        inFlightBodyScans.delete(scanPromise);
+      });
+    inFlightBodyScans.add(scanPromise);
   };
 
   const whenRequestMatches = (
@@ -357,6 +446,46 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     const source = captureMatcherSource(2);
     matcherTable.register(predicate, responseStream, source, opts);
     runScan();
+    // Defensive: under the matcher-predicate purity rule, a pre-existing
+    // body-aware matcher would have already routed any fetch its
+    // predicate accepts on the fetch's arrival-triggered scan, so a new
+    // sync matcher arriving later can't unblock anything by itself. The
+    // re-trigger covers cases the purity rule doesn't strictly cover —
+    // a body-aware matcher's `consumed` flag flipping between scans, or
+    // a future relaxation of the purity contract. `triggerBodyAwareScan`
+    // is a no-op when no body-aware matchers exist and idempotent
+    // otherwise, so the cost of being conservative here is nil.
+    triggerBodyAwareScan();
+  };
+
+  const whenRequestBodyMatches = (
+    predicate: BodyAwareRequestPredicate,
+    responseStream: SimulatedStream,
+    opts?: WhenRequestMatchesOpts,
+  ): void => {
+    if (disposed) {
+      throw new Error(
+        "Harness.scenario.whenRequestBodyMatches: harness has been disposed",
+      );
+    }
+    if (typeof predicate !== "function") {
+      throw new Error(
+        "Harness.scenario.whenRequestBodyMatches: predicate must be a function",
+      );
+    }
+    if (!streamToHandle.has(responseStream)) {
+      throw new Error(
+        `Harness.scenario.whenRequestBodyMatches: stream ${String(responseStream.streamId)} was not minted by this harness`,
+      );
+    }
+    const source = captureMatcherSource(2);
+    matcherTable.registerBodyAware(predicate, responseStream, source, opts);
+    // Sync scan first: a sync matcher might still bind a fetch (the
+    // new body-aware matcher is skipped in the sync pass), and the
+    // sweep below keeps the waiting set tidy before the async scan
+    // reads it.
+    runScan();
+    triggerBodyAwareScan();
   };
 
   const inFlightToolHandlers = new Set<Promise<void>>();
@@ -459,12 +588,14 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     });
   };
 
-  const lastRequest = (): Request | undefined =>
-    // The clone is produced by the (undici-typed) WaitingFetch.request,
+  const matchedRequests = (): Request[] =>
+    // The clones are produced by the (undici-typed) WaitingFetch.request,
     // but the public Scenario type uses the platform's global Request.
-    // The shape is identical; the cast bridges the type-only gap.
+    // The shape is identical; the cast bridges the type-only gap. The
+    // returned array is a fresh copy so caller mutations cannot leak
+    // back into the harness's internal capture list.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- type-only bridge between undici Request and Bun's global Request
-    lastMatchedRequest as Request | undefined;
+    matchedRequestsList.slice() as Request[];
 
   const replyOnce = (
     provider: Provider,
@@ -521,10 +652,11 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
   const scenario: Scenario = {
     createStream,
     whenRequestMatches,
+    whenRequestBodyMatches,
     onTool,
     invokeTool,
     lastToolDispatch,
-    lastRequest,
+    matchedRequests,
     replyOnce,
     stall,
     abortAt,
@@ -571,6 +703,7 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
         resolve,
         reject,
         settled: false,
+        bodyText: undefined,
       };
       if (signal !== undefined) {
         const onAbort = (): void => {
@@ -602,6 +735,13 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
           if (idx >= 0) waiting.splice(idx, 1);
           reject(err);
         }
+      }
+      // If body-aware matchers are registered and this fetch did not
+      // bind on the sync scan, schedule an async body-aware scan. The
+      // promise is tracked on `inFlightBodyScans` so `run`/`advanceTo`
+      // drain it before checking quiescence.
+      if (!entry.settled) {
+        triggerBodyAwareScan();
       }
     });
   };
@@ -712,31 +852,34 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     return first;
   };
 
-  const drainInFlight = async (
+  const drainInFlightSet = async (
+    label: string,
+    set: Set<Promise<void>>,
     startWall: number,
     wallClockBudgetMs: number,
   ): Promise<void> => {
-    // Repeatedly await any in-flight tool handler promises. A handler may
-    // schedule additional clock work or register further handlers on
-    // resolution, so the run/advanceTo callers re-enter the clock loop
-    // after this returns to pick that work up.
+    // Repeatedly await any in-flight promises tracked in `set`. The set's
+    // population may grow during a wait — e.g., a tool handler that
+    // schedules more clock work, or a body-aware scan that triggers a
+    // follow-up scan after routing — so the loop reads `set.size` each
+    // pass and the snapshot is re-taken before each await.
     //
-    // The drain races each batch against a real-time timer so a handler
+    // The drain races each batch against a real-time timer so a promise
     // that's blocked on a real wall-clock timer (e.g., setTimeout(...))
     // surfaces as a ClockWallClockOverrunError instead of hanging the
     // test. This mirrors the budget the clock itself enforces inside
     // `clock.run()`.
-    while (inFlightToolHandlers.size > 0) {
+    while (set.size > 0) {
       if (wallClockBudgetMs === Infinity) {
-        await Promise.all([...inFlightToolHandlers]);
+        await Promise.all([...set]);
         continue;
       }
       const elapsed = performance.now() - startWall;
       const remaining = wallClockBudgetMs - elapsed;
       if (remaining <= 0) {
         throw new ClockWallClockOverrunError(
-          `Harness.run exceeded wall-clock budget of ${String(wallClockBudgetMs)}ms while awaiting in-flight tool handlers (elapsed=${String(elapsed)}ms)`,
-          `in-flight tool handlers: ${String(inFlightToolHandlers.size)}`,
+          `Harness.run exceeded wall-clock budget of ${String(wallClockBudgetMs)}ms while awaiting ${label} (elapsed=${String(elapsed)}ms)`,
+          `${label}: ${String(set.size)}`,
         );
       }
       let timer: ReturnType<typeof setTimeout> | null = null;
@@ -745,24 +888,82 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
           resolve("timeout");
         }, remaining);
       });
-      const allDone = Promise.all([...inFlightToolHandlers]).then(
-        () => "done" as const,
-      );
+      const allDone = Promise.all([...set]).then(() => "done" as const);
       const outcome = await Promise.race([allDone, budgetExpired]);
       if (timer !== null) clearTimeout(timer);
       if (outcome === "timeout") {
         const elapsedNow = performance.now() - startWall;
         throw new ClockWallClockOverrunError(
-          `Harness.run exceeded wall-clock budget of ${String(wallClockBudgetMs)}ms while awaiting in-flight tool handlers (elapsed=${String(elapsedNow)}ms)`,
-          `in-flight tool handlers: ${String(inFlightToolHandlers.size)}`,
+          `Harness.run exceeded wall-clock budget of ${String(wallClockBudgetMs)}ms while awaiting ${label} (elapsed=${String(elapsedNow)}ms)`,
+          `${label}: ${String(set.size)}`,
         );
       }
     }
   };
 
+  const drainInFlight = (
+    startWall: number,
+    wallClockBudgetMs: number,
+  ): Promise<void> =>
+    drainInFlightSet(
+      "in-flight tool handlers",
+      inFlightToolHandlers,
+      startWall,
+      wallClockBudgetMs,
+    );
+
+  const drainBodyScans = (
+    startWall: number,
+    wallClockBudgetMs: number,
+  ): Promise<void> =>
+    drainInFlightSet(
+      "in-flight body-aware scans",
+      inFlightBodyScans,
+      startWall,
+      wallClockBudgetMs,
+    );
+
+  const takeBodyScanError = (): unknown => {
+    if (inFlightScanErrors.length === 0) return undefined;
+    const [first] = inFlightScanErrors.splice(0, inFlightScanErrors.length);
+    return first;
+  };
+
   const clearInFlightState = (): void => {
     inFlightToolHandlers.clear();
     inFlightErrors.length = 0;
+    inFlightBodyScans.clear();
+    inFlightScanErrors.length = 0;
+  };
+
+  const drainPendingWork = async (
+    startWall: number,
+    wallClockBudgetMs: number,
+  ): Promise<boolean> => {
+    // Drains both in-flight tool handlers and in-flight body-aware
+    // scans, in that order, surfacing the first error from either. The
+    // caller (run / advanceTo) loops until this returns `false`,
+    // meaning nothing was drained on this pass — at which point the
+    // clock is also empty and the harness can declare quiescence.
+    //
+    // Order matters: tool handlers can register more matchers (which
+    // can trigger body scans), so draining handlers first lets the
+    // subsequent body-scan drain catch their fallout in the same
+    // outer iteration.
+    let drained = false;
+    if (inFlightToolHandlers.size > 0) {
+      drained = true;
+      await drainInFlight(startWall, wallClockBudgetMs);
+      const handlerErr = takeInFlightError();
+      if (handlerErr !== undefined) throw handlerErr;
+    }
+    if (inFlightBodyScans.size > 0) {
+      drained = true;
+      await drainBodyScans(startWall, wallClockBudgetMs);
+      const scanErr = takeBodyScanError();
+      if (scanErr !== undefined) throw scanErr;
+    }
+    return drained;
   };
 
   const run = async (runOpts?: RunOpts): Promise<void> => {
@@ -774,17 +975,18 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
         await clock.run(runOpts);
         const err = takeInFlightError();
         if (err !== undefined) throw err;
-        if (inFlightToolHandlers.size === 0) break;
-        await drainInFlight(startWall, wallClockBudgetMs);
-        const errAfter = takeInFlightError();
-        if (errAfter !== undefined) throw errAfter;
+        const scanErr = takeBodyScanError();
+        if (scanErr !== undefined) throw scanErr;
+        const drained = await drainPendingWork(startWall, wallClockBudgetMs);
+        if (!drained) break;
         // Loop: handler resolution may have scheduled new heap entries or
-        // registered new matchers; let `clock.run()` settle them before we
-        // declare quiescence.
+        // registered new matchers, and body-aware scans may have routed
+        // fetches into new chunk-firing on the clock; let `clock.run()`
+        // settle the new work before we declare quiescence.
       }
     } catch (err) {
       // The harness is intended to be one-shot, but defensively clear any
-      // tracked in-flight handlers and queued rejections so a caller that
+      // tracked in-flight work and queued rejections so a caller that
       // re-uses this harness after a throw does not inherit stale state.
       clearInFlightState();
       throw err;
@@ -798,17 +1000,20 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
   ): Promise<void> => {
     // advanceTo's wall-clock budget mirrors run()'s default. AdvanceOpts
     // does not expose a wallClockBudgetMs knob today; the in-flight drain
-    // uses the default so a stuck handler still surfaces as an overrun.
+    // uses the default so stuck work still surfaces as an overrun.
     const startWall = performance.now();
     try {
       for (;;) {
         await clock.advanceTo(virtualMs, advanceOpts);
         const err = takeInFlightError();
         if (err !== undefined) throw err;
-        if (inFlightToolHandlers.size === 0) break;
-        await drainInFlight(startWall, DEFAULT_WALL_CLOCK_BUDGET_MS);
-        const errAfter = takeInFlightError();
-        if (errAfter !== undefined) throw errAfter;
+        const scanErr = takeBodyScanError();
+        if (scanErr !== undefined) throw scanErr;
+        const drained = await drainPendingWork(
+          startWall,
+          DEFAULT_WALL_CLOCK_BUDGET_MS,
+        );
+        if (!drained) break;
       }
     } catch (err) {
       clearInFlightState();
@@ -890,6 +1095,8 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     matcherTable.entries.length = 0;
     inFlightToolHandlers.clear();
     inFlightErrors.length = 0;
+    inFlightBodyScans.clear();
+    inFlightScanErrors.length = 0;
     abortAfterRegistrations.length = 0;
     // Resolve any still-pending stall awaits so test code that awaited
     // `stall.awaitAbort` past dispose does not deadlock the test runner.
@@ -898,6 +1105,7 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     }
     stallRegistrations.length = 0;
     lastToolDispatchByName.clear();
+    matchedRequestsList.length = 0;
   };
 
   return {

--- a/packages/inference-testing/src/harness.ts
+++ b/packages/inference-testing/src/harness.ts
@@ -244,10 +244,10 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     return handle.stream;
   };
 
-  // Every matched request, captured in match order as a fresh clone the
-  // test can consume freely. The clones share no state with the original
-  // (which the production reactor reads via the `Response` returned
-  // through the stream) and no state with each other.
+  // Capture list for `scenario.matchedRequests()`. Each entry is a
+  // clone taken at route time and held purely as a clone-source — the
+  // entry itself is never consumed, so `matchedRequests()` can re-clone
+  // it on every call without exhausting its body.
   // Type widened to satisfy the gap between Bun's global Request and
   // the undici Request the fetch stub builds; both have the methods
   // the public surface needs (clone, json, text, headers).
@@ -362,6 +362,16 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
   const inFlightBodyScans = new Set<Promise<void>>();
   const inFlightScanErrors: unknown[] = [];
 
+  // Best-effort buffering, NOT transactional. When one `clone().text()`
+  // call throws, `Promise.all` rejects and `bufferUnreadBodies` itself
+  // rejects — but the other in-flight reads' resolved writes to
+  // `wf.bodyText` still land before the outer scan promise's `.catch`
+  // pushes the error to `inFlightScanErrors`. The next `run()` /
+  // `advanceTo()` rethrows that error at the call site. Readers
+  // expecting all-or-nothing buffering semantics should know that this
+  // function leaves partially-buffered state behind on failure — fine
+  // for the one-shot harness contract (a new test creates a fresh
+  // harness), but worth flagging.
   const bufferUnreadBodies = async (): Promise<void> => {
     // Loop until no unbuffered waiting fetches remain. The loop is
     // necessary because new fetches can arrive (via `stubFetch`) while
@@ -382,19 +392,26 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
           // scan may have buffered this same fetch via a parallel
           // `clone().text()` already.
           if (wf.bodyText !== undefined) return;
+          let text: string;
           try {
-            wf.bodyText = await wf.request.clone().text();
-          } catch {
-            // A request with no readable body (e.g., a GET with no
-            // payload) cannot be matched by body-aware predicates;
-            // treat as empty so body-aware predicates can still
-            // evaluate without throwing. If the body genuinely
-            // matters and the read failed, the body-aware predicate
-            // returns false on the empty string and the fetch
-            // surfaces later as UnmatchedFetchError, which is the
-            // correct diagnostic.
-            wf.bodyText = "";
+            text = await wf.request.clone().text();
+          } catch (err) {
+            // The fetch may have been aborted or the harness disposed
+            // while the body read was in flight. In either case the
+            // entry is already settled and we skip silently — the
+            // matching path won't see this fetch again. Anything else
+            // is a genuine read failure (e.g., a Request whose body
+            // stream cannot be re-read) and must surface; the harness
+            // routes the throw through `inFlightScanErrors` so the
+            // next `run()` / `advanceTo()` re-throws it at the call
+            // site rather than letting it manifest as a confusing
+            // downstream `UnmatchedFetchError`.
+            if (wf.settled) return;
+            throw err;
           }
+          if (wf.settled) return;
+          if (wf.bodyText !== undefined) return;
+          wf.bodyText = text;
         }),
       );
     }
@@ -590,13 +607,16 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
   };
 
   const matchedRequests = (): Request[] =>
-    // The clones are produced by the (undici-typed) WaitingFetch.request,
-    // but the public Scenario type uses the platform's global Request.
-    // The shape is identical; the cast bridges the type-only gap. The
-    // returned array is a fresh copy so caller mutations cannot leak
-    // back into the harness's internal capture list.
+    // Re-clone every stored Request on each call so the returned objects
+    // are fully independent — both from one another AND across repeat
+    // calls. The stored route-time clone is never consumed (it's only
+    // used as a source for further `.clone()` calls), so subsequent
+    // body reads against the returned Requests succeed even if a prior
+    // call already drained one. The (undici-typed) WaitingFetch.request
+    // clone is structurally identical to the platform's global Request;
+    // the cast bridges the type-only gap.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- type-only bridge between undici Request and Bun's global Request
-    matchedRequestsList.slice() as Request[];
+    matchedRequestsList.map((r) => r.clone()) as Request[];
 
   let nextAutoCallId = 0;
   // The `call_auto_` prefix is reserved for ids the harness mints on
@@ -961,6 +981,11 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
 
   const takeBodyScanError = (): unknown => {
     if (inFlightScanErrors.length === 0) return undefined;
+    // Surface the first rejection; additional ones (rare — would require
+    // multiple body-aware scans rejecting in the same tick, e.g., two
+    // concurrent body reads both throwing) are dropped to keep the
+    // contract simple, mirroring `takeInFlightError`. A future slice
+    // can extend to AggregateError if real tests need it.
     const [first] = inFlightScanErrors.splice(0, inFlightScanErrors.length);
     return first;
   };

--- a/packages/inference-testing/src/harness.ts
+++ b/packages/inference-testing/src/harness.ts
@@ -25,6 +25,7 @@ import {
   scanWaitingSet,
   type BodyAwareRequestPredicate,
   type ReplyOnceOpts,
+  type ReplyOnceToolCall,
   type RequestPredicate,
   type Scenario,
   type StallHandle,
@@ -597,6 +598,39 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- type-only bridge between undici Request and Bun's global Request
     matchedRequestsList.slice() as Request[];
 
+  let nextAutoCallId = 0;
+  // The `call_auto_` prefix is reserved for ids the harness mints on
+  // behalf of the friendlier `{ name, args }` shape. Tests that pin an
+  // explicit `callId` against the explicit shape must not collide with
+  // it; rejecting at registration is friendlier than the silent
+  // confusion of two tool calls sharing an id mid-stream.
+  const AUTO_CALL_ID_PREFIX = "call_auto_";
+  const normalizeToolCalls = (
+    toolCalls: readonly ReplyOnceToolCall[],
+  ): { callId: string; name: string; argsJSON: string }[] => {
+    return toolCalls.map((tc) => {
+      if ("argsJSON" in tc) {
+        if (tc.callId.startsWith(AUTO_CALL_ID_PREFIX)) {
+          throw new Error(
+            `Harness.scenario.replyOnce: callId ${JSON.stringify(tc.callId)} uses the reserved ${JSON.stringify(AUTO_CALL_ID_PREFIX)} prefix; pick a different id for explicit-shape tool calls.`,
+          );
+        }
+        return { callId: tc.callId, name: tc.name, argsJSON: tc.argsJSON };
+      }
+      if (
+        tc.callId !== undefined &&
+        tc.callId.startsWith(AUTO_CALL_ID_PREFIX)
+      ) {
+        throw new Error(
+          `Harness.scenario.replyOnce: callId ${JSON.stringify(tc.callId)} uses the reserved ${JSON.stringify(AUTO_CALL_ID_PREFIX)} prefix; pick a different id for pinned tool calls.`,
+        );
+      }
+      const callId =
+        tc.callId ?? `${AUTO_CALL_ID_PREFIX}${String(nextAutoCallId++)}`;
+      return { callId, name: tc.name, argsJSON: JSON.stringify(tc.args) };
+    });
+  };
+
   const replyOnce = (
     provider: Provider,
     opts: ReplyOnceOpts,
@@ -604,7 +638,9 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
     const stream = createStream();
     const chunks = completeResponse(provider, {
       ...(opts.text !== undefined ? { text: opts.text } : {}),
-      ...(opts.toolCalls !== undefined ? { toolCalls: opts.toolCalls } : {}),
+      ...(opts.toolCalls !== undefined
+        ? { toolCalls: normalizeToolCalls(opts.toolCalls) }
+        : {}),
       ...(opts.headUsage !== undefined ? { headUsage: opts.headUsage } : {}),
       ...(opts.tailUsage !== undefined ? { tailUsage: opts.tailUsage } : {}),
     });

--- a/packages/inference-testing/src/index.ts
+++ b/packages/inference-testing/src/index.ts
@@ -22,6 +22,7 @@ export type {
   Scenario,
   ReplyOnceOpts,
   RequestPredicate,
+  BodyAwareRequestPredicate,
   StallHandle,
   StallOpts,
   WhenRequestMatchesOpts,

--- a/packages/inference-testing/src/index.ts
+++ b/packages/inference-testing/src/index.ts
@@ -21,6 +21,7 @@ export type {
 export type {
   Scenario,
   ReplyOnceOpts,
+  ReplyOnceToolCall,
   RequestPredicate,
   BodyAwareRequestPredicate,
   StallHandle,

--- a/packages/inference-testing/src/reply-once-toolcalls.test.ts
+++ b/packages/inference-testing/src/reply-once-toolcalls.test.ts
@@ -1,0 +1,303 @@
+// Tests for the friendlier `ReplyOnceToolCall` shape accepted by
+// `scenario.replyOnce`. The original shape — `{ callId, name, argsJSON }` —
+// requires the caller to stringify args and invent a callId. The new
+// shape — `{ name, args, callId? }` — auto-stringifies and auto-IDs.
+// Both shapes must continue to work, and they must be mixable in the
+// same array (a test can pin a single callId for assertion while
+// letting the others auto-generate).
+
+import { describe, test, expect } from "bun:test";
+
+import { setupHarness } from "./harness";
+
+async function drainResponse(response: Response): Promise<string> {
+  const body = response.body;
+  if (body === null) throw new Error("response body is null");
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value !== undefined) out += decoder.decode(value, { stream: true });
+  }
+  out += decoder.decode();
+  return out;
+}
+
+type ExtractedToolCall = {
+  id: string | undefined;
+  name: string | undefined;
+  argumentsConcat: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Pull every `tool_calls` delta out of an OpenAI SSE response stream
+// and concatenate the per-tool fields the test cares about. The shape
+// matches the openai wire DSL emitted by `wire.completeResponse`. The
+// function is purely defensive: every level of the nested JSON is
+// shape-checked before drilling down, so a wire-format change surfaces
+// here as missing data rather than a crashing cast.
+async function extractOpenAIToolCalls(
+  response: Response,
+): Promise<ExtractedToolCall[]> {
+  const text = await drainResponse(response);
+  const byIndex = new Map<number, ExtractedToolCall>();
+  for (const line of text.split("\n")) {
+    if (!line.startsWith("data: ")) continue;
+    const payload = line.slice("data: ".length);
+    if (payload === "[DONE]") continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(payload);
+    } catch {
+      continue;
+    }
+    if (!isRecord(parsed)) continue;
+    const choices = parsed["choices"];
+    if (!Array.isArray(choices)) continue;
+    const choice0: unknown = choices[0];
+    if (!isRecord(choice0)) continue;
+    const delta = choice0["delta"];
+    if (!isRecord(delta)) continue;
+    const tools = delta["tool_calls"];
+    if (!Array.isArray(tools)) continue;
+    for (const tc of tools) {
+      if (!isRecord(tc)) continue;
+      const idx = tc["index"];
+      if (typeof idx !== "number") continue;
+      const entry: ExtractedToolCall = byIndex.get(idx) ?? {
+        id: undefined,
+        name: undefined,
+        argumentsConcat: "",
+      };
+      const idVal = tc["id"];
+      if (typeof idVal === "string") entry.id = idVal;
+      const fn = tc["function"];
+      if (isRecord(fn)) {
+        const nameVal = fn["name"];
+        if (typeof nameVal === "string") entry.name = nameVal;
+        const argsVal = fn["arguments"];
+        if (typeof argsVal === "string") entry.argumentsConcat += argsVal;
+      }
+      byIndex.set(idx, entry);
+    }
+  }
+  const out: ExtractedToolCall[] = [];
+  const indices = [...byIndex.keys()].sort((a, b) => a - b);
+  for (const i of indices) {
+    const entry = byIndex.get(i);
+    if (entry !== undefined) out.push(entry);
+  }
+  return out;
+}
+
+describe("Scenario.replyOnce — ReplyOnceToolCall shape", () => {
+  test("explicit { callId, name, argsJSON } shape (unchanged)", async () => {
+    const harness = setupHarness();
+    try {
+      harness.scenario.replyOnce("openai", {
+        toolCalls: [
+          {
+            callId: "call_explicit",
+            name: "searchTool",
+            argsJSON: JSON.stringify({ q: "hello" }),
+          },
+        ],
+      });
+      const f = harness.deps.fetch("https://example/x");
+      await harness.run();
+      const r = await f;
+      const tools = await extractOpenAIToolCalls(r);
+      expect(tools).toHaveLength(1);
+      const t = tools[0];
+      if (t === undefined) throw new Error("expected one tool");
+      expect(t.id).toBe("call_explicit");
+      expect(t.name).toBe("searchTool");
+      expect(JSON.parse(t.argumentsConcat)).toEqual({ q: "hello" });
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("friendlier { name, args } shape auto-stringifies args and auto-generates callId", async () => {
+    const harness = setupHarness();
+    try {
+      harness.scenario.replyOnce("openai", {
+        toolCalls: [
+          {
+            name: "proposeTask",
+            args: { idHint: "1a-greet", level: 1, dependsOn: [] },
+          },
+        ],
+      });
+      const f = harness.deps.fetch("https://example/x");
+      await harness.run();
+      const r = await f;
+      const tools = await extractOpenAIToolCalls(r);
+      expect(tools).toHaveLength(1);
+      const t = tools[0];
+      if (t === undefined) throw new Error("expected one tool");
+      expect(t.id).not.toBeUndefined();
+      // Auto-generated callId matches the harness's `call_auto_<n>`
+      // shape so tests can pattern-match if they need to.
+      expect(t.id).toMatch(/^call_auto_\d+$/);
+      expect(t.name).toBe("proposeTask");
+      expect(JSON.parse(t.argumentsConcat)).toEqual({
+        idHint: "1a-greet",
+        level: 1,
+        dependsOn: [],
+      });
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("friendlier shape honours an explicit callId when supplied", async () => {
+    const harness = setupHarness();
+    try {
+      harness.scenario.replyOnce("openai", {
+        toolCalls: [
+          {
+            name: "finalizePlan",
+            args: { verificationMode: "baseline-equality" },
+            callId: "call_finalize_pinned",
+          },
+        ],
+      });
+      const f = harness.deps.fetch("https://example/x");
+      await harness.run();
+      const r = await f;
+      const tools = await extractOpenAIToolCalls(r);
+      expect(tools).toHaveLength(1);
+      const t = tools[0];
+      if (t === undefined) throw new Error("expected one tool");
+      expect(t.id).toBe("call_finalize_pinned");
+      expect(t.name).toBe("finalizePlan");
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("explicit and friendlier shapes can be mixed in the same array", async () => {
+    const harness = setupHarness();
+    try {
+      harness.scenario.replyOnce("openai", {
+        toolCalls: [
+          {
+            callId: "call_pin_a",
+            name: "proposeTask",
+            argsJSON: JSON.stringify({ idHint: "a" }),
+          },
+          {
+            name: "proposeTask",
+            args: { idHint: "b" },
+          },
+          {
+            callId: "call_pin_c",
+            name: "finalizePlan",
+            argsJSON: JSON.stringify({}),
+          },
+        ],
+      });
+      const f = harness.deps.fetch("https://example/x");
+      await harness.run();
+      const r = await f;
+      const tools = await extractOpenAIToolCalls(r);
+      expect(tools).toHaveLength(3);
+      const [t0, t1, t2] = tools;
+      if (t0 === undefined || t1 === undefined || t2 === undefined) {
+        throw new Error("expected three tools");
+      }
+      expect(t0.id).toBe("call_pin_a");
+      expect(JSON.parse(t0.argumentsConcat)).toEqual({ idHint: "a" });
+      expect(t1.id).toMatch(/^call_auto_\d+$/);
+      expect(JSON.parse(t1.argumentsConcat)).toEqual({ idHint: "b" });
+      expect(t2.id).toBe("call_pin_c");
+      expect(JSON.parse(t2.argumentsConcat)).toEqual({});
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("anthropic provider accepts the friendlier shape too", async () => {
+    // Body shape diverges across providers but the input contract is
+    // the same. Sanity-check that anthropic dispatch doesn't trip on
+    // the auto-generated callId or the JSON.stringify'd args.
+    const harness = setupHarness();
+    try {
+      harness.scenario.replyOnce("anthropic", {
+        toolCalls: [
+          {
+            name: "search",
+            args: { q: "anthropic" },
+          },
+        ],
+        headUsage: {
+          input: 10,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          thinking: 0,
+        },
+        tailUsage: {
+          input: 0,
+          output: 5,
+          cacheRead: 0,
+          cacheWrite: 0,
+          thinking: 0,
+        },
+      });
+      const f = harness.deps.fetch("https://example/x");
+      await harness.run();
+      const r = await f;
+      const text = await drainResponse(r);
+      // Anthropic's tool_use block carries the auto-generated id and
+      // name; the input_json_delta carries the stringified args.
+      expect(text).toContain('"name":"search"');
+      expect(text).toMatch(/"id":"call_auto_\d+"/);
+      expect(text).toContain('"partial_json":"{\\"q\\":\\"anthropic\\"}"');
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("pinned callId starting with the reserved `call_auto_` prefix is rejected", () => {
+    // The harness mints `call_auto_<n>` ids for the friendlier
+    // `{ name, args }` shape. A pinned callId in either shape that
+    // shadows that namespace would collide with later auto-generated
+    // ids on the same run; reject at registration rather than wait
+    // for the mid-stream confusion.
+    const harness = setupHarness();
+    try {
+      expect(() =>
+        harness.scenario.replyOnce("openai", {
+          toolCalls: [
+            {
+              callId: "call_auto_999",
+              name: "search",
+              argsJSON: JSON.stringify({ q: "x" }),
+            },
+          ],
+        }),
+      ).toThrow(/reserved.*prefix/);
+
+      expect(() =>
+        harness.scenario.replyOnce("openai", {
+          toolCalls: [
+            {
+              callId: "call_auto_pinned",
+              name: "search",
+              args: { q: "x" },
+            },
+          ],
+        }),
+      ).toThrow(/reserved.*prefix/);
+    } finally {
+      harness.dispose();
+    }
+  });
+});

--- a/packages/inference-testing/src/scenario.ts
+++ b/packages/inference-testing/src/scenario.ts
@@ -52,6 +52,11 @@ export type BodyAwareRequestPredicate = (
  *   name and structured arguments.
  *
  * Both shapes may be mixed within the same array.
+ *
+ * Auto-generated callIds use the prefix `call_auto_` followed by a
+ * monotonically-increasing per-harness counter. Tests that pin explicit
+ * callIds via the explicit shape should avoid the `call_auto_` prefix
+ * to keep their pinned ids distinguishable from auto-generated ones.
  */
 export type ReplyOnceToolCall =
   | {
@@ -272,9 +277,12 @@ export type Scenario = {
    * scenario (e.g., per-agent body assertions across a multi-agent dispatch
    * run) rather than only the most-recent one.
    *
-   * Each clone is independent: consuming one's body does not affect any
-   * other (the production reactor reads the body via the `Response`
-   * returned through the stream, not through these clones).
+   * Each call returns fresh clones, so consuming one returned Request's
+   * body does not affect any other returned Request — neither the
+   * siblings returned by the same call nor the Requests returned by
+   * later calls. The harness's internal capture list itself is never
+   * consumed: every `.json()` / `.text()` invocation runs against a
+   * one-shot clone minted at the time `matchedRequests()` was called.
    *
    * To read only the most-recent request, use `matchedRequests().at(-1)`.
    */
@@ -533,13 +541,20 @@ export function scanWaitingSet(
     if (m.bodyAware) {
       if (!includeBodyAware) return false;
       // Body-aware matchers only fire against fetches whose bodies have
-      // already been buffered. A body-aware scan that hasn't yet seen a
-      // fresh fetch (one that arrived after the last `bufferUnreadBodies`
-      // pass) simply treats it as a non-match for this pass; the harness
-      // will run another scan after buffering completes. This is more
-      // robust than throwing — concurrent body-aware scans against an
-      // active waiting set are a legitimate steady-state condition,
-      // not an invariant violation.
+      // already been buffered. A body-aware scan that meets an
+      // unbuffered fetch simply treats it as a non-match for this pass;
+      // the harness will run another scan after buffering completes.
+      //
+      // The unbuffered case is expected, not an invariant violation:
+      // two body-aware scans can be in flight at the same time, e.g.
+      // one queued from a matcher registration and one queued from a
+      // fetch arrival. The first scan snapshots `waiting` and starts
+      // its `clone().text()` reads; while it is awaiting, a new fetch
+      // arrives and pushes onto `waiting`. When the first scan resumes
+      // and calls `scanWaitingSet`, it sees the new fetch with
+      // `bodyText === undefined`. Returning false here lets the second
+      // scan (which buffers the new fetch as part of its own
+      // `bufferUnreadBodies` pass) route it on a later pass.
       if (wf.bodyText === undefined) return false;
       return m.predicate(wf.bodyText, wf.request);
     }

--- a/packages/inference-testing/src/scenario.ts
+++ b/packages/inference-testing/src/scenario.ts
@@ -40,6 +40,32 @@ export type BodyAwareRequestPredicate = (
 ) => boolean;
 
 /**
+ * Tool-call entry accepted by `ReplyOnceOpts.toolCalls`. Two shapes are
+ * permitted:
+ *
+ * - `{ callId, name, argsJSON }` — the original explicit shape. Use when
+ *   the test asserts against an exact `callId` or hand-crafts the
+ *   arguments string (e.g., to exercise malformed-JSON paths).
+ * - `{ name, args, callId? }` — the friendlier shape. `args` is
+ *   `JSON.stringify`'d for you; `callId` is auto-generated if omitted.
+ *   Use for the common case where the test only cares about the tool
+ *   name and structured arguments.
+ *
+ * Both shapes may be mixed within the same array.
+ */
+export type ReplyOnceToolCall =
+  | {
+      readonly callId: string;
+      readonly name: string;
+      readonly argsJSON: string;
+    }
+  | {
+      readonly name: string;
+      readonly args: unknown;
+      readonly callId?: string;
+    };
+
+/**
  * Options for `scenario.replyOnce`. `text` and `toolCalls` are the response
  * payload (passed through to `wire.completeResponse`); `headUsage` and
  * `tailUsage` are optional usage frames. `predicate` narrows which fetch
@@ -48,11 +74,7 @@ export type BodyAwareRequestPredicate = (
  */
 export type ReplyOnceOpts = {
   readonly text?: string;
-  readonly toolCalls?: {
-    callId: string;
-    name: string;
-    argsJSON: string;
-  }[];
+  readonly toolCalls?: readonly ReplyOnceToolCall[];
   readonly headUsage?: {
     input: number;
     output: number;

--- a/packages/inference-testing/src/scenario.ts
+++ b/packages/inference-testing/src/scenario.ts
@@ -23,6 +23,23 @@ export type WireEventPredicate = (event: ChunkFiredEvent) => boolean;
 export type RequestPredicate = (req: Request) => boolean;
 
 /**
+ * Predicate variant for `scenario.whenRequestBodyMatches`. Receives the
+ * buffered request body as a UTF-8 string plus the original `Request` (for
+ * URL/header inspection). The harness buffers the body once per fetch the
+ * first time a body-aware matcher could fire; the same buffered text is
+ * passed to every body-aware predicate evaluated against that fetch.
+ *
+ * The same purity contract that governs `RequestPredicate` applies here:
+ * sync, idempotent, side-effect-free, and independent of mutable harness
+ * state. Reading `bodyText`, `req.url`, `req.method`, and `req.headers` is
+ * fine; everything else is a bug class.
+ */
+export type BodyAwareRequestPredicate = (
+  bodyText: string,
+  req: Request,
+) => boolean;
+
+/**
  * Options for `scenario.replyOnce`. `text` and `toolCalls` are the response
  * payload (passed through to `wire.completeResponse`); `headUsage` and
  * `tailUsage` are optional usage frames. `predicate` narrows which fetch
@@ -153,6 +170,34 @@ export type Scenario = {
     opts?: WhenRequestMatchesOpts,
   ): void;
   /**
+   * Register a single-use matcher whose predicate sees the request body as
+   * a UTF-8 string. Useful when the only field that distinguishes parallel
+   * fetches lives in the body (e.g., a task id in the seed message of a
+   * multi-agent dispatch run).
+   *
+   * The body is buffered once per fetch the first time a body-aware
+   * matcher could fire against it; subsequent body-aware predicates see
+   * the same cached text. URL/header-only predicates registered via
+   * `whenRequestMatches` never trigger a body read.
+   *
+   * Scan ordering: sync `whenRequestMatches` predicates run first. If
+   * none bind a fetch and at least one body-aware matcher is registered,
+   * the harness buffers the bodies of every still-waiting fetch and then
+   * runs a body-aware scan pass. Body-aware matches resolve only after
+   * ALL in-flight body buffers complete — `AmbiguousRequestError` for
+   * body-aware matchers is detected over a fully-buffered set, not as
+   * bodies become available, so the conflict semantics match the sync
+   * scan's "single pass over all waiting fetches" model.
+   *
+   * `opts.status` and `opts.headers` shape the `Response`'s envelope, with
+   * the same defaults as `whenRequestMatches`.
+   */
+  whenRequestBodyMatches(
+    predicate: BodyAwareRequestPredicate,
+    responseStream: SimulatedStream,
+    opts?: WhenRequestMatchesOpts,
+  ): void;
+  /**
    * Register a handler for the tool named `name`. On the default path,
    * `harness.runInference` observes `inference.tool_call.end` events from
    * the production reactor and auto-dispatches the registered handler with
@@ -198,18 +243,20 @@ export type Scenario = {
    */
   lastToolDispatch(name: string): unknown;
   /**
-   * Returns a clone of the most-recently matched `Request`, or `undefined`
-   * if no fetch has been routed by a matcher yet. The harness records
-   * every routed request so tests can `await req.json()` after the fact
-   * to assert on the body shape — the matcher predicate itself is
-   * synchronous on purpose (it runs on every scan pass) and so cannot
-   * read the body, but `lastRequest` is the post-match seam.
+   * Returns the full list of matched `Request`s in match order, each as a
+   * fresh clone whose body the caller can consume freely. Empty until at
+   * least one fetch has been routed by a matcher. Tests use this to assert
+   * against the body shape of every request the harness routed during the
+   * scenario (e.g., per-agent body assertions across a multi-agent dispatch
+   * run) rather than only the most-recent one.
    *
-   * The returned `Request` is a clone so the test can consume its body
-   * without affecting the original (the production reactor will still
-   * read the body via the `Response` returned through the stream).
+   * Each clone is independent: consuming one's body does not affect any
+   * other (the production reactor reads the body via the `Response`
+   * returned through the stream, not through these clones).
+   *
+   * To read only the most-recent request, use `matchedRequests().at(-1)`.
    */
-  lastRequest(): Request | undefined;
+  matchedRequests(): Request[];
   /**
    * Convenience wrapper that creates a stream, builds a complete
    * single-turn response for `provider`, enqueues it at the next safe
@@ -287,21 +334,43 @@ export type Scenario = {
  * consistent with "registration-order, first-match-wins" + per-fetch
  * controllers + the `AmbiguousRequestError` case. If a test wants to match
  * the same request twice, it registers two matchers.
+ *
+ * `bodyAware` discriminates between sync-only predicates (registered via
+ * `whenRequestMatches`) and body-aware predicates (registered via
+ * `whenRequestBodyMatches`). Sync predicates evaluate in the sync scan
+ * pass; body-aware predicates evaluate in a follow-up async scan pass
+ * that runs only after every still-waiting fetch's body has been
+ * buffered.
  */
-export type Matcher = {
-  readonly predicate: RequestPredicate;
-  readonly responseStream: SimulatedStream;
-  /** First two non-anonymous frames of the registration site, if available. */
-  readonly source: string | undefined;
-  readonly opts: WhenRequestMatchesOpts | undefined;
-  consumed: boolean;
-};
+export type Matcher =
+  | {
+      readonly bodyAware: false;
+      readonly predicate: RequestPredicate;
+      readonly responseStream: SimulatedStream;
+      /** First two non-anonymous frames of the registration site, if available. */
+      readonly source: string | undefined;
+      readonly opts: WhenRequestMatchesOpts | undefined;
+      consumed: boolean;
+    }
+  | {
+      readonly bodyAware: true;
+      readonly predicate: BodyAwareRequestPredicate;
+      readonly responseStream: SimulatedStream;
+      readonly source: string | undefined;
+      readonly opts: WhenRequestMatchesOpts | undefined;
+      consumed: boolean;
+    };
 
 /**
  * Internal shape of a fetch parked in the waiting set. The `request` field
  * is constructed once when the fetch enters the waiting set and reused
  * across every predicate evaluation, so that any per-`Request` side effect
- * (consuming a body, header normalization) is paid exactly once.
+ * (header normalization) is paid exactly once.
+ *
+ * `bodyText` is populated lazily — the first body-aware scan pass triggered
+ * against this fetch reads `request.clone().text()` once and caches the
+ * result here. Sync-only fetches never trigger a body read; the field
+ * stays `undefined` for those.
  */
 export type WaitingFetch = {
   readonly request: Request;
@@ -310,6 +379,13 @@ export type WaitingFetch = {
   readonly reject: (err: unknown) => void;
   /** Set true once routed or aborted; prevents duplicate settlement. */
   settled: boolean;
+  /**
+   * Buffered request body, populated lazily by `bufferUnreadBodies`
+   * before the body-aware scan pass. `undefined` means "not yet
+   * buffered". The harness never overwrites a populated entry; each
+   * fetch buffers at most once across its lifetime.
+   */
+  bodyText: string | undefined;
 };
 
 /**
@@ -318,7 +394,7 @@ export type WaitingFetch = {
  * Ordered, append-only registry of `Matcher` entries owned by a single
  * harness. `entries` is exposed so the harness can clear it on `dispose()`
  * without piercing private state; production code should treat the table
- * as opaque and interact only via `register`.
+ * as opaque and interact only via `register` / `registerBodyAware`.
  */
 export type MatcherTable = {
   readonly entries: Matcher[];
@@ -328,6 +404,22 @@ export type MatcherTable = {
     source: string | undefined,
     opts: WhenRequestMatchesOpts | undefined,
   ): void;
+  registerBodyAware(
+    predicate: BodyAwareRequestPredicate,
+    responseStream: SimulatedStream,
+    source: string | undefined,
+    opts: WhenRequestMatchesOpts | undefined,
+  ): void;
+  /**
+   * Returns true when at least one body-aware matcher has ever been
+   * registered against this table (consumed or not). Used by the harness
+   * to decide whether arriving fetches need their bodies buffered for the
+   * body-aware scan pass. Once a body-aware matcher has been registered,
+   * the flag stays true for the lifetime of the table — even after the
+   * matcher consumes — because the registration tells us tests care
+   * about body routing for the run as a whole.
+   */
+  hasBodyAware(): boolean;
 };
 
 /**
@@ -338,6 +430,7 @@ export type MatcherTable = {
  */
 export function createMatcherTable(): MatcherTable {
   const entries: Matcher[] = [];
+  let bodyAwareEverRegistered = false;
   return {
     entries,
     register(
@@ -347,12 +440,32 @@ export function createMatcherTable(): MatcherTable {
       opts: WhenRequestMatchesOpts | undefined,
     ): void {
       entries.push({
+        bodyAware: false,
         predicate,
         responseStream,
         source,
         opts,
         consumed: false,
       });
+    },
+    registerBodyAware(
+      predicate: BodyAwareRequestPredicate,
+      responseStream: SimulatedStream,
+      source: string | undefined,
+      opts: WhenRequestMatchesOpts | undefined,
+    ): void {
+      bodyAwareEverRegistered = true;
+      entries.push({
+        bodyAware: true,
+        predicate,
+        responseStream,
+        source,
+        opts,
+        consumed: false,
+      });
+    },
+    hasBodyAware(): boolean {
+      return bodyAwareEverRegistered;
     },
   };
 }
@@ -375,6 +488,14 @@ export function createMatcherTable(): MatcherTable {
  * and removes the entry from the waiting set. `route` must NOT itself
  * call `scanWaitingSet` — the caller is responsible for re-invoking the
  * scan at the next trigger point.
+ *
+ * `includeBodyAware` controls which matchers are considered. When false
+ * (the sync scan pass), body-aware matchers are skipped entirely — they
+ * remain available for a later async pass once bodies are buffered. When
+ * true, body-aware matchers are evaluated using the fetch's pre-buffered
+ * `bodyText`; a body-aware matcher seen with `bodyText === undefined` is
+ * an internal bug (the harness must buffer before calling with
+ * `includeBodyAware: true`).
  */
 export function scanWaitingSet(
   waiting: WaitingFetch[],
@@ -384,7 +505,25 @@ export function scanWaitingSet(
     stream: SimulatedStream,
     opts: WhenRequestMatchesOpts | undefined,
   ) => void,
+  includeBodyAware = false,
 ): void {
+  const evaluate = (m: Matcher, wf: WaitingFetch): boolean => {
+    if (m.bodyAware) {
+      if (!includeBodyAware) return false;
+      // Body-aware matchers only fire against fetches whose bodies have
+      // already been buffered. A body-aware scan that hasn't yet seen a
+      // fresh fetch (one that arrived after the last `bufferUnreadBodies`
+      // pass) simply treats it as a non-match for this pass; the harness
+      // will run another scan after buffering completes. This is more
+      // robust than throwing — concurrent body-aware scans against an
+      // active waiting set are a legitimate steady-state condition,
+      // not an invariant violation.
+      if (wf.bodyText === undefined) return false;
+      return m.predicate(wf.bodyText, wf.request);
+    }
+    return m.predicate(wf.request);
+  };
+
   // Snapshot: matcher -> first waiting fetch that bound to it. If a second
   // fetch tries to bind to the same matcher in this pass, that's ambiguous.
   // We iterate fetches in arrival order to honor first-match-wins on the
@@ -403,7 +542,7 @@ export function scanWaitingSet(
     for (const m of table.entries) {
       if (m.consumed) continue;
       if (boundThisPass.has(m)) continue;
-      if (m.predicate(wf.request)) {
+      if (evaluate(m, wf)) {
         chosen = m;
         break;
       }
@@ -415,7 +554,7 @@ export function scanWaitingSet(
       for (const m of table.entries) {
         if (m.consumed) continue;
         if (!boundThisPass.has(m)) continue;
-        if (m.predicate(wf.request)) {
+        if (evaluate(m, wf)) {
           const list = conflicts.get(m) ?? [];
           if (list.length === 0) {
             // The prior binding fetch is the conflict's first member.

--- a/tests/agent-multi-provider/cli.test.ts
+++ b/tests/agent-multi-provider/cli.test.ts
@@ -83,9 +83,9 @@ describe("agent-multi-provider CLI", () => {
     expect(stdoutBuf).toContain("smart-reply");
 
     // The model carried by the actual inference request must match
-    // the routed model. lastRequest sees only the most recent
-    // matched request, so we check the smart side here.
-    const last = harness.scenario.lastRequest();
+    // the routed model. matchedRequests() returns every routed request
+    // in match order; we check the most recent (the smart side) here.
+    const last = harness.scenario.matchedRequests().at(-1);
     if (last === undefined) throw new Error("expected a matched request");
     const body: unknown = await last.json();
     expect(body).toMatchObject({ model: "sonnet-test" });

--- a/tests/agent/send-flow.test.ts
+++ b/tests/agent/send-flow.test.ts
@@ -209,7 +209,7 @@ describe("@intx/agent send-flow integration", () => {
       const r = await second;
       expect(r.reply).toBe("rotated reply");
 
-      const matched = harness.scenario.lastRequest();
+      const matched = harness.scenario.matchedRequests().at(-1);
       if (matched === undefined) {
         throw new Error("expected a matched request after setProvider swap");
       }
@@ -256,7 +256,7 @@ describe("@intx/agent send-flow integration", () => {
       const r = await second;
       expect(r.reply).toBe("second-model reply");
 
-      const matched = harness.scenario.lastRequest();
+      const matched = harness.scenario.matchedRequests().at(-1);
       if (matched === undefined) {
         throw new Error("expected a matched request after model swap");
       }

--- a/tests/inference-testing/per-agent-scoping.test.ts
+++ b/tests/inference-testing/per-agent-scoping.test.ts
@@ -1,0 +1,256 @@
+// Pins the per-agent assertion-scoping pattern documented in the
+// @intx/inference-testing README.
+//
+// Multi-agent dispatch tests routinely want to assert "agent A made
+// tool call X" independently of "agent B made tool call Y". The
+// harness already supports this without any explicit per-agent
+// machinery: each call to `harness.runInference(...)` returns its own
+// `AsyncIterable<InferenceEvent>`. If the test collects events per
+// call into separate arrays, every matcher in `expectToolCalls` /
+// `expectToolCall(name).from(events)` is automatically scoped to the
+// agent whose events array it sees.
+//
+// This test pins that contract: two concurrent `harness.runInference`
+// calls collect into two arrays; each `expectToolCalls(...)` invocation
+// only sees the tool calls from its own agent.
+//
+// If a future harness change ever mixes events from multiple
+// `runInference` calls into a shared stream, this test breaks and
+// surfaces the regression at the source.
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { setupHarness, wire } from "@intx/inference-testing";
+import type { Harness } from "@intx/inference-testing";
+import { expectToolCall, expectToolCalls } from "@intx/inference-testing";
+import type {
+  ConversationTurn,
+  InferenceEvent,
+  ProviderConfig,
+} from "@intx/types/runtime";
+
+const PROVIDER_CONFIG: ProviderConfig = {
+  provider: "openai",
+  baseURL: "https://example/v1",
+  apiKey: "test",
+};
+
+const USAGE_HEAD = {
+  input: 5,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  thinking: 0,
+};
+const USAGE_TAIL = {
+  input: 0,
+  output: 3,
+  cacheRead: 0,
+  cacheWrite: 0,
+  thinking: 0,
+};
+
+function userTurn(text: string): ConversationTurn {
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+    timestamp: 0,
+  };
+}
+
+let activeHarness: Harness | null = null;
+
+afterEach(() => {
+  if (activeHarness !== null) {
+    activeHarness.dispose();
+    activeHarness = null;
+  }
+});
+
+describe("per-agent assertion scoping", () => {
+  test("two concurrent runInference calls produce independently-assertable event arrays", async () => {
+    const harness = setupHarness();
+    activeHarness = harness;
+
+    // Two agents fire inference calls in parallel. The harness routes
+    // each to its own response stream (body-content routing — Phase 1
+    // of INTR-83 — would also work here, but for simplicity we use
+    // distinct URLs).
+    harness.scenario.replyOnce("openai", {
+      toolCalls: [{ name: "agentATool", args: { value: "from-A" } }],
+      headUsage: USAGE_HEAD,
+      tailUsage: USAGE_TAIL,
+      predicate: (req) => req.url.includes("/agent-a/"),
+    });
+    harness.scenario.replyOnce("openai", {
+      toolCalls: [{ name: "agentBTool", args: { value: "from-B" } }],
+      headUsage: USAGE_HEAD,
+      tailUsage: USAGE_TAIL,
+      predicate: (req) => req.url.includes("/agent-b/"),
+    });
+
+    // Each agent's tool handler runs locally; we don't care about the
+    // dispatched value, only about the events the harness emits.
+    harness.scenario.onTool("agentATool", () => ({ ok: true }));
+    harness.scenario.onTool("agentBTool", () => ({ ok: true }));
+
+    let seqA = 0;
+    let seqB = 0;
+    const eventsA: InferenceEvent[] = [];
+    const eventsB: InferenceEvent[] = [];
+
+    const collectA = (async () => {
+      for await (const ev of harness.runInference({
+        turns: [userTurn("hello A")],
+        model: "test",
+        providerConfig: {
+          ...PROVIDER_CONFIG,
+          baseURL: "https://example/v1/agent-a",
+        },
+        nextSeq: () => ++seqA,
+      })) {
+        eventsA.push(ev);
+      }
+    })();
+    const collectB = (async () => {
+      for await (const ev of harness.runInference({
+        turns: [userTurn("hello B")],
+        model: "test",
+        providerConfig: {
+          ...PROVIDER_CONFIG,
+          baseURL: "https://example/v1/agent-b",
+        },
+        nextSeq: () => ++seqB,
+      })) {
+        eventsB.push(ev);
+      }
+    })();
+
+    await harness.run();
+    await Promise.all([collectA, collectB]);
+
+    // Agent A's events array contains agentATool and NOT agentBTool.
+    expectToolCalls(eventsA).toInclude({
+      name: "agentATool",
+      arguments: { value: "from-A" },
+    });
+    expectToolCall("agentATool").from(eventsA).toHaveBeenCalledTimes(1);
+    expectToolCall("agentBTool").from(eventsA).toHaveBeenCalledTimes(0);
+
+    // Agent B's events array contains agentBTool and NOT agentATool.
+    expectToolCalls(eventsB).toInclude({
+      name: "agentBTool",
+      arguments: { value: "from-B" },
+    });
+    expectToolCall("agentBTool").from(eventsB).toHaveBeenCalledTimes(1);
+    expectToolCall("agentATool").from(eventsB).toHaveBeenCalledTimes(0);
+
+    // Neither array bleeds events from the other agent: a sanity check
+    // that the iteration didn't mix the streams.
+    const aToolEnds = eventsA.filter(
+      (e) => e.type === "inference.tool_call.end",
+    );
+    const bToolEnds = eventsB.filter(
+      (e) => e.type === "inference.tool_call.end",
+    );
+    expect(aToolEnds).toHaveLength(1);
+    expect(bToolEnds).toHaveLength(1);
+    // Type guards so the property accesses below typecheck. The guards
+    // also subsume the per-array length and type asserts above for a
+    // reader skimming the test.
+    const aEnd = aToolEnds[0];
+    const bEnd = bToolEnds[0];
+    if (aEnd?.type !== "inference.tool_call.end") {
+      throw new Error("unreachable");
+    }
+    if (bEnd?.type !== "inference.tool_call.end") {
+      throw new Error("unreachable");
+    }
+    expect(aEnd.data.name).toBe("agentATool");
+    expect(bEnd.data.name).toBe("agentBTool");
+  });
+
+  test("body-content routing scopes per-agent assertions when URLs are identical", async () => {
+    // The Phase 1 use case: N agents POST to the same URL, distinguished
+    // only by body content. The events arrays remain independent because
+    // they come from separate `runInference` iterators — body routing
+    // only determines which response stream each agent's fetch receives.
+    const harness = setupHarness();
+    activeHarness = harness;
+
+    const streamA = harness.scenario.createStream();
+    streamA.enqueueAll(
+      wire.completeResponse("openai", {
+        toolCalls: [
+          {
+            callId: "call_a",
+            name: "toolA",
+            argsJSON: JSON.stringify({ tag: "A" }),
+          },
+        ],
+      }),
+      { startAt: harness.clock.now() + 1 },
+    );
+    harness.scenario.whenRequestBodyMatches(
+      (body) => body.includes("agent-A-marker"),
+      streamA,
+    );
+
+    const streamB = harness.scenario.createStream();
+    streamB.enqueueAll(
+      wire.completeResponse("openai", {
+        toolCalls: [
+          {
+            callId: "call_b",
+            name: "toolB",
+            argsJSON: JSON.stringify({ tag: "B" }),
+          },
+        ],
+      }),
+      { startAt: harness.clock.now() + 1 },
+    );
+    harness.scenario.whenRequestBodyMatches(
+      (body) => body.includes("agent-B-marker"),
+      streamB,
+    );
+
+    harness.scenario.onTool("toolA", () => ({ ok: true }));
+    harness.scenario.onTool("toolB", () => ({ ok: true }));
+
+    let seqA = 0;
+    let seqB = 0;
+    const eventsA: InferenceEvent[] = [];
+    const eventsB: InferenceEvent[] = [];
+
+    // Both agents POST to the same /chat/completions endpoint. The
+    // body carries the agent-X-marker that distinguishes them.
+    const collectA = (async () => {
+      for await (const ev of harness.runInference({
+        turns: [userTurn("agent-A-marker")],
+        model: "test",
+        providerConfig: PROVIDER_CONFIG,
+        nextSeq: () => ++seqA,
+      })) {
+        eventsA.push(ev);
+      }
+    })();
+    const collectB = (async () => {
+      for await (const ev of harness.runInference({
+        turns: [userTurn("agent-B-marker")],
+        model: "test",
+        providerConfig: PROVIDER_CONFIG,
+        nextSeq: () => ++seqB,
+      })) {
+        eventsB.push(ev);
+      }
+    })();
+
+    await harness.run();
+    await Promise.all([collectA, collectB]);
+
+    expectToolCall("toolA").from(eventsA).toHaveBeenCalledTimes(1);
+    expectToolCall("toolB").from(eventsA).toHaveBeenCalledTimes(0);
+    expectToolCall("toolB").from(eventsB).toHaveBeenCalledTimes(1);
+    expectToolCall("toolA").from(eventsB).toHaveBeenCalledTimes(0);
+  });
+});

--- a/tests/inference-testing/tsconfig.json
+++ b/tests/inference-testing/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Closes the three gaps in `@intx/inference-testing` cataloged by INTR-83
plus one follow-on flagged during planning.

- `scenario.whenRequestBodyMatches(predicate, responseStream, opts?)`
  routes parked fetches by buffered body content. Lazy buffer: only
  fires when at least one body-aware matcher has been registered;
  sync `whenRequestMatches` matchers still bind on the synchronous
  scan pass without paying a body read. Scan ordering: sync first,
  then a follow-up async pass that buffers every still-waiting
  fetch's body and evaluates body-aware matchers in registration
  order over the fully-buffered set. `AmbiguousRequestError` is
  detected across that fully-buffered set so the conflict semantics
  match the sync scan's single-pass model.
- `ReplyOnceOpts.toolCalls` accepts a friendlier `{ name, args }[]`
  shape that auto-`JSON.stringify`s `args` and auto-generates
  `call_auto_<n>` ids when `callId` is omitted. The original
  `{ callId, name, argsJSON }` shape continues to work; the two
  shapes may be mixed in the same array. The `call_auto_` prefix
  is reserved: a pinned `callId` that uses the prefix is rejected
  at registration so a test mixing pinned and auto-generated ids
  can't quietly collide with a later auto-minted id on the same
  run.
- `scenario.lastRequest()` (single-slot) is replaced with
  `scenario.matchedRequests(): Request[]`, returning every routed
  Request in match order as fresh per-call clones. Bodies on the
  returned clones can be read independently — across siblings AND
  across repeat calls. The two pre-existing internal call sites
  were updated.
- README documents the per-agent assertion-scoping pattern (each
  `runInference` call returns its own event iterator; collect events
  per call into separate arrays for per-agent scoping); a new
  integration test in `tests/inference-testing/` pins the contract.

## Changes

- `packages/inference-testing/src/scenario.ts`: new
  `BodyAwareRequestPredicate` and `ReplyOnceToolCall` types,
  `Matcher` discriminated union, `WaitingFetch.bodyText` (lazy
  populated), `MatcherTable.registerBodyAware` / `hasBodyAware`,
  `scanWaitingSet`'s new `includeBodyAware` flag,
  `Scenario.whenRequestBodyMatches`, `Scenario.matchedRequests`.
- `packages/inference-testing/src/harness.ts`: `bufferUnreadBodies`
  + `triggerBodyAwareScan` plumbing with two-pass scan
  orchestration, body-aware drain integrated into `run` /
  `advanceTo`, `normalizeToolCalls` for the friendlier toolCalls
  shape (with reserved-prefix enforcement), `matchedRequestsList`
  replacing single-slot capture.
- `packages/inference-testing/src/body-predicate.test.ts`,
  `packages/inference-testing/src/reply-once-toolcalls.test.ts`,
  `tests/inference-testing/per-agent-scoping.test.ts`: new tests
  covering the body-aware routing surface, the friendlier toolCalls
  shape (including the reserved-prefix rejection), the
  `matchedRequests()` re-clone contract, and per-agent scoping.
- `packages/inference-testing/README.md`: per-agent scoping
  section, body-aware predicates section, purity-rule update
  covering `BodyAwareRequestPredicate`.
- `tests/inference-testing/tsconfig.json` (new) +
  `eslint.config.ts` (drop the now-redundant
  `tests/inference-testing/*.ts` entry from
  `allowDefaultProject`): keeps the new test file from tipping
  ESLint's default-project ceiling, mirroring the convention at
  `tests/inference/`.
- `tests/agent/send-flow.test.ts`,
  `tests/agent-multi-provider/cli.test.ts`: updated for the
  `lastRequest()` → `matchedRequests().at(-1)` rename.

## Testing

- [x] `make all` — 1539 + 9 tests pass; lint clean; docs current.
- [x] Per-commit `make build` clean on all four commits.
- [x] Phase 1 unit tests: substring + JSON-path + regex body routing,
      no-body GET, abort-before-run, ambiguity, registration-order
      priority, foreign-stream / non-function / post-dispose
      rejections, cost-isolation for sync-only tests, and a
      deterministic `Object.defineProperty`-mocked body-read failure
      pinning that genuine read failures surface as the scan error
      rather than `UnmatchedFetchError`.
- [x] Phase 2 unit tests: explicit and friendlier toolCalls shapes
      individually and mixed, anthropic provider compatibility, the
      reserved `call_auto_` prefix rejection.
- [x] Phase 3 integration test: two concurrent `runInference` calls
      with separate event arrays; URL-routed and body-routed
      variants.
- [x] `matchedRequests()` tests: fresh-clone-per-call, match-order
      capture, empty initial state.

Closes INTR-83