### PR TITLE
Add READMEs for the inference-discovery packages

### DIFF
--- a/LAYOUT.md
+++ b/LAYOUT.md
@@ -81,9 +81,12 @@ The portable core packages (`inference`, `harness`, `agent`) never import enviro
 
 ## Development and Testing
 
-| Package                   | Purpose                                                                                                                                                                                                  |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@intx/inference-testing` | Deterministic test harness for the `@intx/inference` streaming pipeline. Virtual-clock-driven simulated fetch, scripted provider wire bytes, matcher suite. Used by tests across the agent runtime tree. |
+| Package                                  | Purpose                                                                                                                                                                                                                                                                  |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `@intx/inference-testing`                | Deterministic test harness for the `@intx/inference` streaming pipeline. Virtual-clock-driven simulated fetch, scripted provider wire bytes, matcher suite. Used by tests across the agent runtime tree.                                                                 |
+| `@intx/inference-discovery`              | Shared runtime for the wire-capture rig: provider plug-in contract, capture runner, capability catalog, support matrix, and the parser behind the `bin/discover.ts` CLI. Produces the fixture bundles under `packages/inference-testing/wire/` that the harness replays. |
+| `@intx/inference-discovery-google-genai` | Google GenAI provider plug-in for the discovery rig. Captures Gemini wire responses (text, multimodal, function calling, code execution, grounding, files API) across streaming and non-streaming variants.                                                              |
+| `@intx/inference-discovery-openai`       | OpenAI-protocol provider plug-in for the discovery rig. Carries the protocol layer plus per-deployment wiring; OpenCode Zen (Moonshot, Z.AI, DeepSeek, Alibaba, Xiaomi MiMo) is the first deployment.                                                                    |
 
 ## Dependency Rules
 

--- a/README.md
+++ b/README.md
@@ -71,3 +71,15 @@ generated into [`docs/API.md`](./docs/API.md) by
 [`bin/gen-api-docs.ts`](./bin/gen-api-docs.ts) from ArkType
 introspection over the type definitions in
 [`@intx/types`](./packages/types).
+
+## Inference discovery
+
+A wire-capture rig records real upstream responses from Gemini
+and the OpenCode Zen relay's five models across text, multimodal,
+function calling, and reasoning capabilities; the captured bytes
+back deterministic tests in
+[`@intx/inference-testing`](./packages/inference-testing). See
+[`@intx/inference-discovery`](./packages/inference-discovery) for
+the runtime and CLI, and
+[`docs/OPENCODE_DISCOVERY.md`](./docs/OPENCODE_DISCOVERY.md) for
+the OpenCode Zen observed-vs-documented narrative.

--- a/docs/OPENCODE_DISCOVERY.md
+++ b/docs/OPENCODE_DISCOVERY.md
@@ -16,8 +16,8 @@ against the relay's `chat/completions` surface.
 The capture corpus lives at
 `packages/inference-testing/wire/opencode-zen/`. The
 model-to-capability matrix is authoritatively defined in the
-`SUPPORT_MATRIX` export of `@intx/inference-discovery-catalog`
-(`packages/inference-discovery-catalog/src/support-matrix.ts`).
+`SUPPORT_MATRIX` export of `@intx/inference-discovery/catalog`
+(`packages/inference-discovery/src/catalog/support-matrix.ts`).
 The fixtures are the ground truth: where the docs and the wire
 disagree, the wire wins. This document is the narrative companion
 to those bytes.
@@ -27,9 +27,10 @@ Thirty-three capture directories were committed, spanning text
 multi-turn), reasoning (streaming and non-streaming), and vision
 input. Five models were exercised: `kimi-k2.6`, `glm-5.1`,
 `deepseek-v4-pro`, `qwen3.6-plus`, and `mimo-v2-omni`. Vision input
-was captured for the three models that the registry marks as
-vision-capable; the other two are exercised by the registry guard
-itself, not by an HTTP call. The companion taxonomy document at
+was captured for the three models that `SUPPORT_MATRIX` marks as
+vision-capable; the other two have non-captured outcomes recorded
+for vision-input and the discover CLI filters them out of its run
+set. The companion taxonomy document at
 `docs/INFERENCE.md` (the "Generalized Multimodal Taxonomy" section)
 generalises these observations into the cross-provider abstractions
 that INTR-79 and INTR-80 will consume. This note records facts;
@@ -39,8 +40,8 @@ design decisions belong in the taxonomy document, not here.
 
 The per-(model, capability) behaviors documented below are the
 _narrative_ layer. The _canonical_ representation is the typed
-`SUPPORT_MATRIX` exported from `@intx/inference-discovery-catalog`
-(`packages/inference-discovery-catalog/src/support-matrix.ts`).
+`SUPPORT_MATRIX` exported from `@intx/inference-discovery/catalog`
+(`packages/inference-discovery/src/catalog/support-matrix.ts`).
 Tooling — the discovery rig, INTR-79's compat-replay layer, and any
 future readers — must consume the matrix programmatically, not parse
 this prose. When this document and the matrix disagree, the matrix
@@ -48,11 +49,10 @@ wins.
 
 ## Models in scope
 
-The five models in scope and their per-capability flags as recorded
-in `bin/opencode-discover/models.ts`:
-
-The `SUPPORT_MATRIX` from `@intx/inference-discovery-catalog` carries
-the same data in typed form.
+The five models in scope and the capability classes captured for
+each, derived from the `SUPPORT_MATRIX` export of
+`@intx/inference-discovery/catalog`
+(`packages/inference-discovery/src/catalog/support-matrix.ts`):
 
 | Model             | Vendor         | text | functionCalling | reasoning | vision |
 | ----------------- | -------------- | ---- | --------------- | --------- | ------ |
@@ -63,15 +63,15 @@ the same data in typed form.
 | `mimo-v2-omni`    | Xiaomi MiMo    | yes  | yes             | yes       | yes    |
 
 The `vision: false` entries for `glm-5.1` and `deepseek-v4-pro` are
-deliberate manual overrides on top of the auto-detected probe
-results, recorded in the comment block at the top of
-`bin/opencode-discover/models.ts`. `glm-5.1`'s probe returned HTTP
-200 but with a textual refusal ("Please provide an image so I can
+recorded in `SUPPORT_MATRIX` as deliberate non-captures: `glm-5.1`
+carries `outcome: "refused"` because the model's probe returned
+HTTP 200 with a textual refusal ("Please provide an image so I can
 describe it for you") rather than a real description, and
-`deepseek-v4-pro` returned HTTP 400 `invalid_request_error: unknown
-variant 'image_url'`. Both models are therefore excluded from the
-vision-input capture, and the capability module's early-return guard
-fires before any HTTP request is dispatched.
+`deepseek-v4-pro` carries `outcome: "http-error"` because
+submitting an OpenAI-style multimodal `messages[].content` array
+elicits HTTP 400 `invalid_request_error: unknown variant
+'image_url'`. The discover CLI filters non-captured entries out of
+its run set, so no HTTP request is dispatched for either pair.
 
 ## kimi-k2.6 (Moonshot)
 
@@ -252,13 +252,13 @@ non-streaming responses.
   identifiers (`frank/GLM-5.1` for non-streaming,
   `accounts/fireworks/models/glm-5p1` for streaming). The shape is
   the same, but the upstream-identifier metadata is not.
-- Per `bin/opencode-discover/models.ts`, vision is set to `false`
-  for `glm-5.1` because the model's probe returned an HTTP 200
-  textual refusal rather than describing the image. No vision
-  capture was attempted; the capability module's early-return guard
-  fires before any HTTP request is dispatched. No fixture under
-  `packages/inference-testing/wire/opencode-zen/glm-5.1/` exists for
-  vision-input.
+- The `SUPPORT_MATRIX` entry for `glm-5.1` vision-input carries
+  `outcome: "refused"` because the model's probe returned an HTTP
+  200 textual refusal rather than describing the image. The
+  discover CLI filters non-captured entries out of its run set, so
+  no HTTP request is dispatched. No fixture under
+  `packages/inference-testing/wire/opencode-zen/glm-5.1/` exists
+  for vision-input.
 
 ## deepseek-v4-pro (DeepSeek)
 
@@ -338,8 +338,8 @@ ends with `data: [DONE]\n\ndata: {"choices":[],"cost":"0"}`.
   value-is-non-null will misclassify DeepSeek's reasoning deltas.
 - `usage.prompt_cache_hit_tokens` and `prompt_cache_miss_tokens`
   are DeepSeek-specific fields not part of the OpenAI usage shape.
-- Per `bin/opencode-discover/models.ts`, vision is set to `false`
-  for `deepseek-v4-pro` because submitting an OpenAI-style
+- The `SUPPORT_MATRIX` entry for `deepseek-v4-pro` vision-input
+  carries `outcome: "http-error"` because submitting an OpenAI-style
   multimodal `messages[].content` array elicits an HTTP 400
   `invalid_request_error: "unknown variant 'image_url', expected
 'text'"`. The model's content path validates that user content
@@ -608,9 +608,10 @@ text on the way out, and consumers will not see content-parts
 arrays in the response. Image cost is reported in
 `usage.prompt_tokens_details.image_tokens` (or vendor-specific
 sibling fields). `glm-5.1` and `deepseek-v4-pro` are not
-vision-capable on this relay; the registry guard in
-`bin/opencode-discover/models.ts` prevents the capability module
-from attempting a capture against them.
+vision-capable on this relay; their `SUPPORT_MATRIX` entries for
+vision-input carry non-captured outcomes (`refused` and
+`http-error` respectively) and the discover CLI filters them out
+of its run set, so no capture is attempted against them.
 
 **Authentication is `Authorization: Bearer <key>`.** Every
 captured request carries this header; in the fixtures the value is

--- a/packages/inference-discovery-google-genai/README.md
+++ b/packages/inference-discovery-google-genai/README.md
@@ -1,0 +1,66 @@
+# @intx/inference-discovery-google-genai
+
+Google GenAI provider plug-in for the discovery rig. Captures
+Gemini wire responses across the capability matrix and writes them
+into the shared fixture corpus.
+
+See [`@intx/inference-discovery`](../inference-discovery/README.md)
+for the runtime, the plug-in contract, and the `discover` CLI.
+
+## Models
+
+- `gemini-2.5-flash` — text, vision, audio, video, document,
+  function calling (multi-turn and with-thinking), code execution,
+  grounding, and the files API. Streaming and non-streaming
+  variants of each.
+- `gemini-2.5-flash-image` — image output, streaming and
+  non-streaming.
+
+The full per-capability list is in `SUPPORT_MATRIX` in
+`@intx/inference-discovery/catalog`.
+
+## Usage
+
+```ts
+import { createGoogleGenaiPlugin } from "@intx/inference-discovery-google-genai";
+
+const plugin = createGoogleGenaiPlugin({ apiKey: process.env.GOOGLE_API_KEY });
+// Hand off to runCapture from @intx/inference-discovery.
+```
+
+In practice the `bin/discover.ts` CLI does this wiring for you;
+construct the plug-in directly only when writing tests or one-off
+scripts.
+
+## Environment
+
+| Variable         | Purpose                              |
+| ---------------- | ------------------------------------ |
+| `GOOGLE_API_KEY` | Sent as the `x-goog-api-key` header. |
+
+The key is redacted in captured fixtures.
+
+## Multi-step capabilities
+
+Two capability families drive multi-step exchanges before the
+runner writes the bundle:
+
+- **Files API** (`files-api-reference`,
+  `files-api-reference-streaming`) — the plug-in first uploads the
+  intent's media asset to the `generativelanguage` upload endpoint,
+  then uses the returned file URI and MIME type to construct the
+  generate-content body for the second step. Each step writes its
+  own `upload/` and `generate/` subdirectory under the run root.
+- **Multi-turn function calling**
+  (`function-calling-multi-turn`,
+  `function-calling-multi-turn-streaming`,
+  `function-calling-with-thinking`,
+  `function-calling-with-thinking-streaming`) — turn 1 is sent as
+  usual; the plug-in extracts the model's assistant content from
+  the parsed response, derives a tool follow-up from the intent's
+  `followUp` (or synthesises one from the intent's tools), and
+  sends a turn-2 body that echoes the assistant turn verbatim and
+  appends the tool response. Each turn writes its own `turn-1/` and
+  `turn-2/` subdirectory.
+
+All other capabilities are single-step.

--- a/packages/inference-discovery-openai/README.md
+++ b/packages/inference-discovery-openai/README.md
@@ -1,0 +1,76 @@
+# @intx/inference-discovery-openai
+
+OpenAI-protocol provider plug-in for the discovery rig. The package
+is organised in two layers:
+
+- `protocol/` — the OpenAI Chat Completions wire format. Auth
+  header construction, endpoint URL assembly, request-body builder,
+  and the multi-step iterator. Reusable across any relay that
+  speaks the OpenAI surface.
+- `deployments/` — concrete deployments built on the protocol
+  layer. Each deployment names a provider, lists its models,
+  declares its auth and redaction policy, and (where needed)
+  overrides reasoning extraction. Today the only deployment is
+  OpenCode Zen.
+
+See [`@intx/inference-discovery`](../inference-discovery/README.md)
+for the runtime, the plug-in contract, and the `discover` CLI.
+
+## OpenCode Zen
+
+OpenCode Zen is an OpenAI-compatible Chat Completions relay that
+fronts five upstream model providers (Moonshot, Z.AI, DeepSeek,
+Alibaba, Xiaomi MiMo) behind a single endpoint.
+
+```ts
+import { createOpencodeZenPlugin } from "@intx/inference-discovery-openai";
+
+const plugin = createOpencodeZenPlugin({
+  apiKey: process.env.OPENAI_API_KEY,
+  baseUrl: process.env.OPENAI_BASE_URL,
+});
+// Hand off to runCapture from @intx/inference-discovery.
+```
+
+Models: `kimi-k2.6`, `glm-5.1`, `deepseek-v4-pro`, `qwen3.6-plus`,
+`mimo-v2-omni`.
+
+For the per-model, per-capability behaviour observed at capture
+time — including the discrepancies between vendor documentation
+and the actual wire bytes — see
+[`docs/OPENCODE_DISCOVERY.md`](../../docs/OPENCODE_DISCOVERY.md).
+The matrix entries for this deployment live in `SUPPORT_MATRIX`;
+two vision entries are marked `refused` and `http-error` and so
+produce no fixtures.
+
+### Reasoning trace extraction
+
+OpenCode Zen routes `kimi-k2.6` between two upstream backends that
+emit reasoning content under different field paths. The deployment
+ships a reasoning extractor that probes the known paths and records
+which one held the non-empty value. For non-streaming reasoning
+captures the runner writes the result to `reasoning-trace.json`
+next to the response so a later routing change is detectable from
+the fixtures alone; streaming reasoning captures do not get the
+sidecar (the runner does not parse SSE bodies), and the routing
+signal lives in the captured event stream itself.
+
+### Environment
+
+| Variable          | Purpose                                                      |
+| ----------------- | ------------------------------------------------------------ |
+| `OPENAI_API_KEY`  | Sent as `Authorization: Bearer <key>`. Redacted in fixtures. |
+| `OPENAI_BASE_URL` | Relay base URL (e.g. `https://opencode.ai/zen/go/v1`).       |
+
+## Adding a new deployment
+
+A new OpenAI-compatible relay is a new file under `deployments/`
+that imports the protocol-layer helpers, declares the provider
+name + model list + redaction policy, and exports a factory that
+returns a plug-in for the runtime.
+
+Then register the new plug-in in `bin/discover.ts` and add its
+(model, capability) entries to `SUPPORT_MATRIX` in
+`@intx/inference-discovery/catalog`. Run `bun bin/discover.ts
+--provider <new-name> --all` against a funded account to produce
+the fixture corpus.

--- a/packages/inference-discovery/README.md
+++ b/packages/inference-discovery/README.md
@@ -1,0 +1,110 @@
+# @intx/inference-discovery
+
+The shared runtime for the inference discovery rig. Defines the
+provider plug-in contract, drives capture runs, and owns the
+capability catalog and support matrix that say which
+(provider, model, capability) tuples the rig knows how to record.
+
+The output of a discovery run is a fixture bundle on disk under
+`packages/inference-testing/wire/<provider>/<model>/<capability>/`,
+which `@intx/inference-testing` then replays in tests. This package
+does not perform the replay; it produces the bytes that the replay
+layer consumes.
+
+Discovery makes real, paid network calls to upstream model providers.
+It must never run in CI. The `assertNotCI` guard exported here aborts
+the process before any plug-in is constructed if the `CI` environment
+variable is set.
+
+## Surface
+
+The package exports two entry points:
+
+- `@intx/inference-discovery` — the runtime: plug-in contract,
+  capture runner, CLI parser, manifest builder, content-type
+  detection, CI guard, env validation, write-capture.
+- `@intx/inference-discovery/catalog` — the data: the `Capability`
+  enum, the `INTENTS` table, the `SUPPORT_MATRIX` listing every
+  (provider, model, capability) tuple the rig knows about, and the
+  `FixtureManifest` schema.
+
+## Driving one capture
+
+```ts
+import { runCapture } from "@intx/inference-discovery";
+import { INTENTS, getFixtureDir } from "@intx/inference-discovery/catalog";
+import { createSomeProviderPlugin } from "@intx/inference-discovery-some-provider";
+
+const plugin = createSomeProviderPlugin({ apiKey });
+
+await runCapture({
+  plugin,
+  model: "some-model",
+  capability: "plain-text",
+  intent: INTENTS["plain-text"],
+  outDir: getFixtureDir({
+    provider: plugin.name,
+    model: "some-model",
+    capability: "plain-text",
+    outcome: "captured",
+  }),
+});
+```
+
+`runCapture` walks the plug-in's capture-step generator, POSTs
+each step, detects SSE vs JSON by content-type, and writes four
+files into the step's subdirectory: `request.json` and
+`response.{json,sse}` carry the bodies verbatim, while
+`request-headers.json` and `response-headers.json` carry the
+headers with the plug-in's redaction lists applied. After the
+generator exhausts it writes `manifest.json` at the run root.
+
+Plug-ins that capture reasoning capabilities can opt into a
+`reasoning-trace.json` sidecar; the runner calls the plug-in's
+extractor and writes the result alongside the response.
+
+## Catalog
+
+`SUPPORT_MATRIX` is the canonical list of what the rig captures.
+Each entry carries an outcome of `captured`, `refused`,
+`http-error`, or `unsupported`. Only `captured` entries produce
+fixtures; the others are negative documentation recording why no
+fixture exists — a deliberate refusal, an observed upstream error,
+or a capability the provider does not implement (see the `glm-5.1`
+refusal and `deepseek-v4-pro` HTTP-error vision entries for
+examples).
+
+`INTENTS` maps each capability to the prompt, tools, follow-up
+turns, and media references the plug-in uses to assemble the
+request body. Intents are deliberately single-sentence and
+low-token so the captured responses stay focused on shape rather
+than substance.
+
+## The `discover` CLI
+
+`bin/discover.ts` at the repo root wires this package together with
+the provider plug-in packages and exposes them as a single command:
+
+```
+bun bin/discover.ts --provider <name> (--all | --model <name> | --only <capability>)
+```
+
+`--all` is mutually exclusive with `--model` and `--only`; at least
+one of the three must be present (an invocation with none errors
+out). Available providers and their required environment variables
+are listed by `bun bin/discover.ts --help`. The CLI calls
+`assertNotCI` first, validates the requested provider's environment
+variables via `requireEnvSet`, filters `SUPPORT_MATRIX` to the
+matching captured entries, and runs each through `runCapture`.
+
+Each invocation incurs per-request usage charges against the
+upstream provider; an `--all` run touches every (model, capability)
+pair in the matrix for the selected provider.
+
+## See also
+
+- [`docs/OPENCODE_DISCOVERY.md`](../../docs/OPENCODE_DISCOVERY.md) —
+  observed-vs-documented narrative for the OpenCode Zen relay, with
+  pointers into the captured corpus.
+- [`@intx/inference-testing`](../inference-testing/README.md) —
+  consumes the fixtures this rig produces.

--- a/packages/inference-discovery/src/catalog/support-matrix.ts
+++ b/packages/inference-discovery/src/catalog/support-matrix.ts
@@ -101,7 +101,7 @@ const MATRIX: SupportEntry[] = [
     capability: "vision-input",
     outcome: "refused",
     notes:
-      "Registry override in bin/opencode-discover/models.ts: probe returned HTTP 200 with the textual refusal 'Please provide an image so I can describe it for you' rather than a real image description, so the vision flag is forced to false and no capture is attempted.",
+      "Probe returned HTTP 200 with the textual refusal 'Please provide an image so I can describe it for you' rather than a real image description; recorded as 'refused' here so no capture is attempted.",
   },
   {
     provider: OPENCODE_PROVIDER,
@@ -109,7 +109,7 @@ const MATRIX: SupportEntry[] = [
     capability: "vision-input",
     outcome: "http-error",
     notes:
-      "OpenAI-style multimodal messages[].content elicits HTTP 400 invalid_request_error \"unknown variant 'image_url', expected 'text'\". Registry override in bin/opencode-discover/models.ts forces vision to false.",
+      "OpenAI-style multimodal messages[].content elicits HTTP 400 invalid_request_error \"unknown variant 'image_url', expected 'text'\"; recorded as 'http-error' here so no capture is attempted.",
   },
 ];
 


### PR DESCRIPTION
## Summary

- Adds package-level READMEs for the three discovery-rig packages: `@intx/inference-discovery`, `@intx/inference-discovery-google-genai`, `@intx/inference-discovery-openai`.
- Lists the three packages in `LAYOUT.md` under "Development and Testing" alongside `@intx/inference-testing`, which consumes the fixtures they produce.
- Adds a short "Inference discovery" section to the top-level `README.md` pointing at the package README and the existing `docs/OPENCODE_DISCOVERY.md` narrative.
- Refreshes `docs/OPENCODE_DISCOVERY.md` to use the current catalog package name (`@intx/inference-discovery/catalog`), the current catalog source path, and the current per-model registry mechanism (`SUPPORT_MATRIX` entries with typed `outcome` fields that the discover CLI filters on) — replacing references to the now-defunct `bin/opencode-discover/models.ts` and its surrounding prose.
- Rewrites the two `SUPPORT_MATRIX` vision-input override notes to describe the observed upstream behaviour directly, without pointing at the defunct registry file.

## Test plan

- [x] `make lint` clean
- [x] `make build` clean
- [x] Each commit builds individually
- [ ] Reviewer to spot-check that the README factual claims about plug-in contracts, the capture runner, and CLI semantics match the source code under `packages/inference-discovery*/src/` and `bin/discover.ts`

Closes INTR-113