### PR TITLE
Generalize the multimodal surface across types, testing, and adapters

### DIFF
--- a/docs/INFERENCE.md
+++ b/docs/INFERENCE.md
@@ -141,6 +141,7 @@ Transformations:
 - **Tool call ID normalization** — Provider ID formats vary (OpenAI Responses API generates 450+ character IDs with pipes; Anthropic has strict format requirements). IDs are normalized to a portable format with a bidirectional mapping for round-trip fidelity.
 - **Thinking block handling** — Encrypted/redacted reasoning blocks are valid only for the originating model. Stripped when replaying to a different provider.
 - **Thinking signature preservation** — Opaque signatures for multi-turn reasoning continuity are kept for same-model, dropped for cross-model.
+- **Citation block handling** — Citation blocks are server-emitted attribution metadata for content the model already produced; they are not part of the active conversation state subsequent turns need to make sense of, and not every provider's input wire shape accepts them. Dropped when serializing history to a target provider whose wire shape has no citation input; downstream consumers that need to preserve citation attribution across provider switches read the finalized turn's `content[]` directly rather than relying on echo-back through history.
 - **Orphaned tool call recovery** — Interrupted conversations show tool calls without results. Synthetic error results are injected so the target model sees a complete tool sequence.
 - **Incomplete turn filtering** — Error/aborted assistant messages are filtered during replay to prevent "reasoning without output" errors on the target model.
 

--- a/docs/INFERENCE.md
+++ b/docs/INFERENCE.md
@@ -127,10 +127,59 @@ The internal message format is provider-agnostic. Messages are converted to and 
 ### Content Types
 
 - **Text** — Plain text output
-- **Thinking** — Reasoning content with optional redaction and opaque signatures for multi-turn continuity
-- **Image** — Base64-encoded image data with MIME type
+- **Thinking** — Reasoning content with an optional cryptographic signature that providers (Anthropic) require echoed back on follow-up turns
+- **Redacted thinking** — Provider-filtered reasoning carrying an opaque `data` blob that must round-trip verbatim on follow-up turns
+- **Image** — Visual media carried via the `MediaSource` shape (see Generalized Multimodal Taxonomy)
+- **Audio** — Audio media via `MediaSource`; not all providers accept this as input
+- **Video** — Video media via `MediaSource`; not all providers accept this as input
+- **Document** — Document media (e.g. PDF) via `MediaSource`
+- **Citation** — Source attribution for an assistant text region, attributed to the nearest preceding TextBlock in the same turn
+- **Code execution request** — The model's request to execute code via a server-side tool
+- **Code execution result** — Result of a code execution request, paired by `requestId`
 - **Tool call** — Function invocation with name, ID, and arguments
 - **Tool result** — Execution result with content blocks, optional detail data, and error flag
+
+### Generalized Multimodal Taxonomy
+
+The content-block surface is shaped to absorb the multimodal capabilities of every provider in the catalog (OpenAI, Anthropic, Gemini, opencode-zen) without forcing each adapter to invent its own wire vocabulary. Three concepts hold this together:
+
+#### MediaSource
+
+Media-bearing blocks (`Image`, `Audio`, `Video`, `Document`) carry their payload through a shared `MediaSource` discriminated union, not a flat data field:
+
+- `base64` — inline payload with `mimeType` and `data` (the base64-encoded bytes).
+- `file-reference` — opaque provider-native handle (Anthropic `file_id`, Gemini `fileUri`) with `mimeType` for caller bookkeeping.
+
+The `mimeType` on `file-reference` is internal discipline: callers must know the content type even when the provider doesn't need it on the wire. Each adapter marshals the variant to its provider's documented shape — Anthropic's `{ type: "base64", media_type, data }` vs. `{ type: "file", file_id }`, OpenAI's `image_url` data URL, etc. `file-reference` handles are provider-scoped by construction: an Anthropic `file_id` is meaningless to OpenAI and adapters surface that constraint loudly rather than attempting cross-provider translation.
+
+#### Per-index block tracking
+
+A streaming response can interleave thinking, text, tool_use, and other blocks at distinct `content_block` indices. The harness keys block state by index in a `Map<number, BlockState>` discriminated by kind. Insertion order is preserved across all keys (JS Map semantic), so the finalized assistant turn reproduces the wire-arrival order of blocks regardless of their numeric values. Per-block state carries:
+
+- Per-thinking-block running text + signature (signatures attach to the right block by index even when they arrive after a subsequent block's deltas have started).
+- Per-tool-call markers anchoring tool_use position relative to text and thinking blocks; the tool-call state machine itself (callId → accumulator) lives separately so per-index ownership of ordering is cleanly separated from per-call ownership of arguments.
+
+Every delta event arriving at the harness must carry an `index`. Providers without a wire-level block index (OpenAI Chat Completions) synthesize one at the adapter boundary in arrival order — whichever kind streams first lands at 0, the other (if it appears) at 1. A missing index at the harness boundary surfaces as a `ProtocolMismatchError`.
+
+#### InferenceEvent variants
+
+The event protocol extensions that surface multimodal content:
+
+- `inference.citation` — emitted when a provider streams citation metadata attached to a text region.
+- `inference.thinking.redacted` — emitted when the provider delivers a redacted_thinking block (one-shot, no delta stream).
+- `inference.image_output` — emitted mid-stream when an adapter finalizes an image-output block, signaling that the image is ready for downstream handoff before the full `inference.done` lands.
+- `inference.code_execution.{start,delta,result}` — emitted when the model invokes a server-side code-execution tool; results pair to requests by `requestId`.
+
+All delta-flavoured events (`inference.text.delta`, `inference.thinking.delta`, `inference.thinking.signature`, `inference.tool_call.start`, `inference.tool_call.delta`) carry an optional `index` field. Presence of `index` means the provider modeled the block position explicitly; absence means a single-block guarantee from the wire (e.g., OpenAI Chat Completions today). Downstream consumers that care about per-block structure walk the finalized `inference.done` turn's `content[]`.
+
+#### Provider coverage
+
+The adapter retrofits land:
+
+- **Anthropic** — image input (base64 + file-reference), document input (base64 + file-reference), `redacted_thinking` round-trip (parser + builder), citation streaming (`citations_delta` to `inference.citation`), full per-index propagation on every delta.
+- **OpenAI** — image input via the `image_url` data-URL shape (base64); file-reference rejection with explicit messaging because Chat Completions only accepts data URLs and public URLs; document input deferred pending a captured fixture against the `file` content type; per-index `tool_calls[]` propagation namespaced into the same counter as text/thinking so a tool_call streamed before text doesn't collide with the later text block.
+
+The wire shapes for both adapters are exercised end-to-end via the compat-replay infrastructure (`packages/inference-testing/src/compat-replay.ts`), which walks the discovery `SUPPORT_MATRIX` and replays every captured fixture through the current adapter with the full Invariant list applied.
 
 ### Cross-Provider Message Transformation
 

--- a/packages/hub-sessions/src/event-collector.test.ts
+++ b/packages/hub-sessions/src/event-collector.test.ts
@@ -162,6 +162,55 @@ describe("EventCollector", () => {
     expect(at(parts, 4).values.type).toBe("step-finish");
   });
 
+  test("image content blocks insert a file part keyed by source kind", async () => {
+    await collector.onEvent(event("inference.start", 1, { model: "gpt-4" }));
+    await collector.onEvent(
+      event("inference.done", 5, {
+        turn: {
+          role: "assistant",
+          content: [
+            {
+              type: "image",
+              source: {
+                kind: "base64",
+                mimeType: "image/png",
+                data: "aGVsbG8=",
+              },
+            },
+            {
+              type: "image",
+              source: {
+                kind: "file-reference",
+                mimeType: "application/pdf",
+                reference: "file_abc123",
+              },
+            },
+          ],
+          model: "gpt-4",
+        },
+        usage: { input: 10, output: 5 },
+      }),
+    );
+
+    const parts = fakeDB.inserts.filter((i) => i.table === "turn_part");
+    // step-start + base64 file + file-reference file + step-finish = 4 parts
+    expect(parts).toHaveLength(4);
+
+    expect(at(parts, 1).values.type).toBe("file");
+    expect(at(parts, 1).values.metadata).toEqual({
+      kind: "base64",
+      mimeType: "image/png",
+      dataLength: 8,
+    });
+
+    expect(at(parts, 2).values.type).toBe("file");
+    expect(at(parts, 2).values.metadata).toEqual({
+      kind: "file-reference",
+      mimeType: "application/pdf",
+      reference: "file_abc123",
+    });
+  });
+
   test("tool.done inserts a tool result part", async () => {
     await collector.onEvent(event("inference.start", 1, { model: "gpt-4" }));
     await collector.onEvent(

--- a/packages/hub-sessions/src/event-collector.test.ts
+++ b/packages/hub-sessions/src/event-collector.test.ts
@@ -162,7 +162,7 @@ describe("EventCollector", () => {
     expect(at(parts, 4).values.type).toBe("step-finish");
   });
 
-  test("image content blocks insert a file part keyed by source kind", async () => {
+  test("media content blocks insert a file part keyed by source kind", async () => {
     await collector.onEvent(event("inference.start", 1, { model: "gpt-4" }));
     await collector.onEvent(
       event("inference.done", 5, {
@@ -185,6 +185,30 @@ describe("EventCollector", () => {
                 reference: "file_abc123",
               },
             },
+            {
+              type: "audio",
+              source: {
+                kind: "base64",
+                mimeType: "audio/wav",
+                data: "UklGRg==",
+              },
+            },
+            {
+              type: "video",
+              source: {
+                kind: "file-reference",
+                mimeType: "video/mp4",
+                reference: "file_video",
+              },
+            },
+            {
+              type: "document",
+              source: {
+                kind: "file-reference",
+                mimeType: "application/pdf",
+                reference: "file_report",
+              },
+            },
           ],
           model: "gpt-4",
         },
@@ -193,8 +217,8 @@ describe("EventCollector", () => {
     );
 
     const parts = fakeDB.inserts.filter((i) => i.table === "turn_part");
-    // step-start + base64 file + file-reference file + step-finish = 4 parts
-    expect(parts).toHaveLength(4);
+    // step-start + 5 media parts + step-finish = 7 parts
+    expect(parts).toHaveLength(7);
 
     expect(at(parts, 1).values.type).toBe("file");
     expect(at(parts, 1).values.metadata).toEqual({
@@ -208,6 +232,27 @@ describe("EventCollector", () => {
       kind: "file-reference",
       mimeType: "application/pdf",
       reference: "file_abc123",
+    });
+
+    expect(at(parts, 3).values.type).toBe("file");
+    expect(at(parts, 3).values.metadata).toEqual({
+      kind: "base64",
+      mimeType: "audio/wav",
+      dataLength: 8,
+    });
+
+    expect(at(parts, 4).values.type).toBe("file");
+    expect(at(parts, 4).values.metadata).toEqual({
+      kind: "file-reference",
+      mimeType: "video/mp4",
+      reference: "file_video",
+    });
+
+    expect(at(parts, 5).values.type).toBe("file");
+    expect(at(parts, 5).values.metadata).toEqual({
+      kind: "file-reference",
+      mimeType: "application/pdf",
+      reference: "file_report",
     });
   });
 

--- a/packages/hub-sessions/src/event-collector.ts
+++ b/packages/hub-sessions/src/event-collector.ts
@@ -250,12 +250,26 @@ export function createEventCollector(
           // Tool results in the content block are echoes of earlier
           // tool.done events. Skip to avoid duplication.
           break;
-        case "image":
-          await insertPart("file", null, {
-            mimeType: block.mimeType,
-            dataLength: block.data.length,
-          });
+        case "image": {
+          const source = block.source;
+          if (source.kind === "base64") {
+            await insertPart("file", null, {
+              kind: "base64",
+              mimeType: source.mimeType,
+              dataLength: source.data.length,
+            });
+          } else if (source.kind === "file-reference") {
+            await insertPart("file", null, {
+              kind: "file-reference",
+              mimeType: source.mimeType,
+              reference: source.reference,
+            });
+          } else {
+            source satisfies never;
+            throw new Error(`unreachable: unknown MediaSource kind`);
+          }
           break;
+        }
       }
     }
 

--- a/packages/hub-sessions/src/event-collector.ts
+++ b/packages/hub-sessions/src/event-collector.ts
@@ -250,6 +250,12 @@ export function createEventCollector(
           // Tool results in the content block are echoes of earlier
           // tool.done events. Skip to avoid duplication.
           break;
+        case "citation":
+          // Citations annotate model output by reference (URI or
+          // document index). Persistence semantics — whether the
+          // cited source warrants an audit row of its own — are not
+          // yet settled; skip until they are.
+          break;
         case "image":
         case "audio":
         case "video":

--- a/packages/hub-sessions/src/event-collector.ts
+++ b/packages/hub-sessions/src/event-collector.ts
@@ -236,6 +236,13 @@ export function createEventCollector(
         case "thinking":
           await insertPart("reasoning", block.thinking, null);
           break;
+        case "redacted_thinking":
+          // The opaque `data` blob is meaningless to humans and
+          // must be preserved verbatim for echo-back on follow-up
+          // turns; persisting it as a reasoning row would invite
+          // truncation or display. Skip and let the adapter layer
+          // own the round-trip.
+          break;
         case "tool_call":
           callNames.set(block.id, block.name);
           callArgs.set(block.id, block.arguments);

--- a/packages/hub-sessions/src/event-collector.ts
+++ b/packages/hub-sessions/src/event-collector.ts
@@ -256,6 +256,14 @@ export function createEventCollector(
           // cited source warrants an audit row of its own — are not
           // yet settled; skip until they are.
           break;
+        case "code_execution_request":
+        case "code_execution_result":
+          // Server-side code execution requests and results.
+          // Persistence semantics — whether the code and its output
+          // warrant audit rows of their own, and how to relate the
+          // pair through the requestId back-pointer — are not yet
+          // settled; skip until they are.
+          break;
         case "image":
         case "audio":
         case "video":

--- a/packages/hub-sessions/src/event-collector.ts
+++ b/packages/hub-sessions/src/event-collector.ts
@@ -250,7 +250,14 @@ export function createEventCollector(
           // Tool results in the content block are echoes of earlier
           // tool.done events. Skip to avoid duplication.
           break;
-        case "image": {
+        case "image":
+        case "audio":
+        case "video":
+        case "document": {
+          // All media block variants persist into the generic "file"
+          // part bucket. The block's own `type` distinguishes the
+          // semantic role; `mimeType` distinguishes the encoding; the
+          // MediaSource discriminant distinguishes inline vs reference.
           const source = block.source;
           if (source.kind === "base64") {
             await insertPart("file", null, {

--- a/packages/inference-testing/src/compat-replay.test.ts
+++ b/packages/inference-testing/src/compat-replay.test.ts
@@ -1,0 +1,109 @@
+import * as path from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { runCompatReplay } from "./compat-replay";
+
+// Workspace-relative fixture root. The compat-replay helper requires an
+// absolute path; tests resolve against the workspace root by walking up
+// from this file's location.
+const WORKSPACE_ROOT = path.resolve(__dirname, "../../..");
+const FIXTURE_ROOT = path.join(
+  WORKSPACE_ROOT,
+  "packages/inference-testing/wire",
+);
+
+describe("runCompatReplay — single-turn streaming SSE", () => {
+  test("opencode-zen/kimi-k2.6/plain-text-streaming: all invariants pass", async () => {
+    const fixtureDir = path.join(
+      FIXTURE_ROOT,
+      "opencode-zen/kimi-k2.6/plain-text-streaming",
+    );
+    const result = await runCompatReplay({
+      fixtureDir,
+      provider: "opencode-zen",
+      model: "kimi-k2.6",
+    });
+
+    if (result.kind !== "replayed") {
+      throw new Error(
+        `expected replay to complete, got skipped: ${result.reason}`,
+      );
+    }
+
+    // Surface every violation in the failure message so a regression is
+    // immediately debuggable. Empty-array equality alone gives no context.
+    expect(result.violations).toEqual([]);
+    if (result.violations.length > 0) {
+      throw new Error(
+        `compat-replay violations:\n${JSON.stringify(result.violations, null, 2)}`,
+      );
+    }
+
+    // Sanity: the replay produced events of the expected categories.
+    const textDeltas = result.events.filter(
+      (e) => e.type === "inference.text.delta",
+    );
+    const dones = result.events.filter((e) => e.type === "inference.done");
+    expect(textDeltas.length).toBeGreaterThan(0);
+    expect(dones).toHaveLength(1);
+  });
+});
+
+describe("runCompatReplay — skip behavior", () => {
+  test("skips with no_adapter_registered when the catalog provider has no mapped adapter", async () => {
+    // google-genai is not in CATALOG_TO_ADAPTER. The helper must skip
+    // rather than throw, so a full-corpus iteration continues past it
+    // without manual exclusion.
+    const fixtureDir = path.join(
+      FIXTURE_ROOT,
+      "google-genai/gemini-2.5-flash/plain-text-streaming",
+    );
+    const result = await runCompatReplay({
+      fixtureDir,
+      provider: "google-genai",
+      model: "gemini-2.5-flash",
+    });
+    expect(result).toEqual({
+      kind: "skipped",
+      reason: "no_adapter_registered",
+    });
+  });
+
+  test("skips with non_streaming_capture when only response.json exists", async () => {
+    // plain-text (non-streaming) carries response.json but no response.sse.
+    // Today's adapter consumes SSE only, so the capture is not replayable
+    // through the existing parser path. Skip rather than throw.
+    const fixtureDir = path.join(
+      FIXTURE_ROOT,
+      "opencode-zen/kimi-k2.6/plain-text",
+    );
+    const result = await runCompatReplay({
+      fixtureDir,
+      provider: "opencode-zen",
+      model: "kimi-k2.6",
+    });
+    expect(result).toEqual({
+      kind: "skipped",
+      reason: "non_streaming_capture",
+    });
+  });
+
+  test("throws when the fixture has neither response.sse nor response.json", async () => {
+    // Point at a directory that exists but contains neither response file
+    // (use the workspace root itself — definitely no response files there).
+    let thrown: unknown;
+    try {
+      await runCompatReplay({
+        fixtureDir: WORKSPACE_ROOT,
+        provider: "opencode-zen",
+        model: "kimi-k2.6",
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    if (!(thrown instanceof Error)) {
+      throw new Error("expected runCompatReplay to throw");
+    }
+    expect(thrown.message).toMatch(/fixture appears malformed/);
+  });
+});

--- a/packages/inference-testing/src/compat-replay.test.ts
+++ b/packages/inference-testing/src/compat-replay.test.ts
@@ -1,7 +1,12 @@
 import * as path from "node:path";
 import { describe, expect, test } from "bun:test";
 
-import { runCompatReplay } from "./compat-replay";
+import {
+  runCompatReplay,
+  runCompatReplayCorpus,
+  type CompatReplayCorpusResult,
+  type CompatReplaySkipReason,
+} from "./compat-replay";
 
 // Workspace-relative fixture root. The compat-replay helper requires an
 // absolute path; tests resolve against the workspace root by walking up
@@ -105,5 +110,85 @@ describe("runCompatReplay — skip behavior", () => {
       throw new Error("expected runCompatReplay to throw");
     }
     expect(thrown.message).toMatch(/fixture appears malformed/);
+  });
+});
+
+describe("runCompatReplayCorpus — full SUPPORT_MATRIX iteration", () => {
+  // Walk every captured row in the discovery support matrix through
+  // the replay pipeline. The corpus is the contract: each captured
+  // fixture must replay through the current adapter without
+  // producing invariant violations, OR skip with a structured
+  // reason that names why. A new invariant landing in INVARIANTS
+  // surfaces here as a failure across the whole corpus — exactly
+  // what the typed Invariant list was built for.
+  //
+  // Expected skip reasons:
+  //   - no_adapter_registered: google-genai rows (Gemini adapter not yet wired).
+  //   - non_streaming_capture: response.json-only captures (no SSE).
+  //   - raw_bytes_upload: files-api `upload/` subdirs carrying request.bin.
+  //   - non_captured_outcome: misled/refused/http-error/unsupported rows.
+  test("every captured leaf either replays clean or skips with a known reason", async () => {
+    const results = await runCompatReplayCorpus({
+      workspaceRoot: WORKSPACE_ROOT,
+    });
+
+    // Sanity: the corpus is non-empty (a future regression that
+    // empties SUPPORT_MATRIX would otherwise silently pass).
+    expect(results.length).toBeGreaterThan(0);
+
+    const ALLOWED_SKIP_REASONS: readonly CompatReplaySkipReason[] = [
+      "no_adapter_registered",
+      "non_streaming_capture",
+      "raw_bytes_upload",
+      "non_captured_outcome",
+    ];
+
+    const replayedWithViolations: CompatReplayCorpusResult[] = [];
+    const skippedUnknown: CompatReplayCorpusResult[] = [];
+
+    for (const result of results) {
+      if (result.kind === "skipped") {
+        if (!ALLOWED_SKIP_REASONS.includes(result.reason)) {
+          skippedUnknown.push(result);
+        }
+        continue;
+      }
+      if (result.violations.length > 0) {
+        replayedWithViolations.push(result);
+      }
+    }
+
+    if (skippedUnknown.length > 0) {
+      throw new Error(
+        `compat-replay corpus: unrecognized skip reasons:\n${skippedUnknown
+          .map(
+            (r) =>
+              `  ${r.entry.provider}/${r.entry.model}/${r.entry.capability}${r.subPath === "" ? "" : `/${r.subPath}`}: ${r.kind === "skipped" ? r.reason : "???"}`,
+          )
+          .join("\n")}`,
+      );
+    }
+
+    if (replayedWithViolations.length > 0) {
+      throw new Error(
+        `compat-replay corpus: ${String(replayedWithViolations.length)} captured replays produced invariant violations:\n${replayedWithViolations
+          .map(
+            (r) =>
+              `  ${r.entry.provider}/${r.entry.model}/${r.entry.capability}${r.subPath === "" ? "" : `/${r.subPath}`}: ${r.kind === "replayed" ? JSON.stringify(r.violations).slice(0, 200) : "???"}`,
+          )
+          .join("\n")}`,
+      );
+    }
+
+    // The corpus should include both real replays (anthropic +
+    // opencode-zen captured rows) and structured skips
+    // (google-genai, misled, etc.). A complete absence of either
+    // category would mean the catalog or the adapter wiring shifted
+    // in a way this suite isn't covering — surface that loudly
+    // rather than as a green pass.
+    const replayedCount = results.filter((r) => r.kind === "replayed").length;
+    const skippedCount = results.filter((r) => r.kind === "skipped").length;
+    expect(replayedCount).toBeGreaterThan(0);
+    expect(skippedCount).toBeGreaterThan(0);
   });
 });

--- a/packages/inference-testing/src/compat-replay.ts
+++ b/packages/inference-testing/src/compat-replay.ts
@@ -1,0 +1,228 @@
+// Compat-replay: drive a captured response through a registered provider
+// adapter and apply invariants over the resulting `InferenceEvent[]`.
+// Captured wire bytes are the fixed input; the event stream is recomputed
+// fresh on every run, so the only way a compat-replay test fails is a
+// code-side change.
+//
+// Scope today: single-turn streaming SSE captures only. The helper skips
+// non-streaming captures and providers without a registered adapter.
+// Multi-turn captures, raw-bytes uploads, and the full SUPPORT_MATRIX
+// iteration are extensions for which the necessary plumbing is not yet
+// in place.
+//
+// Replay fidelity caveats:
+//   - Real SSE arrives in many small TCP chunks; the stub fetch returns
+//     the captured bytes as a single chunk. Parser chunk-boundary bugs
+//     that depend on byte-level fragmentation will not be exercised here.
+//   - Status code is hard-coded to 200. When the manifest carries the
+//     captured status, the stub should switch to the replayed value so
+//     error-path parsers are exercised.
+
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+
+import {
+  createDefaultDependencies,
+  runInference,
+  type Dependencies,
+} from "@intx/inference";
+import type { InferenceEvent, InferenceSource } from "@intx/types/runtime";
+
+import {
+  INVARIANTS,
+  type Invariant,
+  type InvariantViolation,
+} from "./invariants";
+
+// Catalog provider name → registered adapter name. The catalog ("provider"
+// in SUPPORT_MATRIX) and the adapter registry ("provider" in
+// InferenceSource) use overlapping vocabularies for different concepts.
+// This map is the one place that translates from the former to the latter.
+const CATALOG_TO_ADAPTER: Record<string, string> = {
+  "opencode-zen": "openai-compatible",
+  anthropic: "anthropic",
+};
+
+export type CompatReplaySkipReason =
+  | "no_adapter_registered"
+  | "non_streaming_capture";
+
+export type CompatReplayResult =
+  | {
+      kind: "replayed";
+      events: InferenceEvent[];
+      violations: InvariantViolation[];
+    }
+  | { kind: "skipped"; reason: CompatReplaySkipReason };
+
+export type CompatReplayOpts = {
+  /**
+   * Absolute path to a fixture directory containing `request.json`,
+   * `response.sse` (or `response.json`), `response-headers.json`,
+   * `manifest.json`. Catalog-relative paths from `getFixtureDir` must
+   * be resolved by the caller via `path.resolve(workspaceRoot, …)`.
+   */
+  fixtureDir: string;
+  /** Catalog provider name (matches `SupportEntry.provider`). */
+  provider: string;
+  /** Model id (matches `SupportEntry.model`). */
+  model: string;
+  /** Invariants to apply. Defaults to the canonical `INVARIANTS` list. */
+  invariants?: readonly Invariant[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch (cause) {
+    // Only `ENOENT` means "the file is not there." Anything else
+    // (permission denied, IO error, EBUSY) is a real failure that the
+    // caller should see — silently treating EACCES as "missing"
+    // produces a misleading "fixture appears malformed" diagnostic when
+    // the real problem is a chmod.
+    const code =
+      cause !== null && typeof cause === "object" && "code" in cause
+        ? cause.code
+        : undefined;
+    if (code === "ENOENT") return false;
+    throw cause;
+  }
+}
+
+function headersFromRecord(record: Record<string, unknown>): Headers {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(record)) {
+    if (typeof value === "string") {
+      headers.set(key, value);
+    } else if (Array.isArray(value)) {
+      for (const v of value) {
+        if (typeof v === "string") headers.append(key, v);
+      }
+    }
+  }
+  return headers;
+}
+
+export async function runCompatReplay(
+  opts: CompatReplayOpts,
+): Promise<CompatReplayResult> {
+  // 1. Adapter lookup.
+  const adapterName = CATALOG_TO_ADAPTER[opts.provider];
+  if (adapterName === undefined) {
+    return { kind: "skipped", reason: "no_adapter_registered" };
+  }
+
+  // 2. Locate response files. SSE only is in-scope today; a fixture
+  //    that has neither is malformed and surfaces as a thrown error
+  //    rather than a silent skip (skip is for "we don't handle this
+  //    capability shape yet", not "the fixture is broken").
+  const ssePath = path.join(opts.fixtureDir, "response.sse");
+  const jsonPath = path.join(opts.fixtureDir, "response.json");
+  const sseExists = await fileExists(ssePath);
+  const jsonExists = await fileExists(jsonPath);
+  if (!sseExists && !jsonExists) {
+    throw new Error(
+      `compat-replay: ${opts.fixtureDir} has neither response.sse nor response.json — fixture appears malformed`,
+    );
+  }
+  if (!sseExists) {
+    return { kind: "skipped", reason: "non_streaming_capture" };
+  }
+
+  // 3. Load the SSE bytes and the captured response headers. A fixture
+  //    with a `response.sse` but no `response-headers.json` is the same
+  //    class of malformed-fixture problem as the missing-response check
+  //    above; surface symmetrically.
+  const sseBytes = await fs.readFile(ssePath);
+  const headersPath = path.join(opts.fixtureDir, "response-headers.json");
+  if (!(await fileExists(headersPath))) {
+    throw new Error(
+      `compat-replay: ${opts.fixtureDir} carries response.sse but no response-headers.json — fixture appears malformed`,
+    );
+  }
+  const headersJson = await fs.readFile(headersPath, "utf-8");
+  const parsedHeaders: unknown = JSON.parse(headersJson);
+  if (!isRecord(parsedHeaders)) {
+    throw new Error(
+      `compat-replay: ${headersPath} did not parse into a flat object`,
+    );
+  }
+  const headers = headersFromRecord(parsedHeaders);
+  // Force content-type to text/event-stream for SSE replay. Whatever the
+  // capture serialized — including buggy captures that wrote
+  // `application/json` against an SSE body — would otherwise let the
+  // adapter mis-classify the response. The file-existence gate above
+  // pinned this as a streaming capture; the header must match.
+  headers.set("content-type", "text/event-stream");
+
+  // 4. Synthetic source. `source.provider` is the lookup key the harness
+  //    uses against the adapter registry — that's the ADAPTER NAME, not
+  //    the catalog provider name.
+  const source: InferenceSource = {
+    id: `${opts.provider}:${opts.model}`,
+    provider: adapterName,
+    baseURL: "https://compat-replay.invalid",
+    apiKey: "compat-replay-stub",
+    model: opts.model,
+  };
+
+  // 5. Stub fetch — counts calls so a never-called or multi-called
+  //    adapter surfaces as a loud failure rather than silently passing.
+  let fetchCallCount = 0;
+  const defaults = createDefaultDependencies();
+  const deps: Dependencies = {
+    ...defaults,
+    fetch: (_input, _init) => {
+      fetchCallCount++;
+      return Promise.resolve(
+        new Response(sseBytes, {
+          status: 200,
+          headers,
+        }),
+      );
+    },
+  };
+
+  // 6. Run inference, collect events.
+  let seq = 0;
+  const events: InferenceEvent[] = [];
+  for await (const event of runInference({
+    turns: [
+      {
+        role: "user",
+        content: [{ type: "text", text: "x" }],
+        timestamp: 0,
+      },
+    ],
+    source,
+    nextSeq: () => ++seq,
+    deps,
+  })) {
+    events.push(event);
+  }
+
+  if (fetchCallCount === 0) {
+    throw new Error(
+      `compat-replay: adapter for ${opts.provider} did not call fetch; the replay window was never opened`,
+    );
+  }
+  if (fetchCallCount > 1) {
+    throw new Error(
+      `compat-replay: adapter for ${opts.provider} called fetch ${String(fetchCallCount)} times; single-turn replay only supports one call`,
+    );
+  }
+
+  // 7. Apply invariants.
+  const checks = opts.invariants ?? INVARIANTS;
+  const violations: InvariantViolation[] = [];
+  for (const invariant of checks) {
+    violations.push(...invariant.check(events));
+  }
+
+  return { kind: "replayed", events, violations };
+}

--- a/packages/inference-testing/src/compat-replay.ts
+++ b/packages/inference-testing/src/compat-replay.ts
@@ -26,6 +26,11 @@ import {
   runInference,
   type Dependencies,
 } from "@intx/inference";
+import {
+  SUPPORT_MATRIX,
+  getFixtureDir,
+  type SupportEntry,
+} from "@intx/inference-discovery/catalog";
 import type { InferenceEvent, InferenceSource } from "@intx/types/runtime";
 
 import {
@@ -45,7 +50,9 @@ const CATALOG_TO_ADAPTER: Record<string, string> = {
 
 export type CompatReplaySkipReason =
   | "no_adapter_registered"
-  | "non_streaming_capture";
+  | "non_streaming_capture"
+  | "raw_bytes_upload"
+  | "non_captured_outcome";
 
 export type CompatReplayResult =
   | {
@@ -225,4 +232,196 @@ export async function runCompatReplay(
   }
 
   return { kind: "replayed", events, violations };
+}
+
+// ---------------------------------------------------------------------------
+// Full-corpus iteration
+//
+// Walk every captured fixture in the discovery `SUPPORT_MATRIX` through
+// the same replay pipeline. Multi-turn captures live under
+// `<capability>/turn-1/`, `turn-2/`, …; files-api captures live under
+// `<capability>/upload/`, `generate/`, where the upload directory
+// carries `request.bin` (raw bytes) instead of `request.json` — those
+// are out of scope for the inference layer and skip with
+// `raw_bytes_upload`. Single-turn captures place `request.json`
+// directly in the capability directory.
+// ---------------------------------------------------------------------------
+
+/**
+ * A single replayable leaf within a capability's fixture tree.
+ * `fixtureDir` is the leaf directory carrying `request.json` +
+ * `response.sse` (or `response.json`); `subPath` is the relative
+ * path from the capability root, used in result reporting to
+ * distinguish multi-turn replays from each other.
+ */
+export type CompatReplayCorpusLeaf = {
+  entry: SupportEntry;
+  fixtureDir: string;
+  /** Relative path from the capability root ("" for single-turn). */
+  subPath: string;
+};
+
+/**
+ * Result for a single corpus leaf: either the replay outcome or a
+ * shaped reason for skipping. Aggregated across the full corpus by
+ * `runCompatReplayCorpus`.
+ */
+export type CompatReplayCorpusResult = CompatReplayCorpusLeaf &
+  (
+    | {
+        kind: "replayed";
+        events: InferenceEvent[];
+        violations: InvariantViolation[];
+      }
+    | { kind: "skipped"; reason: CompatReplaySkipReason }
+  );
+
+export type CompatReplayCorpusOpts = {
+  /**
+   * Absolute path of the workspace root. The catalog's
+   * `getFixtureDir` returns workspace-relative paths; this option
+   * resolves them.
+   */
+  workspaceRoot: string;
+  /** Invariants to apply to each replay. Defaults to canonical INVARIANTS. */
+  invariants?: readonly Invariant[];
+  /**
+   * Optional filter on support entries. Receives a candidate entry
+   * before any fixture-walking; return `false` to skip. Useful for
+   * narrowing the suite during development.
+   */
+  filter?: (entry: SupportEntry) => boolean;
+};
+
+async function findCapturedRequestDirs(
+  capabilityRoot: string,
+): Promise<{ subPath: string; rawBytesUpload: boolean }[]> {
+  // Walk the capability directory looking for leaves with either
+  // `request.json` or `request.bin`. Returns a sorted list (by
+  // subPath) so iteration is deterministic.
+  const leaves: { subPath: string; rawBytesUpload: boolean }[] = [];
+  async function walk(dir: string, subPath: string): Promise<void> {
+    let entries: string[];
+    try {
+      entries = await fs.readdir(dir);
+    } catch (cause) {
+      const code =
+        cause !== null && typeof cause === "object" && "code" in cause
+          ? cause.code
+          : undefined;
+      if (code === "ENOENT") return;
+      throw cause;
+    }
+    // Check if this directory is itself a leaf (contains a request
+    // file). If so, record it and don't descend further — leaves
+    // don't nest.
+    const hasRequestJson = entries.includes("request.json");
+    const hasRequestBin = entries.includes("request.bin");
+    if (hasRequestJson || hasRequestBin) {
+      leaves.push({
+        subPath,
+        rawBytesUpload: hasRequestBin && !hasRequestJson,
+      });
+      return;
+    }
+    // Otherwise, descend into subdirectories in sorted order for
+    // deterministic walk. Use stat to discriminate dirs from files.
+    const subdirs: string[] = [];
+    for (const name of entries.sort()) {
+      const stat = await fs.stat(path.join(dir, name));
+      if (stat.isDirectory()) subdirs.push(name);
+    }
+    for (const name of subdirs) {
+      const nextSubPath = subPath === "" ? name : `${subPath}/${name}`;
+      await walk(path.join(dir, name), nextSubPath);
+    }
+  }
+  await walk(capabilityRoot, "");
+  return leaves;
+}
+
+/**
+ * Iterate every captured leaf in the discovery SUPPORT_MATRIX
+ * through `runCompatReplay`. Returns a flat array of per-leaf
+ * results — each carrying either a replay outcome (events,
+ * violations) or a structured skip reason. Non-captured outcomes
+ * (`misled`, `refused`, etc.) are skipped with `non_captured_outcome`;
+ * providers without a registered adapter (currently `google-genai`)
+ * skip with `no_adapter_registered`; raw-bytes upload leaves
+ * (files-api `upload/`) skip with `raw_bytes_upload`; non-streaming
+ * captures (response.json only) skip with `non_streaming_capture`.
+ */
+export async function runCompatReplayCorpus(
+  opts: CompatReplayCorpusOpts,
+): Promise<CompatReplayCorpusResult[]> {
+  const results: CompatReplayCorpusResult[] = [];
+  for (const entry of SUPPORT_MATRIX) {
+    if (opts.filter && !opts.filter(entry)) continue;
+
+    if (entry.outcome !== "captured") {
+      results.push({
+        entry,
+        fixtureDir: "",
+        subPath: "",
+        kind: "skipped",
+        reason: "non_captured_outcome",
+      });
+      continue;
+    }
+
+    const relDir = getFixtureDir(entry);
+    if (relDir === null) {
+      // Outcome was "captured" so getFixtureDir should return a path;
+      // a null return here would mean the catalog and outcome model
+      // disagree. Surface as a thrown error so the catalog discrepancy
+      // is visible, not silently masked as a skip.
+      throw new Error(
+        `compat-replay corpus: captured entry has null fixture dir: ${entry.provider}/${entry.model}/${entry.capability}`,
+      );
+    }
+    const capabilityRoot = path.resolve(opts.workspaceRoot, relDir);
+    const leaves = await findCapturedRequestDirs(capabilityRoot);
+
+    for (const leaf of leaves) {
+      const fixtureDir = path.join(capabilityRoot, leaf.subPath);
+      if (leaf.rawBytesUpload) {
+        results.push({
+          entry,
+          fixtureDir,
+          subPath: leaf.subPath,
+          kind: "skipped",
+          reason: "raw_bytes_upload",
+        });
+        continue;
+      }
+      const runOpts: CompatReplayOpts = {
+        fixtureDir,
+        provider: entry.provider,
+        model: entry.model,
+        ...(opts.invariants !== undefined
+          ? { invariants: opts.invariants }
+          : {}),
+      };
+      const result = await runCompatReplay(runOpts);
+      if (result.kind === "skipped") {
+        results.push({
+          entry,
+          fixtureDir,
+          subPath: leaf.subPath,
+          kind: "skipped",
+          reason: result.reason,
+        });
+      } else {
+        results.push({
+          entry,
+          fixtureDir,
+          subPath: leaf.subPath,
+          kind: "replayed",
+          events: result.events,
+          violations: result.violations,
+        });
+      }
+    }
+  }
+  return results;
 }

--- a/packages/inference-testing/src/index.ts
+++ b/packages/inference-testing/src/index.ts
@@ -45,12 +45,27 @@ export type { UnmatchedFetchInfo, AmbiguousFetchInfo } from "./errors";
 
 export * as wire from "./wire";
 
-export { expectEvents, expectToolCalls, expectToolCall } from "./matchers";
+export {
+  expectEvents,
+  expectMediaBlock,
+  expectToolCalls,
+  expectToolCall,
+} from "./matchers";
 export type {
   EventAssertion,
   EventPartial,
   ToolCallsAssertion,
   ToolCallPartial,
   CollectedToolCall,
+  MediaBlock,
+  MediaBlockAssertion,
+  ExpectMediaBlockOpts,
   SingleToolCallAssertion,
 } from "./matchers";
+
+export { INVARIANTS, formatEventBrief } from "./invariants";
+export type {
+  Invariant,
+  InvariantViolation,
+  ReplayContext,
+} from "./invariants";

--- a/packages/inference-testing/src/index.ts
+++ b/packages/inference-testing/src/index.ts
@@ -69,3 +69,10 @@ export type {
   InvariantViolation,
   ReplayContext,
 } from "./invariants";
+
+export { runCompatReplay } from "./compat-replay";
+export type {
+  CompatReplayOpts,
+  CompatReplayResult,
+  CompatReplaySkipReason,
+} from "./compat-replay";

--- a/packages/inference-testing/src/invariants.test.ts
+++ b/packages/inference-testing/src/invariants.test.ts
@@ -1,0 +1,630 @@
+import { describe, test, expect } from "bun:test";
+
+import type {
+  ContentBlock,
+  InferenceEvent,
+  PartialMessage,
+  TokenUsage,
+} from "@intx/types/runtime";
+
+import { INVARIANTS, formatEventBrief, type Invariant } from "./invariants";
+
+const EMPTY_PARTIAL: PartialMessage = { text: "" };
+const ZERO_USAGE: TokenUsage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  thinking: 0,
+};
+
+function findInvariant(name: string): Invariant {
+  const found = INVARIANTS.find((inv) => inv.name === name);
+  if (found === undefined) throw new Error(`unknown invariant: ${name}`);
+  return found;
+}
+
+function startEvent(seq = 0): InferenceEvent {
+  return { type: "inference.start", seq, data: { model: "test" } };
+}
+
+function doneEvent(
+  seq: number,
+  content: ContentBlock[] = [],
+  usage: TokenUsage = ZERO_USAGE,
+): InferenceEvent {
+  return {
+    type: "inference.done",
+    seq,
+    data: {
+      turn: { role: "assistant", content, model: "test", timestamp: 0 },
+      usage,
+    },
+  };
+}
+
+function errorEvent(seq: number): InferenceEvent {
+  return {
+    type: "inference.error",
+    seq,
+    data: {
+      error: { category: "retryable", message: "x" },
+      partial: EMPTY_PARTIAL,
+    },
+  };
+}
+
+function usageEvent(seq: number, usage: TokenUsage): InferenceEvent {
+  return { type: "inference.usage", seq, data: { usage } };
+}
+
+function textDelta(seq: number, token: string, index?: number): InferenceEvent {
+  return {
+    type: "inference.text.delta",
+    seq,
+    data: {
+      token,
+      partial: EMPTY_PARTIAL,
+      ...(index !== undefined && { index }),
+    },
+  };
+}
+
+function thinkingDelta(
+  seq: number,
+  token: string,
+  index?: number,
+): InferenceEvent {
+  return {
+    type: "inference.thinking.delta",
+    seq,
+    data: {
+      token,
+      partial: EMPTY_PARTIAL,
+      ...(index !== undefined && { index }),
+    },
+  };
+}
+
+function thinkingSig(
+  seq: number,
+  signature: string,
+  index?: number,
+): InferenceEvent {
+  return {
+    type: "inference.thinking.signature",
+    seq,
+    data: { signature, ...(index !== undefined && { index }) },
+  };
+}
+
+function toolStart(
+  seq: number,
+  callId: string,
+  name: string,
+  index?: number,
+): InferenceEvent {
+  return {
+    type: "inference.tool_call.start",
+    seq,
+    data: {
+      callId,
+      name,
+      partial: EMPTY_PARTIAL,
+      ...(index !== undefined && { index }),
+    },
+  };
+}
+
+function toolEnd(
+  seq: number,
+  callId: string,
+  name: string,
+  args: Record<string, unknown>,
+  index?: number,
+): InferenceEvent {
+  return {
+    type: "inference.tool_call.end",
+    seq,
+    data: {
+      callId,
+      name,
+      arguments: args,
+      partial: EMPTY_PARTIAL,
+      ...(index !== undefined && { index }),
+    },
+  };
+}
+
+describe("INVARIANTS list — basic shape", () => {
+  test("exports a non-empty readonly array", () => {
+    expect(INVARIANTS.length).toBeGreaterThan(0);
+  });
+
+  test("each invariant has a unique name", () => {
+    const names = INVARIANTS.map((inv) => inv.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("schema_validity is first (foundational ordering)", () => {
+    expect(INVARIANTS[0]?.name).toBe("schema_validity");
+  });
+});
+
+describe("formatEventBrief — payload elision", () => {
+  test("elides long text-delta tokens", () => {
+    const long = "x".repeat(500);
+    const out = formatEventBrief(textDelta(0, long));
+    expect(out).not.toContain(long);
+    expect(out).toContain("<500 chars>");
+  });
+
+  test("never includes the raw redacted-thinking data blob", () => {
+    const blob = "EncryptedOpaqueBlob".repeat(100);
+    const event: InferenceEvent = {
+      type: "inference.thinking.redacted",
+      seq: 1,
+      data: { redactedThinking: { type: "redacted_thinking", data: blob } },
+    };
+    const out = formatEventBrief(event);
+    expect(out).not.toContain(blob);
+  });
+
+  test("never includes raw image base64 data in image_output", () => {
+    const blob = "A".repeat(2000);
+    const event: InferenceEvent = {
+      type: "inference.image_output",
+      seq: 1,
+      data: {
+        image: {
+          type: "image",
+          source: { kind: "base64", mimeType: "image/png", data: blob },
+        },
+      },
+    };
+    const out = formatEventBrief(event);
+    expect(out).not.toContain(blob);
+    expect(out).toContain("mime=image/png");
+  });
+
+  test("elides a long file-reference URI on image_output", () => {
+    // Signed URLs from provider file APIs can run long; the reference
+    // field must elide just like inline base64 does.
+    const longReference = `https://example.com/signed/${"a".repeat(500)}`;
+    const event: InferenceEvent = {
+      type: "inference.image_output",
+      seq: 1,
+      data: {
+        image: {
+          type: "image",
+          source: {
+            kind: "file-reference",
+            mimeType: "image/png",
+            reference: longReference,
+          },
+        },
+      },
+    };
+    const out = formatEventBrief(event);
+    expect(out).not.toContain(longReference);
+    expect(out).toContain("file-reference");
+  });
+
+  test("elides citedText on inference.citation", () => {
+    const long = "lorem ipsum ".repeat(50);
+    const event: InferenceEvent = {
+      type: "inference.citation",
+      seq: 1,
+      data: {
+        citation: {
+          type: "citation",
+          citedText: long,
+          source: { uri: "https://example.com/article" },
+        },
+      },
+    };
+    const out = formatEventBrief(event);
+    expect(out).not.toContain(long);
+    expect(out).toContain("citedText");
+  });
+
+  test("elides code on inference.code_execution.start", () => {
+    const longCode = "x = 1\n".repeat(100);
+    const event: InferenceEvent = {
+      type: "inference.code_execution.start",
+      seq: 1,
+      data: {
+        request: {
+          type: "code_execution_request",
+          id: "srvtoolu_01",
+          code: longCode,
+        },
+      },
+    };
+    const out = formatEventBrief(event);
+    expect(out).not.toContain(longCode);
+    expect(out).toContain("code:");
+  });
+
+  test("summarizes inference.code_execution.result without dumping stdout", () => {
+    const event: InferenceEvent = {
+      type: "inference.code_execution.result",
+      seq: 1,
+      data: {
+        result: {
+          type: "code_execution_result",
+          requestId: "srvtoolu_01",
+          status: "ok",
+          stdout: "x".repeat(1000),
+        },
+      },
+    };
+    const out = formatEventBrief(event);
+    expect(out).not.toContain("x".repeat(1000));
+    expect(out).toContain("srvtoolu_01");
+    expect(out).toContain("ok");
+  });
+});
+
+describe("schema_validity invariant", () => {
+  const inv = findInvariant("schema_validity");
+
+  test("passes on an empty array", () => {
+    expect(inv.check([])).toEqual([]);
+  });
+
+  test("passes on a well-formed sequence", () => {
+    expect(inv.check([startEvent(0), textDelta(1, "x"), doneEvent(2)])).toEqual(
+      [],
+    );
+  });
+
+  test("flags an event that fails arktype validation", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- modeling an adapter bug that produces a structurally-typed but runtime-invalid event (missing required `partial` field)
+    const bad = {
+      type: "inference.text.delta",
+      seq: 0,
+      data: { token: "x" },
+    } as unknown as InferenceEvent;
+    const violations = inv.check([bad]);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]?.invariant).toBe("schema_validity");
+  });
+});
+
+describe("tool_call_pairing invariant", () => {
+  const inv = findInvariant("tool_call_pairing");
+
+  test("passes on an empty array", () => {
+    expect(inv.check([])).toEqual([]);
+  });
+
+  test("passes when every start has a matching end", () => {
+    expect(
+      inv.check([
+        startEvent(0),
+        toolStart(1, "call_a", "search"),
+        toolEnd(2, "call_a", "search", { q: "x" }),
+        doneEvent(3),
+      ]),
+    ).toEqual([]);
+  });
+
+  test("flags a start without an end", () => {
+    const violations = inv.check([
+      toolStart(0, "call_orphan", "search"),
+      doneEvent(1),
+    ]);
+    expect(violations.some((v) => v.message.includes("call_orphan"))).toBe(
+      true,
+    );
+  });
+
+  test("flags an end without a start (orphan end)", () => {
+    const violations = inv.check([
+      toolEnd(0, "call_phantom", "search", {}),
+      doneEvent(1),
+    ]);
+    expect(
+      violations.some((v) =>
+        v.message.includes("no preceding tool_call.start"),
+      ),
+    ).toBe(true);
+  });
+
+  test("flags a duplicate tool_call.start for the same callId", () => {
+    // Two starts with the same callId is structurally invalid; the
+    // wire emits one start per call.
+    const violations = inv.check([
+      toolStart(0, "call_dup", "search"),
+      toolStart(1, "call_dup", "search"),
+      toolEnd(2, "call_dup", "search", {}),
+      doneEvent(3),
+    ]);
+    expect(
+      violations.some(
+        (v) =>
+          v.message.includes("call_dup") && v.message.includes("appears 2"),
+      ),
+    ).toBe(true);
+  });
+
+  test("flags a duplicate tool_call.end for the same callId", () => {
+    const violations = inv.check([
+      toolStart(0, "call_a", "search"),
+      toolEnd(1, "call_a", "search", {}),
+      toolEnd(2, "call_a", "search", {}),
+      doneEvent(3),
+    ]);
+    expect(
+      violations.some(
+        (v) =>
+          v.message.includes("tool_call.end") &&
+          v.message.includes("appears 2"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("terminal_exclusivity invariant", () => {
+  const inv = findInvariant("terminal_exclusivity");
+
+  test("flags an empty array as missing terminal", () => {
+    const violations = inv.check([]);
+    expect(
+      violations.some((v) => v.message.includes("no terminal event")),
+    ).toBe(true);
+  });
+
+  test("passes with exactly one inference.done", () => {
+    expect(inv.check([startEvent(0), doneEvent(1)])).toEqual([]);
+  });
+
+  test("passes with exactly one inference.error", () => {
+    expect(inv.check([startEvent(0), errorEvent(1)])).toEqual([]);
+  });
+
+  test("flags both done and error appearing", () => {
+    const violations = inv.check([startEvent(0), doneEvent(1), errorEvent(2)]);
+    expect(
+      violations.some((v) =>
+        v.message.includes("both inference.done and inference.error"),
+      ),
+    ).toBe(true);
+  });
+
+  test("flags multiple done events", () => {
+    const violations = inv.check([startEvent(0), doneEvent(1), doneEvent(2)]);
+    expect(
+      violations.some((v) => v.message.includes("multiple inference.done")),
+    ).toBe(true);
+  });
+});
+
+describe("usage_coherence_monotonic_non_decreasing invariant", () => {
+  const inv = findInvariant("usage_coherence_monotonic_non_decreasing");
+
+  test("passes on an empty array", () => {
+    expect(inv.check([])).toEqual([]);
+  });
+
+  test("passes on monotonically growing usage", () => {
+    expect(
+      inv.check([
+        usageEvent(0, { ...ZERO_USAGE, input: 10 }),
+        usageEvent(1, { ...ZERO_USAGE, input: 10, output: 5 }),
+        doneEvent(2, [], { ...ZERO_USAGE, input: 10, output: 12 }),
+      ]),
+    ).toEqual([]);
+  });
+
+  test("flags negative usage fields", () => {
+    const violations = inv.check([
+      usageEvent(0, { ...ZERO_USAGE, output: -1 }),
+    ]);
+    expect(violations.some((v) => v.message.includes("negative"))).toBe(true);
+  });
+
+  test("flags NaN usage", () => {
+    const violations = inv.check([
+      usageEvent(0, { ...ZERO_USAGE, input: NaN }),
+    ]);
+    expect(violations.some((v) => v.message.includes("not a finite"))).toBe(
+      true,
+    );
+  });
+
+  test("flags decreasing input across events", () => {
+    const violations = inv.check([
+      usageEvent(0, { ...ZERO_USAGE, input: 100 }),
+      usageEvent(1, { ...ZERO_USAGE, input: 50 }),
+    ]);
+    expect(violations.some((v) => v.message.includes("decreased"))).toBe(true);
+  });
+});
+
+describe("recognized_content_blocks invariant", () => {
+  const inv = findInvariant("recognized_content_blocks");
+
+  test("passes on an empty array", () => {
+    expect(inv.check([])).toEqual([]);
+  });
+
+  test("passes when all blocks have known types", () => {
+    expect(inv.check([doneEvent(0, [{ type: "text", text: "hi" }])])).toEqual(
+      [],
+    );
+  });
+
+  test("flags an unknown block type in inference.done content", () => {
+    const sneaky = { type: "fictional_block_type", text: "x" };
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- modeling an adapter bug that emits a content block whose type isn't part of the ContentBlock union
+    const event = {
+      type: "inference.done" as const,
+      seq: 0,
+      data: {
+        turn: {
+          role: "assistant" as const,
+          content: [sneaky],
+          model: "test",
+          timestamp: 0,
+        },
+        usage: ZERO_USAGE,
+      },
+    } as unknown as InferenceEvent;
+    const violations = inv.check([event]);
+    expect(
+      violations.some((v) => v.message.includes("fictional_block_type")),
+    ).toBe(true);
+  });
+});
+
+describe("tool_args_parse_as_json invariant", () => {
+  const inv = findInvariant("tool_args_parse_as_json");
+
+  test("passes on an empty array", () => {
+    expect(inv.check([])).toEqual([]);
+  });
+
+  test("passes on parsed arguments", () => {
+    expect(
+      inv.check([toolEnd(0, "call_a", "search", { q: "x" }), doneEvent(1)]),
+    ).toEqual([]);
+  });
+
+  test("flags arguments wrapped in _raw (unparseable)", () => {
+    const violations = inv.check([
+      toolEnd(0, "call_a", "search", { _raw: '{"unterminated' }),
+    ]);
+    expect(violations.some((v) => v.message.includes("_raw"))).toBe(true);
+  });
+});
+
+describe("redacted_thinking_data_non_empty invariant", () => {
+  const inv = findInvariant("redacted_thinking_data_non_empty");
+
+  test("passes on an empty array", () => {
+    expect(inv.check([])).toEqual([]);
+  });
+
+  test("passes when a thinking block has no signature (non-Anthropic providers)", () => {
+    // OpenCode-Zen / kimi emits reasoning_content thinking without a
+    // signature; the invariant deliberately does NOT flag this.
+    expect(
+      inv.check([doneEvent(0, [{ type: "thinking", thinking: "hmm" }])]),
+    ).toEqual([]);
+  });
+
+  test("passes when a redacted_thinking block has a non-empty data blob", () => {
+    expect(
+      inv.check([
+        doneEvent(0, [{ type: "redacted_thinking", data: "encrypted-blob" }]),
+      ]),
+    ).toEqual([]);
+  });
+
+  test("flags a redacted_thinking block with empty data", () => {
+    const violations = inv.check([
+      doneEvent(0, [{ type: "redacted_thinking", data: "" }]),
+    ]);
+    expect(violations.some((v) => v.message.includes("empty data"))).toBe(true);
+  });
+
+  test("flags an inference.thinking.redacted streaming event with empty data", () => {
+    // Streaming consumers subscribing to the event before the finalized
+    // turn arrives need the data populated even more than done consumers
+    // — an empty blob silently corrupts downstream state.
+    const event: InferenceEvent = {
+      type: "inference.thinking.redacted",
+      seq: 0,
+      data: { redactedThinking: { type: "redacted_thinking", data: "" } },
+    };
+    const violations = inv.check([event]);
+    expect(violations.some((v) => v.message.includes("empty data"))).toBe(true);
+  });
+});
+
+describe("index_density invariant", () => {
+  const inv = findInvariant("index_density");
+
+  test("passes on an empty array", () => {
+    expect(inv.check([])).toEqual([]);
+  });
+
+  test("passes when no events use index (single-block scenario)", () => {
+    expect(inv.check([textDelta(0, "Hello"), textDelta(1, " world")])).toEqual(
+      [],
+    );
+  });
+
+  test("passes when indices are dense from 0", () => {
+    expect(
+      inv.check([
+        textDelta(0, "first", 0),
+        textDelta(1, "second", 1),
+        textDelta(2, "third", 2),
+      ]),
+    ).toEqual([]);
+  });
+
+  test("flags mixed-mode (some events with index, some without)", () => {
+    const violations = inv.check([
+      textDelta(0, "first", 0),
+      textDelta(1, "second"), // no index
+    ]);
+    expect(violations.some((v) => v.message.includes("mixes"))).toBe(true);
+  });
+
+  test("flags non-dense indices (gap)", () => {
+    const violations = inv.check([
+      textDelta(0, "first", 0),
+      textDelta(1, "third", 2), // skips 1
+    ]);
+    expect(violations.some((v) => v.message.includes("not dense"))).toBe(true);
+  });
+
+  test("separately clusters by tool callId", () => {
+    // Each tool call is its own cluster, so each carrying index 0 is fine.
+    expect(
+      inv.check([
+        toolStart(0, "call_a", "f", 0),
+        toolEnd(1, "call_a", "f", {}, 0),
+        toolStart(2, "call_b", "g", 0),
+        toolEnd(3, "call_b", "g", {}, 0),
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("signature_precedence invariant", () => {
+  const inv = findInvariant("signature_precedence");
+
+  test("passes on an empty array", () => {
+    expect(inv.check([])).toEqual([]);
+  });
+
+  test("passes when a signature follows a delta with the same index", () => {
+    expect(
+      inv.check([thinkingDelta(0, "thought", 0), thinkingSig(1, "sig_xyz", 0)]),
+    ).toEqual([]);
+  });
+
+  test("passes when single-block (no index) ordering holds", () => {
+    expect(
+      inv.check([thinkingDelta(0, "thought"), thinkingSig(1, "sig_xyz")]),
+    ).toEqual([]);
+  });
+
+  test("flags a signature with no preceding delta at the same index", () => {
+    const violations = inv.check([
+      thinkingDelta(0, "thought-for-block-0", 0),
+      // signature is for block 1, but no delta at index 1 precedes it
+      thinkingSig(1, "sig_for_block_1", 1),
+    ]);
+    expect(
+      violations.some((v) =>
+        v.message.includes("no preceding inference.thinking.delta"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/inference-testing/src/invariants.ts
+++ b/packages/inference-testing/src/invariants.ts
@@ -1,0 +1,568 @@
+// Invariant checks over a computed `InferenceEvent[]` produced by replaying
+// a captured fixture through `runInference`. Each invariant is a property
+// that must hold for any well-formed call, regardless of provider; the
+// compat-replay layer applies the full list uniformly.
+//
+// Invariants are ordered foundational-first: schema validity comes before
+// everything else, since the higher-level checks build on the assumption
+// that events parse cleanly. A failing schema check usually makes the
+// downstream invariants noise built on garbage.
+
+import { type } from "arktype";
+
+import { parseInferenceEvent, type InferenceEvent } from "@intx/types/runtime";
+
+/**
+ * Per-replay context an invariant may consult. Empty today; expand with
+ * additional fields (original request payload, declared tool list, etc.)
+ * when an invariant needs information beyond the event stream itself.
+ *
+ * Adding optional fields is backward compatible; check signatures take it
+ * as `context?: ReplayContext` so today's callers don't pass it.
+ */
+export type ReplayContext = Record<string, never>;
+
+/**
+ * A single failure surfaced by an invariant. The `message` is a one-line
+ * human-readable summary; `events` lists the indices into the original
+ * array that the violation refers to, so a caller can quote them through
+ * `formatEventBrief` for richer context without forcing every invariant
+ * to format its own.
+ */
+export type InvariantViolation = {
+  invariant: string;
+  message: string;
+  events: number[];
+};
+
+/**
+ * A property check over a computed `InferenceEvent[]`. Returns an array
+ * of violations (empty when the property holds). Implementations should
+ * surface every violation they find, not stop at the first, so a single
+ * compat-replay pass reveals everything wrong with a fixture rather than
+ * forcing fix-and-rerun cycles.
+ */
+export type Invariant = {
+  name: string;
+  check(
+    events: readonly InferenceEvent[],
+    context?: ReplayContext,
+  ): InvariantViolation[];
+};
+
+// ---------------------------------------------------------------------------
+// Event formatting — elided to prevent payload leaks in violation messages
+// ---------------------------------------------------------------------------
+
+const BYTES_FIELD_THRESHOLD = 64;
+
+function abbreviateString(
+  value: string,
+  limit = BYTES_FIELD_THRESHOLD,
+): string {
+  if (value.length <= limit) return JSON.stringify(value);
+  return `<${String(value.length)} chars>`;
+}
+
+/**
+ * Format an event for inclusion in a violation message. Elides large
+ * string fields (text/thinking tokens, redacted-thinking data blobs,
+ * code fragments, image base64) with a `<N chars>` placeholder so an
+ * invariant that fires on a megabyte-scale `inference.image_output`
+ * doesn't dump the payload into test logs.
+ *
+ * Output shape: `inference.text.delta[seq=12] { token: "Hello" }`.
+ */
+export function formatEventBrief(event: InferenceEvent): string {
+  const head = `${event.type}[seq=${String(event.seq)}]`;
+  switch (event.type) {
+    case "inference.text.delta":
+    case "inference.thinking.delta":
+      return `${head} { token: ${abbreviateString(event.data.token)} }`;
+    case "inference.thinking.signature":
+      return `${head} { signature: ${abbreviateString(event.data.signature)} }`;
+    case "inference.thinking.redacted":
+      return `${head} { redactedThinking: <${String(event.data.redactedThinking.data.length)} chars> }`;
+    case "inference.code_execution.start":
+      return `${head} { request: { id: ${JSON.stringify(event.data.request.id)}, code: ${abbreviateString(event.data.request.code)} } }`;
+    case "inference.code_execution.delta":
+      return `${head} { requestId: ${JSON.stringify(event.data.requestId)}, codeFragment: ${abbreviateString(event.data.codeFragment)} }`;
+    case "inference.code_execution.result":
+      return `${head} { result: { requestId: ${JSON.stringify(event.data.result.requestId)}, status: ${JSON.stringify(event.data.result.status)} } }`;
+    case "inference.image_output": {
+      const src = event.data.image.source;
+      // file-reference URIs can be signed URLs or other large opaque
+      // handles; abbreviate them with the same threshold the rest of
+      // the helper uses for string fields rather than dump them verbatim.
+      const summary =
+        src.kind === "base64"
+          ? `base64 mime=${src.mimeType} <${String(src.data.length)} chars>`
+          : `file-reference mime=${src.mimeType} reference=${abbreviateString(src.reference)}`;
+      return `${head} { image: ${summary} }`;
+    }
+    case "inference.citation":
+      return `${head} { citation: { citedText: ${abbreviateString(event.data.citation.citedText)} } }`;
+    case "inference.tool_call.start":
+      return `${head} { callId: ${JSON.stringify(event.data.callId)}, name: ${JSON.stringify(event.data.name)} }`;
+    case "inference.tool_call.delta":
+      return `${head} { callId: ${JSON.stringify(event.data.callId)}, argumentFragment: ${abbreviateString(event.data.argumentFragment)} }`;
+    case "inference.tool_call.end":
+      return `${head} { callId: ${JSON.stringify(event.data.callId)}, name: ${JSON.stringify(event.data.name)} }`;
+    default:
+      return head;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// clusterKeyFor — groups events for the index-density check
+//
+// "Block-type cluster" is the set of events that route to the same logical
+// content block. Different content kinds get separate clusters; tool calls
+// are correlated by `callId` since the wire emits one block per call but
+// each call's deltas should land contiguously.
+// ---------------------------------------------------------------------------
+
+function clusterKeyFor(event: InferenceEvent): string | null {
+  switch (event.type) {
+    case "inference.text.delta":
+      return "text";
+    case "inference.thinking.delta":
+    case "inference.thinking.signature":
+    case "inference.thinking.redacted":
+      return "thinking";
+    case "inference.tool_call.start":
+    case "inference.tool_call.delta":
+    case "inference.tool_call.end":
+      return `tool_call:${event.data.callId}`;
+    default:
+      return null;
+  }
+}
+
+function eventIndex(event: InferenceEvent): number | undefined {
+  switch (event.type) {
+    case "inference.text.delta":
+    case "inference.thinking.delta":
+    case "inference.thinking.signature":
+    case "inference.thinking.redacted":
+    case "inference.tool_call.start":
+    case "inference.tool_call.delta":
+    case "inference.tool_call.end":
+      return event.data.index;
+    default:
+      return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Individual invariants
+// ---------------------------------------------------------------------------
+
+const schemaValidity: Invariant = {
+  name: "schema_validity",
+  check(events) {
+    const violations: InvariantViolation[] = [];
+    events.forEach((event, idx) => {
+      const result = parseInferenceEvent(event);
+      if (result instanceof type.errors) {
+        violations.push({
+          invariant: "schema_validity",
+          message: `event at index ${String(idx)} (${formatEventBrief(event)}) failed arktype validation: ${result.summary}`,
+          events: [idx],
+        });
+      }
+    });
+    return violations;
+  },
+};
+
+const toolCallPairing: Invariant = {
+  name: "tool_call_pairing",
+  check(events) {
+    // Track every start and end per callId rather than a single Map
+    // entry. A Map<callId, idx> silently overwrites duplicates, so two
+    // starts with the same callId followed by one end would look like a
+    // clean pair — but the wire shape (one start + one end per call)
+    // makes a duplicate start a real protocol-level bug worth flagging.
+    const startsByCallId = new Map<string, number[]>();
+    const endsByCallId = new Map<string, number[]>();
+    events.forEach((event, idx) => {
+      if (event.type === "inference.tool_call.start") {
+        const list = startsByCallId.get(event.data.callId) ?? [];
+        list.push(idx);
+        startsByCallId.set(event.data.callId, list);
+      } else if (event.type === "inference.tool_call.end") {
+        const list = endsByCallId.get(event.data.callId) ?? [];
+        list.push(idx);
+        endsByCallId.set(event.data.callId, list);
+      }
+    });
+    const violations: InvariantViolation[] = [];
+    for (const [callId, startIdxs] of startsByCallId) {
+      if (startIdxs.length > 1) {
+        violations.push({
+          invariant: "tool_call_pairing",
+          message: `tool_call.start for callId=${JSON.stringify(callId)} appears ${String(startIdxs.length)} times; the wire emits one start per call`,
+          events: startIdxs,
+        });
+      }
+      if (!endsByCallId.has(callId)) {
+        const firstStart = startIdxs[0] ?? -1;
+        violations.push({
+          invariant: "tool_call_pairing",
+          message: `tool_call.start for callId=${JSON.stringify(callId)} has no matching tool_call.end`,
+          events: firstStart >= 0 ? [firstStart] : [],
+        });
+      }
+    }
+    for (const [callId, endIdxs] of endsByCallId) {
+      if (endIdxs.length > 1) {
+        violations.push({
+          invariant: "tool_call_pairing",
+          message: `tool_call.end for callId=${JSON.stringify(callId)} appears ${String(endIdxs.length)} times; the wire emits one end per call`,
+          events: endIdxs,
+        });
+      }
+      if (!startsByCallId.has(callId)) {
+        const firstEnd = endIdxs[0] ?? -1;
+        violations.push({
+          invariant: "tool_call_pairing",
+          message: `tool_call.end for callId=${JSON.stringify(callId)} has no preceding tool_call.start`,
+          events: firstEnd >= 0 ? [firstEnd] : [],
+        });
+      }
+    }
+    return violations;
+  },
+};
+
+const terminalExclusivity: Invariant = {
+  name: "terminal_exclusivity",
+  check(events) {
+    const doneIndices: number[] = [];
+    const errorIndices: number[] = [];
+    events.forEach((event, idx) => {
+      if (event.type === "inference.done") doneIndices.push(idx);
+      else if (event.type === "inference.error") errorIndices.push(idx);
+    });
+    const violations: InvariantViolation[] = [];
+    if (doneIndices.length === 0 && errorIndices.length === 0) {
+      violations.push({
+        invariant: "terminal_exclusivity",
+        message:
+          "no terminal event: stream lacks both inference.done and inference.error",
+        events: [],
+      });
+    }
+    if (doneIndices.length > 0 && errorIndices.length > 0) {
+      violations.push({
+        invariant: "terminal_exclusivity",
+        message: `stream carries both inference.done and inference.error: done@${String(doneIndices[0])}, error@${String(errorIndices[0])}`,
+        events: [doneIndices[0] ?? -1, errorIndices[0] ?? -1].filter(
+          (n) => n >= 0,
+        ),
+      });
+    }
+    if (doneIndices.length > 1) {
+      violations.push({
+        invariant: "terminal_exclusivity",
+        message: `multiple inference.done events: ${String(doneIndices.length)} occurrences`,
+        events: doneIndices,
+      });
+    }
+    if (errorIndices.length > 1) {
+      violations.push({
+        invariant: "terminal_exclusivity",
+        message: `multiple inference.error events: ${String(errorIndices.length)} occurrences`,
+        events: errorIndices,
+      });
+    }
+    return violations;
+  },
+};
+
+const usageCoherence: Invariant = {
+  // Assumes cumulative usage semantics — both head (early) and tail
+  // (terminal) usage events report running totals, not deltas. Providers
+  // that emit deltas would fail this check; if such a provider lands,
+  // surface the discrepancy and update the invariant rather than silently
+  // accommodate.
+  name: "usage_coherence_monotonic_non_decreasing",
+  check(events) {
+    const violations: InvariantViolation[] = [];
+    let prevInput: number | undefined;
+    let prevOutput: number | undefined;
+    let prevCacheRead: number | undefined;
+    let prevCacheWrite: number | undefined;
+
+    events.forEach((event, idx) => {
+      const usage =
+        event.type === "inference.usage"
+          ? event.data.usage
+          : event.type === "inference.done"
+            ? event.data.usage
+            : null;
+      if (usage === null) return;
+      const fields = [
+        ["input", usage.input],
+        ["output", usage.output],
+        ["cacheRead", usage.cacheRead],
+        ["cacheWrite", usage.cacheWrite],
+        ["thinking", usage.thinking],
+      ] as const;
+      for (const [field, value] of fields) {
+        if (typeof value !== "number") continue;
+        if (!Number.isFinite(value) || Number.isNaN(value)) {
+          violations.push({
+            invariant: "usage_coherence_monotonic_non_decreasing",
+            message: `usage.${field} is not a finite number at index ${String(idx)}: ${String(value)}`,
+            events: [idx],
+          });
+        }
+        if (value < 0) {
+          violations.push({
+            invariant: "usage_coherence_monotonic_non_decreasing",
+            message: `usage.${field} is negative at index ${String(idx)}: ${String(value)}`,
+            events: [idx],
+          });
+        }
+      }
+      const checkMonotone = (
+        name: string,
+        prev: number | undefined,
+        next: number,
+      ): void => {
+        if (prev !== undefined && next < prev) {
+          violations.push({
+            invariant: "usage_coherence_monotonic_non_decreasing",
+            message: `usage.${name} decreased from ${String(prev)} to ${String(next)} at index ${String(idx)} (expected cumulative non-decreasing)`,
+            events: [idx],
+          });
+        }
+      };
+      checkMonotone("input", prevInput, usage.input);
+      checkMonotone("output", prevOutput, usage.output);
+      if (usage.cacheRead !== undefined) {
+        checkMonotone("cacheRead", prevCacheRead, usage.cacheRead);
+        prevCacheRead = usage.cacheRead;
+      }
+      if (usage.cacheWrite !== undefined) {
+        checkMonotone("cacheWrite", prevCacheWrite, usage.cacheWrite);
+        prevCacheWrite = usage.cacheWrite;
+      }
+      prevInput = usage.input;
+      prevOutput = usage.output;
+    });
+
+    return violations;
+  },
+};
+
+const recognizedContentBlocks: Invariant = {
+  name: "recognized_content_blocks",
+  check(events) {
+    // Known ContentBlock type discriminants. Keep this list in sync with
+    // ContentBlock's union in `packages/types/src/runtime.ts`.
+    const known = new Set([
+      "text",
+      "thinking",
+      "redacted_thinking",
+      "image",
+      "audio",
+      "video",
+      "document",
+      "citation",
+      "code_execution_request",
+      "code_execution_result",
+      "tool_call",
+      "tool_result",
+    ]);
+    const violations: InvariantViolation[] = [];
+    events.forEach((event, idx) => {
+      if (event.type !== "inference.done") return;
+      event.data.turn.content.forEach((block, bi) => {
+        if (!known.has(block.type)) {
+          violations.push({
+            invariant: "recognized_content_blocks",
+            message: `inference.done at index ${String(idx)} carries unrecognized content block type "${block.type}" at content[${String(bi)}]`,
+            events: [idx],
+          });
+        }
+      });
+    });
+    return violations;
+  },
+};
+
+const toolArgsJson: Invariant = {
+  name: "tool_args_parse_as_json",
+  check(events) {
+    const violations: InvariantViolation[] = [];
+    events.forEach((event, idx) => {
+      if (event.type !== "inference.tool_call.end") return;
+      // The end event carries `arguments` as already-parsed Record. The
+      // wire path that produces it goes through JSON.parse on the
+      // accumulated argument fragments; if that fails the adapter
+      // typically falls back to `{ _raw: <buffer> }` and surfaces the
+      // failure here. Treat presence of `_raw` as the failure marker.
+      if ("_raw" in event.data.arguments) {
+        violations.push({
+          invariant: "tool_args_parse_as_json",
+          message: `tool_call.end at index ${String(idx)} (callId=${JSON.stringify(event.data.callId)}) carries unparseable arguments wrapped in _raw`,
+          events: [idx],
+        });
+      }
+    });
+    return violations;
+  },
+};
+
+const redactedThinkingDataNonEmpty: Invariant = {
+  // A redacted_thinking block whose `data` is empty is meaningless on
+  // every wire — providers that emit redacted_thinking carry an opaque
+  // payload because that payload is what the next turn must echo back
+  // verbatim. An empty data field would round-trip as if there were no
+  // redacted thinking at all, which silently corrupts the conversation.
+  //
+  // The signature-presence check on regular thinking blocks is
+  // intentionally NOT part of this invariant: it is Anthropic-specific
+  // (only Anthropic's extended-thinking surface emits signatures), and
+  // applying it to providers like OpenCode-Zen — whose reasoning
+  // content arrives via `reasoning_content` without any signature
+  // concept — would flag every cross-provider thinking turn. When
+  // ReplayContext carries the source provider, a per-provider
+  // signature-required check can land alongside.
+  name: "redacted_thinking_data_non_empty",
+  check(events) {
+    const violations: InvariantViolation[] = [];
+    events.forEach((event, idx) => {
+      if (event.type === "inference.done") {
+        event.data.turn.content.forEach((block, bi) => {
+          if (block.type === "redacted_thinking" && block.data.length === 0) {
+            violations.push({
+              invariant: "redacted_thinking_data_non_empty",
+              message: `inference.done at index ${String(idx)} content[${String(bi)}] is a redacted_thinking block with an empty data blob`,
+              events: [idx],
+            });
+          }
+        });
+      } else if (event.type === "inference.thinking.redacted") {
+        // Streaming variant: an empty data blob here corrupts downstream
+        // consumers that subscribe to the streaming event before the
+        // finalized turn arrives.
+        if (event.data.redactedThinking.data.length === 0) {
+          violations.push({
+            invariant: "redacted_thinking_data_non_empty",
+            message: `inference.thinking.redacted at index ${String(idx)} carries an empty data blob`,
+            events: [idx],
+          });
+        }
+      }
+    });
+    return violations;
+  },
+};
+
+const indexDensity: Invariant = {
+  // For each block-type cluster, if any event in the cluster carries an
+  // `index`, all events in that cluster must carry one and the index set
+  // must be dense from 0 (no gaps). Streams that omit `index` entirely
+  // are legal (single-block scenarios) and skip the check for that
+  // cluster.
+  name: "index_density",
+  check(events) {
+    const clusters = new Map<
+      string,
+      { withIndex: Set<number>; missingIndexAt: number[] }
+    >();
+    events.forEach((event, idx) => {
+      const cluster = clusterKeyFor(event);
+      if (cluster === null) return;
+      const eIdx = eventIndex(event);
+      const entry = clusters.get(cluster) ?? {
+        withIndex: new Set<number>(),
+        missingIndexAt: [],
+      };
+      if (eIdx === undefined) {
+        entry.missingIndexAt.push(idx);
+      } else {
+        entry.withIndex.add(eIdx);
+      }
+      clusters.set(cluster, entry);
+    });
+    const violations: InvariantViolation[] = [];
+    for (const [cluster, entry] of clusters) {
+      if (entry.withIndex.size === 0) continue; // no indices used in this cluster
+      // Some events carry index, others don't — mixed-mode failure.
+      if (entry.missingIndexAt.length > 0) {
+        violations.push({
+          invariant: "index_density",
+          message: `cluster "${cluster}" mixes events with and without index (events without index at indices ${entry.missingIndexAt.join(", ")})`,
+          events: entry.missingIndexAt,
+        });
+        continue;
+      }
+      // All events have index — check density.
+      const sorted = [...entry.withIndex].sort((a, b) => a - b);
+      for (let i = 0; i < sorted.length; i++) {
+        if (sorted[i] !== i) {
+          violations.push({
+            invariant: "index_density",
+            message: `cluster "${cluster}" indices are not dense from 0: observed ${sorted.join(", ")}`,
+            events: [],
+          });
+          break;
+        }
+      }
+    }
+    return violations;
+  },
+};
+
+const signaturePrecedence: Invariant = {
+  name: "signature_precedence",
+  check(events) {
+    const violations: InvariantViolation[] = [];
+    // For each thinking signature, scan backwards for a thinking.delta
+    // with the same index (or undefined index, single-block scenarios).
+    events.forEach((event, sigIdx) => {
+      if (event.type !== "inference.thinking.signature") return;
+      const sigIndex = event.data.index;
+      let foundDelta = false;
+      for (let j = sigIdx - 1; j >= 0; j--) {
+        const e = events[j];
+        if (e === undefined) continue;
+        if (e.type !== "inference.thinking.delta") continue;
+        if (e.data.index === sigIndex) {
+          foundDelta = true;
+          break;
+        }
+      }
+      if (!foundDelta) {
+        violations.push({
+          invariant: "signature_precedence",
+          message: `inference.thinking.signature at index ${String(sigIdx)} (index=${String(sigIndex)}) has no preceding inference.thinking.delta with the same index`,
+          events: [sigIdx],
+        });
+      }
+    });
+    return violations;
+  },
+};
+
+/**
+ * The canonical list applied by the compat-replay layer. Ordered
+ * foundational-first: schema_validity catches structural problems before
+ * the higher-level checks build on potentially-garbage events.
+ */
+export const INVARIANTS: readonly Invariant[] = [
+  schemaValidity,
+  toolCallPairing,
+  terminalExclusivity,
+  usageCoherence,
+  recognizedContentBlocks,
+  toolArgsJson,
+  redactedThinkingDataNonEmpty,
+  indexDensity,
+  signaturePrecedence,
+] as const;

--- a/packages/inference-testing/src/matchers.test.ts
+++ b/packages/inference-testing/src/matchers.test.ts
@@ -2,7 +2,13 @@ import { describe, test, expect } from "bun:test";
 
 import type { InferenceEvent, PartialMessage } from "@intx/types/runtime";
 
-import { expectEvents, expectToolCall, expectToolCalls } from "./matchers";
+import {
+  expectEvents,
+  expectMediaBlock,
+  expectToolCall,
+  expectToolCalls,
+  type MediaBlock,
+} from "./matchers";
 
 const EMPTY_PARTIAL: PartialMessage = { text: "" };
 
@@ -204,5 +210,167 @@ describe("expectToolCall(name).from(events).toHaveBeenCalledTimes", () => {
       .from(events)
       .toHaveBeenCalledTimes(1)
       .toHaveBeenCalledTimes(1);
+  });
+});
+
+// A tiny base64 blob (~64 chars → ~48 decoded bytes); the contents are
+// realistic-looking but small, so a failed assertion that accidentally
+// leaks the data is easy to spot.
+const SHORT_B64 = "aGVsbG8gd29ybGQ=";
+// A larger base64 string (1024 chars → 768 decoded bytes). 1024 is a
+// multiple of 4 with no padding required, so the formula gives an exact
+// decoded count and the fixture is well-formed.
+const LONG_B64 = "A".repeat(1024);
+
+function baseBlock(
+  type: MediaBlock["type"],
+  mimeType: string,
+  data: string,
+): MediaBlock {
+  return { type, source: { kind: "base64", mimeType, data } };
+}
+
+function referenceBlock(
+  type: MediaBlock["type"],
+  mimeType: string,
+  reference: string,
+): MediaBlock {
+  return { type, source: { kind: "file-reference", mimeType, reference } };
+}
+
+describe("expectMediaBlock — happy paths", () => {
+  test.each(["image", "audio", "video", "document"] as const)(
+    "accepts a %s base64 block matching mimeType and byte length",
+    (type) => {
+      const block = baseBlock(type, "application/octet-stream", SHORT_B64);
+      expectMediaBlock(block, { source: "base64" })
+        .toHaveMimeType("application/octet-stream")
+        .toHaveByteLengthAtLeast(5)
+        .toHaveByteLength(11); // "hello world" = 11 bytes
+    },
+  );
+
+  test.each(["image", "audio", "video", "document"] as const)(
+    "accepts a %s file-reference block matching mimeType",
+    (type) => {
+      const block = referenceBlock(type, "image/png", "file_abc");
+      expectMediaBlock(block, { source: "file-reference" }).toHaveMimeType(
+        "image/png",
+      );
+    },
+  );
+
+  test("is chainable across all assertions", () => {
+    const block = baseBlock("image", "image/png", SHORT_B64);
+    expectMediaBlock(block)
+      .toHaveMimeType("image/png")
+      .toHaveByteLengthAtLeast(1)
+      .toHaveByteLengthAtLeast(5);
+  });
+
+  test("chain returns the same assertion object every step", () => {
+    // The chain identity matters because each terminal method returns
+    // `this`; if any returned a fresh assertion, callers could miss
+    // state-carrying behavior in future extensions of the matcher.
+    const block = baseBlock("image", "image/png", SHORT_B64);
+    const a = expectMediaBlock(block);
+    const b = a.toHaveMimeType("image/png");
+    const c = b.toHaveByteLengthAtLeast(1);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  test("base64ByteLength throws on input whose length is not a multiple of 4", () => {
+    // "===" is three padding chars — neither a valid base64 nor a sane
+    // input to the byte-length helper. Surfacing it as a thrown error
+    // beats returning a negative byte count that callers then assert
+    // against without realising they're operating on garbage.
+    const block = baseBlock("image", "image/png", "===");
+    expect(() => expectMediaBlock(block).toHaveByteLength(0)).toThrow(
+      /not a multiple of 4/,
+    );
+  });
+});
+
+describe("expectMediaBlock — failure paths", () => {
+  test("rejects on wrong source kind via opts", () => {
+    const block = baseBlock("image", "image/png", SHORT_B64);
+    expect(() => expectMediaBlock(block, { source: "file-reference" })).toThrow(
+      /expected source=file-reference/,
+    );
+  });
+
+  test("rejects on mismatched mimeType", () => {
+    const block = baseBlock("image", "image/png", SHORT_B64);
+    expect(() => expectMediaBlock(block).toHaveMimeType("image/jpeg")).toThrow(
+      /toHaveMimeType/,
+    );
+  });
+
+  test("rejects byte-length assertions on file-reference sources", () => {
+    const block = referenceBlock("image", "image/png", "file_abc");
+    expect(() => expectMediaBlock(block).toHaveByteLength(100)).toThrow(
+      /not observable on file-reference sources/,
+    );
+    expect(() => expectMediaBlock(block).toHaveByteLengthAtLeast(100)).toThrow(
+      /not observable on file-reference sources/,
+    );
+  });
+
+  test("rejects when actual byte length is below minimum", () => {
+    const block = baseBlock("audio", "audio/wav", SHORT_B64);
+    expect(() =>
+      expectMediaBlock(block).toHaveByteLengthAtLeast(1_000_000),
+    ).toThrow(/toHaveByteLengthAtLeast/);
+  });
+
+  test("rejects when exact byte length mismatches", () => {
+    const block = baseBlock("audio", "audio/wav", SHORT_B64);
+    expect(() => expectMediaBlock(block).toHaveByteLength(99)).toThrow(
+      /toHaveByteLength/,
+    );
+  });
+});
+
+describe("expectMediaBlock — failure messages never leak base64 payload", () => {
+  // This is the load-bearing property of the helper. A failing assertion
+  // on a megabyte-sized image must NOT dump the raw payload into test
+  // logs; the elided format is what callers debug against.
+
+  function captureError(fn: () => void): string {
+    try {
+      fn();
+    } catch (e) {
+      return e instanceof Error ? e.message : String(e);
+    }
+    throw new Error("expected the assertion to throw");
+  }
+
+  test("mismatched mimeType error elides the payload", () => {
+    const block = baseBlock("image", "image/png", LONG_B64);
+    const msg = captureError(() =>
+      expectMediaBlock(block).toHaveMimeType("image/jpeg"),
+    );
+    expect(msg).not.toContain(LONG_B64);
+    expect(msg).toContain("bytes=");
+    expect(msg).toContain("source=base64");
+  });
+
+  test("byte-length-below-minimum error elides the payload", () => {
+    const block = baseBlock("video", "video/mp4", LONG_B64);
+    const msg = captureError(() =>
+      expectMediaBlock(block).toHaveByteLengthAtLeast(10_000_000),
+    );
+    expect(msg).not.toContain(LONG_B64);
+    expect(msg).toContain("bytes=");
+  });
+
+  test("wrong-source-kind error elides the payload", () => {
+    const block = baseBlock("document", "application/pdf", LONG_B64);
+    const msg = captureError(() =>
+      expectMediaBlock(block, { source: "file-reference" }),
+    );
+    expect(msg).not.toContain(LONG_B64);
+    expect(msg).toContain("source=base64");
   });
 });

--- a/packages/inference-testing/src/matchers.ts
+++ b/packages/inference-testing/src/matchers.ts
@@ -6,7 +6,7 @@
 // throws a descriptive `Error` on failure — callers should let those bubble
 // up through bun:test's normal failure machinery.
 
-import type { InferenceEvent } from "@intx/types/runtime";
+import type { ContentBlock, InferenceEvent } from "@intx/types/runtime";
 
 /**
  * Partial expectation against an `InferenceEvent`. The `type` is required;
@@ -289,4 +289,138 @@ export function expectToolCall(name: string): {
       return assertion;
     },
   };
+}
+
+// ---------------------------------------------------------------------------
+// Media block matchers
+//
+// Content blocks that carry a MediaSource (image, audio, video, document)
+// can hold base64 payloads in the megabyte range — Anthropic's image-output
+// captures show ~1MB blobs. A failing assertion that serializes the whole
+// block leaves multi-MB of base64 in test logs, which makes debugging the
+// failure dramatically worse than the failure itself.
+//
+// `expectMediaBlock` is the assertion entry point that formats failure
+// messages with an elided representation: kind, mime, source discriminant,
+// and decoded byte length — never the raw `data` field. Use this matcher
+// instead of `expect(block).toEqual(...)` for any media block whose source
+// kind might be `"base64"`.
+// ---------------------------------------------------------------------------
+
+export type MediaBlock = Extract<
+  ContentBlock,
+  { type: "image" | "audio" | "video" | "document" }
+>;
+
+export type ExpectMediaBlockOpts = {
+  /** When supplied, asserts the block's source.kind matches before any chain. */
+  source?: "base64" | "file-reference";
+};
+
+export type MediaBlockAssertion = {
+  /** Assert the block's mimeType (sources record their own mimeType). */
+  toHaveMimeType(expected: string): MediaBlockAssertion;
+  /**
+   * Assert the decoded payload byte count is at least `min`. Only valid on
+   * base64 sources — throws on file-reference sources because their byte
+   * length is provider-side and not observable from the block.
+   */
+  toHaveByteLengthAtLeast(min: number): MediaBlockAssertion;
+  /**
+   * Exact byte count. Use sparingly — provider re-encodes are common and
+   * `toHaveByteLengthAtLeast` is usually the right assertion. Same
+   * file-reference caveat as `toHaveByteLengthAtLeast`.
+   */
+  toHaveByteLength(exact: number): MediaBlockAssertion;
+};
+
+/**
+ * Decode the byte length of a base64 string without materializing the
+ * decoded bytes. Each four base64 characters encode three bytes, less
+ * trailing `=` padding.
+ *
+ * Validates structural invariants — length divisible by 4 and at most
+ * two trailing padding chars — and throws on violation. A silent
+ * fallback that returns a meaningless count (negative numbers for
+ * stray `=` clusters) would let downstream assertions like
+ * `toHaveByteLengthAtLeast(-2)` pass on garbage; surfacing the
+ * malformed input loudly forces callers to feed real base64.
+ */
+function base64ByteLength(b64: string): number {
+  if (b64.length % 4 !== 0) {
+    throw new Error(
+      `base64ByteLength: input length ${String(b64.length)} is not a multiple of 4; not a well-formed base64 string`,
+    );
+  }
+  const padMatch = /=+$/.exec(b64);
+  const pad = padMatch === null ? 0 : padMatch[0].length;
+  if (pad > 2) {
+    throw new Error(
+      `base64ByteLength: input carries ${String(pad)} trailing padding chars; base64 permits at most 2`,
+    );
+  }
+  return Math.floor((b64.length * 3) / 4) - pad;
+}
+
+function describeMediaBlock(block: MediaBlock): string {
+  const src = block.source;
+  if (src.kind === "base64") {
+    return `<${block.type} mime=${src.mimeType} source=base64 bytes=${String(
+      base64ByteLength(src.data),
+    )}>`;
+  }
+  return `<${block.type} mime=${src.mimeType} source=file-reference reference=${src.reference}>`;
+}
+
+export function expectMediaBlock(
+  block: MediaBlock,
+  opts: ExpectMediaBlockOpts = {},
+): MediaBlockAssertion {
+  if (opts.source !== undefined && block.source.kind !== opts.source) {
+    throw new Error(
+      `expectMediaBlock: expected source=${opts.source}, got ${describeMediaBlock(block)}`,
+    );
+  }
+
+  const assertion: MediaBlockAssertion = {
+    toHaveMimeType(expected) {
+      if (block.source.mimeType !== expected) {
+        throw new Error(
+          `expectMediaBlock.toHaveMimeType(${JSON.stringify(expected)}): got ${describeMediaBlock(block)}`,
+        );
+      }
+      return assertion;
+    },
+
+    toHaveByteLengthAtLeast(min) {
+      if (block.source.kind !== "base64") {
+        throw new Error(
+          `expectMediaBlock.toHaveByteLengthAtLeast: byte length is not observable on file-reference sources; got ${describeMediaBlock(block)}`,
+        );
+      }
+      const actual = base64ByteLength(block.source.data);
+      if (actual < min) {
+        throw new Error(
+          `expectMediaBlock.toHaveByteLengthAtLeast(${String(min)}): got ${describeMediaBlock(block)} (actual ${String(actual)} bytes)`,
+        );
+      }
+      return assertion;
+    },
+
+    toHaveByteLength(exact) {
+      if (block.source.kind !== "base64") {
+        throw new Error(
+          `expectMediaBlock.toHaveByteLength: byte length is not observable on file-reference sources; got ${describeMediaBlock(block)}`,
+        );
+      }
+      const actual = base64ByteLength(block.source.data);
+      if (actual !== exact) {
+        throw new Error(
+          `expectMediaBlock.toHaveByteLength(${String(exact)}): got ${describeMediaBlock(block)} (actual ${String(actual)} bytes)`,
+        );
+      }
+      return assertion;
+    },
+  };
+  return assertion;
 }

--- a/packages/inference-testing/src/wire/anthropic.test.ts
+++ b/packages/inference-testing/src/wire/anthropic.test.ts
@@ -221,3 +221,194 @@ describe("anthropic wire DSL", () => {
     expect(textDeltas).toHaveLength(1);
   });
 });
+
+/**
+ * Extract decoded JSON event objects from a sequence of wire bytes,
+ * bypassing the Anthropic adapter. Used to assert the structural wire
+ * shape a helper produces, independently of whether the adapter knows
+ * how to interpret it. (Adapter integration is tested elsewhere; here
+ * we pin the wire bytes the helper emits.)
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function decodeEvents(
+  chunks: Uint8Array[],
+): Promise<Record<string, unknown>[]> {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+  const out: Record<string, unknown>[] = [];
+  for await (const sseData of parseSSE(stream)) {
+    const parsed: unknown = JSON.parse(sseData);
+    if (isRecord(parsed)) {
+      out.push(parsed);
+    }
+  }
+  return out;
+}
+
+describe("anthropic wire DSL — new content block variants", () => {
+  test("redactedThinkingBlock emits start+stop with the opaque data blob", async () => {
+    const events = await decodeEvents(
+      anthropic.redactedThinkingBlock("EncryptedOpaqueBlobAAAA==", 0),
+    );
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({
+      type: "content_block_start",
+      index: 0,
+      content_block: {
+        type: "redacted_thinking",
+        data: "EncryptedOpaqueBlobAAAA==",
+      },
+    });
+    expect(events[1]).toEqual({ type: "content_block_stop", index: 0 });
+  });
+
+  test("redactedThinkingBlock at a non-zero index", async () => {
+    const events = await decodeEvents(
+      anthropic.redactedThinkingBlock("blob", 3),
+    );
+    expect(events[0]).toMatchObject({ index: 3 });
+    expect(events[1]).toMatchObject({ index: 3 });
+  });
+
+  test("serverToolUseBlock streams its input as JSON deltas", async () => {
+    const events = await decodeEvents(
+      anthropic.serverToolUseBlock(
+        "srvtoolu_01",
+        "code_execution",
+        '{"code": "print(1)"}',
+        2,
+      ),
+    );
+    expect(events).toHaveLength(3);
+    expect(events[0]).toEqual({
+      type: "content_block_start",
+      index: 2,
+      content_block: {
+        type: "server_tool_use",
+        id: "srvtoolu_01",
+        name: "code_execution",
+        input: {},
+      },
+    });
+    expect(events[1]).toEqual({
+      type: "content_block_delta",
+      index: 2,
+      delta: { type: "input_json_delta", partial_json: '{"code": "print(1)"}' },
+    });
+    expect(events[2]).toEqual({ type: "content_block_stop", index: 2 });
+  });
+
+  test("codeExecutionToolResultBlock bakes the result into start with no deltas", async () => {
+    const events = await decodeEvents(
+      anthropic.codeExecutionToolResultBlock(
+        "srvtoolu_01",
+        { stdout: "144", stderr: "", return_code: 0 },
+        3,
+      ),
+    );
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({
+      type: "content_block_start",
+      index: 3,
+      content_block: {
+        type: "code_execution_tool_result",
+        tool_use_id: "srvtoolu_01",
+        content: {
+          type: "code_execution_result",
+          stdout: "144",
+          stderr: "",
+          return_code: 0,
+        },
+      },
+    });
+    expect(events[1]).toEqual({ type: "content_block_stop", index: 3 });
+  });
+
+  test("codeExecutionToolResultBlock carries an aborted-run shape", async () => {
+    const events = await decodeEvents(
+      anthropic.codeExecutionToolResultBlock("srvtoolu_02", {
+        stdout: "",
+        stderr: "killed",
+        return_code: 137,
+        abort_reason: "timeout",
+      }),
+    );
+    const start = events[0];
+    if (start === undefined) throw new Error("missing content_block_start");
+    const contentBlock = start["content_block"];
+    expect(contentBlock).toMatchObject({
+      type: "code_execution_tool_result",
+      tool_use_id: "srvtoolu_02",
+      content: {
+        type: "code_execution_result",
+        stderr: "killed",
+        return_code: 137,
+        abort_reason: "timeout",
+      },
+    });
+  });
+
+  test("textBlockWithCitations interleaves text_delta and citations_delta", async () => {
+    const citation1 = {
+      type: "web_search_result_location",
+      cited_text: "first cited span",
+      url: "https://example.com/a",
+      title: "A",
+      encrypted_index: "enc1",
+    };
+    const citation2 = {
+      type: "char_location",
+      cited_text: "second cited span",
+      document_index: 0,
+      document_title: "doc.pdf",
+      start_char_index: 0,
+      end_char_index: 10,
+    };
+    const events = await decodeEvents(
+      anthropic.textBlockWithCitations(
+        "The body text",
+        [citation1, citation2],
+        1,
+      ),
+    );
+    // start, text_delta, citations_delta * 2, stop = 5 events.
+    expect(events).toHaveLength(5);
+    expect(events[0]).toEqual({
+      type: "content_block_start",
+      index: 1,
+      content_block: { type: "text", text: "", citations: [] },
+    });
+    expect(events[1]).toEqual({
+      type: "content_block_delta",
+      index: 1,
+      delta: { type: "text_delta", text: "The body text" },
+    });
+    expect(events[2]).toEqual({
+      type: "content_block_delta",
+      index: 1,
+      delta: { type: "citations_delta", citation: citation1 },
+    });
+    expect(events[3]).toEqual({
+      type: "content_block_delta",
+      index: 1,
+      delta: { type: "citations_delta", citation: citation2 },
+    });
+    expect(events[4]).toEqual({ type: "content_block_stop", index: 1 });
+  });
+
+  test("textBlockWithCitations with no citations matches a plain textBlock", async () => {
+    const withEmpty = await decodeEvents(
+      anthropic.textBlockWithCitations("Hello", [], 0),
+    );
+    // start, text_delta, stop = 3 events (no citation deltas).
+    expect(withEmpty).toHaveLength(3);
+    expect(withEmpty[2]).toEqual({ type: "content_block_stop", index: 0 });
+  });
+});

--- a/packages/inference-testing/src/wire/anthropic.test.ts
+++ b/packages/inference-testing/src/wire/anthropic.test.ts
@@ -72,10 +72,23 @@ describe("anthropic wire DSL", () => {
     const thinkEvents = events.filter(
       (e) => e.type === "inference.thinking.delta",
     );
-    expect(thinkEvents).toHaveLength(1);
-    if (thinkEvents[0]?.type === "inference.thinking.delta") {
-      expect(thinkEvents[0].data.token).toBe("Let me think...");
+    // The parser anchors the thinking block at content_block_start
+    // with an empty-token thinking.delta so the harness can attach a
+    // later signature_delta even when no visible text streams in
+    // between. The thinkingBlock wire helper emits content_block_start
+    // + content_block_delta, so a single visible-text block yields
+    // two thinking.delta events: the empty anchor and the content.
+    expect(thinkEvents).toHaveLength(2);
+    const anchor = thinkEvents[0];
+    const content = thinkEvents[1];
+    if (
+      anchor?.type !== "inference.thinking.delta" ||
+      content?.type !== "inference.thinking.delta"
+    ) {
+      throw new Error("expected two thinking.delta events");
     }
+    expect(anchor.data.token).toBe("");
+    expect(content.data.token).toBe("Let me think...");
   });
 
   test("thinkingBlock with signature emits inference.thinking.signature", async () => {

--- a/packages/inference-testing/src/wire/anthropic.ts
+++ b/packages/inference-testing/src/wire/anthropic.ts
@@ -316,3 +316,133 @@ export function unknownDelta(index = 0): Uint8Array {
     delta: { type: "garbage_delta", text: "ignored" },
   });
 }
+
+/**
+ * Convenience: emit a complete redacted_thinking content block. Anthropic
+ * delivers redacted thinking as a one-shot inside `content_block_start`
+ * carrying an opaque `data` blob — no delta stream. The block must echo
+ * back verbatim on follow-up turns or the API rejects the request.
+ *
+ * `index` defaults to 0; supply a higher index when interleaving with
+ * other content blocks.
+ */
+export function redactedThinkingBlock(data: string, index = 0): Uint8Array[] {
+  return [
+    contentBlockStart({
+      index,
+      kind: "raw",
+      contentBlock: { type: "redacted_thinking", data },
+    }),
+    contentBlockStop({ index }),
+  ];
+}
+
+/**
+ * Convenience: emit a complete server_tool_use content block. Anthropic
+ * uses this for server-side tools (code_execution, web_search, etc.).
+ * Wire pattern mirrors `tool_use`: start with empty input, stream the
+ * input as JSON via `input_json_delta`, then stop. `name` selects which
+ * server-side tool (e.g., `"code_execution"`).
+ *
+ * `index` defaults to 0.
+ */
+export function serverToolUseBlock(
+  id: string,
+  name: string,
+  argsJSON: string,
+  index = 0,
+): Uint8Array[] {
+  return [
+    contentBlockStart({
+      index,
+      kind: "raw",
+      contentBlock: { type: "server_tool_use", id, name, input: {} },
+    }),
+    contentBlockDelta({
+      index,
+      kind: "input_json_delta",
+      partialJson: argsJSON,
+    }),
+    contentBlockStop({ index }),
+  ];
+}
+
+/**
+ * Inner result shape for `codeExecutionToolResultBlock`. Mirrors
+ * Anthropic's `code_execution_result` payload as captured in
+ * `wire/anthropic/.../code-execution/response.json`.
+ */
+export type AnthropicCodeExecutionResult = {
+  stdout?: string;
+  stderr?: string;
+  return_code?: number;
+  abort_reason?: string | null;
+  content?: Record<string, unknown>[];
+};
+
+/**
+ * Convenience: emit a complete code_execution_tool_result content block.
+ * Anthropic delivers this as a one-shot inside `content_block_start`
+ * with the full `code_execution_result` payload baked in — no delta
+ * stream. `toolUseId` correlates the result back to the preceding
+ * `server_tool_use` block's id.
+ *
+ * `index` defaults to 0; in a normal code-execution response the
+ * server_tool_use is at index N and the result follows at index N+1.
+ */
+export function codeExecutionToolResultBlock(
+  toolUseId: string,
+  result: AnthropicCodeExecutionResult,
+  index = 0,
+): Uint8Array[] {
+  return [
+    contentBlockStart({
+      index,
+      kind: "raw",
+      contentBlock: {
+        type: "code_execution_tool_result",
+        tool_use_id: toolUseId,
+        content: { type: "code_execution_result", ...result },
+      },
+    }),
+    contentBlockStop({ index }),
+  ];
+}
+
+/**
+ * Convenience: emit a complete text content block carrying inline
+ * citations. Anthropic's citation wire shape is a text block initialized
+ * with an empty `citations: []` array, followed by `text_delta` events
+ * for the body, then one `content_block_delta` per citation with
+ * `delta.type === "citations_delta"`. Each citation's inner shape varies
+ * by source (e.g., `web_search_result_location` for web_search,
+ * `char_location` / `page_location` / `content_block_location` for
+ * document-based citations); pass them in already-shaped.
+ *
+ * `index` defaults to 0.
+ */
+export function textBlockWithCitations(
+  text: string,
+  citations: Record<string, unknown>[],
+  index = 0,
+): Uint8Array[] {
+  const events: Uint8Array[] = [
+    contentBlockStart({
+      index,
+      kind: "raw",
+      contentBlock: { type: "text", text: "", citations: [] },
+    }),
+    contentBlockDelta({ index, kind: "text_delta", text }),
+  ];
+  for (const citation of citations) {
+    events.push(
+      contentBlockDelta({
+        index,
+        kind: "raw",
+        delta: { type: "citations_delta", citation },
+      }),
+    );
+  }
+  events.push(contentBlockStop({ index }));
+  return events;
+}

--- a/packages/inference/src/harness.test.ts
+++ b/packages/inference/src/harness.test.ts
@@ -350,6 +350,107 @@ describe("runInference — source.defaults merge precedence", () => {
   });
 });
 
+// providerOptions on InferenceSourceDefaults is the model-bound bag of
+// provider-native knobs. Per-call InferenceOptions.providerOptions
+// overrides via the same shallow-spread merge that handles maxTokens.
+// The merge is shallow: a per-call providerOptions object wholesale
+// replaces the source-bound one rather than deep-merging per key.
+describe("runInference — providerOptions merge precedence", () => {
+  function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  }
+
+  async function captureAdapterOptions(opts: {
+    sourceProviderOptions?: Record<string, unknown>;
+    perCallProviderOptions?: Record<string, unknown>;
+  }): Promise<Record<string, unknown> | undefined> {
+    // Use a fresh provider name per call so concurrent test runs don't
+    // race on the global registry. The `registerProvider` API has no
+    // unregister counterpart; leaked test providers are inert.
+    const providerName = `test-provideroptions-${Math.random().toString(36).slice(2)}`;
+    let captured: Record<string, unknown> | undefined | "absent" = "absent";
+
+    const { registerProvider } = await import("./providers/registry");
+    registerProvider(providerName, () => ({
+      buildRequest: (_messages, _model, options) => {
+        captured = isRecord(options.providerOptions)
+          ? options.providerOptions
+          : undefined;
+        return {
+          url: "/test",
+          headers: { "content-type": "application/json" },
+          body: "{}",
+        };
+      },
+      parseResponse: () => [],
+    }));
+
+    const source: InferenceSource = {
+      id: `${providerName}:test-model`,
+      provider: providerName,
+      baseURL: "https://test.invalid",
+      apiKey: "test",
+      model: "test-model",
+      ...(opts.sourceProviderOptions !== undefined
+        ? { defaults: { providerOptions: opts.sourceProviderOptions } }
+        : {}),
+    };
+
+    const deps: Dependencies = {
+      fetch: () =>
+        Promise.resolve(
+          new Response("", {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }),
+        ),
+    };
+
+    let seq = 0;
+    await collect(
+      runInference({
+        turns: [userTurn("hi")],
+        source,
+        ...(opts.perCallProviderOptions !== undefined
+          ? {
+              inferenceOptions: {
+                providerOptions: opts.perCallProviderOptions,
+              },
+            }
+          : {}),
+        nextSeq: () => ++seq,
+        deps,
+      }),
+    );
+
+    if (captured === "absent")
+      throw new Error("adapter buildRequest not called");
+    return captured;
+  }
+
+  test("source-bound providerOptions reaches the adapter when no per-call override", async () => {
+    const seen = await captureAdapterOptions({
+      sourceProviderOptions: { user: "user_123", store: false },
+    });
+    expect(seen).toEqual({ user: "user_123", store: false });
+  });
+
+  test("per-call providerOptions wholesale replaces the source-bound bag", async () => {
+    const seen = await captureAdapterOptions({
+      sourceProviderOptions: { user: "user_123", store: false },
+      perCallProviderOptions: { user: "user_999" },
+    });
+    // Shallow merge: per-call object wins entirely, source-bound `store`
+    // does NOT survive the override.
+    expect(seen).toEqual({ user: "user_999" });
+  });
+
+  test("neither set: the adapter sees options.providerOptions === undefined", async () => {
+    const seen = await captureAdapterOptions({});
+    expect(seen).toBeUndefined();
+  });
+});
+
 // The JSDoc on `Dependencies` documents which reflective APIs leak the
 // optional `[HarnessId]` tag. Pin those claims so a future refactor that
 // makes the tag enumerable (e.g., renaming it to a string key) cannot

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -21,6 +21,7 @@ import type {
   InferenceOptions,
   InferenceSource,
   PartialMessage,
+  RedactedThinkingBlock,
   TokenUsage,
   AssistantTurn,
   ContentBlock,
@@ -163,6 +164,12 @@ export async function* runInference(
   // any follow-up turn that includes the thinking block in history; see
   // `inference.thinking.signature` in `runtime.ts`.
   let thinkingSignature: string | undefined;
+  // Redacted thinking blocks delivered as one-shots inside
+  // content_block_start. Each block's opaque `data` blob must echo back
+  // verbatim on follow-up turns; the harness preserves insertion order
+  // here so the final assistant turn carries them in the same sequence
+  // they arrived on the wire.
+  const redactedThinkingBlocks: RedactedThinkingBlock[] = [];
   let usageSeen: TokenUsage | null = null;
 
   // Tool call state: keyed by callId (or index for OpenAI).
@@ -457,6 +464,37 @@ export async function* runInference(
               break;
             }
 
+            case "inference.thinking.redacted": {
+              // Redacted thinking blocks arrive as one-shots inside
+              // content_block_start (no delta stream). Preserve insertion
+              // order so multi-block scenarios reproduce the wire order in
+              // the final assistant turn. The block's `data` is opaque
+              // base64 that must echo back verbatim on every follow-up
+              // turn — passing it through the runtime type rather than
+              // re-serializing protects it from any accidental mutation.
+              //
+              // The conditional spread on `index` is forced by the
+              // runtime type's `"index?": "number"`: the field is
+              // omit-or-number, not omit-or-number-or-undefined, so
+              // passing `raw.data.index` directly when it could be
+              // undefined fails TypeScript narrowing. Today's parser
+              // always sets it, but the harness accepts other emitters
+              // that may not.
+              guardNonZeroIndex(raw, "redacted_thinking");
+              redactedThinkingBlocks.push(raw.data.redactedThinking);
+              yield {
+                type: "inference.thinking.redacted",
+                seq: nextSeq(),
+                data: {
+                  redactedThinking: raw.data.redactedThinking,
+                  ...(raw.data.index !== undefined
+                    ? { index: raw.data.index }
+                    : {}),
+                },
+              };
+              break;
+            }
+
             case "inference.tool_call.start": {
               const { callId, name } = raw.data;
               openToolCalls.set(callId, { callId, name, argsBuffer: "" });
@@ -625,6 +663,11 @@ export async function* runInference(
           : {}),
       });
     }
+    // Redacted thinking blocks land before the assistant text on the
+    // wire (Anthropic streams them ahead of any text block); preserving
+    // that order is what lets the request builder echo them back in the
+    // same position on the next turn.
+    contentBlocks.push(...redactedThinkingBlocks);
     if (partial.text.length > 0) {
       contentBlocks.push({ type: "text", text: partial.text });
     }

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -22,7 +22,6 @@ import type {
   InferenceOptions,
   InferenceSource,
   PartialMessage,
-  RedactedThinkingBlock,
   TokenUsage,
   AssistantTurn,
   ContentBlock,
@@ -159,22 +158,26 @@ export async function* runInference(
 
   // Mutable partial state — the harness owns this.
   const partial: PartialMessage = { text: "" };
-  let thinkingBuffer = "";
-  // Cryptographic signature for the thinking block, when the provider
-  // emits one. Anthropic requires this signature to be echoed back on
-  // any follow-up turn that includes the thinking block in history; see
-  // `inference.thinking.signature` in `runtime.ts`.
-  let thinkingSignature: string | undefined;
-  // Redacted thinking blocks delivered as one-shots inside
-  // content_block_start. Each block's opaque `data` blob must echo back
-  // verbatim on follow-up turns; the harness preserves insertion order
-  // here so the final assistant turn carries them in the same sequence
-  // they arrived on the wire.
-  const redactedThinkingBlocks: RedactedThinkingBlock[] = [];
-  // Citations streamed from the provider, in arrival order. Each
-  // citation typically annotates the most recently emitted text run;
-  // preserving the streaming order lets downstream consumers
-  // re-attach citations to their text regions.
+  // Per-index block tracking. The map preserves insertion order (JS
+  // Map guarantee, even for integer keys — unlike plain objects).
+  // Each entry records one block's running state; final-turn
+  // assembly walks the map in arrival order and emits one ContentBlock
+  // per entry. The `tool_use` entries are index markers only — the
+  // tool-call state machine lives in `openToolCalls` /
+  // `completedToolCalls` and is resolved into the final block at
+  // assembly time via the marker's `callId`.
+  type BlockState =
+    | { kind: "text"; text: string }
+    | { kind: "thinking"; text: string; signature?: string }
+    | { kind: "redacted_thinking"; data: string }
+    | { kind: "tool_use"; callId: string };
+  const blockMap = new Map<number, BlockState>();
+  // Citations streamed from the provider, in arrival order. The
+  // `inference.citation` event today doesn't carry the source content
+  // block index (citations attribute to the nearest preceding
+  // TextBlock per the CitationBlock docstring), so citations are
+  // collected as a flat array and appended after the per-index walk
+  // in final-turn assembly.
   const citationBlocks: CitationBlock[] = [];
   let usageSeen: TokenUsage | null = null;
 
@@ -427,7 +430,22 @@ export async function* runInference(
         for (const raw of rawEvents) {
           switch (raw.type) {
             case "inference.text.delta": {
-              guardNonZeroIndex(raw, "text");
+              const idx = requireIndex(raw, "text.delta");
+              const existing = blockMap.get(idx);
+              if (existing === undefined) {
+                blockMap.set(idx, { kind: "text", text: raw.data.token });
+              } else if (existing.kind === "text") {
+                existing.text += raw.data.token;
+              } else {
+                throw new ProtocolMismatchError(
+                  `harness: text.delta at index ${String(idx)} collides with existing ${existing.kind} block`,
+                  raw,
+                );
+              }
+              // Running concat of all text deltas — backwards
+              // compatible with consumers that treat `partial.text` as
+              // "everything the assistant has typed so far," regardless
+              // of which content block it came from.
               partial.text += raw.data.token;
               yield {
                 type: "inference.text.delta",
@@ -441,9 +459,26 @@ export async function* runInference(
             }
 
             case "inference.thinking.delta": {
-              guardNonZeroIndex(raw, "thinking");
-              thinkingBuffer += raw.data.token;
-              partial.thinking = thinkingBuffer;
+              const idx = requireIndex(raw, "thinking.delta");
+              const existing = blockMap.get(idx);
+              if (existing === undefined) {
+                blockMap.set(idx, { kind: "thinking", text: raw.data.token });
+              } else if (existing.kind === "thinking") {
+                existing.text += raw.data.token;
+              } else {
+                throw new ProtocolMismatchError(
+                  `harness: thinking.delta at index ${String(idx)} collides with existing ${existing.kind} block`,
+                  raw,
+                );
+              }
+              // Running concat of all thinking deltas across every
+              // thinking block. Under interleaving (thinking@0 "A",
+              // text@1 "X", thinking@2 "B"), `partial.thinking` ends
+              // up "AB" — backwards compatible with the pre-per-index
+              // single-buffer semantics. Consumers needing per-block
+              // structure walk the finalized turn's `content[]`.
+              const concat = (partial.thinking ?? "") + raw.data.token;
+              partial.thinking = concat;
               yield {
                 type: "inference.thinking.delta",
                 seq: nextSeq(),
@@ -456,12 +491,21 @@ export async function* runInference(
             }
 
             case "inference.thinking.signature": {
-              // Anthropic emits the signature once per thinking block, after
-              // the thinking_delta stream. The harness collapses all thinking
-              // content into a single block today, so a single trailing
-              // signature is captured here and attached at finalisation.
-              guardNonZeroIndex(raw, "signature");
-              thinkingSignature = raw.data.signature;
+              const idx = requireIndex(raw, "thinking.signature");
+              const existing = blockMap.get(idx);
+              if (existing === undefined) {
+                throw new ProtocolMismatchError(
+                  `harness: thinking.signature at index ${String(idx)} has no preceding thinking block at that index`,
+                  raw,
+                );
+              }
+              if (existing.kind !== "thinking") {
+                throw new ProtocolMismatchError(
+                  `harness: thinking.signature at index ${String(idx)} targets an existing ${existing.kind} block, not a thinking block`,
+                  raw,
+                );
+              }
+              existing.signature = raw.data.signature;
               yield {
                 type: "inference.thinking.signature",
                 seq: nextSeq(),
@@ -471,10 +515,11 @@ export async function* runInference(
             }
 
             case "inference.citation": {
-              // Citations stream interleaved with text deltas. The
-              // harness preserves arrival order so consumers building
-              // citation-aware UI can re-attach each citation to the
-              // text region that immediately precedes it.
+              // Citations don't carry a content-block index on their
+              // event payload today, so they're collected flat and
+              // appended at the end of the final turn per the
+              // CitationBlock attribution rule. Index-precise
+              // attribution is tracked separately.
               citationBlocks.push(raw.data.citation);
               yield {
                 type: "inference.citation",
@@ -485,31 +530,24 @@ export async function* runInference(
             }
 
             case "inference.thinking.redacted": {
-              // Redacted thinking blocks arrive as one-shots inside
-              // content_block_start (no delta stream). Preserve insertion
-              // order so multi-block scenarios reproduce the wire order in
-              // the final assistant turn. The block's `data` is opaque
-              // base64 that must echo back verbatim on every follow-up
-              // turn — passing it through the runtime type rather than
-              // re-serializing protects it from any accidental mutation.
-              //
-              // The conditional spread on `index` is forced by the
-              // runtime type's `"index?": "number"`: the field is
-              // omit-or-number, not omit-or-number-or-undefined, so
-              // passing `raw.data.index` directly when it could be
-              // undefined fails TypeScript narrowing. Today's parser
-              // always sets it, but the harness accepts other emitters
-              // that may not.
-              guardNonZeroIndex(raw, "redacted_thinking");
-              redactedThinkingBlocks.push(raw.data.redactedThinking);
+              const idx = requireIndex(raw, "thinking.redacted");
+              const existing = blockMap.get(idx);
+              if (existing !== undefined) {
+                throw new ProtocolMismatchError(
+                  `harness: thinking.redacted at index ${String(idx)} collides with existing ${existing.kind} block`,
+                  raw,
+                );
+              }
+              blockMap.set(idx, {
+                kind: "redacted_thinking",
+                data: raw.data.redactedThinking.data,
+              });
               yield {
                 type: "inference.thinking.redacted",
                 seq: nextSeq(),
                 data: {
                   redactedThinking: raw.data.redactedThinking,
-                  ...(raw.data.index !== undefined
-                    ? { index: raw.data.index }
-                    : {}),
+                  index: idx,
                 },
               };
               break;
@@ -518,10 +556,48 @@ export async function* runInference(
             case "inference.tool_call.start": {
               const { callId, name } = raw.data;
               openToolCalls.set(callId, { callId, name, argsBuffer: "" });
-              // OpenAI sends deltas with a string index ("0", "1", ...) as the
-              // callId. Map each index to the real callId so deltas resolve.
-              // The index is the position of this tool call in the current batch.
-              indexToCallId.set(String(openToolCalls.size - 1), callId);
+              // OpenAI-flavoured adapters synthesize a placeholder
+              // callId on tool_call.delta events (the real id is only
+              // present on the start). Key the resolution map on the
+              // start event's `data.index` so the placeholder the
+              // delta emits (`String(blockIndex)`) maps back to the
+              // real id even when `tcDelta.index` is non-zero or
+              // non-contiguous. The fallback to arrival-order
+              // (`openToolCalls.size - 1`) preserves behaviour for
+              // legacy adapters that don't propagate index on the
+              // start event.
+              if (raw.data.index !== undefined) {
+                indexToCallId.set(String(raw.data.index), callId);
+              } else {
+                indexToCallId.set(String(openToolCalls.size - 1), callId);
+              }
+              // Anchor the tool_use position in the per-index map.
+              // The map walk in final assembly will resolve the marker
+              // via `completedToolCalls` so the tool_use block lands
+              // in its wire-arrival position relative to text and
+              // thinking blocks. Collisions with another kind at the
+              // same index throw, matching the discipline of the
+              // text/thinking/redacted_thinking branches above —
+              // distinct kinds cannot share an index without losing
+              // the per-index ordering guarantee. When the parser
+              // doesn't supply an index (legacy emitters), the marker
+              // is skipped and the tool call falls back to the
+              // append-after-walk path in final assembly.
+              const toolIdx = raw.data.index;
+              if (toolIdx !== undefined) {
+                const existingAtIdx = blockMap.get(toolIdx);
+                if (existingAtIdx === undefined) {
+                  blockMap.set(toolIdx, { kind: "tool_use", callId });
+                } else if (
+                  existingAtIdx.kind !== "tool_use" ||
+                  existingAtIdx.callId !== callId
+                ) {
+                  throw new ProtocolMismatchError(
+                    `harness: tool_call.start at index ${String(toolIdx)} collides with existing ${existingAtIdx.kind} block`,
+                    raw,
+                  );
+                }
+              }
               partial.toolCalls = [
                 ...(partial.toolCalls ?? []),
                 {
@@ -672,31 +748,74 @@ export async function* runInference(
       };
     }
 
-    // Build the final assistant message.
+    // Build the final assistant message by walking the per-index map
+    // in insertion order. JS `Map` preserves insertion order for all
+    // keys (including integers — distinct from plain object behaviour),
+    // so iteration here reproduces the wire-arrival order of content
+    // blocks regardless of the numeric values. Tool-call markers are
+    // resolved to the finalized ContentBlock from the completedToolCalls
+    // array via the marker's callId.
+    const completedToolCallsByCallId = new Map<string, ContentBlock>();
+    for (const tc of completedToolCalls) {
+      if (tc.type === "tool_call") {
+        completedToolCallsByCallId.set(tc.id, tc);
+      }
+    }
     const contentBlocks: ContentBlock[] = [];
-    if (thinkingBuffer.length > 0) {
-      contentBlocks.push({
-        type: "thinking",
-        thinking: thinkingBuffer,
-        ...(thinkingSignature !== undefined
-          ? { signature: thinkingSignature }
-          : {}),
-      });
+    const emittedToolCallIds = new Set<string>();
+    for (const entry of blockMap.values()) {
+      if (entry.kind === "text") {
+        if (entry.text.length > 0) {
+          contentBlocks.push({ type: "text", text: entry.text });
+        }
+        continue;
+      }
+      if (entry.kind === "thinking") {
+        // Emit thinking blocks even when text is empty if a signature
+        // was captured — Anthropic's redacted-adjacent flow can
+        // produce a thinking block whose visible text is empty but
+        // whose signature must round-trip on follow-up turns.
+        if (entry.text.length === 0 && entry.signature === undefined) {
+          continue;
+        }
+        contentBlocks.push({
+          type: "thinking",
+          thinking: entry.text,
+          ...(entry.signature !== undefined
+            ? { signature: entry.signature }
+            : {}),
+        });
+        continue;
+      }
+      if (entry.kind === "redacted_thinking") {
+        contentBlocks.push({ type: "redacted_thinking", data: entry.data });
+        continue;
+      }
+      if (entry.kind === "tool_use") {
+        const finalized = completedToolCallsByCallId.get(entry.callId);
+        if (finalized !== undefined) {
+          contentBlocks.push(finalized);
+          emittedToolCallIds.add(entry.callId);
+        }
+        continue;
+      }
+      entry satisfies never;
     }
-    // Redacted thinking blocks land before the assistant text on the
-    // wire (Anthropic streams them ahead of any text block); preserving
-    // that order is what lets the request builder echo them back in the
-    // same position on the next turn.
-    contentBlocks.push(...redactedThinkingBlocks);
-    if (partial.text.length > 0) {
-      contentBlocks.push({ type: "text", text: partial.text });
+    // Tool calls that completed without a corresponding tool_use
+    // marker in the map (legacy callers that don't propagate index
+    // through tool_call.start) still land in the final turn so the
+    // pre-per-index behaviour is preserved.
+    for (const tc of completedToolCalls) {
+      if (tc.type === "tool_call" && !emittedToolCallIds.has(tc.id)) {
+        contentBlocks.push(tc);
+      }
     }
-    // Citations are appended after the text they annotate. The
-    // CitationBlock type documents this attribution rule
-    // (CitationBlock comment in runtime.ts): consumers attribute
-    // trailing CitationBlocks to the nearest preceding TextBlock.
+    // Citations append after the per-index walk. Their event payload
+    // doesn't carry the source content-block index today, so they
+    // attribute by adjacency to the nearest preceding TextBlock per
+    // the CitationBlock docstring. Index-precise attribution is a
+    // separately tracked extension.
     contentBlocks.push(...citationBlocks);
-    contentBlocks.push(...completedToolCalls);
 
     const finalTurn: AssistantTurn = {
       role: "assistant",
@@ -835,36 +954,33 @@ function snapshotPartial(partial: PartialMessage): PartialMessage {
   };
 }
 
-// Guards the single-buffer text accumulator, the single-buffer thinking
-// accumulator, and the single-slot thinking-signature capture against
-// non-zero block indices. Per-block routing requires a per-index
-// accumulator that does not yet exist in the harness; without it,
-// deltas from different blocks would silently concatenate into the
-// same buffer (or, for the signature, the later block would overwrite
-// the earlier). The guard makes that failure surface loudly.
-//
-// Thrown as a `ProtocolMismatchError` so the harness's stream-error
-// catch routes it through `classifyStreamError` to the
-// `"protocol_mismatch"` category — non-retryable — rather than the
-// generic-Error `"retryable"` fallback that would invite a retry loop
-// to mask a deterministic wiring bug.
-function guardNonZeroIndex(
+// The harness's per-index routing is load-bearing on every delta
+// carrying an `index`. Provider adapters synthesize a default at the
+// adapter boundary if their wire shape doesn't carry one (e.g.
+// OpenAI Chat Completions emits `index: 0` explicitly on text and
+// thinking deltas because Chat Completions ships a single content
+// block per kind per response). A delta arriving at the harness
+// without an index is a wiring bug at the adapter, not data the
+// harness should silently route to block 0 — surfacing it as a
+// ProtocolMismatchError is the load-bearing alternative to corrupt
+// state.
+function requireIndex(
   event: {
     type: string;
     data: { index?: number };
   },
-  bufferName: string,
-): void {
+  variant: string,
+): number {
   const index = event.data.index;
-  if (index !== undefined && index !== 0) {
+  if (index === undefined) {
     throw new ProtocolMismatchError(
-      `harness received ${event.type} carrying index=${String(index)}; ` +
-        `the single-buffer ${bufferName} accumulator cannot route per-index ` +
-        `deltas. The per-index harness refactor must precede parsers that ` +
-        `emit non-zero indices.`,
+      `harness received ${event.type} (${variant}) without an index; ` +
+        `provider adapters must synthesize an index at the boundary even ` +
+        `when the wire shape doesn't carry one`,
       event,
     );
   }
+  return index;
 }
 
 function mergeUsage(

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -16,6 +16,7 @@
 import { type } from "arktype";
 
 import type {
+  CitationBlock,
   ConversationTurn,
   InferenceEvent,
   InferenceOptions,
@@ -170,6 +171,11 @@ export async function* runInference(
   // here so the final assistant turn carries them in the same sequence
   // they arrived on the wire.
   const redactedThinkingBlocks: RedactedThinkingBlock[] = [];
+  // Citations streamed from the provider, in arrival order. Each
+  // citation typically annotates the most recently emitted text run;
+  // preserving the streaming order lets downstream consumers
+  // re-attach citations to their text regions.
+  const citationBlocks: CitationBlock[] = [];
   let usageSeen: TokenUsage | null = null;
 
   // Tool call state: keyed by callId (or index for OpenAI).
@@ -464,6 +470,20 @@ export async function* runInference(
               break;
             }
 
+            case "inference.citation": {
+              // Citations stream interleaved with text deltas. The
+              // harness preserves arrival order so consumers building
+              // citation-aware UI can re-attach each citation to the
+              // text region that immediately precedes it.
+              citationBlocks.push(raw.data.citation);
+              yield {
+                type: "inference.citation",
+                seq: nextSeq(),
+                data: { citation: raw.data.citation },
+              };
+              break;
+            }
+
             case "inference.thinking.redacted": {
               // Redacted thinking blocks arrive as one-shots inside
               // content_block_start (no delta stream). Preserve insertion
@@ -671,6 +691,11 @@ export async function* runInference(
     if (partial.text.length > 0) {
       contentBlocks.push({ type: "text", text: partial.text });
     }
+    // Citations are appended after the text they annotate. The
+    // CitationBlock type documents this attribution rule
+    // (CitationBlock comment in runtime.ts): consumers attribute
+    // trailing CitationBlocks to the nearest preceding TextBlock.
+    contentBlocks.push(...citationBlocks);
     contentBlocks.push(...completedToolCalls);
 
     const finalTurn: AssistantTurn = {

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -646,12 +646,21 @@ export async function* runInference(
 
             case "inference.usage": {
               // Accumulate usage — providers may send multiple usage events
-              // (e.g., Anthropic sends one at message_start, one at message_delta).
+              // (e.g., Anthropic sends one at message_start with input
+              // tokens, then one at message_delta with output tokens
+              // and input deliberately set to 0 by the parser to mean
+              // "no change to input"). Emit the cumulative
+              // post-merge total rather than the raw incoming so
+              // downstream consumers and invariants see a monotone
+              // non-decreasing stream — the raw incoming would
+              // observably "decrease" input from a real count back
+              // to 0 between the two events even though no decrease
+              // occurred in the underlying counter.
               usageSeen = mergeUsage(usageSeen, raw.data.usage);
               yield {
                 type: "inference.usage",
                 seq: nextSeq(),
-                data: { usage: raw.data.usage },
+                data: { usage: usageSeen },
               };
               break;
             }

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -34,6 +34,7 @@ import {
   classifyAbortError,
   classifyStreamError,
   classifyTimeoutError,
+  ProtocolMismatchError,
 } from "./errors";
 
 /**
@@ -413,6 +414,7 @@ export async function* runInference(
         for (const raw of rawEvents) {
           switch (raw.type) {
             case "inference.text.delta": {
+              guardNonZeroIndex(raw, "text");
               partial.text += raw.data.token;
               yield {
                 type: "inference.text.delta",
@@ -426,6 +428,7 @@ export async function* runInference(
             }
 
             case "inference.thinking.delta": {
+              guardNonZeroIndex(raw, "thinking");
               thinkingBuffer += raw.data.token;
               partial.thinking = thinkingBuffer;
               yield {
@@ -444,6 +447,7 @@ export async function* runInference(
               // the thinking_delta stream. The harness collapses all thinking
               // content into a single block today, so a single trailing
               // signature is captured here and attached at finalisation.
+              guardNonZeroIndex(raw, "signature");
               thinkingSignature = raw.data.signature;
               yield {
                 type: "inference.thinking.signature",
@@ -761,6 +765,38 @@ function snapshotPartial(partial: PartialMessage): PartialMessage {
         }
       : {}),
   };
+}
+
+// Guards the single-buffer text accumulator, the single-buffer thinking
+// accumulator, and the single-slot thinking-signature capture against
+// non-zero block indices. Per-block routing requires a per-index
+// accumulator that does not yet exist in the harness; without it,
+// deltas from different blocks would silently concatenate into the
+// same buffer (or, for the signature, the later block would overwrite
+// the earlier). The guard makes that failure surface loudly.
+//
+// Thrown as a `ProtocolMismatchError` so the harness's stream-error
+// catch routes it through `classifyStreamError` to the
+// `"protocol_mismatch"` category — non-retryable — rather than the
+// generic-Error `"retryable"` fallback that would invite a retry loop
+// to mask a deterministic wiring bug.
+function guardNonZeroIndex(
+  event: {
+    type: string;
+    data: { index?: number };
+  },
+  bufferName: string,
+): void {
+  const index = event.data.index;
+  if (index !== undefined && index !== 0) {
+    throw new ProtocolMismatchError(
+      `harness received ${event.type} carrying index=${String(index)}; ` +
+        `the single-buffer ${bufferName} accumulator cannot route per-index ` +
+        `deltas. The per-index harness refactor must precede parsers that ` +
+        `emit non-zero indices.`,
+      event,
+    );
+  }
 }
 
 function mergeUsage(

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -554,6 +554,7 @@ export async function* runInference(
             }
 
             case "inference.tool_call.start": {
+              const toolIdx = requireIndex(raw, "tool_call.start");
               const { callId, name } = raw.data;
               openToolCalls.set(callId, { callId, name, argsBuffer: "" });
               // OpenAI-flavoured adapters synthesize a placeholder
@@ -562,15 +563,8 @@ export async function* runInference(
               // start event's `data.index` so the placeholder the
               // delta emits (`String(blockIndex)`) maps back to the
               // real id even when `tcDelta.index` is non-zero or
-              // non-contiguous. The fallback to arrival-order
-              // (`openToolCalls.size - 1`) preserves behaviour for
-              // legacy adapters that don't propagate index on the
-              // start event.
-              if (raw.data.index !== undefined) {
-                indexToCallId.set(String(raw.data.index), callId);
-              } else {
-                indexToCallId.set(String(openToolCalls.size - 1), callId);
-              }
+              // non-contiguous.
+              indexToCallId.set(String(toolIdx), callId);
               // Anchor the tool_use position in the per-index map.
               // The map walk in final assembly will resolve the marker
               // via `completedToolCalls` so the tool_use block lands
@@ -579,24 +573,18 @@ export async function* runInference(
               // same index throw, matching the discipline of the
               // text/thinking/redacted_thinking branches above —
               // distinct kinds cannot share an index without losing
-              // the per-index ordering guarantee. When the parser
-              // doesn't supply an index (legacy emitters), the marker
-              // is skipped and the tool call falls back to the
-              // append-after-walk path in final assembly.
-              const toolIdx = raw.data.index;
-              if (toolIdx !== undefined) {
-                const existingAtIdx = blockMap.get(toolIdx);
-                if (existingAtIdx === undefined) {
-                  blockMap.set(toolIdx, { kind: "tool_use", callId });
-                } else if (
-                  existingAtIdx.kind !== "tool_use" ||
-                  existingAtIdx.callId !== callId
-                ) {
-                  throw new ProtocolMismatchError(
-                    `harness: tool_call.start at index ${String(toolIdx)} collides with existing ${existingAtIdx.kind} block`,
-                    raw,
-                  );
-                }
+              // the per-index ordering guarantee.
+              const existingAtIdx = blockMap.get(toolIdx);
+              if (existingAtIdx === undefined) {
+                blockMap.set(toolIdx, { kind: "tool_use", callId });
+              } else if (
+                existingAtIdx.kind !== "tool_use" ||
+                existingAtIdx.callId !== callId
+              ) {
+                throw new ProtocolMismatchError(
+                  `harness: tool_call.start at index ${String(toolIdx)} collides with existing ${existingAtIdx.kind} block`,
+                  raw,
+                );
               }
               partial.toolCalls = [
                 ...(partial.toolCalls ?? []),
@@ -771,7 +759,6 @@ export async function* runInference(
       }
     }
     const contentBlocks: ContentBlock[] = [];
-    const emittedToolCallIds = new Set<string>();
     for (const entry of blockMap.values()) {
       if (entry.kind === "text") {
         if (entry.text.length > 0) {
@@ -802,22 +789,25 @@ export async function* runInference(
       }
       if (entry.kind === "tool_use") {
         const finalized = completedToolCallsByCallId.get(entry.callId);
-        if (finalized !== undefined) {
-          contentBlocks.push(finalized);
-          emittedToolCallIds.add(entry.callId);
+        if (finalized === undefined) {
+          // Every tool_use marker is added in the
+          // inference.tool_call.start handler at the same time the
+          // entry is inserted into openToolCalls. The finalize loop
+          // above turns every openToolCalls entry into a
+          // completedToolCalls entry. So a marker whose callId is
+          // missing from completedToolCallsByCallId here would mean
+          // the start-time bookkeeping diverged from the finalize-
+          // time bookkeeping — surface it loudly rather than dropping
+          // the tool call from the final turn.
+          throw new ProtocolMismatchError(
+            `harness: tool_use marker at callId ${entry.callId} has no matching completed tool call`,
+            entry,
+          );
         }
+        contentBlocks.push(finalized);
         continue;
       }
       entry satisfies never;
-    }
-    // Tool calls that completed without a corresponding tool_use
-    // marker in the map (legacy callers that don't propagate index
-    // through tool_call.start) still land in the final turn so the
-    // pre-per-index behaviour is preserved.
-    for (const tc of completedToolCalls) {
-      if (tc.type === "tool_call" && !emittedToolCallIds.has(tc.id)) {
-        contentBlocks.push(tc);
-      }
     }
     // Citations append after the per-index walk. Their event payload
     // doesn't carry the source content-block index today, so they

--- a/packages/inference/src/providers/anthropic.test.ts
+++ b/packages/inference/src/providers/anthropic.test.ts
@@ -360,3 +360,305 @@ describe("Anthropic adapter — redacted_thinking parser-to-builder round-trip",
     expect(bodyText).toContain(`"type":"redacted_thinking"`);
   });
 });
+
+function pickFirstCitation(
+  events: InferenceEvent[],
+): Extract<InferenceEvent, { type: "inference.citation" }> {
+  const ev = events[0];
+  if (ev === undefined) throw new Error("expected at least one event");
+  if (ev.type !== "inference.citation") {
+    throw new Error(`expected inference.citation, got ${ev.type}`);
+  }
+  return ev;
+}
+
+describe("Anthropic parser — citations_delta to inference.citation", () => {
+  test("web_search_result_location maps to source.uri + title with no location", () => {
+    // Anthropic's web_search citations carry url + title + cited_text +
+    // encrypted_index. The encrypted_index has no echo-back target in
+    // CitationBlock today and is intentionally dropped at the adapter.
+    const adapter = createAnthropicAdapter();
+    const events = parse(adapter, {
+      type: "content_block_delta",
+      index: 3,
+      delta: {
+        type: "citations_delta",
+        citation: {
+          type: "web_search_result_location",
+          cited_text: "Quoted span from the web search result.",
+          url: "https://example.com/article",
+          title: "Example Article Title",
+          encrypted_index: "EncryptedIndexAAAA==",
+        },
+      },
+    });
+    const ev = pickFirstCitation(events);
+    expect(ev.data.citation.type).toBe("citation");
+    expect(ev.data.citation.citedText).toBe(
+      "Quoted span from the web search result.",
+    );
+    expect(ev.data.citation.source.uri).toBe("https://example.com/article");
+    expect(ev.data.citation.source.title).toBe("Example Article Title");
+    expect(ev.data.citation.location).toBeUndefined();
+    // textOffset is intentionally never populated at this layer.
+    expect(ev.data.citation.textOffset).toBeUndefined();
+  });
+
+  test("page_location maps to location.kind=page with start/end page numbers", () => {
+    const adapter = createAnthropicAdapter();
+    const events = parse(adapter, {
+      type: "content_block_delta",
+      index: 0,
+      delta: {
+        type: "citations_delta",
+        citation: {
+          type: "page_location",
+          cited_text: "Excerpt from page 4.",
+          document_index: 0,
+          document_title: "Quarterly Report",
+          start_page_number: 4,
+          end_page_number: 5,
+        },
+      },
+    });
+    const ev = pickFirstCitation(events);
+    expect(ev.data.citation.citedText).toBe("Excerpt from page 4.");
+    expect(ev.data.citation.source.title).toBe("Quarterly Report");
+    expect(ev.data.citation.source.documentRef).toEqual({ index: 0 });
+    expect(ev.data.citation.location).toEqual({
+      kind: "page",
+      start: 4,
+      end: 5,
+    });
+  });
+
+  test("char_location maps to location.kind=char with character offsets", () => {
+    const adapter = createAnthropicAdapter();
+    const events = parse(adapter, {
+      type: "content_block_delta",
+      index: 1,
+      delta: {
+        type: "citations_delta",
+        citation: {
+          type: "char_location",
+          cited_text: "Inline quote.",
+          document_index: 2,
+          document_title: "Spec",
+          start_char_index: 1024,
+          end_char_index: 1037,
+        },
+      },
+    });
+    const ev = pickFirstCitation(events);
+    expect(ev.data.citation.source.documentRef).toEqual({ index: 2 });
+    expect(ev.data.citation.location).toEqual({
+      kind: "char",
+      start: 1024,
+      end: 1037,
+    });
+  });
+
+  test("content_block_location maps to location.kind=content-block", () => {
+    const adapter = createAnthropicAdapter();
+    const events = parse(adapter, {
+      type: "content_block_delta",
+      index: 0,
+      delta: {
+        type: "citations_delta",
+        citation: {
+          type: "content_block_location",
+          cited_text: "Block-indexed quote.",
+          document_index: 1,
+          document_title: "Structured doc",
+          start_block_index: 7,
+          end_block_index: 8,
+        },
+      },
+    });
+    const ev = pickFirstCitation(events);
+    expect(ev.data.citation.source.documentRef).toEqual({ index: 1 });
+    expect(ev.data.citation.location).toEqual({
+      kind: "content-block",
+      start: 7,
+      end: 8,
+    });
+  });
+
+  test("unrecognized citation variant throws ProtocolMismatchError naming the variant", () => {
+    const adapter = createAnthropicAdapter();
+    let thrown: unknown;
+    try {
+      parse(adapter, {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "citations_delta",
+          citation: {
+            type: "future_unknown_location",
+            cited_text: "x",
+          },
+        },
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(ProtocolMismatchError);
+    if (thrown instanceof ProtocolMismatchError) {
+      expect(thrown.message).toMatch(/unrecognized citation variant/);
+      expect(thrown.message).toMatch(/future_unknown_location/);
+    }
+  });
+
+  test("citations_delta missing citation payload throws ProtocolMismatchError", () => {
+    const adapter = createAnthropicAdapter();
+    let thrown: unknown;
+    try {
+      parse(adapter, {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "citations_delta" },
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(ProtocolMismatchError);
+    if (thrown instanceof ProtocolMismatchError) {
+      expect(thrown.message).toMatch(/missing citation payload/);
+    }
+  });
+
+  test("citation missing cited_text throws ProtocolMismatchError", () => {
+    // CitationBlock.citedText is required ("Both providers emit it;
+    // required for inspection and for fallback offset reconstruction"
+    // — runtime.ts). Surfacing a missing wire field as a thrown error
+    // is the load-bearing alternative to coalescing to an empty
+    // string and silently emitting a content-free citation.
+    const adapter = createAnthropicAdapter();
+    let thrown: unknown;
+    try {
+      parse(adapter, {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "citations_delta",
+          citation: {
+            type: "web_search_result_location",
+            url: "https://example.com/",
+            title: "Title",
+          },
+        },
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(ProtocolMismatchError);
+    if (thrown instanceof ProtocolMismatchError) {
+      expect(thrown.message).toMatch(/cited_text/);
+      expect(thrown.message).toMatch(/block 0/);
+    }
+  });
+
+  test("citations interleave with text deltas preserving arrival order", () => {
+    // Anthropic streams citations attached to the most recent text
+    // run as `citations_delta` events interleaved with subsequent
+    // `text_delta`s. Downstream consumers building citation-aware UI
+    // re-attach each citation to the text region preceding it, so
+    // the parser-emitted event stream must preserve the wire order
+    // exactly. Feed a mixed sequence and assert the emitted events
+    // come out in the same order they went in.
+    const adapter = createAnthropicAdapter();
+    const events: InferenceEvent[] = [];
+    events.push(
+      ...parse(adapter, {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "First claim. " },
+      }),
+    );
+    events.push(
+      ...parse(adapter, {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "citations_delta",
+          citation: {
+            type: "web_search_result_location",
+            cited_text: "supporting quote one",
+            url: "https://example.com/one",
+            title: "Source One",
+          },
+        },
+      }),
+    );
+    events.push(
+      ...parse(adapter, {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Second claim. " },
+      }),
+    );
+    events.push(
+      ...parse(adapter, {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "citations_delta",
+          citation: {
+            type: "web_search_result_location",
+            cited_text: "supporting quote two",
+            url: "https://example.com/two",
+            title: "Source Two",
+          },
+        },
+      }),
+    );
+
+    const types = events.map((e) => e.type);
+    expect(types).toEqual([
+      "inference.text.delta",
+      "inference.citation",
+      "inference.text.delta",
+      "inference.citation",
+    ]);
+    // Verify each citation's citedText so the alternation isn't just
+    // type-correct but content-accurate.
+    const citations = events.filter((e) => e.type === "inference.citation");
+    expect(citations).toHaveLength(2);
+    const first = citations[0];
+    const second = citations[1];
+    if (
+      first?.type !== "inference.citation" ||
+      second?.type !== "inference.citation"
+    ) {
+      throw new Error("expected two citation events");
+    }
+    expect(first.data.citation.citedText).toBe("supporting quote one");
+    expect(second.data.citation.citedText).toBe("supporting quote two");
+  });
+
+  test("page_location missing start_page_number throws ProtocolMismatchError", () => {
+    const adapter = createAnthropicAdapter();
+    let thrown: unknown;
+    try {
+      parse(adapter, {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "citations_delta",
+          citation: {
+            type: "page_location",
+            cited_text: "Quote",
+            document_index: 0,
+            end_page_number: 5,
+          },
+        },
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(ProtocolMismatchError);
+    if (thrown instanceof ProtocolMismatchError) {
+      expect(thrown.message).toMatch(/start_page_number/);
+    }
+  });
+});

--- a/packages/inference/src/providers/anthropic.test.ts
+++ b/packages/inference/src/providers/anthropic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import type { InferenceEvent } from "@intx/types/runtime";
+import type { ConversationTurn, InferenceEvent } from "@intx/types/runtime";
 
 import { ProtocolMismatchError } from "../errors";
 import { createAnthropicAdapter } from "./anthropic";
@@ -193,7 +193,7 @@ describe("Anthropic parser — multi-tool callId routing across indices", () => 
 describe("Anthropic parser — required-index schema enforcement", () => {
   // Anthropic's SSE protocol guarantees `index` on every content_block_*
   // event. A missing `index` is a protocol violation, not a "default to
-  // 0" situation — the harness's per-index routing (task #22) is
+  // 0" situation — the parser's `blockIndexToCallId` cache is
   // load-bearing on the index being real, not synthesized.
 
   test("content_block_delta without index throws ProtocolMismatchError", () => {
@@ -236,5 +236,127 @@ describe("Anthropic parser — required-index schema enforcement", () => {
       thrown = e;
     }
     expect(thrown).toBeInstanceOf(ProtocolMismatchError);
+  });
+});
+
+// All redacted_thinking test fixtures below are SYNTHETIC: derived
+// from Anthropic's documented wire shape rather than from a real
+// captured response. The fixture corpus carries no captured
+// redacted_thinking bytes today because Anthropic's documented canary
+// did not trigger the safety classifier on capture day — every
+// `redacted-thinking[-streaming]` row landed in the corpus with
+// `outcome: "misled"` and contains regular `thinking` blocks instead.
+//
+// The opaque `data` payload below mimics Anthropic's format
+// (long base64-looking string) but carries no real cryptographic
+// content. Round-trip tests assert the harness/adapter pass the
+// bytes verbatim — the actual contents are irrelevant to the
+// invariant being tested.
+const SYNTHETIC_REDACTED_DATA =
+  "ErUBCkYIBxgCKkABEHk1RmZpaWlsOXJxN0Z6cVB" +
+  "QcjBQYS9wQUdBQUFBQUFBQUFBQUFRQUFBQUFBQU" +
+  "FBQUFBQUFBQUFBQT09EhJYWXpBOXJxN0Z6cVBQc" +
+  "jBQYS9wAAA=";
+
+function pickFirstThinkingRedacted(
+  events: InferenceEvent[],
+): Extract<InferenceEvent, { type: "inference.thinking.redacted" }> {
+  const ev = events[0];
+  if (ev === undefined) throw new Error("expected at least one event");
+  if (ev.type !== "inference.thinking.redacted") {
+    throw new Error(`expected inference.thinking.redacted, got ${ev.type}`);
+  }
+  return ev;
+}
+
+describe("Anthropic parser — redacted_thinking content_block_start", () => {
+  test("emits inference.thinking.redacted carrying the data and source index", () => {
+    const adapter = createAnthropicAdapter();
+    const events = parse(adapter, {
+      type: "content_block_start",
+      index: 0,
+      content_block: {
+        type: "redacted_thinking",
+        data: SYNTHETIC_REDACTED_DATA,
+      },
+    });
+    expect(events).toHaveLength(1);
+    const ev = pickFirstThinkingRedacted(events);
+    expect(ev.data.index).toBe(0);
+    expect(ev.data.redactedThinking.type).toBe("redacted_thinking");
+    expect(ev.data.redactedThinking.data).toBe(SYNTHETIC_REDACTED_DATA);
+  });
+
+  test("preserves the data verbatim — no normalization or transformation", () => {
+    const adapter = createAnthropicAdapter();
+    // The data is an opaque blob; any mutation breaks the round-trip.
+    // Use a string with characters that an over-eager normalizer would
+    // touch (newlines, whitespace, base64 padding).
+    const adversarial = "abc\n  ==\r\n\tdef==";
+    const events = parse(adapter, {
+      type: "content_block_start",
+      index: 2,
+      content_block: { type: "redacted_thinking", data: adversarial },
+    });
+    const ev = pickFirstThinkingRedacted(events);
+    expect(ev.data.redactedThinking.data).toBe(adversarial);
+  });
+
+  test("missing `data` field throws ProtocolMismatchError naming the field", () => {
+    const adapter = createAnthropicAdapter();
+    let thrown: unknown;
+    try {
+      parse(adapter, {
+        type: "content_block_start",
+        index: 4,
+        content_block: { type: "redacted_thinking" },
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(ProtocolMismatchError);
+    if (thrown instanceof ProtocolMismatchError) {
+      expect(thrown.message).toMatch(/redacted_thinking/);
+      expect(thrown.message).toMatch(/data/);
+      expect(thrown.message).toMatch(/index 4/);
+    }
+  });
+});
+
+describe("Anthropic adapter — redacted_thinking parser-to-builder round-trip", () => {
+  // The parser-side wire shape and the request-builder-side wire shape
+  // are tested independently elsewhere. This test closes the loop: it
+  // proves that the opaque `data` blob the parser surfaces in
+  // `inference.thinking.redacted` reconstructs back to a request body
+  // that carries the same bytes verbatim. That round-trip is the
+  // invariant Anthropic requires on every follow-up turn.
+  test("data survives parse → reconstruct → buildRequest unchanged", () => {
+    const adapter = createAnthropicAdapter();
+    const events = parse(adapter, {
+      type: "content_block_start",
+      index: 0,
+      content_block: {
+        type: "redacted_thinking",
+        data: SYNTHETIC_REDACTED_DATA,
+      },
+    });
+    const ev = pickFirstThinkingRedacted(events);
+    const reconstructed: ConversationTurn = {
+      role: "assistant",
+      content: [ev.data.redactedThinking],
+      timestamp: 0,
+    };
+    const req = adapter.buildRequest([reconstructed], "claude-test", {
+      maxTokens: 100,
+    });
+    // The structural shape of the body is asserted elsewhere — here
+    // we care only that the opaque `data` survives the round-trip.
+    // Use a structural extraction via JSON.parse + cast through unknown
+    // because the integration-style assertion lives in the broader
+    // tests/inference/providers/anthropic.test.ts and is already
+    // exercised.
+    const bodyText = req.body;
+    expect(bodyText).toContain(SYNTHETIC_REDACTED_DATA);
+    expect(bodyText).toContain(`"type":"redacted_thinking"`);
   });
 });

--- a/packages/inference/src/providers/anthropic.test.ts
+++ b/packages/inference/src/providers/anthropic.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from "bun:test";
+
+import type { InferenceEvent } from "@intx/types/runtime";
+
+import { ProtocolMismatchError } from "../errors";
+import { createAnthropicAdapter } from "./anthropic";
+
+// The parser is exercised through the public adapter rather than imported
+// directly. parseResponse is intentionally not exported — the adapter
+// owns the per-request `blockIndexToCallId` map and creating it through
+// the same factory production uses keeps tests honest about the lifecycle.
+
+function parse(
+  adapter: ReturnType<typeof createAnthropicAdapter>,
+  sse: object,
+): InferenceEvent[] {
+  return adapter.parseResponse(JSON.stringify(sse));
+}
+
+// Inline narrowing utilities. Each `pickFirst*` returns the strongly-typed
+// variant by exhausting the failure modes — empty result or wrong type
+// throw a descriptive error, leaving the body of the test to operate on
+// the narrowed value without an unsafe cast.
+
+function pickFirstTextDelta(
+  events: InferenceEvent[],
+): Extract<InferenceEvent, { type: "inference.text.delta" }> {
+  const ev = events[0];
+  if (ev === undefined) throw new Error("expected at least one event");
+  if (ev.type !== "inference.text.delta") {
+    throw new Error(`expected inference.text.delta, got ${ev.type}`);
+  }
+  return ev;
+}
+
+function pickFirstThinkingDelta(
+  events: InferenceEvent[],
+): Extract<InferenceEvent, { type: "inference.thinking.delta" }> {
+  const ev = events[0];
+  if (ev === undefined) throw new Error("expected at least one event");
+  if (ev.type !== "inference.thinking.delta") {
+    throw new Error(`expected inference.thinking.delta, got ${ev.type}`);
+  }
+  return ev;
+}
+
+function pickFirstThinkingSignature(
+  events: InferenceEvent[],
+): Extract<InferenceEvent, { type: "inference.thinking.signature" }> {
+  const ev = events[0];
+  if (ev === undefined) throw new Error("expected at least one event");
+  if (ev.type !== "inference.thinking.signature") {
+    throw new Error(`expected inference.thinking.signature, got ${ev.type}`);
+  }
+  return ev;
+}
+
+function pickFirstToolCallStart(
+  events: InferenceEvent[],
+): Extract<InferenceEvent, { type: "inference.tool_call.start" }> {
+  const ev = events[0];
+  if (ev === undefined) throw new Error("expected at least one event");
+  if (ev.type !== "inference.tool_call.start") {
+    throw new Error(`expected inference.tool_call.start, got ${ev.type}`);
+  }
+  return ev;
+}
+
+function pickFirstToolCallDelta(
+  events: InferenceEvent[],
+): Extract<InferenceEvent, { type: "inference.tool_call.delta" }> {
+  const ev = events[0];
+  if (ev === undefined) throw new Error("expected at least one event");
+  if (ev.type !== "inference.tool_call.delta") {
+    throw new Error(`expected inference.tool_call.delta, got ${ev.type}`);
+  }
+  return ev;
+}
+
+describe("Anthropic parser — index propagation on delta events", () => {
+  test("text_delta carries the SSE block index forward as data.index", () => {
+    const adapter = createAnthropicAdapter();
+    const events = parse(adapter, {
+      type: "content_block_delta",
+      index: 1,
+      delta: { type: "text_delta", text: "hi" },
+    });
+    expect(events).toHaveLength(1);
+    const ev = pickFirstTextDelta(events);
+    expect(ev.data.index).toBe(1);
+    expect(ev.data.token).toBe("hi");
+  });
+
+  test("thinking_delta carries the SSE block index forward as data.index", () => {
+    const adapter = createAnthropicAdapter();
+    const events = parse(adapter, {
+      type: "content_block_delta",
+      index: 2,
+      delta: { type: "thinking_delta", thinking: "reasoning" },
+    });
+    expect(events).toHaveLength(1);
+    const ev = pickFirstThinkingDelta(events);
+    expect(ev.data.index).toBe(2);
+    expect(ev.data.token).toBe("reasoning");
+  });
+
+  test("signature_delta carries the SSE block index forward as data.index", () => {
+    const adapter = createAnthropicAdapter();
+    const events = parse(adapter, {
+      type: "content_block_delta",
+      index: 3,
+      delta: { type: "signature_delta", signature: "sig-abc" },
+    });
+    expect(events).toHaveLength(1);
+    const ev = pickFirstThinkingSignature(events);
+    expect(ev.data.index).toBe(3);
+    expect(ev.data.signature).toBe("sig-abc");
+  });
+
+  test("tool_call.start carries the SSE block index forward as data.index", () => {
+    const adapter = createAnthropicAdapter();
+    const events = parse(adapter, {
+      type: "content_block_start",
+      index: 4,
+      content_block: { type: "tool_use", id: "call_xyz", name: "search" },
+    });
+    expect(events).toHaveLength(1);
+    const ev = pickFirstToolCallStart(events);
+    expect(ev.data.index).toBe(4);
+    expect(ev.data.callId).toBe("call_xyz");
+  });
+
+  test("tool_call.delta carries the SSE block index forward as data.index", () => {
+    const adapter = createAnthropicAdapter();
+    parse(adapter, {
+      type: "content_block_start",
+      index: 5,
+      content_block: { type: "tool_use", id: "call_abc", name: "search" },
+    });
+    const events = parse(adapter, {
+      type: "content_block_delta",
+      index: 5,
+      delta: { type: "input_json_delta", partial_json: '{"q":' },
+    });
+    expect(events).toHaveLength(1);
+    const ev = pickFirstToolCallDelta(events);
+    expect(ev.data.index).toBe(5);
+    expect(ev.data.callId).toBe("call_abc");
+    expect(ev.data.argumentFragment).toBe('{"q":');
+  });
+});
+
+describe("Anthropic parser — multi-tool callId routing across indices", () => {
+  // Regression target: when two tool_use blocks open at distinct indices,
+  // the input_json_delta lookup must resolve to the correct callId per
+  // index. Collapsing the indices into one slot would route the second
+  // tool's argument fragments to the first tool's callId.
+  test("input_json_deltas at distinct indices resolve to distinct callIds", () => {
+    const adapter = createAnthropicAdapter();
+    parse(adapter, {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "tool_use", id: "call_first", name: "alpha" },
+    });
+    parse(adapter, {
+      type: "content_block_start",
+      index: 1,
+      content_block: { type: "tool_use", id: "call_second", name: "beta" },
+    });
+
+    const firstFrag = parse(adapter, {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "input_json_delta", partial_json: '{"a":1}' },
+    });
+    const secondFrag = parse(adapter, {
+      type: "content_block_delta",
+      index: 1,
+      delta: { type: "input_json_delta", partial_json: '{"b":2}' },
+    });
+
+    const first = pickFirstToolCallDelta(firstFrag);
+    const second = pickFirstToolCallDelta(secondFrag);
+    expect(first.data.callId).toBe("call_first");
+    expect(first.data.index).toBe(0);
+    expect(first.data.argumentFragment).toBe('{"a":1}');
+    expect(second.data.callId).toBe("call_second");
+    expect(second.data.index).toBe(1);
+    expect(second.data.argumentFragment).toBe('{"b":2}');
+  });
+});
+
+describe("Anthropic parser — required-index schema enforcement", () => {
+  // Anthropic's SSE protocol guarantees `index` on every content_block_*
+  // event. A missing `index` is a protocol violation, not a "default to
+  // 0" situation — the harness's per-index routing (task #22) is
+  // load-bearing on the index being real, not synthesized.
+
+  test("content_block_delta without index throws ProtocolMismatchError", () => {
+    const adapter = createAnthropicAdapter();
+    let thrown: unknown;
+    try {
+      parse(adapter, {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "hi" },
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(ProtocolMismatchError);
+    if (thrown instanceof ProtocolMismatchError) {
+      expect(thrown.message).toMatch(/schema validation/);
+    }
+  });
+
+  test("content_block_start without index throws ProtocolMismatchError", () => {
+    const adapter = createAnthropicAdapter();
+    let thrown: unknown;
+    try {
+      parse(adapter, {
+        type: "content_block_start",
+        content_block: { type: "tool_use", id: "x", name: "y" },
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(ProtocolMismatchError);
+  });
+
+  test("content_block_stop without index throws ProtocolMismatchError", () => {
+    const adapter = createAnthropicAdapter();
+    let thrown: unknown;
+    try {
+      parse(adapter, { type: "content_block_stop" });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(ProtocolMismatchError);
+  });
+});

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -256,9 +256,19 @@ export type AnthropicRawEvent =
   | { kind: "message_stop" }
   | { kind: "skip" };
 
+// Anthropic's SSE protocol guarantees `index` on every content_block_*
+// event. Parsing it as required (not optional) means the type system
+// carries the guarantee through to every emission site below — no
+// defensive `?? 0` fallback that would silently route real protocol
+// violations to block 0 and corrupt the `blockIndexToCallId` cache the
+// parser uses to resolve input_json_delta lookups across multiple
+// tool_use blocks at distinct indices. A malformed upstream missing
+// `index` surfaces as a ProtocolMismatchError via the schema-validation
+// throw site, with the offending payload preserved in `error.raw` for
+// inspection.
 const ContentBlockDelta = type({
   type: "'content_block_delta'",
-  "index?": "number",
+  index: "number",
   delta: {
     type: "string",
     "text?": "string",
@@ -270,7 +280,7 @@ const ContentBlockDelta = type({
 
 const ContentBlockStart = type({
   type: "'content_block_start'",
-  "index?": "number",
+  index: "number",
   // Anthropic sends either content_block (snake_case) or contentBlock (camelCase).
   "content_block?": { type: "string", "id?": "string", "name?": "string" },
   "contentBlock?": { type: "string", "id?": "string", "name?": "string" },
@@ -278,7 +288,7 @@ const ContentBlockStart = type({
 
 const ContentBlockStop = type({
   type: "'content_block_stop'",
-  "index?": "number",
+  index: "number",
 });
 
 const MessageDelta = type({
@@ -343,7 +353,7 @@ function parseResponse(
 
   switch (event.type) {
     case "content_block_delta": {
-      const { delta } = event;
+      const { delta, index } = event;
 
       if (delta.type === "text_delta") {
         const token = delta.text ?? "";
@@ -351,7 +361,7 @@ function parseResponse(
           {
             type: "inference.text.delta",
             seq,
-            data: { token, partial: EMPTY_PARTIAL },
+            data: { token, partial: EMPTY_PARTIAL, index },
           },
         ];
       }
@@ -362,7 +372,7 @@ function parseResponse(
           {
             type: "inference.thinking.delta",
             seq,
-            data: { token, partial: EMPTY_PARTIAL },
+            data: { token, partial: EMPTY_PARTIAL, index },
           },
         ];
       }
@@ -379,13 +389,12 @@ function parseResponse(
           {
             type: "inference.thinking.signature",
             seq,
-            data: { signature },
+            data: { signature, index },
           },
         ];
       }
 
       if (delta.type === "input_json_delta") {
-        const index = event.index ?? 0;
         const callId = blockIndexToCallId.get(index);
         if (callId === undefined) {
           throw new ProtocolMismatchError(
@@ -402,6 +411,7 @@ function parseResponse(
               callId,
               argumentFragment: fragment,
               partial: EMPTY_PARTIAL,
+              index,
             },
           },
         ];
@@ -415,7 +425,7 @@ function parseResponse(
       if (block === undefined) return [];
 
       if (block.type === "tool_use") {
-        const index = event.index ?? 0;
+        const { index } = event;
         const callId = block.id ?? String(index);
         blockIndexToCallId.set(index, callId);
         const name = block.name ?? "";
@@ -423,10 +433,18 @@ function parseResponse(
           {
             type: "inference.tool_call.start",
             seq,
-            data: { callId, name, partial: EMPTY_PARTIAL },
+            data: { callId, name, partial: EMPTY_PARTIAL, index },
           },
         ];
       }
+      // Non-tool_use content_block_start events (text, thinking) emit
+      // nothing here by design: each content_block_delta arrives with
+      // a typed delta (text_delta, thinking_delta, signature_delta)
+      // that the switch above discriminates on directly, so an upfront
+      // start emission would be redundant. Tool calls are the
+      // exception because their callId arrives only in the start
+      // event and must be cached against the block index for
+      // subsequent input_json_delta lookups.
       return [];
     }
 

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -124,10 +124,15 @@ function toAnthropicBlock(block: ContentBlock): Record<string, unknown> {
       };
 
     case "redacted_thinking":
-      throw new Error(
-        "Anthropic adapter does not yet echo redacted_thinking content " +
-          "blocks back on follow-up turns.",
-      );
+      // The opaque `data` blob must echo back verbatim on every
+      // follow-up turn that includes this block as context. Any
+      // mutation (truncation, base64-decoding-and-reencoding,
+      // whitespace normalization) produces a 400 from Anthropic with
+      // "messages.N.content.M.redacted_thinking: Field required" or
+      // a context-corruption error on subsequent turns. The
+      // RedactedThinkingBlock type carries it as `string` (opaque
+      // base64); pass through untouched.
+      return { type: "redacted_thinking", data: block.data };
 
     case "image": {
       const source = block.source;
@@ -281,9 +286,24 @@ const ContentBlockDelta = type({
 const ContentBlockStart = type({
   type: "'content_block_start'",
   index: "number",
-  // Anthropic sends either content_block (snake_case) or contentBlock (camelCase).
-  "content_block?": { type: "string", "id?": "string", "name?": "string" },
-  "contentBlock?": { type: "string", "id?": "string", "name?": "string" },
+  // Anthropic sends either content_block (snake_case) or contentBlock
+  // (camelCase). `data` is optional on the shared shape because only
+  // redacted_thinking blocks carry it; the redacted_thinking branch in
+  // the parser asserts presence and throws ProtocolMismatchError when
+  // it is missing, rather than synthesizing an empty string that would
+  // round-trip back to Anthropic as a corrupted block.
+  "content_block?": {
+    type: "string",
+    "id?": "string",
+    "name?": "string",
+    "data?": "string",
+  },
+  "contentBlock?": {
+    type: "string",
+    "id?": "string",
+    "name?": "string",
+    "data?": "string",
+  },
 });
 
 const ContentBlockStop = type({
@@ -437,14 +457,47 @@ function parseResponse(
           },
         ];
       }
-      // Non-tool_use content_block_start events (text, thinking) emit
-      // nothing here by design: each content_block_delta arrives with
-      // a typed delta (text_delta, thinking_delta, signature_delta)
-      // that the switch above discriminates on directly, so an upfront
-      // start emission would be redundant. Tool calls are the
-      // exception because their callId arrives only in the start
-      // event and must be cached against the block index for
-      // subsequent input_json_delta lookups.
+
+      if (block.type === "redacted_thinking") {
+        // Anthropic delivers redacted_thinking as a one-shot inside
+        // content_block_start (no delta stream). The opaque `data`
+        // blob must echo back verbatim on every follow-up turn —
+        // mutating or synthesizing it corrupts the conversation
+        // context. A start event missing `data` is a protocol
+        // violation, not a default-to-empty case.
+        const { index } = event;
+        if (block.data === undefined) {
+          throw new ProtocolMismatchError(
+            `anthropic parseResponse: content_block_start of type redacted_thinking ` +
+              `at index ${String(index)} missing required \`data\` field`,
+            event,
+          );
+        }
+        return [
+          {
+            type: "inference.thinking.redacted",
+            seq,
+            data: {
+              redactedThinking: {
+                type: "redacted_thinking",
+                data: block.data,
+              },
+              index,
+            },
+          },
+        ];
+      }
+
+      // Non-tool_use, non-redacted_thinking content_block_start events
+      // (text, thinking) emit nothing here by design: each
+      // content_block_delta arrives with a typed delta (text_delta,
+      // thinking_delta, signature_delta) that the switch above
+      // discriminates on directly, so an upfront start emission would
+      // be redundant. Tool calls are the exception because their
+      // callId arrives only in the start event and must be cached
+      // against the block index for subsequent input_json_delta
+      // lookups; redacted_thinking is the exception because the block
+      // is delivered start-only with no follow-on deltas.
       return [];
     }
 

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -9,6 +9,7 @@ import type {
   PartialMessage,
   TokenUsage,
 } from "@intx/types/runtime";
+import { CitationBlock as CitationBlockType } from "@intx/types/runtime";
 import type { ProviderAdapter, BuiltRequest } from "../adapter";
 import { ProtocolMismatchError } from "../errors";
 
@@ -136,6 +137,107 @@ function toAnthropicMediaSource(source: MediaSource): Record<string, unknown> {
   // here fails this compile-time check.
   source satisfies never;
   throw new Error(`unreachable: unknown MediaSource kind`);
+}
+
+// Map an Anthropic-streamed citation onto the internal CitationBlock.
+// `textOffset` is intentionally not populated for any variant:
+// Anthropic's offsets are document-relative (page numbers, doc char
+// offsets, doc block indices) rather than text-relative — they don't
+// correspond to UTF-16 positions in the preceding TextBlock that
+// `CitationBlock.textOffset` describes. Computing text-relative
+// offsets from `cited_text` substring search produces wrong answers
+// whenever `cited_text` is paraphrased, appears multiple times, or
+// spans wire-chunk boundaries; better to leave the field unset than
+// guess.
+//
+// `encrypted_index` (web_search_result_location) has no echo-back
+// target in CitationBlock today and is intentionally dropped at this
+// layer. When echo-back of citation context lands, this is the layer
+// to preserve it from.
+function toCitationBlock(
+  wire: typeof AnthropicCitation.infer,
+  index: number,
+): typeof CitationBlockType.infer {
+  if (wire.cited_text === undefined) {
+    throw new ProtocolMismatchError(
+      `anthropic parseResponse: citation at block ${index} missing required \`cited_text\``,
+      wire,
+    );
+  }
+  const citedText = wire.cited_text;
+  const source: {
+    title?: string;
+    uri?: string;
+    documentRef?: { index: number };
+  } = {};
+  if (wire.title !== undefined) source.title = wire.title;
+  if (wire.url !== undefined) source.uri = wire.url;
+  if (wire.document_title !== undefined && source.title === undefined) {
+    source.title = wire.document_title;
+  }
+  if (wire.document_index !== undefined) {
+    source.documentRef = { index: wire.document_index };
+  }
+
+  switch (wire.type) {
+    case "web_search_result_location":
+      return { type: "citation", citedText, source };
+    case "page_location": {
+      // Anthropic page numbers are 1-indexed and inclusive on both
+      // ends per the documented PDF citation shape.
+      const start = wire.start_page_number;
+      const end = wire.end_page_number;
+      if (start === undefined || end === undefined) {
+        throw new ProtocolMismatchError(
+          `anthropic parseResponse: page_location citation at block ${index} missing start_page_number or end_page_number`,
+          wire,
+        );
+      }
+      return {
+        type: "citation",
+        citedText,
+        source,
+        location: { kind: "page", start, end },
+      };
+    }
+    case "char_location": {
+      const start = wire.start_char_index;
+      const end = wire.end_char_index;
+      if (start === undefined || end === undefined) {
+        throw new ProtocolMismatchError(
+          `anthropic parseResponse: char_location citation at block ${index} missing start_char_index or end_char_index`,
+          wire,
+        );
+      }
+      return {
+        type: "citation",
+        citedText,
+        source,
+        location: { kind: "char", start, end },
+      };
+    }
+    case "content_block_location": {
+      const start = wire.start_block_index;
+      const end = wire.end_block_index;
+      if (start === undefined || end === undefined) {
+        throw new ProtocolMismatchError(
+          `anthropic parseResponse: content_block_location citation at block ${index} missing start_block_index or end_block_index`,
+          wire,
+        );
+      }
+      return {
+        type: "citation",
+        citedText,
+        source,
+        location: { kind: "content-block", start, end },
+      };
+    }
+    default:
+      throw new ProtocolMismatchError(
+        `anthropic parseResponse: unrecognized citation variant "${wire.type}" at block ${index}`,
+        wire,
+      );
+  }
 }
 
 function toAnthropicBlock(block: ContentBlock): Record<string, unknown> {
@@ -272,6 +374,33 @@ export type AnthropicRawEvent =
 // `index` surfaces as a ProtocolMismatchError via the schema-validation
 // throw site, with the offending payload preserved in `error.raw` for
 // inspection.
+// Anthropic's wire shape for a single citation, streamed inside a
+// `citations_delta`. The `type` discriminator selects the location
+// model:
+//   - web_search_result_location: URL + title, no document offsets
+//   - page_location: 1-indexed page numbers (inclusive start/end)
+//   - char_location: 0-indexed character offsets into the document
+//   - content_block_location: index into the document's content blocks
+// Fields not relevant to a given variant are absent; the union is
+// flat at the wire level. `encrypted_index` (web_search) is recorded
+// only on the wire — it has no echo-back target in the internal
+// CitationBlock today, so the adapter drops it.
+const AnthropicCitation = type({
+  type: "string",
+  "cited_text?": "string",
+  "url?": "string",
+  "title?": "string",
+  "encrypted_index?": "string",
+  "document_index?": "number",
+  "document_title?": "string",
+  "start_page_number?": "number",
+  "end_page_number?": "number",
+  "start_char_index?": "number",
+  "end_char_index?": "number",
+  "start_block_index?": "number",
+  "end_block_index?": "number",
+});
+
 const ContentBlockDelta = type({
   type: "'content_block_delta'",
   index: "number",
@@ -281,6 +410,7 @@ const ContentBlockDelta = type({
     "thinking?": "string",
     "partial_json?": "string",
     "signature?": "string",
+    "citation?": AnthropicCitation,
   },
 });
 
@@ -434,6 +564,24 @@ function parseResponse(
               partial: EMPTY_PARTIAL,
               index,
             },
+          },
+        ];
+      }
+
+      if (delta.type === "citations_delta") {
+        const wireCitation = delta.citation;
+        if (wireCitation === undefined) {
+          throw new ProtocolMismatchError(
+            `anthropic parseResponse: citations_delta missing citation payload at block ${index}`,
+            event,
+          );
+        }
+        const citation = toCitationBlock(wireCitation, index);
+        return [
+          {
+            type: "inference.citation",
+            seq,
+            data: { citation },
           },
         ];
       }

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -150,6 +150,13 @@ function toAnthropicBlock(block: ContentBlock): Record<string, unknown> {
       throw new Error(`unreachable: unknown MediaSource kind`);
     }
 
+    case "audio":
+    case "video":
+    case "document":
+      throw new Error(
+        `Anthropic adapter does not yet handle ${block.type} content blocks.`,
+      );
+
     case "tool_call":
       return {
         type: "tool_use",
@@ -165,6 +172,15 @@ function toAnthropicBlock(block: ContentBlock): Record<string, unknown> {
         content: block.content.map((c) => {
           if (c.type === "text") {
             return { type: "text", text: c.text };
+          }
+          if (c.type !== "image") {
+            // audio / video / document in tool_result content. The
+            // ContentBlock union allows these so the type system can
+            // grow uniformly; no Anthropic wire path exists today.
+            throw new Error(
+              `Anthropic adapter does not yet handle ${c.type} content ` +
+                `blocks in tool results.`,
+            );
           }
           const source = c.source;
           if (source.kind === "base64") {

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -157,6 +157,11 @@ function toAnthropicBlock(block: ContentBlock): Record<string, unknown> {
         `Anthropic adapter does not yet handle ${block.type} content blocks.`,
       );
 
+    case "citation":
+      throw new Error(
+        "Anthropic adapter does not yet emit citation content blocks.",
+      );
+
     case "tool_call":
       return {
         type: "tool_use",

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -607,6 +607,27 @@ function parseResponse(
         ];
       }
 
+      if (block.type === "thinking") {
+        // Anchor the thinking block in the harness's per-index map
+        // via an empty thinking.delta. Anthropic can stream a
+        // signature_delta for a thinking block whose visible text is
+        // empty (redacted-adjacent flow); without this anchor, the
+        // signature would arrive at the harness with no preceding
+        // thinking entry at the same index and the per-index router
+        // would (correctly) reject it as a protocol violation. The
+        // empty-token delta is the parser-side analogue of the wire's
+        // `content_block_start` for thinking — it carries no visible
+        // content but reserves the index.
+        const { index } = event;
+        return [
+          {
+            type: "inference.thinking.delta",
+            seq,
+            data: { token: "", partial: EMPTY_PARTIAL, index },
+          },
+        ];
+      }
+
       if (block.type === "redacted_thinking") {
         // Anthropic delivers redacted_thinking as a one-shot inside
         // content_block_start (no delta stream). The opaque `data`

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -126,15 +126,29 @@ function toAnthropicBlock(block: ContentBlock): Record<string, unknown> {
           : {}),
       };
 
-    case "image":
-      return {
-        type: "image",
-        source: {
-          type: "base64",
-          media_type: block.mimeType,
-          data: block.data,
-        },
-      };
+    case "image": {
+      const source = block.source;
+      if (source.kind === "base64") {
+        return {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: source.mimeType,
+            data: source.data,
+          },
+        };
+      }
+      if (source.kind === "file-reference") {
+        throw new Error(
+          "Anthropic adapter does not yet handle file-reference image " +
+            "sources.",
+        );
+      }
+      // Exhaustiveness: a new MediaSource variant added without a case
+      // here fails this compile-time check.
+      source satisfies never;
+      throw new Error(`unreachable: unknown MediaSource kind`);
+    }
 
     case "tool_call":
       return {
@@ -152,10 +166,25 @@ function toAnthropicBlock(block: ContentBlock): Record<string, unknown> {
           if (c.type === "text") {
             return { type: "text", text: c.text };
           }
-          return {
-            type: "image",
-            source: { type: "base64", media_type: c.mimeType, data: c.data },
-          };
+          const source = c.source;
+          if (source.kind === "base64") {
+            return {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: source.mimeType,
+                data: source.data,
+              },
+            };
+          }
+          if (source.kind === "file-reference") {
+            throw new Error(
+              "Anthropic adapter does not yet handle file-reference image " +
+                "sources in tool results.",
+            );
+          }
+          source satisfies never;
+          throw new Error(`unreachable: unknown MediaSource kind`);
         }),
         ...(block.isError ? { is_error: true } : {}),
       };

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -5,6 +5,7 @@ import type {
   ContentBlock,
   InferenceEvent,
   InferenceOptions,
+  MediaSource,
   PartialMessage,
   TokenUsage,
 } from "@intx/types/runtime";
@@ -109,6 +110,34 @@ function toAnthropicMessage(
   return { role, content };
 }
 
+// Marshal a MediaSource into Anthropic's nested `source` shape.
+// Base64 sources carry the mimeType on the wire as `media_type`.
+// File-reference sources carry only the file id — Anthropic identifies
+// the file by id alone, encoding the content-type server-side at
+// upload time, so the MediaSource's mimeType is intentionally dropped
+// at this layer. The internal `mimeType` requirement on
+// `MediaSourceFileReference` keeps callers honest about what they
+// have in hand even when the provider doesn't need it.
+function toAnthropicMediaSource(source: MediaSource): Record<string, unknown> {
+  if (source.kind === "base64") {
+    return {
+      type: "base64",
+      media_type: source.mimeType,
+      data: source.data,
+    };
+  }
+  if (source.kind === "file-reference") {
+    return {
+      type: "file",
+      file_id: source.reference,
+    };
+  }
+  // Exhaustiveness: a new MediaSource variant added without a case
+  // here fails this compile-time check.
+  source satisfies never;
+  throw new Error(`unreachable: unknown MediaSource kind`);
+}
+
 function toAnthropicBlock(block: ContentBlock): Record<string, unknown> {
   switch (block.type) {
     case "text":
@@ -134,33 +163,14 @@ function toAnthropicBlock(block: ContentBlock): Record<string, unknown> {
       // base64); pass through untouched.
       return { type: "redacted_thinking", data: block.data };
 
-    case "image": {
-      const source = block.source;
-      if (source.kind === "base64") {
-        return {
-          type: "image",
-          source: {
-            type: "base64",
-            media_type: source.mimeType,
-            data: source.data,
-          },
-        };
-      }
-      if (source.kind === "file-reference") {
-        throw new Error(
-          "Anthropic adapter does not yet handle file-reference image " +
-            "sources.",
-        );
-      }
-      // Exhaustiveness: a new MediaSource variant added without a case
-      // here fails this compile-time check.
-      source satisfies never;
-      throw new Error(`unreachable: unknown MediaSource kind`);
-    }
+    case "image":
+      return { type: "image", source: toAnthropicMediaSource(block.source) };
+
+    case "document":
+      return { type: "document", source: toAnthropicMediaSource(block.source) };
 
     case "audio":
     case "video":
-    case "document":
       throw new Error(
         `Anthropic adapter does not yet handle ${block.type} content blocks.`,
       );
@@ -192,34 +202,25 @@ function toAnthropicBlock(block: ContentBlock): Record<string, unknown> {
           if (c.type === "text") {
             return { type: "text", text: c.text };
           }
-          if (c.type !== "image") {
-            // audio / video / document in tool_result content. The
-            // ContentBlock union allows these so the type system can
-            // grow uniformly; no Anthropic wire path exists today.
-            throw new Error(
-              `Anthropic adapter does not yet handle ${c.type} content ` +
-                `blocks in tool results.`,
-            );
-          }
-          const source = c.source;
-          if (source.kind === "base64") {
+          if (c.type === "image") {
             return {
               type: "image",
-              source: {
-                type: "base64",
-                media_type: source.mimeType,
-                data: source.data,
-              },
+              source: toAnthropicMediaSource(c.source),
             };
           }
-          if (source.kind === "file-reference") {
-            throw new Error(
-              "Anthropic adapter does not yet handle file-reference image " +
-                "sources in tool results.",
-            );
-          }
-          source satisfies never;
-          throw new Error(`unreachable: unknown MediaSource kind`);
+          // Anthropic's tool_result.content accepts only `text` and
+          // `image` blocks today. `document` in particular is rejected
+          // at the API edge; surface the failure at the marshaling
+          // site with the specific block type so the failure shows
+          // where the wrong block type was authored, not as an opaque
+          // HTTP 400 a round-trip later. The ContentBlock union allows
+          // these so the type system can grow uniformly; the wire
+          // surface lags.
+          throw new Error(
+            `Anthropic adapter does not handle ${c.type} content blocks ` +
+              `inside tool_result.content; the API accepts only text and ` +
+              `image here.`,
+          );
         }),
         ...(block.isError ? { is_error: true } : {}),
       };

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -115,9 +115,6 @@ function toAnthropicBlock(block: ContentBlock): Record<string, unknown> {
       return { type: "text", text: block.text };
 
     case "thinking":
-      if (block.redacted) {
-        return { type: "thinking", thinking: "", thinking_type: "redacted" };
-      }
       return {
         type: "thinking",
         thinking: block.thinking,
@@ -125,6 +122,12 @@ function toAnthropicBlock(block: ContentBlock): Record<string, unknown> {
           ? { signature: block.signature }
           : {}),
       };
+
+    case "redacted_thinking":
+      throw new Error(
+        "Anthropic adapter does not yet echo redacted_thinking content " +
+          "blocks back on follow-up turns.",
+      );
 
     case "image": {
       const source = block.source;

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -162,6 +162,12 @@ function toAnthropicBlock(block: ContentBlock): Record<string, unknown> {
         "Anthropic adapter does not yet emit citation content blocks.",
       );
 
+    case "code_execution_request":
+    case "code_execution_result":
+      throw new Error(
+        `Anthropic adapter does not yet emit ${block.type} content blocks.`,
+      );
+
     case "tool_call":
       return {
         type: "tool_use",

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -178,6 +178,18 @@ function toOpenAIContentPart(block: ContentBlock): unknown {
       throw new Error(
         `OpenAI adapter does not yet handle ${block.type} content blocks.`,
       );
+    case "citation":
+      // Citation blocks are server-emitted attribution metadata for
+      // content the model already produced; they're not part of the
+      // active conversation state the next turn needs to make sense
+      // of. OpenAI's Chat Completions has no input wire shape for
+      // citations either, so re-uploading them on a follow-up turn
+      // would be ignored at best. Drop them when serializing history
+      // to OpenAI; a downstream consumer that wants to preserve them
+      // across provider switches reads the finalized turn's content[]
+      // directly. See INFERENCE.md § Cross-Provider Message
+      // Transformation for the general policy on history-drop fields.
+      return "";
     case "thinking":
       // Thinking blocks are not forwarded to OpenAI endpoints.
       return "";

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -104,6 +104,20 @@ function toOpenAIMessage(msg: ConversationTurn): unknown[] {
   }
 
   if (msg.role === "assistant") {
+    // Detect block types that cannot survive the OpenAI assistant
+    // message shape and surface the failure rather than silently
+    // dropping them. Code execution blocks are first-class semantic
+    // content; their loss would corrupt cross-provider conversations.
+    for (const block of msg.content) {
+      if (
+        block.type === "code_execution_request" ||
+        block.type === "code_execution_result"
+      ) {
+        throw new Error(
+          `OpenAI adapter does not handle ${block.type} content blocks.`,
+        );
+      }
+    }
     const textBlocks = msg.content.filter(
       (b): b is { type: "text"; text: string } => b.type === "text",
     );
@@ -190,6 +204,14 @@ function toOpenAIContentPart(block: ContentBlock): unknown {
       // directly. See INFERENCE.md § Cross-Provider Message
       // Transformation for the general policy on history-drop fields.
       return "";
+    case "code_execution_request":
+    case "code_execution_result":
+      // Code execution blocks are first-class semantic content; silently
+      // dropping them would lose the model's tool invocation entirely.
+      // OpenAI has no first-class code execution surface today.
+      throw new Error(
+        `OpenAI adapter does not handle ${block.type} content blocks.`,
+      );
     case "thinking":
       // Thinking blocks are not forwarded to OpenAI endpoints.
       return "";

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -215,6 +215,10 @@ function toOpenAIContentPart(block: ContentBlock): unknown {
     case "thinking":
       // Thinking blocks are not forwarded to OpenAI endpoints.
       return "";
+    case "redacted_thinking":
+      // Redacted thinking blocks are opaque by design; the cross-
+      // provider mapping is meaningless on OpenAI's surface.
+      return "";
     case "tool_call":
     case "tool_result":
       // These are handled separately in toOpenAIMessage.

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -178,9 +178,20 @@ function toOpenAIContentPart(block: ContentBlock): unknown {
         };
       }
       if (source.kind === "file-reference") {
+        // OpenAI's Chat Completions endpoint accepts images only via
+        // `image_url: { url }` (data URL or public URL). It does not
+        // accept opaque uploaded-file references the way Anthropic's
+        // `{ type: "file", file_id }` does. A `file-reference`
+        // handle minted by some other provider (an Anthropic file_id,
+        // a Gemini fileUri) is meaningless to OpenAI; the adapter
+        // would have to round-trip the bytes through base64 to be
+        // useful, which is a caller-level choice, not an adapter one.
+        // Surface the constraint loudly with the apparent reference
+        // so an operator triaging the failure sees what was sent.
         throw new Error(
-          "OpenAI adapter does not yet handle file-reference image " +
-            "sources.",
+          `OpenAI Chat Completions does not accept file-reference image ` +
+            `sources; the API only takes base64 data URLs or public URLs ` +
+            `via image_url. Received reference: ${source.reference}`,
         );
       }
       source satisfies never;

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -199,9 +199,22 @@ function toOpenAIContentPart(block: ContentBlock): unknown {
     }
     case "audio":
     case "video":
-    case "document":
       throw new Error(
         `OpenAI adapter does not yet handle ${block.type} content blocks.`,
+      );
+    case "document":
+      // OpenAI's Chat Completions added a `file` content type with
+      // `file_data`/`file_id` for PDF inputs, but the exact field
+      // names and required metadata (filename, content disposition)
+      // are version-sensitive and the OpenCode-Zen capture corpus
+      // carries no OpenAI document-input fixtures to ground-truth
+      // against. Surface the failure with explicit context rather
+      // than emitting an unverified wire shape that may 400 or — worse
+      // — silently land as malformed input the model ignores.
+      throw new Error(
+        "OpenAI adapter does not yet emit document content blocks; the " +
+          "Chat Completions file-content-type wire shape needs a captured " +
+          "fixture before the adapter can be wired against it.",
       );
     case "citation":
       // Citation blocks are server-emitted attribution metadata for

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -300,7 +300,62 @@ const OpenAIChunk = type({
   "usage?": OpenAIChunkUsage.or("null"),
 });
 
-function parseResponse(sseData: string): InferenceEvent[] {
+// Per-request state for the OpenAI parser. OpenAI's Chat Completions
+// has no wire-level content_block index — reasoning_content, content,
+// and tool_calls all appear as fields on the same delta chunk
+// without per-block positional indices. The harness's per-index
+// routing nevertheless requires distinct indices for distinct
+// content blocks at distinct positions, so the parser assigns block
+// indices on first observation in arrival order, threaded through
+// this shared counter. Tool calls share the same counter to avoid
+// colliding with text/thinking indices: a tool_call that arrives
+// before any text gets the next free block index, NOT zero, so the
+// later text doesn't try to land on top of it.
+//
+// `tcDelta.index` (OpenAI's position in `tool_calls[]`) is a
+// tool-call-local index, distinct from a content-block index. The
+// indexer maintains a `toolCallBlockIndex` map from tcDelta.index to
+// the block index assigned at first observation; subsequent deltas
+// for the same tcDelta.index reuse it.
+type OpenAIBlockIndexer = {
+  nextIndex: number;
+  textIndex: number | null;
+  thinkingIndex: number | null;
+  toolCallBlockIndex: Map<number, number>;
+};
+
+function getOrAssignTextIndex(state: OpenAIBlockIndexer): number {
+  if (state.textIndex === null) {
+    state.textIndex = state.nextIndex;
+    state.nextIndex += 1;
+  }
+  return state.textIndex;
+}
+
+function getOrAssignThinkingIndex(state: OpenAIBlockIndexer): number {
+  if (state.thinkingIndex === null) {
+    state.thinkingIndex = state.nextIndex;
+    state.nextIndex += 1;
+  }
+  return state.thinkingIndex;
+}
+
+function getOrAssignToolCallIndex(
+  state: OpenAIBlockIndexer,
+  toolCallIndex: number,
+): number {
+  const existing = state.toolCallBlockIndex.get(toolCallIndex);
+  if (existing !== undefined) return existing;
+  const assigned = state.nextIndex;
+  state.nextIndex += 1;
+  state.toolCallBlockIndex.set(toolCallIndex, assigned);
+  return assigned;
+}
+
+function parseResponse(
+  sseData: string,
+  indexer: OpenAIBlockIndexer,
+): InferenceEvent[] {
   // parseSSE strips the `[DONE]` sentinel before yielding payloads, so
   // anything that reaches us here is supposed to be a JSON chunk. A
   // JSON.parse failure or an arktype rejection means the upstream
@@ -359,12 +414,25 @@ function parseResponse(sseData: string): InferenceEvent[] {
   //   - kimi (via OpenRouter): delta.reasoning
   //   - kimi (direct): delta.reasoning_content
   //   - DeepSeek / others: delta.reasoning_content
+  //
+  // OpenAI's Chat Completions ships reasoning_content and content as
+  // separate logical content blocks without a wire-level block index.
+  // The parser assigns indices on first observation in arrival order
+  // via the per-request `indexer`: whichever kind streams first lands
+  // at 0, the other (if it appears) at 1. This satisfies the harness's
+  // per-index routing contract — distinct kinds get distinct indices
+  // and the harness's collision detection between block kinds at the
+  // same index never fires from a normal OpenAI response.
   const reasoning = delta.reasoning_content ?? delta.reasoning;
   if (typeof reasoning === "string" && reasoning.length > 0) {
     events.push({
       type: "inference.thinking.delta",
       seq,
-      data: { token: reasoning, partial: EMPTY_PARTIAL },
+      data: {
+        token: reasoning,
+        partial: EMPTY_PARTIAL,
+        index: getOrAssignThinkingIndex(indexer),
+      },
     });
   }
 
@@ -373,7 +441,11 @@ function parseResponse(sseData: string): InferenceEvent[] {
     events.push({
       type: "inference.text.delta",
       seq,
-      data: { token: content, partial: EMPTY_PARTIAL },
+      data: {
+        token: content,
+        partial: EMPTY_PARTIAL,
+        index: getOrAssignTextIndex(indexer),
+      },
     });
   }
 
@@ -381,7 +453,14 @@ function parseResponse(sseData: string): InferenceEvent[] {
 
   if (toolCallDeltas !== undefined) {
     for (const tcDelta of toolCallDeltas) {
-      const index = tcDelta.index ?? 0;
+      const toolCallSlot = tcDelta.index ?? 0;
+      // The harness's per-index map keys on content-block index, not
+      // OpenAI's `tool_calls[]` slot. Map this tool call's slot to a
+      // content-block index that doesn't collide with text/thinking:
+      // first observation of each unique `tcDelta.index` allocates a
+      // fresh content-block index from the shared `nextIndex`
+      // counter; subsequent deltas for the same slot reuse it.
+      const blockIndex = getOrAssignToolCallIndex(indexer, toolCallSlot);
       // Normalize null → undefined: Fireworks emits literal null on every
       // delta after the first; we treat that the same as the field being
       // absent so the start / fragment branches below remain simple.
@@ -402,35 +481,46 @@ function parseResponse(sseData: string): InferenceEvent[] {
       // carry both a start signal (id + non-null name) and an argument
       // fragment; both must be emitted.
       //
-      // Two `index`-shaped fields participate here and they are NOT
-      // interchangeable:
-      //   - `data.callId`: the OpenAI-provided id when present
-      //     (`tcDelta.id`); when absent on continuation deltas, we
-      //     synthesize a per-stream placeholder from `index` so the
-      //     harness's index-keyed accumulator can merge fragments
-      //     until the real id resolves at finalize time.
-      //   - `data.index`: the wire-level position in `tool_calls[]`,
-      //     propagated from `tcDelta.index`. This is real provider
-      //     state and downstream consumers can rely on it for per-block
-      //     routing.
-      // The two fields happen to stringify-equal when there is only
-      // one tool call (both are "0") but they describe different things.
+      // `data.callId` is the OpenAI-provided id when present
+      // (`tcDelta.id`); when absent on continuation deltas, the
+      // adapter synthesizes a per-stream placeholder from
+      // `toolCallSlot` so the harness's id-keyed accumulator can
+      // merge fragments until the real id resolves at finalize time.
+      // `data.index` is the content-block index allocated above —
+      // namespaced into the same counter as text/thinking indices so
+      // a tool_call arriving before any text doesn't collide with a
+      // later text block at the same numeric index.
       if (id !== undefined && name !== undefined) {
         events.push({
           type: "inference.tool_call.start",
           seq,
-          data: { callId: id, name, partial: EMPTY_PARTIAL, index },
+          data: {
+            callId: id,
+            name,
+            partial: EMPTY_PARTIAL,
+            index: blockIndex,
+          },
         });
       }
       if (argFragment !== undefined && argFragment.length > 0) {
+        // The delta's `callId` is a per-stream placeholder used by the
+        // harness to resolve fragments to the real id minted on the
+        // start event. Use `String(blockIndex)` rather than
+        // `String(toolCallSlot)` so the placeholder matches the key
+        // the harness registers in `indexToCallId` on start —
+        // otherwise a non-zero, non-contiguous `tcDelta.index`
+        // (single tool at slot 3, or parallel tools at slots 0/3)
+        // would land its fragments under a key the harness never
+        // registered, and the harness's accumulator would silently
+        // drop them.
         events.push({
           type: "inference.tool_call.delta",
           seq,
           data: {
-            callId: String(index),
+            callId: String(blockIndex),
             argumentFragment: argFragment,
             partial: EMPTY_PARTIAL,
-            index,
+            index: blockIndex,
           },
         });
       }
@@ -511,9 +601,19 @@ function parseDuration(value: string): number | undefined {
 }
 
 export function createOpenAIAdapter(): ProviderAdapter {
+  // Per-request indexer state. Adapter instances are created per
+  // request (see `adapter.ts`), so each call to `createOpenAIAdapter`
+  // gets a fresh counter for assigning block indices to reasoning vs.
+  // content streams in arrival order.
+  const indexer: OpenAIBlockIndexer = {
+    nextIndex: 0,
+    textIndex: null,
+    thinkingIndex: null,
+    toolCallBlockIndex: new Map<number, number>(),
+  };
   return {
     buildRequest,
-    parseResponse,
+    parseResponse: (sseData) => parseResponse(sseData, indexer),
     extractRetryAfterMs,
     extractPacingDelayMs,
   };

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -388,17 +388,28 @@ function parseResponse(sseData: string): InferenceEvent[] {
       // Treat the two signals independently. A single delta may legitimately
       // carry both a start signal (id + non-null name) and an argument
       // fragment; both must be emitted.
+      //
+      // Two `index`-shaped fields participate here and they are NOT
+      // interchangeable:
+      //   - `data.callId`: the OpenAI-provided id when present
+      //     (`tcDelta.id`); when absent on continuation deltas, we
+      //     synthesize a per-stream placeholder from `index` so the
+      //     harness's index-keyed accumulator can merge fragments
+      //     until the real id resolves at finalize time.
+      //   - `data.index`: the wire-level position in `tool_calls[]`,
+      //     propagated from `tcDelta.index`. This is real provider
+      //     state and downstream consumers can rely on it for per-block
+      //     routing.
+      // The two fields happen to stringify-equal when there is only
+      // one tool call (both are "0") but they describe different things.
       if (id !== undefined && name !== undefined) {
         events.push({
           type: "inference.tool_call.start",
           seq,
-          data: { callId: id, name, partial: EMPTY_PARTIAL },
+          data: { callId: id, name, partial: EMPTY_PARTIAL, index },
         });
       }
       if (argFragment !== undefined && argFragment.length > 0) {
-        // Argument fragment. We use the index as a temporary callId placeholder
-        // since the upstream harness merges fragments by index — the real id is
-        // resolved at finalize time.
         events.push({
           type: "inference.tool_call.delta",
           seq,
@@ -406,6 +417,7 @@ function parseResponse(sseData: string): InferenceEvent[] {
             callId: String(index),
             argumentFragment: argFragment,
             partial: EMPTY_PARTIAL,
+            index,
           },
         });
       }

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -172,6 +172,12 @@ function toOpenAIContentPart(block: ContentBlock): unknown {
       source satisfies never;
       throw new Error(`unreachable: unknown MediaSource kind`);
     }
+    case "audio":
+    case "video":
+    case "document":
+      throw new Error(
+        `OpenAI adapter does not yet handle ${block.type} content blocks.`,
+      );
     case "thinking":
       // Thinking blocks are not forwarded to OpenAI endpoints.
       return "";

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -153,11 +153,25 @@ function toOpenAIContentPart(block: ContentBlock): unknown {
   switch (block.type) {
     case "text":
       return block.text;
-    case "image":
-      return {
-        type: "image_url",
-        image_url: { url: `data:${block.mimeType};base64,${block.data}` },
-      };
+    case "image": {
+      const source = block.source;
+      if (source.kind === "base64") {
+        return {
+          type: "image_url",
+          image_url: {
+            url: `data:${source.mimeType};base64,${source.data}`,
+          },
+        };
+      }
+      if (source.kind === "file-reference") {
+        throw new Error(
+          "OpenAI adapter does not yet handle file-reference image " +
+            "sources.",
+        );
+      }
+      source satisfies never;
+      throw new Error(`unreachable: unknown MediaSource kind`);
+    }
     case "thinking":
       // Thinking blocks are not forwarded to OpenAI endpoints.
       return "";

--- a/packages/inference/src/turns.ts
+++ b/packages/inference/src/turns.ts
@@ -9,39 +9,6 @@ import type {
 
 export type { ConversationTurn, ContentBlock, AssistantTurn };
 
-export type TextBlock = { type: "text"; text: string };
-
-export type ThinkingBlock = {
-  type: "thinking";
-  thinking: string;
-  signature?: string;
-  redacted?: boolean;
-};
-
-export type ImageBlock = {
-  type: "image";
-  mimeType: string;
-  data: string;
-};
-
-export type ToolCallBlock = {
-  type: "tool_call";
-  id: string;
-  name: string;
-  arguments: Record<string, unknown>;
-};
-
-export type ToolResultBlock = {
-  type: "tool_result";
-  callId: string;
-  content: (
-    | { type: "text"; text: string }
-    | { type: "image"; mimeType: string; data: string }
-  )[];
-  detail?: unknown;
-  isError?: boolean;
-};
-
 export type { ToolCall, ToolResult };
 
 export function createInboundTurn(

--- a/packages/types/src/runtime.test.ts
+++ b/packages/types/src/runtime.test.ts
@@ -499,3 +499,90 @@ describe("ImageBlock shape on ContentBlock", () => {
     expect(result instanceof type.errors).toBe(false);
   });
 });
+
+describe("AudioBlock / VideoBlock / DocumentBlock variants on ContentBlock", () => {
+  test.each([
+    ["audio", "audio/wav", "UklGRg=="],
+    ["video", "video/mp4", "AAAAGGZ0eXA="],
+    ["document", "application/pdf", "JVBERi0="],
+  ])("accepts a %s block with a base64 source", (kind, mimeType, data) => {
+    const result = ContentBlock({
+      type: kind,
+      source: { kind: "base64", mimeType, data },
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test.each([
+    ["audio", "audio/wav"],
+    ["video", "video/mp4"],
+    ["document", "application/pdf"],
+  ])("accepts a %s block with a file-reference source", (kind, mimeType) => {
+    const result = ContentBlock({
+      type: kind,
+      source: { kind: "file-reference", mimeType, reference: "file_abc" },
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test.each(["audio", "video", "document"])(
+    "rejects a %s block without a source",
+    (kind) => {
+      const result = ContentBlock({ type: kind });
+      expect(result instanceof type.errors).toBe(true);
+    },
+  );
+
+  test.each(["audio", "video", "document"])(
+    "rejects a %s block with the legacy flat shape (mimeType/data, no source)",
+    (kind) => {
+      const result = ContentBlock({
+        type: kind,
+        mimeType: "application/octet-stream",
+        data: "aGVsbG8=",
+      });
+      expect(result instanceof type.errors).toBe(true);
+    },
+  );
+
+  test.each([
+    ["audio", "audio/wav", "UklGRg=="],
+    ["video", "video/mp4", "AAAAGGZ0eXA="],
+    ["document", "application/pdf", "JVBERi0="],
+  ])(
+    "accepts a %s block (base64) inside a tool_result content array",
+    (kind, mimeType, data) => {
+      const result = ContentBlock({
+        type: "tool_result",
+        callId: "call_xyz",
+        content: [
+          { type: "text", text: "the payload:" },
+          { type: kind, source: { kind: "base64", mimeType, data } },
+        ],
+      });
+      expect(result instanceof type.errors).toBe(false);
+    },
+  );
+
+  test.each([
+    ["audio", "audio/wav", "file_audio"],
+    ["video", "video/mp4", "file_video"],
+    ["document", "application/pdf", "file_doc"],
+  ])(
+    "accepts a %s block (file-reference) inside a tool_result content array",
+    (kind, mimeType, reference) => {
+      const result = ContentBlock({
+        type: "tool_result",
+        callId: "call_xyz",
+        content: [
+          { type: "text", text: "the payload:" },
+          {
+            type: kind,
+            source: { kind: "file-reference", mimeType, reference },
+          },
+        ],
+      });
+      expect(result instanceof type.errors).toBe(false);
+    },
+  );
+});

--- a/packages/types/src/runtime.test.ts
+++ b/packages/types/src/runtime.test.ts
@@ -719,13 +719,12 @@ describe("CodeExecutionRequestBlock and CodeExecutionResultBlock", () => {
     expect(result instanceof type.errors).toBe(false);
   });
 
-  test("accepts a code_execution_request with language and index", () => {
+  test("accepts a code_execution_request with a language hint", () => {
     const result = ContentBlock({
       type: "code_execution_request",
       id: "srvtoolu_01",
       code: "print('hi')",
       language: "python",
-      index: 2,
     });
     expect(result instanceof type.errors).toBe(false);
   });
@@ -767,7 +766,6 @@ describe("CodeExecutionRequestBlock and CodeExecutionResultBlock", () => {
       stderr: "",
       returnCode: 0,
       providerOutcome: "OUTCOME_OK",
-      index: 3,
     });
     expect(result instanceof type.errors).toBe(false);
   });
@@ -888,15 +886,6 @@ describe("RedactedThinkingBlock and inference.thinking.redacted event", () => {
     expect(result instanceof type.errors).toBe(false);
   });
 
-  test("accepts a redacted_thinking block with an index", () => {
-    const result = ContentBlock({
-      type: "redacted_thinking",
-      data: "EncryptedOpaqueBlobAAAA==",
-      index: 0,
-    });
-    expect(result instanceof type.errors).toBe(false);
-  });
-
   test("rejects a redacted_thinking block missing data", () => {
     const result = ContentBlock({ type: "redacted_thinking" });
     expect(result instanceof type.errors).toBe(true);
@@ -910,8 +899,8 @@ describe("RedactedThinkingBlock and inference.thinking.redacted event", () => {
         redactedThinking: {
           type: "redacted_thinking",
           data: "EncryptedOpaqueBlobAAAA==",
-          index: 1,
         },
+        index: 1,
       },
     });
     expect(result instanceof type.errors).toBe(false);
@@ -1006,6 +995,86 @@ describe("optional index on delta event variants", () => {
       type: "inference.text.delta",
       seq: 1,
       data: { token: "x", partial, index: "two" },
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+});
+
+describe("inference.image_output event", () => {
+  test("accepts an event wrapping an ImageBlock with a base64 source", () => {
+    const result = InferenceEvent({
+      type: "inference.image_output",
+      seq: 8,
+      data: {
+        image: {
+          type: "image",
+          source: {
+            kind: "base64",
+            mimeType: "image/png",
+            data: "iVBORw0KGgo=",
+          },
+        },
+      },
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("accepts an event with an index field", () => {
+    const result = InferenceEvent({
+      type: "inference.image_output",
+      seq: 8,
+      data: {
+        image: {
+          type: "image",
+          source: {
+            kind: "base64",
+            mimeType: "image/png",
+            data: "iVBORw0KGgo=",
+          },
+        },
+        index: 1,
+      },
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("accepts an event wrapping an ImageBlock with a file-reference", () => {
+    const result = InferenceEvent({
+      type: "inference.image_output",
+      seq: 8,
+      data: {
+        image: {
+          type: "image",
+          source: {
+            kind: "file-reference",
+            mimeType: "image/png",
+            reference: "file_generated",
+          },
+        },
+      },
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("rejects an event missing the image payload", () => {
+    const result = InferenceEvent({
+      type: "inference.image_output",
+      seq: 8,
+      data: {},
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("rejects an event with a malformed image block", () => {
+    const result = InferenceEvent({
+      type: "inference.image_output",
+      seq: 8,
+      data: {
+        image: {
+          type: "image",
+          // Missing `source` field.
+        },
+      },
     });
     expect(result instanceof type.errors).toBe(true);
   });

--- a/packages/types/src/runtime.test.ts
+++ b/packages/types/src/runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "bun:test";
 import { type } from "arktype";
 import {
   ContentBlock,
+  InferenceEvent,
   MediaSource,
   TransformRecord,
   type ContextTransform,
@@ -585,4 +586,125 @@ describe("AudioBlock / VideoBlock / DocumentBlock variants on ContentBlock", () 
       expect(result instanceof type.errors).toBe(false);
     },
   );
+});
+
+describe("CitationBlock", () => {
+  test("accepts a minimal citation with a uri source", () => {
+    const result = ContentBlock({
+      type: "citation",
+      citedText: "the answer is 42",
+      source: { uri: "https://example.com/article", title: "Article" },
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("accepts a citation with a documentRef source", () => {
+    const result = ContentBlock({
+      type: "citation",
+      citedText: "per the report",
+      source: { documentRef: { index: 0 }, title: "Q3.pdf" },
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("accepts a citation with both location and textOffset", () => {
+    const result = ContentBlock({
+      type: "citation",
+      citedText: "Martinis.",
+      source: { uri: "https://example.com/" },
+      location: { kind: "char", start: 100, end: 109 },
+      textOffset: { start: 99, end: 108 },
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test.each(["page", "char", "content-block"] as const)(
+    "accepts a citation with location kind=%s",
+    (kind) => {
+      const result = ContentBlock({
+        type: "citation",
+        citedText: "x",
+        source: { uri: "https://example.com/" },
+        location: { kind, start: 1, end: 2 },
+      });
+      expect(result instanceof type.errors).toBe(false);
+    },
+  );
+
+  test("rejects a citation with an unknown location kind", () => {
+    const result = ContentBlock({
+      type: "citation",
+      citedText: "x",
+      source: { uri: "https://example.com/" },
+      location: { kind: "span", start: 1, end: 2 },
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("rejects a citation missing citedText", () => {
+    const result = ContentBlock({
+      type: "citation",
+      source: { uri: "https://example.com/" },
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("rejects a citation missing source", () => {
+    const result = ContentBlock({ type: "citation", citedText: "x" });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("rejects a citation block inside a tool_result content array", () => {
+    // tool_result.content is deliberately narrow; citations annotate
+    // model output, not tool output.
+    const result = ContentBlock({
+      type: "tool_result",
+      callId: "call_abc",
+      content: [
+        {
+          type: "citation",
+          citedText: "x",
+          source: { uri: "https://example.com/" },
+        },
+      ],
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+});
+
+describe("inference.citation event", () => {
+  test("accepts an inference.citation event wrapping a CitationBlock", () => {
+    const result = InferenceEvent({
+      type: "inference.citation",
+      seq: 7,
+      data: {
+        citation: {
+          type: "citation",
+          citedText: "the answer is 42",
+          source: { uri: "https://example.com/" },
+          location: { kind: "char", start: 0, end: 16 },
+          textOffset: { start: 0, end: 16 },
+        },
+      },
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("rejects an inference.citation event missing the citation payload", () => {
+    const result = InferenceEvent({
+      type: "inference.citation",
+      seq: 7,
+      data: {},
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("rejects an inference.citation event with a malformed citation", () => {
+    const result = InferenceEvent({
+      type: "inference.citation",
+      seq: 7,
+      data: { citation: { type: "citation", citedText: "x" } },
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
 });

--- a/packages/types/src/runtime.test.ts
+++ b/packages/types/src/runtime.test.ts
@@ -878,3 +878,51 @@ describe("inference.code_execution.* events", () => {
     expect(result instanceof type.errors).toBe(true);
   });
 });
+
+describe("RedactedThinkingBlock and inference.thinking.redacted event", () => {
+  test("accepts a minimal redacted_thinking block", () => {
+    const result = ContentBlock({
+      type: "redacted_thinking",
+      data: "EncryptedOpaqueBlobAAAA==",
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("accepts a redacted_thinking block with an index", () => {
+    const result = ContentBlock({
+      type: "redacted_thinking",
+      data: "EncryptedOpaqueBlobAAAA==",
+      index: 0,
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("rejects a redacted_thinking block missing data", () => {
+    const result = ContentBlock({ type: "redacted_thinking" });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("accepts an inference.thinking.redacted event wrapping the block", () => {
+    const result = InferenceEvent({
+      type: "inference.thinking.redacted",
+      seq: 3,
+      data: {
+        redactedThinking: {
+          type: "redacted_thinking",
+          data: "EncryptedOpaqueBlobAAAA==",
+          index: 1,
+        },
+      },
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("rejects an inference.thinking.redacted event with a malformed payload", () => {
+    const result = InferenceEvent({
+      type: "inference.thinking.redacted",
+      seq: 3,
+      data: { redactedThinking: { type: "redacted_thinking" } },
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+});

--- a/packages/types/src/runtime.test.ts
+++ b/packages/types/src/runtime.test.ts
@@ -926,3 +926,87 @@ describe("RedactedThinkingBlock and inference.thinking.redacted event", () => {
     expect(result instanceof type.errors).toBe(true);
   });
 });
+
+describe("optional index on delta event variants", () => {
+  const partial = { text: "" };
+
+  const cases: { name: string; type: string; data: Record<string, unknown> }[] =
+    [
+      {
+        name: "inference.text.delta",
+        type: "inference.text.delta",
+        data: { token: "x", partial },
+      },
+      {
+        name: "inference.thinking.delta",
+        type: "inference.thinking.delta",
+        data: { token: "x", partial },
+      },
+      {
+        name: "inference.thinking.signature",
+        type: "inference.thinking.signature",
+        data: { signature: "sig_abc" },
+      },
+      {
+        name: "inference.tool_call.start",
+        type: "inference.tool_call.start",
+        data: { callId: "call_1", name: "fn", partial },
+      },
+      {
+        name: "inference.tool_call.delta",
+        type: "inference.tool_call.delta",
+        data: { callId: "call_1", argumentFragment: "{", partial },
+      },
+      {
+        name: "inference.tool_call.end",
+        type: "inference.tool_call.end",
+        data: { callId: "call_1", name: "fn", arguments: {}, partial },
+      },
+    ];
+
+  for (const c of cases) {
+    test(`${c.name} accepts an optional index field`, () => {
+      const result = InferenceEvent({
+        type: c.type,
+        seq: 1,
+        data: { ...c.data, index: 3 },
+      });
+      expect(result instanceof type.errors).toBe(false);
+    });
+  }
+
+  test("two text.delta events with different indices round-trip distinctly", () => {
+    // Locks the per-block semantic: index 0 and index 1 are distinct
+    // blocks, not aliases for "same buffer."
+    const e0 = InferenceEvent({
+      type: "inference.text.delta",
+      seq: 1,
+      data: { token: "hello", partial, index: 0 },
+    });
+    const e1 = InferenceEvent({
+      type: "inference.text.delta",
+      seq: 2,
+      data: { token: "world", partial, index: 1 },
+    });
+    expect(e0 instanceof type.errors).toBe(false);
+    expect(e1 instanceof type.errors).toBe(false);
+    if (e0 instanceof type.errors || e1 instanceof type.errors) return;
+    if (e0.type !== "inference.text.delta") {
+      throw new Error("e0 narrowed incorrectly");
+    }
+    if (e1.type !== "inference.text.delta") {
+      throw new Error("e1 narrowed incorrectly");
+    }
+    expect(e0.data.index).toBe(0);
+    expect(e1.data.index).toBe(1);
+  });
+
+  test("rejects a malformed (non-number) index value", () => {
+    const result = InferenceEvent({
+      type: "inference.text.delta",
+      seq: 1,
+      data: { token: "x", partial, index: "two" },
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+});

--- a/packages/types/src/runtime.test.ts
+++ b/packages/types/src/runtime.test.ts
@@ -1,6 +1,8 @@
 import { describe, test, expect } from "bun:test";
 import { type } from "arktype";
 import {
+  ContentBlock,
+  MediaSource,
   TransformRecord,
   type ContextTransform,
   type ToolResultTransform,
@@ -385,5 +387,115 @@ describe("createBlobReader", () => {
     }
     expect(thrown?.message).toContain("invalid tool-output URI scheme");
     expect(touched).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MediaSource validator and ImageBlock shape
+// ---------------------------------------------------------------------------
+
+describe("MediaSource validator", () => {
+  test("accepts a well-formed base64 source", () => {
+    const result = MediaSource({
+      kind: "base64",
+      mimeType: "image/png",
+      data: "aGVsbG8=",
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("accepts a well-formed file-reference source", () => {
+    const result = MediaSource({
+      kind: "file-reference",
+      mimeType: "application/pdf",
+      reference: "file_abc123",
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("rejects a base64 source missing mimeType", () => {
+    const result = MediaSource({ kind: "base64", data: "aGVsbG8=" });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("rejects a base64 source missing data", () => {
+    const result = MediaSource({ kind: "base64", mimeType: "image/png" });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("rejects a file-reference source missing mimeType", () => {
+    const result = MediaSource({
+      kind: "file-reference",
+      reference: "file_abc",
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("rejects a file-reference source missing reference", () => {
+    const result = MediaSource({
+      kind: "file-reference",
+      mimeType: "image/png",
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("rejects an unknown kind", () => {
+    const result = MediaSource({
+      kind: "url",
+      mimeType: "image/png",
+      url: "https://example.com/img.png",
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+});
+
+describe("ImageBlock shape on ContentBlock", () => {
+  test("accepts an image block with a base64 source", () => {
+    const result = ContentBlock({
+      type: "image",
+      source: { kind: "base64", mimeType: "image/png", data: "aGVsbG8=" },
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("accepts an image block with a file-reference source", () => {
+    const result = ContentBlock({
+      type: "image",
+      source: {
+        kind: "file-reference",
+        mimeType: "application/pdf",
+        reference: "file_abc",
+      },
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("rejects the legacy flat shape (mimeType/data without source)", () => {
+    const result = ContentBlock({
+      type: "image",
+      mimeType: "image/png",
+      data: "aGVsbG8=",
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("rejects an image block without a source", () => {
+    const result = ContentBlock({ type: "image" });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("accepts an image inside a tool_result content array", () => {
+    const result = ContentBlock({
+      type: "tool_result",
+      callId: "call_abc",
+      content: [
+        { type: "text", text: "the screenshot:" },
+        {
+          type: "image",
+          source: { kind: "base64", mimeType: "image/png", data: "aGVsbG8=" },
+        },
+      ],
+    });
+    expect(result instanceof type.errors).toBe(false);
   });
 });

--- a/packages/types/src/runtime.test.ts
+++ b/packages/types/src/runtime.test.ts
@@ -708,3 +708,173 @@ describe("inference.citation event", () => {
     expect(result instanceof type.errors).toBe(true);
   });
 });
+
+describe("CodeExecutionRequestBlock and CodeExecutionResultBlock", () => {
+  test("accepts a minimal code_execution_request", () => {
+    const result = ContentBlock({
+      type: "code_execution_request",
+      id: "srvtoolu_01",
+      code: "print('hi')",
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("accepts a code_execution_request with language and index", () => {
+    const result = ContentBlock({
+      type: "code_execution_request",
+      id: "srvtoolu_01",
+      code: "print('hi')",
+      language: "python",
+      index: 2,
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("rejects a code_execution_request missing id", () => {
+    const result = ContentBlock({
+      type: "code_execution_request",
+      code: "print('hi')",
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("rejects a code_execution_request missing code", () => {
+    const result = ContentBlock({
+      type: "code_execution_request",
+      id: "srvtoolu_01",
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test.each(["ok", "error", "aborted", "timeout"] as const)(
+    "accepts a code_execution_result with status=%s",
+    (status) => {
+      const result = ContentBlock({
+        type: "code_execution_result",
+        requestId: "srvtoolu_01",
+        status,
+      });
+      expect(result instanceof type.errors).toBe(false);
+    },
+  );
+
+  test("accepts a code_execution_result with all optional fields populated", () => {
+    const result = ContentBlock({
+      type: "code_execution_result",
+      requestId: "srvtoolu_01",
+      status: "ok",
+      stdout: "144\n",
+      stderr: "",
+      returnCode: 0,
+      providerOutcome: "OUTCOME_OK",
+      index: 3,
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("accepts a code_execution_result with abortReason on an aborted run", () => {
+    const result = ContentBlock({
+      type: "code_execution_result",
+      requestId: "srvtoolu_01",
+      status: "aborted",
+      abortReason: "execution time exceeded the 30s limit",
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("rejects a code_execution_result missing requestId", () => {
+    const result = ContentBlock({
+      type: "code_execution_result",
+      status: "ok",
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("rejects a code_execution_result with an unknown status value", () => {
+    const result = ContentBlock({
+      type: "code_execution_result",
+      requestId: "srvtoolu_01",
+      status: "unknown",
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("rejects a code_execution_request or _result inside tool_result content", () => {
+    // tool_result.content is deliberately narrow; server-side code
+    // execution has a distinct lifecycle from the user-tool round-trip.
+    const requestInTool = ContentBlock({
+      type: "tool_result",
+      callId: "call_abc",
+      content: [
+        { type: "code_execution_request", id: "srvtoolu_01", code: "x" },
+      ],
+    });
+    expect(requestInTool instanceof type.errors).toBe(true);
+
+    const resultInTool = ContentBlock({
+      type: "tool_result",
+      callId: "call_abc",
+      content: [
+        {
+          type: "code_execution_result",
+          requestId: "srvtoolu_01",
+          status: "ok",
+        },
+      ],
+    });
+    expect(resultInTool instanceof type.errors).toBe(true);
+  });
+});
+
+describe("inference.code_execution.* events", () => {
+  test("accepts a start event wrapping a CodeExecutionRequestBlock", () => {
+    const result = InferenceEvent({
+      type: "inference.code_execution.start",
+      seq: 4,
+      data: {
+        request: {
+          type: "code_execution_request",
+          id: "srvtoolu_01",
+          code: "print('hi')",
+          language: "python",
+        },
+      },
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("accepts a delta event with a code fragment", () => {
+    const result = InferenceEvent({
+      type: "inference.code_execution.delta",
+      seq: 5,
+      data: { requestId: "srvtoolu_01", codeFragment: "print(" },
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("accepts a result event wrapping a CodeExecutionResultBlock", () => {
+    const result = InferenceEvent({
+      type: "inference.code_execution.result",
+      seq: 6,
+      data: {
+        result: {
+          type: "code_execution_result",
+          requestId: "srvtoolu_01",
+          status: "ok",
+          stdout: "hi\n",
+          returnCode: 0,
+        },
+      },
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("rejects a code_execution event with a malformed payload", () => {
+    const result = InferenceEvent({
+      type: "inference.code_execution.start",
+      seq: 4,
+      data: { request: { type: "code_execution_request", id: "x" } },
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+});

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -608,10 +608,34 @@ export type TokenUsage = typeof TokenUsage.infer;
  * (INFERENCE.md § Message Format › Content Types)
  */
 const TextBlock = type({ type: "'text'", text: "string" });
-const ImageBlock = type({
-  type: "'image'",
+
+/**
+ * How a media payload is carried by a content block. Either inline as a
+ * base64-encoded string, or by reference to an opaque provider-native
+ * handle (e.g. a Gemini fileUri, an Anthropic file_id). The wire shape
+ * each provider expects is built by the provider adapter; MediaSource is
+ * the internal, provider-agnostic representation.
+ *
+ * (INFERENCE.md § Generalized Multimodal Taxonomy)
+ */
+const MediaSourceBase64 = type({
+  kind: "'base64'",
   mimeType: "string",
   data: "string",
+});
+
+const MediaSourceFileReference = type({
+  kind: "'file-reference'",
+  mimeType: "string",
+  reference: "string",
+});
+
+export const MediaSource = MediaSourceBase64.or(MediaSourceFileReference);
+export type MediaSource = typeof MediaSource.infer;
+
+const ImageBlock = type({
+  type: "'image'",
+  source: MediaSource,
 });
 
 const ThinkingBlock = type({

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -974,12 +974,16 @@ export const InferenceEvent = type({
   .or({
     type: "'inference.thinking.delta'",
     seq: "number",
-    data: { token: "string", partial: PartialMessage },
+    data: {
+      token: "string",
+      partial: PartialMessage,
+      "index?": "number",
+    },
   })
   .or({
     type: "'inference.thinking.signature'",
     seq: "number",
-    data: { signature: "string" },
+    data: { signature: "string", "index?": "number" },
   })
   .or({
     type: "'inference.thinking.redacted'",
@@ -989,12 +993,21 @@ export const InferenceEvent = type({
   .or({
     type: "'inference.text.delta'",
     seq: "number",
-    data: { token: "string", partial: PartialMessage },
+    data: {
+      token: "string",
+      partial: PartialMessage,
+      "index?": "number",
+    },
   })
   .or({
     type: "'inference.tool_call.start'",
     seq: "number",
-    data: { callId: "string", name: "string", partial: PartialMessage },
+    data: {
+      callId: "string",
+      name: "string",
+      partial: PartialMessage,
+      "index?": "number",
+    },
   })
   .or({
     type: "'inference.tool_call.delta'",
@@ -1003,6 +1016,7 @@ export const InferenceEvent = type({
       callId: "string",
       argumentFragment: "string",
       partial: PartialMessage,
+      "index?": "number",
     },
   })
   .or({
@@ -1013,6 +1027,7 @@ export const InferenceEvent = type({
       name: "string",
       arguments: "Record<string, unknown>",
       partial: PartialMessage,
+      "index?": "number",
     },
   })
   .or({
@@ -1149,12 +1164,12 @@ export type InferenceEvent =
   | {
       type: "inference.thinking.delta";
       seq: number;
-      data: { token: string; partial: PartialMessage };
+      data: { token: string; partial: PartialMessage; index?: number };
     }
   | {
       type: "inference.thinking.signature";
       seq: number;
-      data: { signature: string };
+      data: { signature: string; index?: number };
     }
   | {
       type: "inference.thinking.redacted";
@@ -1164,12 +1179,17 @@ export type InferenceEvent =
   | {
       type: "inference.text.delta";
       seq: number;
-      data: { token: string; partial: PartialMessage };
+      data: { token: string; partial: PartialMessage; index?: number };
     }
   | {
       type: "inference.tool_call.start";
       seq: number;
-      data: { callId: string; name: string; partial: PartialMessage };
+      data: {
+        callId: string;
+        name: string;
+        partial: PartialMessage;
+        index?: number;
+      };
     }
   | {
       type: "inference.tool_call.delta";
@@ -1178,6 +1198,7 @@ export type InferenceEvent =
         callId: string;
         argumentFragment: string;
         partial: PartialMessage;
+        index?: number;
       };
     }
   | {
@@ -1188,6 +1209,7 @@ export type InferenceEvent =
         name: string;
         arguments: Record<string, unknown>;
         partial: PartialMessage;
+        index?: number;
       };
     }
   | {

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -570,6 +570,14 @@ export interface ToolRunner {
  * content blocks seen so far so late-joining subscribers receive current
  * state without replaying deltas.
  *
+ * `text` and `thinking` are cumulative across every emitted delta of
+ * that kind in the current turn — intentionally flat, even when the
+ * harness's per-index block tracking has split the stream into
+ * multiple ThinkingBlocks or TextBlocks. Consumers that need per-block
+ * structure walk the finalized inference.done turn's content[]; this
+ * snapshot is the live "what bytes has the assistant streamed so
+ * far" view.
+ *
  * (INFERENCE.md § Event Protocol › Partial State)
  */
 export const PartialMessage = type({

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -1767,6 +1767,15 @@ export type AbortReason = typeof AbortReason.infer;
  */
 export const InferenceSourceDefaults = type({
   "maxTokens?": "number",
+  // A bag of provider-native knobs the caller wants merged into the
+  // outbound request body (Anthropic's `metadata.user_id`,
+  // OpenAI's `user`, Gemini's `safetySettings`, etc.). Adapters that
+  // recognize keys translate; unrecognized keys are passed through or
+  // dropped per the adapter's documented behavior. The merge into
+  // per-call `InferenceOptions.providerOptions` is shallow — a per-
+  // call providerOptions object wholesale replaces the source-bound
+  // one, it does not deep-merge per key.
+  "providerOptions?": "Record<string, unknown>",
 });
 export type InferenceSourceDefaults = typeof InferenceSourceDefaults.infer;
 
@@ -1870,6 +1879,15 @@ export type InferenceOptions = {
    * field. When omitted the provider's default modalities apply.
    */
   responseModalities?: ("text" | "image" | "audio")[];
+  /**
+   * A bag of provider-native knobs the adapter merges into the outbound
+   * request body. Primary home is `InferenceSourceDefaults.providerOptions`
+   * (model-bound); this field exists for per-call overrides through the
+   * standard merge precedence at the top of `runInference`. The merge is
+   * shallow: a per-call providerOptions object wholesale replaces the
+   * source-bound one, it does not deep-merge per key.
+   */
+  providerOptions?: Record<string, unknown>;
   /**
    * Per-call inactivity timeout in milliseconds. If the harness yields no
    * event (other than `inference.start`) for this many ms, the underlying

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -665,9 +665,67 @@ const ToolCallBlock = type({
   name: "string",
   arguments: "Record<string, unknown>",
 });
+/**
+ * Location of a citation's cited span within its source document.
+ * The unit of `start` and `end` varies by `kind`:
+ *   - "page": 1-indexed page numbers (Anthropic `page_location`).
+ *   - "char": UTF-16 character offsets, matching JS string semantics
+ *     (Anthropic `char_location`; Gemini `groundingSupports[].segment`).
+ *   - "content-block": index into a structured source's content blocks
+ *     (Anthropic `content_block_location`).
+ */
+const CitationLocation = type({
+  kind: "'page' | 'char' | 'content-block'",
+  start: "number",
+  end: "number",
+});
+
+const CitationSource = type({
+  "title?": "string",
+  // Self-contained dereferenceable URL — populated by providers whose
+  // citations carry URLs directly (Gemini `groundingChunks[].web.uri`).
+  "uri?": "string",
+  // Back-pointer into the request's `documents` array, populated by
+  // providers that cite uploaded documents by position (Anthropic
+  // `document_index`).
+  "documentRef?": type({ index: "number" }),
+});
+
+/**
+ * A citation that supports a span of assistant text. Emitted in
+ * conversation-turn order immediately following the TextBlock it
+ * annotates. Consumers MUST attribute trailing CitationBlocks to the
+ * nearest preceding TextBlock in the same turn.
+ *
+ * Citations are deliberately excluded from ToolResultBlock.content
+ * — they annotate model output, not tool output.
+ *
+ * Exported because `inference.citation` events reference it by name,
+ * following the same pattern as `AssistantTurn`, `ToolCall`, and
+ * `ToolResult`.
+ */
+export const CitationBlock = type({
+  type: "'citation'",
+  // The exact substring of the preceding TextBlock this citation
+  // supports. Both providers emit it; required for inspection and
+  // for fallback offset reconstruction.
+  citedText: "string",
+  source: CitationSource,
+  "location?": CitationLocation,
+  // UTF-16 character offsets into the preceding TextBlock's text.
+  // Providers that emit offsets natively populate these directly;
+  // adapters that derive offsets from a cited substring populate
+  // them only when the substring appears unambiguously in the
+  // preceding text. Omitted when the offset cannot be determined.
+  "textOffset?": type({ start: "number", end: "number" }),
+});
+export type CitationBlock = typeof CitationBlock.infer;
+
 const ToolResultBlock = type({
   type: "'tool_result'",
   callId: "string",
+  // Deliberately narrow: tool results carry user-facing media, not
+  // CitationBlocks (citations annotate the model's text output).
   content: TextBlock.or(ImageBlock)
     .or(AudioBlock)
     .or(VideoBlock)
@@ -682,6 +740,7 @@ export const ContentBlock = TextBlock.or(ThinkingBlock)
   .or(AudioBlock)
   .or(VideoBlock)
   .or(DocumentBlock)
+  .or(CitationBlock)
   .or(ToolCallBlock)
   .or(ToolResultBlock);
 export type ContentBlock = typeof ContentBlock.infer;
@@ -863,6 +922,11 @@ export const InferenceEvent = type({
     data: { error: InferenceError, partial: PartialMessage },
   })
   .or({
+    type: "'inference.citation'",
+    seq: "number",
+    data: { citation: CitationBlock },
+  })
+  .or({
     type: "'tool.start'",
     seq: "number",
     data: { call: ToolCall },
@@ -1007,6 +1071,11 @@ export type InferenceEvent =
       type: "inference.error";
       seq: number;
       data: { error: InferenceError; partial: PartialMessage };
+    }
+  | {
+      type: "inference.citation";
+      seq: number;
+      data: { citation: CitationBlock };
     }
   | { type: "tool.start"; seq: number; data: { call: ToolCall } }
   | {

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -638,6 +638,21 @@ const ImageBlock = type({
   source: MediaSource,
 });
 
+const AudioBlock = type({
+  type: "'audio'",
+  source: MediaSource,
+});
+
+const VideoBlock = type({
+  type: "'video'",
+  source: MediaSource,
+});
+
+const DocumentBlock = type({
+  type: "'document'",
+  source: MediaSource,
+});
+
 const ThinkingBlock = type({
   type: "'thinking'",
   thinking: "string",
@@ -653,13 +668,20 @@ const ToolCallBlock = type({
 const ToolResultBlock = type({
   type: "'tool_result'",
   callId: "string",
-  content: TextBlock.or(ImageBlock).array(),
+  content: TextBlock.or(ImageBlock)
+    .or(AudioBlock)
+    .or(VideoBlock)
+    .or(DocumentBlock)
+    .array(),
   "detail?": "unknown",
   "isError?": "boolean",
 });
 
 export const ContentBlock = TextBlock.or(ThinkingBlock)
   .or(ImageBlock)
+  .or(AudioBlock)
+  .or(VideoBlock)
+  .or(DocumentBlock)
   .or(ToolCallBlock)
   .or(ToolResultBlock);
 export type ContentBlock = typeof ContentBlock.infer;

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -1861,6 +1861,16 @@ export type InferenceOptions = {
   systemPrompt?: string;
   tools?: ToolDefinition[];
   /**
+   * Modalities the caller wants the model to emit. Adapters translate
+   * to the provider-native shape (Gemini's
+   * `generationConfig.responseModalities` accepts `"TEXT"` / `"IMAGE"`
+   * uppercase; see `packages/inference-testing/wire/google-genai/
+   * gemini-2.5-flash-image/image-output/request.json` for the captured
+   * shape). Providers that do not expose a modality switch ignore the
+   * field. When omitted the provider's default modalities apply.
+   */
+  responseModalities?: ("text" | "image" | "audio")[];
+  /**
    * Per-call inactivity timeout in milliseconds. If the harness yields no
    * event (other than `inference.start`) for this many ms, the underlying
    * fetch is aborted and the call ends with `inference.error` of category

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -657,8 +657,26 @@ const ThinkingBlock = type({
   type: "'thinking'",
   thinking: "string",
   "signature?": "string",
-  "redacted?": "boolean",
 });
+
+/**
+ * A thinking block whose content the provider has filtered. The
+ * opaque `data` blob must echo back verbatim on every follow-up turn
+ * — Anthropic 400s the request if it changes or goes missing. Treat
+ * the bytes as opaque: do not log them and do not render them to
+ * users.
+ *
+ * Exported because `inference.thinking.redacted` events reference it
+ * by name.
+ */
+export const RedactedThinkingBlock = type({
+  type: "'redacted_thinking'",
+  data: "string",
+  // Index in the response's content-block stream, matching the
+  // provider-native content_block index where the block originated.
+  "index?": "number",
+});
+export type RedactedThinkingBlock = typeof RedactedThinkingBlock.infer;
 const ToolCallBlock = type({
   type: "'tool_call'",
   id: "string",
@@ -823,6 +841,7 @@ const ToolResultBlock = type({
 });
 
 export const ContentBlock = TextBlock.or(ThinkingBlock)
+  .or(RedactedThinkingBlock)
   .or(ImageBlock)
   .or(AudioBlock)
   .or(VideoBlock)
@@ -961,6 +980,11 @@ export const InferenceEvent = type({
     type: "'inference.thinking.signature'",
     seq: "number",
     data: { signature: "string" },
+  })
+  .or({
+    type: "'inference.thinking.redacted'",
+    seq: "number",
+    data: { redactedThinking: RedactedThinkingBlock },
   })
   .or({
     type: "'inference.text.delta'",
@@ -1131,6 +1155,11 @@ export type InferenceEvent =
       type: "inference.thinking.signature";
       seq: number;
       data: { signature: string };
+    }
+  | {
+      type: "inference.thinking.redacted";
+      seq: number;
+      data: { redactedThinking: RedactedThinkingBlock };
     }
   | {
       type: "inference.text.delta";

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -633,10 +633,14 @@ const MediaSourceFileReference = type({
 export const MediaSource = MediaSourceBase64.or(MediaSourceFileReference);
 export type MediaSource = typeof MediaSource.infer;
 
-const ImageBlock = type({
+// Exported because `inference.image_output` events reference it by
+// name, following the same pattern as `CitationBlock`,
+// `CodeExecutionRequestBlock`, and `RedactedThinkingBlock`.
+export const ImageBlock = type({
   type: "'image'",
   source: MediaSource,
 });
+export type ImageBlock = typeof ImageBlock.infer;
 
 const AudioBlock = type({
   type: "'audio'",
@@ -672,9 +676,6 @@ const ThinkingBlock = type({
 export const RedactedThinkingBlock = type({
   type: "'redacted_thinking'",
   data: "string",
-  // Index in the response's content-block stream, matching the
-  // provider-native content_block index where the block originated.
-  "index?": "number",
 });
 export type RedactedThinkingBlock = typeof RedactedThinkingBlock.infer;
 const ToolCallBlock = type({
@@ -766,11 +767,6 @@ export const CodeExecutionRequestBlock = type({
   // adapters MUST NOT default this — callers narrow on its
   // presence rather than fall through to a guessed language.
   "language?": "string",
-  // Index in the response's content-block stream. Provider-native
-  // when available (Anthropic content_block index); otherwise
-  // synthesized by the adapter to preserve ordering with other
-  // blocks in the same response.
-  "index?": "number",
 });
 export type CodeExecutionRequestBlock = typeof CodeExecutionRequestBlock.infer;
 
@@ -818,9 +814,6 @@ export const CodeExecutionResultBlock = type({
   // Human-readable reason populated when status is "aborted"
   // (Anthropic `abort_reason`). Absent otherwise.
   "abortReason?": "string",
-  // Index in the response's content-block stream. Same semantics
-  // as CodeExecutionRequestBlock.index.
-  "index?": "number",
 });
 export type CodeExecutionResultBlock = typeof CodeExecutionResultBlock.infer;
 
@@ -988,7 +981,7 @@ export const InferenceEvent = type({
   .or({
     type: "'inference.thinking.redacted'",
     seq: "number",
-    data: { redactedThinking: RedactedThinkingBlock },
+    data: { redactedThinking: RedactedThinkingBlock, "index?": "number" },
   })
   .or({
     type: "'inference.text.delta'",
@@ -1057,17 +1050,40 @@ export const InferenceEvent = type({
   .or({
     type: "'inference.code_execution.start'",
     seq: "number",
-    data: { request: CodeExecutionRequestBlock },
+    data: { request: CodeExecutionRequestBlock, "index?": "number" },
   })
   .or({
     type: "'inference.code_execution.delta'",
     seq: "number",
-    data: { requestId: "string", codeFragment: "string" },
+    // requestId correlates fragments back to the originating
+    // CodeExecutionRequestBlock; index is the positional hint into
+    // the response's content-block stream. They are independent: a
+    // single response may stream code execution for multiple
+    // requests interleaved, distinguished by requestId; index lets
+    // the harness's per-block accumulator route the fragment to
+    // the correct block when the array isn't yet finalized.
+    data: {
+      requestId: "string",
+      codeFragment: "string",
+      "index?": "number",
+    },
   })
   .or({
     type: "'inference.code_execution.result'",
     seq: "number",
-    data: { result: CodeExecutionResultBlock },
+    data: { result: CodeExecutionResultBlock, "index?": "number" },
+  })
+  .or({
+    type: "'inference.image_output'",
+    seq: "number",
+    // Fires mid-stream when an adapter finalizes an image-output
+    // block, signaling that the image is ready for downstream
+    // handoff before the full inference.done lands. The wrapped
+    // ImageBlock typically carries a base64 MediaSource — the
+    // payload can be large (Gemini's image-output captures show
+    // ~1MB inline blobs); consumers that subscribe to this event
+    // should treat it as a non-trivial transport size.
+    data: { image: ImageBlock, "index?": "number" },
   })
   .or({
     type: "'tool.start'",
@@ -1174,7 +1190,7 @@ export type InferenceEvent =
   | {
       type: "inference.thinking.redacted";
       seq: number;
-      data: { redactedThinking: RedactedThinkingBlock };
+      data: { redactedThinking: RedactedThinkingBlock; index?: number };
     }
   | {
       type: "inference.text.delta";
@@ -1235,17 +1251,22 @@ export type InferenceEvent =
   | {
       type: "inference.code_execution.start";
       seq: number;
-      data: { request: CodeExecutionRequestBlock };
+      data: { request: CodeExecutionRequestBlock; index?: number };
     }
   | {
       type: "inference.code_execution.delta";
       seq: number;
-      data: { requestId: string; codeFragment: string };
+      data: { requestId: string; codeFragment: string; index?: number };
     }
   | {
       type: "inference.code_execution.result";
       seq: number;
-      data: { result: CodeExecutionResultBlock };
+      data: { result: CodeExecutionResultBlock; index?: number };
+    }
+  | {
+      type: "inference.image_output";
+      seq: number;
+      data: { image: ImageBlock; index?: number };
     }
   | { type: "tool.start"; seq: number; data: { call: ToolCall } }
   | {

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -721,11 +721,98 @@ export const CitationBlock = type({
 });
 export type CitationBlock = typeof CitationBlock.infer;
 
+/**
+ * The model's request to execute code via a server-side execution tool.
+ * Paired with a CodeExecutionResultBlock carrying the same `id` as the
+ * result's `requestId`. Streaming order within a single execution is
+ * `inference.code_execution.start` → zero or more
+ * `inference.code_execution.delta` → `inference.code_execution.result`,
+ * uninterrupted by other events that share the same `requestId`; events
+ * with different `requestId`s or for other block kinds at distinct
+ * `index`es may interleave.
+ *
+ * Exported because `inference.code_execution.start` references it by
+ * name.
+ */
+export const CodeExecutionRequestBlock = type({
+  type: "'code_execution_request'",
+  // Identifier for the execution request. Populated from the
+  // provider's call id where one exists (Anthropic
+  // `srvtoolu_...`); synthesized by the adapter for providers that
+  // don't emit one (Gemini), using a deterministic per-response
+  // position-based scheme so replays match.
+  id: "string",
+  // Source code the model is asking to execute.
+  code: "string",
+  // Language hint. Absent when the provider does not emit one;
+  // adapters MUST NOT default this — callers narrow on its
+  // presence rather than fall through to a guessed language.
+  "language?": "string",
+  // Index in the response's content-block stream. Provider-native
+  // when available (Anthropic content_block index); otherwise
+  // synthesized by the adapter to preserve ordering with other
+  // blocks in the same response.
+  "index?": "number",
+});
+export type CodeExecutionRequestBlock = typeof CodeExecutionRequestBlock.infer;
+
+/**
+ * The result of executing a CodeExecutionRequestBlock. The `requestId`
+ * back-points to the request block's `id`. Status is normalized across
+ * providers; raw provider signals (return code, native outcome string,
+ * abort reason) are preserved on optional fields for callers that need
+ * them.
+ *
+ * File outputs from code execution (e.g. generated plots that
+ * Anthropic returns in `code_execution_tool_result.content`) are NOT
+ * modeled by this block today. The block carries no field for them;
+ * surfacing file outputs is a separate concern.
+ *
+ * Exported because `inference.code_execution.result` references it by
+ * name.
+ */
+export const CodeExecutionResultBlock = type({
+  type: "'code_execution_result'",
+  // Back-pointer to the originating CodeExecutionRequestBlock.id.
+  requestId: "string",
+  // Normalized outcome. Translated from provider-specific signals:
+  //   - Anthropic: derived from `return_code` (0 → "ok", non-zero →
+  //     "error") and `abort_reason` (non-null → "aborted" or
+  //     "timeout" per the reason).
+  //   - Gemini: derived from the `outcome` enum
+  //     (OUTCOME_OK → "ok", OUTCOME_FAILED → "error",
+  //     OUTCOME_DEADLINE_EXCEEDED → "timeout", etc.).
+  status: "'ok' | 'error' | 'aborted' | 'timeout'",
+  // Standard output. Providers that don't split stdout from stderr
+  // (Gemini) map their combined `output` here and leave `stderr` empty.
+  "stdout?": "string",
+  // Standard error. Empty for providers that don't split.
+  "stderr?": "string",
+  // Provider-native numeric return code when available
+  // (Anthropic `return_code`). Absent for providers whose outcome
+  // is enum-only (Gemini).
+  "returnCode?": "number",
+  // Provider-native outcome string preserved verbatim for callers
+  // that need the raw signal (Gemini `OUTCOME_OK` /
+  // `OUTCOME_FAILED` / `OUTCOME_DEADLINE_EXCEEDED` / ...). Absent
+  // when the provider does not emit one (Anthropic).
+  "providerOutcome?": "string",
+  // Human-readable reason populated when status is "aborted"
+  // (Anthropic `abort_reason`). Absent otherwise.
+  "abortReason?": "string",
+  // Index in the response's content-block stream. Same semantics
+  // as CodeExecutionRequestBlock.index.
+  "index?": "number",
+});
+export type CodeExecutionResultBlock = typeof CodeExecutionResultBlock.infer;
+
 const ToolResultBlock = type({
   type: "'tool_result'",
   callId: "string",
   // Deliberately narrow: tool results carry user-facing media, not
-  // CitationBlocks (citations annotate the model's text output).
+  // CitationBlocks (citations annotate the model's text output) and
+  // not CodeExecution blocks (server-side code execution is a
+  // distinct lifecycle from the user-tool round-trip).
   content: TextBlock.or(ImageBlock)
     .or(AudioBlock)
     .or(VideoBlock)
@@ -741,6 +828,8 @@ export const ContentBlock = TextBlock.or(ThinkingBlock)
   .or(VideoBlock)
   .or(DocumentBlock)
   .or(CitationBlock)
+  .or(CodeExecutionRequestBlock)
+  .or(CodeExecutionResultBlock)
   .or(ToolCallBlock)
   .or(ToolResultBlock);
 export type ContentBlock = typeof ContentBlock.infer;
@@ -927,6 +1016,21 @@ export const InferenceEvent = type({
     data: { citation: CitationBlock },
   })
   .or({
+    type: "'inference.code_execution.start'",
+    seq: "number",
+    data: { request: CodeExecutionRequestBlock },
+  })
+  .or({
+    type: "'inference.code_execution.delta'",
+    seq: "number",
+    data: { requestId: "string", codeFragment: "string" },
+  })
+  .or({
+    type: "'inference.code_execution.result'",
+    seq: "number",
+    data: { result: CodeExecutionResultBlock },
+  })
+  .or({
     type: "'tool.start'",
     seq: "number",
     data: { call: ToolCall },
@@ -1076,6 +1180,21 @@ export type InferenceEvent =
       type: "inference.citation";
       seq: number;
       data: { citation: CitationBlock };
+    }
+  | {
+      type: "inference.code_execution.start";
+      seq: number;
+      data: { request: CodeExecutionRequestBlock };
+    }
+  | {
+      type: "inference.code_execution.delta";
+      seq: number;
+      data: { requestId: string; codeFragment: string };
+    }
+  | {
+      type: "inference.code_execution.result";
+      seq: number;
+      data: { result: CodeExecutionResultBlock };
     }
   | { type: "tool.start"; seq: number; data: { call: ToolCall } }
   | {

--- a/tests/inference/multi-turn-thinking-roundtrip.test.ts
+++ b/tests/inference/multi-turn-thinking-roundtrip.test.ts
@@ -1,0 +1,287 @@
+// End-to-end multi-turn proof against the captured Anthropic
+// `function-calling-with-thinking-streaming` corpus. The test
+// chains turn-1's response through the harness, takes the
+// finalized assistant turn, builds turn-2's request from it via
+// the production request builder, and asserts the rebuilt body
+// carries every wire-required field byte-identical to the
+// captured turn-2 request.json — most importantly the thinking
+// block's cryptographic signature, which Anthropic rejects with
+// `messages.N.content.M.thinking.signature: Field required` if it
+// drifts.
+//
+// The corpus has thinking@0, text@1, tool_use@2 in the assistant
+// response. The post-task-22 per-index harness preserves that
+// ordering through the final turn. The post-task-17 request
+// builder echoes the thinking signature back. This test is the
+// integration proof that those two pieces line up against real
+// captured wire bytes.
+
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  createAnthropicAdapter,
+  runInference,
+  type Dependencies,
+  type Scheduler,
+} from "@intx/inference";
+import type {
+  AssistantTurn,
+  ConversationTurn,
+  InferenceEvent,
+  InferenceSource,
+} from "@intx/types/runtime";
+
+const WORKSPACE_ROOT = path.resolve(__dirname, "../..");
+const CORPUS_ROOT = path.join(
+  WORKSPACE_ROOT,
+  "packages/inference-testing/wire/anthropic/claude-haiku-4-5-20251001/function-calling-with-thinking-streaming",
+);
+
+const SOURCE: InferenceSource = {
+  id: "anthropic:claude-haiku-4-5-20251001",
+  provider: "anthropic",
+  baseURL: "https://api.anthropic.com",
+  apiKey: "test",
+  model: "claude-haiku-4-5-20251001",
+};
+
+const inertScheduler: Scheduler = {
+  setTimeout: () => () => {
+    /* tests do not exercise timer firing */
+  },
+};
+
+async function drain(
+  stream: AsyncIterable<InferenceEvent>,
+): Promise<InferenceEvent[]> {
+  const out: InferenceEvent[] = [];
+  for await (const event of stream) {
+    out.push(event);
+  }
+  return out;
+}
+
+function streamingFetchFromBytes(sseBytes: Uint8Array): Dependencies["fetch"] {
+  return () => {
+    return Promise.resolve(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(sseBytes);
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+describe("multi-turn integration: function-calling-with-thinking-streaming", () => {
+  test("turn-1 → turn-2 round-trip carries the thinking signature byte-identical", async () => {
+    // 1. Load turn-1's captured response.sse and turn-1's request.json
+    //    (to seed the initial user turn for the harness's request
+    //    building — we won't actually rebuild turn-1's request here,
+    //    just consume its response).
+    const turn1Sse = await fs.readFile(
+      path.join(CORPUS_ROOT, "turn-1/response.sse"),
+    );
+    const turn1ReqRaw = await fs.readFile(
+      path.join(CORPUS_ROOT, "turn-1/request.json"),
+      "utf-8",
+    );
+    const turn2ReqRaw = await fs.readFile(
+      path.join(CORPUS_ROOT, "turn-2/request.json"),
+      "utf-8",
+    );
+    const turn1ReqUnknown: unknown = JSON.parse(turn1ReqRaw);
+    const turn2ReqUnknown: unknown = JSON.parse(turn2ReqRaw);
+    if (!isRecord(turn1ReqUnknown) || !isRecord(turn2ReqUnknown)) {
+      throw new Error("expected request.json files to parse as objects");
+    }
+
+    // 2. Replay turn-1 through the harness.
+    const deps: Dependencies = {
+      fetch: streamingFetchFromBytes(turn1Sse),
+      scheduler: inertScheduler,
+    };
+    let seq = 0;
+    const events = await drain(
+      runInference({
+        turns: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "What's the weather in Boston, MA?" },
+            ],
+            timestamp: 0,
+          },
+        ],
+        source: SOURCE,
+        nextSeq: () => seq++,
+        deps,
+      }),
+    );
+
+    // 3. Extract the final assistant turn from inference.done.
+    const done = events.find((e) => e.type === "inference.done");
+    if (done?.type !== "inference.done") {
+      const err = events.find((e) => e.type === "inference.error");
+      throw new Error(
+        `turn-1 replay did not reach inference.done${err?.type === "inference.error" ? `: ${JSON.stringify(err.data.error).slice(0, 300)}` : ""}`,
+      );
+    }
+    const reconstructed: AssistantTurn = done.data.turn;
+
+    // 4. Sanity: the reconstructed turn has the expected block
+    //    structure (thinking → text → tool_call). This is the
+    //    function-calling-with-thinking-streaming corpus shape.
+    const kinds = reconstructed.content.map((b) => b.type);
+    expect(kinds).toEqual(["thinking", "text", "tool_call"]);
+
+    const thinkingBlock = reconstructed.content[0];
+    const textBlock = reconstructed.content[1];
+    const toolCallBlock = reconstructed.content[2];
+    if (
+      thinkingBlock?.type !== "thinking" ||
+      textBlock?.type !== "text" ||
+      toolCallBlock?.type !== "tool_call"
+    ) {
+      throw new Error("unexpected reconstructed block kinds");
+    }
+    expect(thinkingBlock.signature).toBeDefined();
+    expect(typeof thinkingBlock.signature).toBe("string");
+    expect((thinkingBlock.signature ?? "").length).toBeGreaterThan(0);
+
+    // 5. Build turn-2's request body via the production builder.
+    //    The wire's turn-2 request has [user, assistant, user-with-
+    //    tool_result]. Mirror that with the reconstructed assistant
+    //    turn in the middle slot.
+    const adapter = createAnthropicAdapter();
+    const turns: ConversationTurn[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "What's the weather in Boston, MA?" }],
+        timestamp: 0,
+      },
+      reconstructed,
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            callId: toolCallBlock.id,
+            content: [{ type: "text", text: "{}" }],
+          },
+        ],
+        timestamp: 1,
+      },
+    ];
+    const req = adapter.buildRequest(
+      turns,
+      "claude-haiku-4-5-20251001",
+      // The captured turn-2 request carries `thinking: { type: enabled,
+      // budget_tokens: ... }` from the original request options;
+      // reproduce that so the rebuilt body matches structurally.
+      {
+        thinking: { enabled: true, budgetTokens: 4096 },
+        tools: [
+          {
+            name: "get_weather",
+            description: "Get the current weather for a location.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                location: { type: "string", description: "City and state" },
+              },
+              required: ["location"],
+            },
+          },
+        ],
+        maxTokens: 4096,
+      },
+    );
+
+    // 6. Decode the rebuilt body and walk into the assistant
+    //    message's thinking block. Assert the signature matches the
+    //    captured turn-2 wire's signature byte-identical — this is
+    //    the load-bearing invariant Anthropic enforces on every
+    //    follow-up turn that includes a prior thinking block.
+    const rebuilt: unknown = JSON.parse(req.body);
+    if (!isRecord(rebuilt)) throw new Error("rebuilt body is not an object");
+    const rebuiltMessages = rebuilt["messages"];
+    if (!Array.isArray(rebuiltMessages)) {
+      throw new Error("rebuilt body.messages is not an array");
+    }
+    const rebuiltAssistant = rebuiltMessages
+      .filter(isRecord)
+      .find((m) => m["role"] === "assistant");
+    if (rebuiltAssistant === undefined) {
+      throw new Error("rebuilt body has no assistant message");
+    }
+    const rebuiltContent = rebuiltAssistant["content"];
+    if (!Array.isArray(rebuiltContent)) {
+      throw new Error("rebuilt assistant content is not an array");
+    }
+    const rebuiltThinking = rebuiltContent
+      .filter(isRecord)
+      .find((b) => b["type"] === "thinking");
+    if (rebuiltThinking === undefined) {
+      throw new Error("rebuilt assistant has no thinking block");
+    }
+
+    // Now pull the captured turn-2 thinking signature for
+    // byte-identical comparison.
+    const capturedMessages = turn2ReqUnknown["messages"];
+    if (!Array.isArray(capturedMessages)) {
+      throw new Error("captured turn-2 messages is not an array");
+    }
+    const capturedAssistant = capturedMessages
+      .filter(isRecord)
+      .find((m) => m["role"] === "assistant");
+    if (capturedAssistant === undefined) {
+      throw new Error("captured turn-2 has no assistant message");
+    }
+    const capturedContent = capturedAssistant["content"];
+    if (!Array.isArray(capturedContent)) {
+      throw new Error("captured turn-2 assistant content is not an array");
+    }
+    const capturedThinking = capturedContent
+      .filter(isRecord)
+      .find((b) => b["type"] === "thinking");
+    if (capturedThinking === undefined) {
+      throw new Error("captured turn-2 has no thinking block");
+    }
+
+    expect(rebuiltThinking["signature"]).toBe(capturedThinking["signature"]);
+    expect(rebuiltThinking["thinking"]).toBe(capturedThinking["thinking"]);
+
+    // 7. Tool_use round-trip — id, name, and input must match
+    //    byte-identical too. The id is what links the assistant
+    //    turn's tool_use to the next user turn's tool_result.
+    const rebuiltToolUse = rebuiltContent
+      .filter(isRecord)
+      .find((b) => b["type"] === "tool_use");
+    const capturedToolUse = capturedContent
+      .filter(isRecord)
+      .find((b) => b["type"] === "tool_use");
+    if (rebuiltToolUse === undefined || capturedToolUse === undefined) {
+      throw new Error("missing tool_use block in rebuilt or captured turn-2");
+    }
+    expect(rebuiltToolUse["id"]).toBe(capturedToolUse["id"]);
+    expect(rebuiltToolUse["name"]).toBe(capturedToolUse["name"]);
+    expect(rebuiltToolUse["input"]).toEqual(capturedToolUse["input"]);
+
+    // Reference turn1ReqUnknown to keep it from being dead — we
+    // loaded it as a sanity check that the corpus is structurally
+    // consistent with what we feed the harness above.
+    expect(turn1ReqUnknown["messages"]).toBeDefined();
+  });
+});

--- a/tests/inference/per-index-blocks.test.ts
+++ b/tests/inference/per-index-blocks.test.ts
@@ -1,0 +1,556 @@
+// Per-index block tracking in the inference harness. The harness
+// keys block state by `content_block` index (Map<number, BlockState>),
+// preserving insertion order so the final assistant turn reproduces
+// the wire-arrival order of content blocks even when those blocks
+// were authored at non-monotonic or non-contiguous indices.
+//
+// These tests exercise the harness end-to-end via `runInference` with
+// synthesized SSE bytes from the Anthropic wire DSL, covering:
+//
+//   - Multi-block interleaving: thinking@0 → text@1 → tool_use@2
+//     lands in the final turn's content[] in that order.
+//   - Map insertion order with non-monotonic keys: index 2 inserted
+//     before index 0 still iterates in insertion order.
+//   - Signature arrives after the next block's deltas: signature
+//     attaches to the right thinking block by index.
+//   - Empty thinking block with signature only: emitted, not dropped.
+//   - Kind collision at the same index: ProtocolMismatchError.
+//   - Missing index at the harness boundary: ProtocolMismatchError.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  runInference,
+  type Dependencies,
+  type Scheduler,
+} from "@intx/inference";
+import { wire } from "@intx/inference-testing";
+import type {
+  ContentBlock,
+  ConversationTurn,
+  InferenceEvent,
+  InferenceSource,
+} from "@intx/types/runtime";
+
+// ThinkingBlock is not exported from @intx/types/runtime, so narrow
+// to it via Extract on the ContentBlock union.
+type ThinkingBlock = Extract<ContentBlock, { type: "thinking" }>;
+
+const SOURCE: InferenceSource = {
+  id: "anthropic:claude-test",
+  provider: "anthropic",
+  baseURL: "https://test.invalid/v1",
+  apiKey: "test",
+  model: "claude-test",
+};
+
+const inertScheduler: Scheduler = {
+  setTimeout: () => () => {
+    /* tests do not exercise timer firing */
+  },
+};
+
+async function drain(
+  stream: AsyncIterable<InferenceEvent>,
+): Promise<InferenceEvent[]> {
+  const out: InferenceEvent[] = [];
+  for await (const event of stream) {
+    out.push(event);
+  }
+  return out;
+}
+
+function streamingFetch(chunks: Uint8Array[]): Dependencies["fetch"] {
+  return () => {
+    return Promise.resolve(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            for (const chunk of chunks) controller.enqueue(chunk);
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+  };
+}
+
+async function runWithChunks(chunks: Uint8Array[]): Promise<InferenceEvent[]> {
+  const deps: Dependencies = {
+    fetch: streamingFetch(chunks),
+    scheduler: inertScheduler,
+  };
+  let seq = 0;
+  return drain(
+    runInference({
+      turns: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "x" }],
+          timestamp: 0,
+        },
+      ],
+      source: SOURCE,
+      nextSeq: () => seq++,
+      deps,
+    }),
+  );
+}
+
+function finalTurn(events: InferenceEvent[]): ConversationTurn {
+  const done = events.find((e) => e.type === "inference.done");
+  if (done?.type !== "inference.done") {
+    throw new Error("expected inference.done event");
+  }
+  return done.data.turn;
+}
+
+describe("runInference — per-index final turn assembly", () => {
+  test("thinking@0 + text@1 + tool_use@2 lands in arrival order in the final turn", async () => {
+    // function-calling-with-thinking-streaming corpus shape: thinking
+    // at block 0, text at block 1, tool_use at block 2. The final
+    // turn's content[] must reproduce that order.
+    const chunks: Uint8Array[] = [
+      wire.anthropic.messageStart({
+        usage: { inputTokens: 5, outputTokens: 0 },
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 0,
+        kind: "thinking_delta",
+        thinking: "Reasoning about which tool to call.",
+      }),
+      wire.anthropic.contentBlockStop({ index: 0 }),
+      wire.anthropic.contentBlockDelta({
+        index: 1,
+        kind: "text_delta",
+        text: "I'll call the search tool. ",
+      }),
+      wire.anthropic.contentBlockStop({ index: 1 }),
+      wire.anthropic.contentBlockStart({
+        index: 2,
+        kind: "tool_use",
+        id: "toolu_search",
+        name: "search",
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 2,
+        kind: "input_json_delta",
+        partialJson: '{"q":"hi"}',
+      }),
+      wire.anthropic.contentBlockStop({ index: 2 }),
+      wire.anthropic.messageDelta({ stopReason: "tool_use", outputTokens: 1 }),
+      wire.anthropic.messageStop(),
+    ];
+
+    const events = await runWithChunks(chunks);
+    const turn = finalTurn(events);
+    const kinds = turn.content.map((b) => b.type);
+    expect(kinds).toEqual(["thinking", "text", "tool_call"]);
+    const thinkingBlock = turn.content[0];
+    if (thinkingBlock?.type !== "thinking") {
+      throw new Error("expected thinking block at content[0]");
+    }
+    expect(thinkingBlock.thinking).toBe("Reasoning about which tool to call.");
+    const textBlock = turn.content[1];
+    if (textBlock?.type !== "text") {
+      throw new Error("expected text block at content[1]");
+    }
+    expect(textBlock.text).toBe("I'll call the search tool. ");
+    const toolCallBlock = turn.content[2];
+    if (toolCallBlock?.type !== "tool_call") {
+      throw new Error("expected tool_call block at content[2]");
+    }
+    expect(toolCallBlock.name).toBe("search");
+    expect(toolCallBlock.arguments).toEqual({ q: "hi" });
+  });
+
+  test("non-monotonic block index arrival preserves insertion order", async () => {
+    // Anthropic doesn't actually emit non-monotonic indices in
+    // practice, but the harness's per-index Map must use insertion
+    // order rather than numeric key order. If a future provider
+    // streams content_block_start at index 2 before index 0
+    // (e.g., for re-ordered server-side rendering), the final turn
+    // must reflect arrival order, not key order.
+    const chunks: Uint8Array[] = [
+      wire.anthropic.messageStart({
+        usage: { inputTokens: 5, outputTokens: 0 },
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 2,
+        kind: "text_delta",
+        text: "FIRST_INSERTED",
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 0,
+        kind: "text_delta",
+        text: "SECOND_INSERTED",
+      }),
+      wire.anthropic.messageDelta({ stopReason: "end_turn", outputTokens: 1 }),
+      wire.anthropic.messageStop(),
+    ];
+
+    const events = await runWithChunks(chunks);
+    const turn = finalTurn(events);
+    const textBlocks = turn.content.filter((b) => b.type === "text");
+    expect(textBlocks).toHaveLength(2);
+    const first = textBlocks[0];
+    const second = textBlocks[1];
+    if (first?.type !== "text" || second?.type !== "text") {
+      throw new Error("expected two text blocks");
+    }
+    // Verify Map insertion-order semantics: index 2 was inserted
+    // first, so it appears first in the final turn even though its
+    // numeric key is higher than index 0.
+    expect(first.text).toBe("FIRST_INSERTED");
+    expect(second.text).toBe("SECOND_INSERTED");
+  });
+
+  test("signature attaches to the right thinking block when it arrives after another block's deltas", async () => {
+    // Anthropic emits signature_delta for a thinking block after
+    // content_block_stop for that block — but the wire-level
+    // streaming model permits the signature to arrive after deltas
+    // for a subsequent block have already started. The harness must
+    // route the signature by index, not by recency.
+    const chunks: Uint8Array[] = [
+      wire.anthropic.messageStart({
+        usage: { inputTokens: 5, outputTokens: 0 },
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 0,
+        kind: "thinking_delta",
+        thinking: "Reasoning step one.",
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 1,
+        kind: "text_delta",
+        text: "Answer text.",
+      }),
+      // Signature for thinking@0 arrives AFTER text@1 has streamed.
+      wire.anthropic.contentBlockDelta({
+        index: 0,
+        kind: "signature_delta",
+        signature: "sig_for_block_0",
+      }),
+      wire.anthropic.messageDelta({ stopReason: "end_turn", outputTokens: 1 }),
+      wire.anthropic.messageStop(),
+    ];
+
+    const events = await runWithChunks(chunks);
+    const turn = finalTurn(events);
+    const thinkingBlock: ThinkingBlock | undefined = turn.content.find(
+      (b): b is ThinkingBlock => b.type === "thinking",
+    );
+    if (thinkingBlock === undefined) {
+      throw new Error("expected a thinking block in the final turn");
+    }
+    expect(thinkingBlock.thinking).toBe("Reasoning step one.");
+    expect(thinkingBlock.signature).toBe("sig_for_block_0");
+  });
+
+  test("empty thinking block with signature only is still emitted", async () => {
+    // A thinking block whose visible text is empty but whose
+    // signature must round-trip on follow-up turns. The signature is
+    // load-bearing for multi-turn redacted-thinking-adjacent flows;
+    // dropping the empty-text block would lose it.
+    const chunks: Uint8Array[] = [
+      wire.anthropic.messageStart({
+        usage: { inputTokens: 5, outputTokens: 0 },
+      }),
+      wire.anthropic.contentBlockStart({
+        index: 0,
+        kind: "thinking",
+        thinking: "",
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 0,
+        kind: "signature_delta",
+        signature: "sig_empty_block",
+      }),
+      wire.anthropic.contentBlockStop({ index: 0 }),
+      wire.anthropic.contentBlockDelta({
+        index: 1,
+        kind: "text_delta",
+        text: "Answer.",
+      }),
+      wire.anthropic.messageDelta({ stopReason: "end_turn", outputTokens: 1 }),
+      wire.anthropic.messageStop(),
+    ];
+
+    const events = await runWithChunks(chunks);
+    const turn = finalTurn(events);
+    const thinkingBlocks: ThinkingBlock[] = turn.content.filter(
+      (b): b is ThinkingBlock => b.type === "thinking",
+    );
+    expect(thinkingBlocks).toHaveLength(1);
+    const block = thinkingBlocks[0];
+    if (block === undefined) {
+      throw new Error("expected one thinking block");
+    }
+    expect(block.thinking).toBe("");
+    expect(block.signature).toBe("sig_empty_block");
+  });
+
+  test("partial.thinking is a running concat across multiple thinking blocks under interleaving", async () => {
+    // Under per-index, thinking@0 "A" then thinking@2 "B" produces
+    // two distinct ThinkingBlocks in the final turn, but
+    // `partial.thinking` (the live snapshot) is the running concat
+    // "AB" — backwards compatible with the pre-per-index single-
+    // buffer semantics where `partial.thinking` was the cumulative
+    // thinking text the assistant had emitted so far.
+    const chunks: Uint8Array[] = [
+      wire.anthropic.messageStart({
+        usage: { inputTokens: 5, outputTokens: 0 },
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 0,
+        kind: "thinking_delta",
+        thinking: "A",
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 1,
+        kind: "text_delta",
+        text: "X",
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 2,
+        kind: "thinking_delta",
+        thinking: "B",
+      }),
+      wire.anthropic.messageDelta({ stopReason: "end_turn", outputTokens: 1 }),
+      wire.anthropic.messageStop(),
+    ];
+
+    const events = await runWithChunks(chunks);
+    // The last thinking-delta event's `partial.thinking` should reflect
+    // the running concat at that point.
+    const thinkingDeltas = events.filter(
+      (e) => e.type === "inference.thinking.delta",
+    );
+    expect(thinkingDeltas).toHaveLength(2);
+    const lastThinking = thinkingDeltas[1];
+    if (lastThinking?.type !== "inference.thinking.delta") {
+      throw new Error("expected two thinking.delta events");
+    }
+    expect(lastThinking.data.partial.thinking).toBe("AB");
+    // And the final turn carries TWO distinct ThinkingBlocks.
+    const turn = finalTurn(events);
+    const blockKinds = turn.content.map((b) => b.type);
+    expect(blockKinds).toEqual(["thinking", "text", "thinking"]);
+    const block0 = turn.content[0];
+    const block2 = turn.content[2];
+    if (block0?.type !== "thinking" || block2?.type !== "thinking") {
+      throw new Error("expected thinking blocks at 0 and 2");
+    }
+    expect(block0.thinking).toBe("A");
+    expect(block2.thinking).toBe("B");
+  });
+});
+
+describe("runInference — per-index protocol violations", () => {
+  function errorOf(events: InferenceEvent[]) {
+    const err = events.find((e) => e.type === "inference.error");
+    if (err?.type !== "inference.error") {
+      throw new Error("expected inference.error event");
+    }
+    return err.data.error;
+  }
+
+  test("kind collision at the same index produces inference.error protocol_mismatch", async () => {
+    // A text delta arriving at index 0 after a thinking delta at the
+    // same index is a wire-level protocol violation — distinct kinds
+    // can't share an index. Surface as protocol_mismatch with the
+    // colliding kind named in the message so a future regression is
+    // immediately diagnosable.
+    const chunks: Uint8Array[] = [
+      wire.anthropic.messageStart({
+        usage: { inputTokens: 5, outputTokens: 0 },
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 0,
+        kind: "thinking_delta",
+        thinking: "T",
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 0,
+        kind: "text_delta",
+        text: "X",
+      }),
+    ];
+
+    const events = await runWithChunks(chunks);
+    const err = errorOf(events);
+    expect(err.category).toBe("protocol_mismatch");
+    expect(err.message).toMatch(/text\.delta at index 0 collides/);
+  });
+
+  test("signature targeting a non-thinking block at that index throws a kind-specific protocol_mismatch", async () => {
+    // The signature error path has two distinct branches with
+    // different operator triage signals: "no block at this index"
+    // (the empty-slot case) vs. "wrong kind at this index" (the
+    // collision case). The second branch fires when a signature_delta
+    // arrives at an index already populated by a non-thinking block —
+    // e.g., a text block was opened at that index and now a signature
+    // tries to attach. The error message must name the colliding
+    // kind so an operator knows whether the bug is upstream (text
+    // landed at the wrong index) or downstream (signature routed to
+    // the wrong index).
+    const chunks: Uint8Array[] = [
+      wire.anthropic.messageStart({
+        usage: { inputTokens: 5, outputTokens: 0 },
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 2,
+        kind: "text_delta",
+        text: "some text",
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 2,
+        kind: "signature_delta",
+        signature: "stray_sig",
+      }),
+    ];
+
+    const events = await runWithChunks(chunks);
+    const err = errorOf(events);
+    expect(err.category).toBe("protocol_mismatch");
+    expect(err.message).toMatch(
+      /thinking\.signature at index 2 targets an existing text block, not a thinking block/,
+    );
+  });
+
+  test("signature without preceding thinking at that index throws protocol_mismatch", async () => {
+    // A signature_delta arriving at an index where no thinking block
+    // has been opened is a wire violation — Anthropic always emits
+    // signature_delta after at least one thinking_delta for the same
+    // block.
+    const chunks: Uint8Array[] = [
+      wire.anthropic.messageStart({
+        usage: { inputTokens: 5, outputTokens: 0 },
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 7,
+        kind: "signature_delta",
+        signature: "stray_sig",
+      }),
+    ];
+
+    const events = await runWithChunks(chunks);
+    const err = errorOf(events);
+    expect(err.category).toBe("protocol_mismatch");
+    expect(err.message).toMatch(
+      /thinking\.signature at index 7 has no preceding thinking block/,
+    );
+  });
+});
+
+// A small synthetic verifier that the harness's tool_use marker in
+// the per-index map resolves to the right ContentBlock at assembly
+// time. This locks in greybeard's "keep tool_use markers separate
+// from the openToolCalls state machine" design.
+describe("runInference — OpenAI tool_call slot/blockIndex resolution", () => {
+  // Regression: an OpenAI tool_call whose `tcDelta.index` is non-zero
+  // and non-contiguous (a single tool call at slot 3, or sparse
+  // parallel slots) used to land its argument fragments under a
+  // placeholder callId that the harness had never registered in
+  // `indexToCallId`. The fragments were silently dropped and the
+  // final tool_call.end carried empty arguments. This test exercises
+  // the full path: parser emits start at slot 3, delta with
+  // placeholder callId, harness resolves to the real id, finalized
+  // turn carries the assembled arguments.
+
+  test("OpenAI tool_call at sparse tcDelta.index accumulates argument fragments", async () => {
+    const { wire } = await import("@intx/inference-testing");
+    const openaiSource: InferenceSource = {
+      id: "openai:gpt-test",
+      provider: "openai",
+      baseURL: "https://test.invalid/v1",
+      apiKey: "test",
+      model: "gpt-test",
+    };
+
+    // Build SSE chunks: tool_call.start at slot 3, then two delta
+    // chunks at slot 3 with argument fragments, then a usage final
+    // chunk.
+    const chunks: Uint8Array[] = [
+      wire.openai.toolCallStart(3, "call_sparse", "search"),
+      wire.openai.toolCallArgumentsDelta(3, '{"a":'),
+      wire.openai.toolCallArgumentsDelta(3, "1}"),
+      wire.openai.usageChunk({ promptTokens: 5, completionTokens: 1 }),
+    ];
+
+    const deps: Dependencies = {
+      fetch: streamingFetch(chunks),
+      scheduler: inertScheduler,
+    };
+    let seq = 0;
+    const events = await drain(
+      runInference({
+        turns: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "x" }],
+            timestamp: 0,
+          },
+        ],
+        source: openaiSource,
+        nextSeq: () => seq++,
+        deps,
+      }),
+    );
+
+    const done = events.find((e) => e.type === "inference.done");
+    if (done?.type !== "inference.done") {
+      throw new Error("expected inference.done event");
+    }
+    const turn = done.data.turn;
+    const toolCall = turn.content.find((b) => b.type === "tool_call");
+    if (toolCall?.type !== "tool_call") {
+      throw new Error("expected tool_call block in final turn");
+    }
+    expect(toolCall.id).toBe("call_sparse");
+    expect(toolCall.name).toBe("search");
+    expect(toolCall.arguments).toEqual({ a: 1 });
+  });
+});
+
+describe("runInference — tool_use marker resolution", () => {
+  test("tool_use marker at index N resolves to the finalized ContentBlock for that callId", async () => {
+    const chunks: Uint8Array[] = [
+      wire.anthropic.messageStart({
+        usage: { inputTokens: 5, outputTokens: 0 },
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 0,
+        kind: "text_delta",
+        text: "Calling: ",
+      }),
+      wire.anthropic.contentBlockStart({
+        index: 1,
+        kind: "tool_use",
+        id: "toolu_specific",
+        name: "search",
+      }),
+      wire.anthropic.contentBlockDelta({
+        index: 1,
+        kind: "input_json_delta",
+        partialJson: '{"q":"x"}',
+      }),
+      wire.anthropic.contentBlockStop({ index: 1 }),
+      wire.anthropic.messageDelta({ stopReason: "tool_use", outputTokens: 1 }),
+      wire.anthropic.messageStop(),
+    ];
+
+    const events = await runWithChunks(chunks);
+    const turn = finalTurn(events);
+    const blockKinds = turn.content.map((b) => b.type);
+    expect(blockKinds).toEqual(["text", "tool_call"]);
+    const toolCall: ContentBlock | undefined = turn.content[1];
+    if (toolCall?.type !== "tool_call") {
+      throw new Error("expected tool_call at content[1]");
+    }
+    expect(toolCall.id).toBe("toolu_specific");
+    expect(toolCall.name).toBe("search");
+    expect(toolCall.arguments).toEqual({ q: "x" });
+  });
+});

--- a/tests/inference/providers/anthropic.test.ts
+++ b/tests/inference/providers/anthropic.test.ts
@@ -19,7 +19,23 @@ const AnthropicContentBlock = type({
   "id?": "string",
   "name?": "string",
   "data?": "string",
+  // `source` is a nested object whose shape depends on the block
+  // variant (base64 vs file). Validated separately via
+  // AnthropicMediaSourceBase64 / AnthropicMediaSourceFile at each
+  // test site rather than baking the union here.
+  "source?": "unknown",
   "cache_control?": { type: "string" },
+});
+
+const AnthropicMediaSourceBase64 = type({
+  type: "'base64'",
+  media_type: "string",
+  data: "string",
+});
+
+const AnthropicMediaSourceFile = type({
+  type: "'file'",
+  file_id: "string",
 });
 
 const AnthropicMessage = type({
@@ -338,7 +354,10 @@ describe("Anthropic adapter: buildRequest", () => {
     expect(body.max_tokens).toBe(512);
   });
 
-  test("rejects a file-reference image source until Files API wiring lands", () => {
+  test("emits a file-reference image as { type: file, file_id }", () => {
+    // Anthropic identifies uploaded files by id alone; the
+    // content-type is encoded server-side at upload time. The
+    // MediaSource's `mimeType` is intentionally not propagated.
     const messages: ConversationTurn[] = [
       {
         role: "user",
@@ -356,12 +375,91 @@ describe("Anthropic adapter: buildRequest", () => {
       },
     ];
 
-    expect(() =>
-      adapter.buildRequest(messages, "claude-3-5-sonnet-20241022", {}),
-    ).toThrow(/file-reference image sources\./);
+    const req = adapter.buildRequest(
+      messages,
+      "claude-3-5-sonnet-20241022",
+      {},
+    );
+    const body = AnthropicRequestBody.assert(JSON.parse(req.body));
+    const block = body.messages[0]?.content[0];
+    if (block?.type !== "image") {
+      throw new Error("expected image block in the request");
+    }
+    const source = AnthropicMediaSourceFile.assert(block.source);
+    expect(source.type).toBe("file");
+    expect(source.file_id).toBe("file_abc123");
   });
 
-  test.each(["audio", "video", "document"] as const)(
+  test("emits a base64 document as { type: document, source: { type: base64, media_type, data } }", () => {
+    // PDF input — Anthropic's documented multimodal-pdf shape carries
+    // `media_type: "application/pdf"` and base64 payload.
+    const messages: ConversationTurn[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "document",
+            source: {
+              kind: "base64",
+              mimeType: "application/pdf",
+              data: "JVBERi0xLjQK", // truncated PDF magic
+            },
+          },
+        ],
+        timestamp: 1000,
+      },
+    ];
+
+    const req = adapter.buildRequest(
+      messages,
+      "claude-3-5-sonnet-20241022",
+      {},
+    );
+    const body = AnthropicRequestBody.assert(JSON.parse(req.body));
+    const block = body.messages[0]?.content[0];
+    if (block?.type !== "document") {
+      throw new Error("expected document block in the request");
+    }
+    const source = AnthropicMediaSourceBase64.assert(block.source);
+    expect(source.type).toBe("base64");
+    expect(source.media_type).toBe("application/pdf");
+    expect(source.data).toBe("JVBERi0xLjQK");
+  });
+
+  test("emits a file-reference document as { type: file, file_id }", () => {
+    const messages: ConversationTurn[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "document",
+            source: {
+              kind: "file-reference",
+              mimeType: "application/pdf",
+              reference: "file_doc_456",
+            },
+          },
+        ],
+        timestamp: 1000,
+      },
+    ];
+
+    const req = adapter.buildRequest(
+      messages,
+      "claude-3-5-sonnet-20241022",
+      {},
+    );
+    const body = AnthropicRequestBody.assert(JSON.parse(req.body));
+    const block = body.messages[0]?.content[0];
+    if (block?.type !== "document") {
+      throw new Error("expected document block in the request");
+    }
+    const source = AnthropicMediaSourceFile.assert(block.source);
+    expect(source.type).toBe("file");
+    expect(source.file_id).toBe("file_doc_456");
+  });
+
+  test.each(["audio", "video"] as const)(
     "rejects a %s content block until provider support is wired",
     (blockType) => {
       const messages: ConversationTurn[] = [
@@ -413,9 +511,16 @@ describe("Anthropic adapter: buildRequest", () => {
         },
       ];
 
+      // Anthropic's tool_result.content accepts only text and image
+      // blocks; document/audio/video are surfaced at the marshaling
+      // site rather than as an opaque HTTP error from Anthropic.
       expect(() =>
         adapter.buildRequest(messages, "claude-3-5-sonnet-20241022", {}),
-      ).toThrow(new RegExp(`${blockType} content blocks in tool results`));
+      ).toThrow(
+        new RegExp(
+          `does not handle ${blockType} content blocks inside tool_result`,
+        ),
+      );
     },
   );
 
@@ -515,7 +620,7 @@ describe("Anthropic adapter: buildRequest", () => {
     ).toThrow(/citation content blocks/);
   });
 
-  test("rejects a file-reference image inside a tool_result", () => {
+  test("emits a file-reference image inside a tool_result", () => {
     const messages: ConversationTurn[] = [
       {
         role: "user",
@@ -539,11 +644,50 @@ describe("Anthropic adapter: buildRequest", () => {
       },
     ];
 
-    expect(() =>
-      adapter.buildRequest(messages, "claude-3-5-sonnet-20241022", {}),
-    ).toThrow(/file-reference image sources in tool results/);
+    const req = adapter.buildRequest(
+      messages,
+      "claude-3-5-sonnet-20241022",
+      {},
+    );
+    // The arktype AnthropicRequestBody schema doesn't carry the
+    // tool_result.content[].source shape (it's deeply nested and
+    // variant-specific). Walk into the body with type-guard helpers
+    // so each step surfaces violations explicitly rather than via
+    // `as` casts.
+    const parsed: unknown = JSON.parse(req.body);
+    if (!isRecord(parsed)) throw new Error("expected body to be a JSON object");
+    const msgs = parsed["messages"];
+    if (!Array.isArray(msgs) || msgs.length === 0) {
+      throw new Error("expected messages array");
+    }
+    const firstMsg = msgs[0];
+    if (!isRecord(firstMsg)) throw new Error("expected first message");
+    const content = firstMsg["content"];
+    if (!Array.isArray(content) || content.length === 0) {
+      throw new Error("expected content array");
+    }
+    const tr = content[0];
+    if (!isRecord(tr) || tr["type"] !== "tool_result") {
+      throw new Error("expected tool_result content[0]");
+    }
+    const trContent = tr["content"];
+    if (!Array.isArray(trContent) || trContent.length === 0) {
+      throw new Error("expected tool_result.content to be a non-empty array");
+    }
+    const inner = trContent[0];
+    if (!isRecord(inner)) {
+      throw new Error("expected tool_result.content[0] to be a JSON object");
+    }
+    expect(inner["type"]).toBe("image");
+    const source = AnthropicMediaSourceFile.assert(inner["source"]);
+    expect(source.type).toBe("file");
+    expect(source.file_id).toBe("file_abc123");
   });
 });
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 describe("Anthropic adapter: parseResponse", () => {
   test("throws ProtocolMismatchError on malformed JSON in SSE payload", () => {

--- a/tests/inference/providers/anthropic.test.ts
+++ b/tests/inference/providers/anthropic.test.ts
@@ -418,6 +418,26 @@ describe("Anthropic adapter: buildRequest", () => {
     },
   );
 
+  test("rejects a citation content block in a request", () => {
+    const messages: ConversationTurn[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "citation",
+            citedText: "the answer",
+            source: { uri: "https://example.com/" },
+          },
+        ],
+        timestamp: 1000,
+      },
+    ];
+
+    expect(() =>
+      adapter.buildRequest(messages, "claude-3-5-sonnet-20241022", {}),
+    ).toThrow(/citation content blocks/);
+  });
+
   test("rejects a file-reference image inside a tool_result", () => {
     const messages: ConversationTurn[] = [
       {

--- a/tests/inference/providers/anthropic.test.ts
+++ b/tests/inference/providers/anthropic.test.ts
@@ -360,6 +360,64 @@ describe("Anthropic adapter: buildRequest", () => {
     ).toThrow(/file-reference image sources\./);
   });
 
+  test.each(["audio", "video", "document"] as const)(
+    "rejects a %s content block until provider support is wired",
+    (blockType) => {
+      const messages: ConversationTurn[] = [
+        {
+          role: "user",
+          content: [
+            {
+              type: blockType,
+              source: {
+                kind: "base64",
+                mimeType: "application/octet-stream",
+                data: "aGVsbG8=",
+              },
+            },
+          ],
+          timestamp: 1000,
+        },
+      ];
+
+      expect(() =>
+        adapter.buildRequest(messages, "claude-3-5-sonnet-20241022", {}),
+      ).toThrow(new RegExp(`${blockType} content blocks`));
+    },
+  );
+
+  test.each(["audio", "video", "document"] as const)(
+    "rejects a %s content block inside a tool_result",
+    (blockType) => {
+      const messages: ConversationTurn[] = [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              callId: "call_xyz",
+              content: [
+                {
+                  type: blockType,
+                  source: {
+                    kind: "base64",
+                    mimeType: "application/octet-stream",
+                    data: "aGVsbG8=",
+                  },
+                },
+              ],
+            },
+          ],
+          timestamp: 1000,
+        },
+      ];
+
+      expect(() =>
+        adapter.buildRequest(messages, "claude-3-5-sonnet-20241022", {}),
+      ).toThrow(new RegExp(`${blockType} content blocks in tool results`));
+    },
+  );
+
   test("rejects a file-reference image inside a tool_result", () => {
     const messages: ConversationTurn[] = [
       {

--- a/tests/inference/providers/anthropic.test.ts
+++ b/tests/inference/providers/anthropic.test.ts
@@ -18,6 +18,7 @@ const AnthropicContentBlock = type({
   "signature?": "string",
   "id?": "string",
   "name?": "string",
+  "data?": "string",
   "cache_control?": { type: "string" },
 });
 
@@ -418,23 +419,51 @@ describe("Anthropic adapter: buildRequest", () => {
     },
   );
 
-  test("rejects a redacted_thinking content block (echo-back not yet wired)", () => {
+  test("echoes a redacted_thinking content block back verbatim", () => {
+    // Anthropic delivers redacted_thinking as a one-shot start event
+    // carrying an opaque `data` blob. That blob must echo back
+    // verbatim on every follow-up turn that includes the block —
+    // mutation or omission produces a 400 or silent context
+    // corruption.
+    const data = "EncryptedOpaqueBlobAAAA==";
     const messages: ConversationTurn[] = [
       {
         role: "assistant",
         content: [
           {
             type: "redacted_thinking",
-            data: "EncryptedOpaqueBlobAAAA==",
+            data,
           },
         ],
         timestamp: 1000,
       },
     ];
 
-    expect(() =>
-      adapter.buildRequest(messages, "claude-3-5-sonnet-20241022", {}),
-    ).toThrow(/redacted_thinking content blocks/);
+    const req = adapter.buildRequest(
+      messages,
+      "claude-3-5-sonnet-20241022",
+      {},
+    );
+    const body = AnthropicRequestBody.assert(JSON.parse(req.body));
+    const assistantMsg = body.messages.find((m) => m.role === "assistant");
+    if (assistantMsg === undefined) {
+      throw new Error("expected an assistant message in the request body");
+    }
+    const block = assistantMsg.content.find(
+      (b) => b.type === "redacted_thinking",
+    );
+    if (block === undefined) {
+      throw new Error(
+        "expected a redacted_thinking block in the assistant message",
+      );
+    }
+    expect(block.data).toBe(data);
+    // Negative: must NOT carry the legacy wire-invalid shape that an
+    // earlier branch of this adapter emitted
+    // ({ type: "thinking", thinking: "", thinking_type: "redacted" }).
+    expect(block.thinking).toBeUndefined();
+    // The arktype schema does not list `thinking_type`, so the assert
+    // call above already rejects any block carrying it.
   });
 
   test.each(["code_execution_request", "code_execution_result"] as const)(
@@ -632,6 +661,28 @@ describe("Anthropic adapter: parseResponse", () => {
     expect(events[0]?.type).toBe("inference.thinking.signature");
     if (events[0]?.type === "inference.thinking.signature") {
       expect(events[0].data.signature).toBe("sig_abc123");
+    }
+  });
+
+  test("parses redacted_thinking content_block_start into inference.thinking.redacted", async () => {
+    // Anthropic delivers redacted thinking as a one-shot inside
+    // content_block_start carrying an opaque `data` blob — no delta
+    // stream. The parser must surface it as inference.thinking.redacted
+    // with the index propagated for downstream routing.
+    const a = createAnthropicAdapter();
+    const events = await parseWire(
+      a,
+      wire.anthropic.redactedThinkingBlock("OpaqueBlobXYZ==", 0),
+    );
+    const redactedEvents = events.filter(
+      (e) => e.type === "inference.thinking.redacted",
+    );
+    expect(redactedEvents).toHaveLength(1);
+    const ev = redactedEvents[0];
+    if (ev?.type === "inference.thinking.redacted") {
+      expect(ev.data.redactedThinking.type).toBe("redacted_thinking");
+      expect(ev.data.redactedThinking.data).toBe("OpaqueBlobXYZ==");
+      expect(ev.data.index).toBe(0);
     }
   });
 

--- a/tests/inference/providers/anthropic.test.ts
+++ b/tests/inference/providers/anthropic.test.ts
@@ -418,6 +418,25 @@ describe("Anthropic adapter: buildRequest", () => {
     },
   );
 
+  test("rejects a redacted_thinking content block (echo-back not yet wired)", () => {
+    const messages: ConversationTurn[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "redacted_thinking",
+            data: "EncryptedOpaqueBlobAAAA==",
+          },
+        ],
+        timestamp: 1000,
+      },
+    ];
+
+    expect(() =>
+      adapter.buildRequest(messages, "claude-3-5-sonnet-20241022", {}),
+    ).toThrow(/redacted_thinking content blocks/);
+  });
+
   test.each(["code_execution_request", "code_execution_result"] as const)(
     "rejects a %s content block in a request",
     (blockType) => {

--- a/tests/inference/providers/anthropic.test.ts
+++ b/tests/inference/providers/anthropic.test.ts
@@ -418,6 +418,35 @@ describe("Anthropic adapter: buildRequest", () => {
     },
   );
 
+  test.each(["code_execution_request", "code_execution_result"] as const)(
+    "rejects a %s content block in a request",
+    (blockType) => {
+      const block =
+        blockType === "code_execution_request"
+          ? {
+              type: blockType,
+              id: "srvtoolu_01",
+              code: "print('hi')",
+            }
+          : {
+              type: blockType,
+              requestId: "srvtoolu_01",
+              status: "ok" as const,
+            };
+      const messages: ConversationTurn[] = [
+        {
+          role: "assistant",
+          content: [block],
+          timestamp: 1000,
+        },
+      ];
+
+      expect(() =>
+        adapter.buildRequest(messages, "claude-3-5-sonnet-20241022", {}),
+      ).toThrow(new RegExp(`${blockType} content blocks`));
+    },
+  );
+
   test("rejects a citation content block in a request", () => {
     const messages: ConversationTurn[] = [
       {

--- a/tests/inference/providers/anthropic.test.ts
+++ b/tests/inference/providers/anthropic.test.ts
@@ -336,6 +336,58 @@ describe("Anthropic adapter: buildRequest", () => {
     const body = AnthropicRequestBody.assert(JSON.parse(req.body));
     expect(body.max_tokens).toBe(512);
   });
+
+  test("rejects a file-reference image source until Files API wiring lands", () => {
+    const messages: ConversationTurn[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              kind: "file-reference",
+              mimeType: "image/png",
+              reference: "file_abc123",
+            },
+          },
+        ],
+        timestamp: 1000,
+      },
+    ];
+
+    expect(() =>
+      adapter.buildRequest(messages, "claude-3-5-sonnet-20241022", {}),
+    ).toThrow(/file-reference image sources\./);
+  });
+
+  test("rejects a file-reference image inside a tool_result", () => {
+    const messages: ConversationTurn[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            callId: "call_xyz",
+            content: [
+              {
+                type: "image",
+                source: {
+                  kind: "file-reference",
+                  mimeType: "image/png",
+                  reference: "file_abc123",
+                },
+              },
+            ],
+          },
+        ],
+        timestamp: 1000,
+      },
+    ];
+
+    expect(() =>
+      adapter.buildRequest(messages, "claude-3-5-sonnet-20241022", {}),
+    ).toThrow(/file-reference image sources in tool results/);
+  });
 });
 
 describe("Anthropic adapter: parseResponse", () => {

--- a/tests/inference/providers/openai.test.ts
+++ b/tests/inference/providers/openai.test.ts
@@ -310,6 +310,67 @@ describe("OpenAI adapter: buildRequest", () => {
     },
   );
 
+  test.each(["code_execution_request", "code_execution_result"] as const)(
+    "rejects a %s content block (no OpenAI surface)",
+    (blockType) => {
+      const block =
+        blockType === "code_execution_request"
+          ? {
+              type: blockType,
+              id: "srvtoolu_01",
+              code: "print('hi')",
+            }
+          : {
+              type: blockType,
+              requestId: "srvtoolu_01",
+              status: "ok" as const,
+            };
+      const messages: ConversationTurn[] = [
+        {
+          role: "assistant",
+          content: [block],
+          timestamp: 1000,
+        },
+      ];
+
+      expect(() => adapter.buildRequest(messages, "gpt-4o", {})).toThrow(
+        new RegExp(`${blockType} content blocks`),
+      );
+    },
+  );
+
+  test("throws on a mixed-content assistant turn that includes code execution", () => {
+    // Guards the placement of the assistant-role detection loop. The
+    // loop must fire even when valid text and tool_call blocks are
+    // present alongside the code execution block — a regression that
+    // moved the check after the existing field filters would silently
+    // succeed on the simpler single-block test, but must fail here.
+    const messages: ConversationTurn[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Running the calculation:" },
+          {
+            type: "code_execution_request",
+            id: "srvtoolu_01",
+            code: "print('hi')",
+          },
+          {
+            type: "tool_call",
+            id: "call_abc",
+            name: "search",
+            arguments: { q: "x" },
+          },
+        ],
+        timestamp: 1000,
+      },
+    ];
+
+    expect(() => adapter.buildRequest(messages, "gpt-4o", {})).toThrow(
+      /code_execution_request content blocks/,
+    );
+  });
+
   test("silently drops citation content blocks (not part of OpenAI surface)", () => {
     const messages: ConversationTurn[] = [
       {

--- a/tests/inference/providers/openai.test.ts
+++ b/tests/inference/providers/openai.test.ts
@@ -371,6 +371,27 @@ describe("OpenAI adapter: buildRequest", () => {
     );
   });
 
+  test("silently drops redacted_thinking content blocks (opaque, no OpenAI surface)", () => {
+    const messages: ConversationTurn[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Hello" },
+          {
+            type: "redacted_thinking",
+            data: "EncryptedOpaqueBlobAAAA==",
+          },
+        ],
+        timestamp: 1000,
+      },
+    ];
+
+    const req = adapter.buildRequest(messages, "gpt-4o", {});
+    const body = OpenAIRequestBody.assert(JSON.parse(req.body));
+    const msg = OpenAIPlainMessage.assert(body.messages[0]);
+    expect(msg.content).toBe("Hello");
+  });
+
   test("silently drops citation content blocks (not part of OpenAI surface)", () => {
     const messages: ConversationTurn[] = [
       {

--- a/tests/inference/providers/openai.test.ts
+++ b/tests/inference/providers/openai.test.ts
@@ -260,6 +260,29 @@ describe("OpenAI adapter: buildRequest", () => {
     const body = OpenAIRequestBody.assert(JSON.parse(req.body));
     expect(body.max_tokens).toBe(256);
   });
+
+  test("rejects a file-reference image source until Files API wiring lands", () => {
+    const messages: ConversationTurn[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              kind: "file-reference",
+              mimeType: "image/png",
+              reference: "file_abc123",
+            },
+          },
+        ],
+        timestamp: 1000,
+      },
+    ];
+
+    expect(() => adapter.buildRequest(messages, "gpt-4o", {})).toThrow(
+      /file-reference image sources/,
+    );
+  });
 });
 
 describe("OpenAI adapter: parseResponse", () => {

--- a/tests/inference/providers/openai.test.ts
+++ b/tests/inference/providers/openai.test.ts
@@ -1,5 +1,5 @@
 import { type } from "arktype";
-import { describe, test, expect } from "bun:test";
+import { beforeEach, describe, test, expect } from "bun:test";
 import { wire } from "@intx/inference-testing";
 import {
   parseSSE,
@@ -9,7 +9,16 @@ import {
 } from "@intx/inference";
 import type { ConversationTurn, InferenceEvent } from "@intx/types/runtime";
 
-const adapter = createOpenAIAdapter();
+// A fresh adapter per test: the OpenAI parser holds per-request
+// indexer state (text/thinking/tool_call block indices allocated in
+// arrival order) on the adapter instance, and sharing one adapter
+// across tests would leak indexer state, making per-index assertions
+// order-dependent and surprising. A test-local re-creation guards
+// against that footgun.
+let adapter: ProviderAdapter;
+beforeEach(() => {
+  adapter = createOpenAIAdapter();
+});
 
 const OpenAIFunctionCall = type({
   name: "string",
@@ -555,6 +564,40 @@ describe("OpenAI adapter: parseResponse", () => {
       expect(events[0].data.argumentFragment).toBe('{"q":"');
       expect(events[0].data.index).toBe(0);
     }
+  });
+
+  test("tool_call emitted before text content gets a distinct content-block index", async () => {
+    // Regression: when the OpenAI stream emits a tool_call before any
+    // text content, the parser's per-request indexer must allocate a
+    // fresh content-block index for the tool_call rather than reusing
+    // 0 — otherwise a later text delta would also land at 0 and
+    // collide with the tool_use marker in the harness's per-index map.
+    // The harness would (correctly) raise a protocol_mismatch error;
+    // the bug surfaces as the whole turn failing instead of producing
+    // [tool_call, text] in the final content[].
+    const events = await parseWire(adapter, [
+      wire.openai.toolCallStart(0, "call_first", "search"),
+      wire.openai.toolCallArgumentsDelta(0, '{"q":"hi"}'),
+      wire.openai.chunk({ content: "Calling search now." }),
+    ]);
+
+    const starts = events.filter((e) => e.type === "inference.tool_call.start");
+    const textDeltas = events.filter((e) => e.type === "inference.text.delta");
+    expect(starts).toHaveLength(1);
+    expect(textDeltas).toHaveLength(1);
+
+    const start = starts[0];
+    const textDelta = textDeltas[0];
+    if (
+      start?.type !== "inference.tool_call.start" ||
+      textDelta?.type !== "inference.text.delta"
+    ) {
+      throw new Error("expected one tool_call.start and one text.delta");
+    }
+    // The tool_call lands at content-block index 0 (first observed);
+    // the text lands at 1 (next free) — NOT both at 0.
+    expect(start.data.index).toBe(0);
+    expect(textDelta.data.index).toBe(1);
   });
 
   test("propagates distinct tool_calls indices to data.index across parallel tool calls", async () => {

--- a/tests/inference/providers/openai.test.ts
+++ b/tests/inference/providers/openai.test.ts
@@ -348,7 +348,7 @@ describe("OpenAI adapter: buildRequest", () => {
     expect(imageParts[1]?.image_url.url).toBe("data:image/jpeg;base64,SECOND");
   });
 
-  test.each(["audio", "video", "document"] as const)(
+  test.each(["audio", "video"] as const)(
     "rejects a %s content block until provider support is wired",
     (blockType) => {
       const messages: ConversationTurn[] = [
@@ -373,6 +373,39 @@ describe("OpenAI adapter: buildRequest", () => {
       );
     },
   );
+
+  test("rejects a document content block with a message naming the missing capture", () => {
+    // OpenAI's Chat Completions has a `file` content type for PDFs,
+    // but the exact wire shape (field names, required filename
+    // metadata) is version-sensitive and the capture corpus has no
+    // OpenAI document fixtures to verify against. The throw is the
+    // honest answer: surface explicit context rather than emitting
+    // an unverified shape that might silently land as malformed
+    // input the model ignores.
+    const messages: ConversationTurn[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "document",
+            source: {
+              kind: "base64",
+              mimeType: "application/pdf",
+              data: "JVBERi0xLjQK",
+            },
+          },
+        ],
+        timestamp: 1000,
+      },
+    ];
+
+    expect(() => adapter.buildRequest(messages, "gpt-4o", {})).toThrow(
+      /document content blocks/,
+    );
+    expect(() => adapter.buildRequest(messages, "gpt-4o", {})).toThrow(
+      /captured fixture/,
+    );
+  });
 
   test.each(["code_execution_request", "code_execution_result"] as const)(
     "rejects a %s content block (no OpenAI surface)",

--- a/tests/inference/providers/openai.test.ts
+++ b/tests/inference/providers/openai.test.ts
@@ -283,6 +283,32 @@ describe("OpenAI adapter: buildRequest", () => {
       /file-reference image sources/,
     );
   });
+
+  test.each(["audio", "video", "document"] as const)(
+    "rejects a %s content block until provider support is wired",
+    (blockType) => {
+      const messages: ConversationTurn[] = [
+        {
+          role: "user",
+          content: [
+            {
+              type: blockType,
+              source: {
+                kind: "base64",
+                mimeType: "application/octet-stream",
+                data: "aGVsbG8=",
+              },
+            },
+          ],
+          timestamp: 1000,
+        },
+      ];
+
+      expect(() => adapter.buildRequest(messages, "gpt-4o", {})).toThrow(
+        new RegExp(`${blockType} content blocks`),
+      );
+    },
+  );
 });
 
 describe("OpenAI adapter: parseResponse", () => {

--- a/tests/inference/providers/openai.test.ts
+++ b/tests/inference/providers/openai.test.ts
@@ -22,15 +22,19 @@ const OpenAIToolCall = type({
   function: OpenAIFunctionCall,
 });
 
+// `content` is either a plain string (text-only messages) or an array
+// of content parts (multimodal: text + image_url etc). The schema
+// accepts either shape with passthrough for parts so each test site
+// validates the specific shape it cares about.
 const OpenAIAssistantMessage = type({
   role: "string",
-  "content?": "string | null",
+  "content?": "string | null | unknown[]",
   "tool_calls?": OpenAIToolCall.array(),
 });
 
 const OpenAIPlainMessage = type({
   role: "string",
-  "content?": "string | null",
+  "content?": "string | null | unknown[]",
   "tool_call_id?": "string",
 });
 
@@ -261,7 +265,12 @@ describe("OpenAI adapter: buildRequest", () => {
     expect(body.max_tokens).toBe(256);
   });
 
-  test("rejects a file-reference image source until Files API wiring lands", () => {
+  test("rejects a file-reference image source with a message naming the reference", () => {
+    // OpenAI's Chat Completions doesn't accept opaque file references
+    // — only data URLs and public URLs through `image_url`. The throw
+    // names the actual reference value so an operator triaging the
+    // failure sees what was sent (a stale Anthropic file_id, a Gemini
+    // fileUri, etc.) rather than just "not supported."
     const messages: ConversationTurn[] = [
       {
         role: "user",
@@ -282,6 +291,61 @@ describe("OpenAI adapter: buildRequest", () => {
     expect(() => adapter.buildRequest(messages, "gpt-4o", {})).toThrow(
       /file-reference image sources/,
     );
+    expect(() => adapter.buildRequest(messages, "gpt-4o", {})).toThrow(
+      /file_abc123/,
+    );
+  });
+
+  test("emits multiple base64 image content parts preserving wire order", () => {
+    // A single user turn may carry multiple image content blocks
+    // (e.g., before/after comparison). The adapter must preserve their
+    // order on the wire — a reordering bug would invert "compare
+    // these two screenshots" prompts and produce wrong answers
+    // silently. Each image lands as a distinct `image_url` content
+    // part with its own data URL.
+    const messages: ConversationTurn[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Compare:" },
+          {
+            type: "image",
+            source: { kind: "base64", mimeType: "image/png", data: "FIRST" },
+          },
+          {
+            type: "image",
+            source: { kind: "base64", mimeType: "image/jpeg", data: "SECOND" },
+          },
+        ],
+        timestamp: 1000,
+      },
+    ];
+
+    const req = adapter.buildRequest(messages, "gpt-4o", {});
+    const body = OpenAIRequestBody.assert(JSON.parse(req.body));
+    const userMsg = body.messages[0];
+    if (userMsg === undefined) {
+      throw new Error("expected one message");
+    }
+    const content = userMsg.content;
+    if (!Array.isArray(content)) {
+      throw new Error("expected content to be an array of parts");
+    }
+    const isRecord = (v: unknown): v is Record<string, unknown> =>
+      typeof v === "object" && v !== null && !Array.isArray(v);
+    const isImagePart = (
+      p: unknown,
+    ): p is { type: "image_url"; image_url: { url: string } } => {
+      if (!isRecord(p)) return false;
+      if (p["type"] !== "image_url") return false;
+      const inner = p["image_url"];
+      if (!isRecord(inner)) return false;
+      return typeof inner["url"] === "string";
+    };
+    const imageParts = content.filter(isImagePart);
+    expect(imageParts).toHaveLength(2);
+    expect(imageParts[0]?.image_url.url).toBe("data:image/png;base64,FIRST");
+    expect(imageParts[1]?.image_url.url).toBe("data:image/jpeg;base64,SECOND");
   });
 
   test.each(["audio", "video", "document"] as const)(

--- a/tests/inference/providers/openai.test.ts
+++ b/tests/inference/providers/openai.test.ts
@@ -309,6 +309,29 @@ describe("OpenAI adapter: buildRequest", () => {
       );
     },
   );
+
+  test("silently drops citation content blocks (not part of OpenAI surface)", () => {
+    const messages: ConversationTurn[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Hello" },
+          {
+            type: "citation",
+            citedText: "x",
+            source: { uri: "https://example.com/" },
+          },
+        ],
+        timestamp: 1000,
+      },
+    ];
+
+    const req = adapter.buildRequest(messages, "gpt-4o", {});
+    const body = OpenAIRequestBody.assert(JSON.parse(req.body));
+    // The citation block contributes an empty string; the text remains.
+    const msg = OpenAIPlainMessage.assert(body.messages[0]);
+    expect(msg.content).toBe("Hello");
+  });
 });
 
 describe("OpenAI adapter: parseResponse", () => {

--- a/tests/inference/providers/openai.test.ts
+++ b/tests/inference/providers/openai.test.ts
@@ -499,7 +499,7 @@ describe("OpenAI adapter: parseResponse", () => {
     expect(events).toEqual([]);
   });
 
-  test("parses tool_call start with id and name", async () => {
+  test("parses tool_call start with id and name and propagates the wire index", async () => {
     const events = await parseWire(adapter, [
       wire.openai.toolCallStart(0, "call_xyz", "search"),
     ]);
@@ -508,10 +508,11 @@ describe("OpenAI adapter: parseResponse", () => {
     if (events[0]?.type === "inference.tool_call.start") {
       expect(events[0].data.callId).toBe("call_xyz");
       expect(events[0].data.name).toBe("search");
+      expect(events[0].data.index).toBe(0);
     }
   });
 
-  test("parses tool_call argument fragment", async () => {
+  test("parses tool_call argument fragment and propagates the wire index", async () => {
     const events = await parseWire(adapter, [
       wire.openai.toolCallArgumentsDelta(0, '{"q":"'),
     ]);
@@ -519,7 +520,55 @@ describe("OpenAI adapter: parseResponse", () => {
     expect(events[0]?.type).toBe("inference.tool_call.delta");
     if (events[0]?.type === "inference.tool_call.delta") {
       expect(events[0].data.argumentFragment).toBe('{"q":"');
+      expect(events[0].data.index).toBe(0);
     }
+  });
+
+  test("propagates distinct tool_calls indices to data.index across parallel tool calls", async () => {
+    // Multi-tool-call regression target: two parallel tool calls in
+    // a single response stream interleaved deltas at indices 0 and 1.
+    // The parser must propagate each delta's wire-level `index` to
+    // the emitted event's `data.index` so the harness's per-block
+    // routing resolves to the right tool. Collapsing both indices to
+    // 0 would route the second tool's argument fragments onto the
+    // first tool's accumulator.
+    const events = await parseWire(adapter, [
+      wire.openai.toolCallStart(0, "call_first", "alpha"),
+      wire.openai.toolCallStart(1, "call_second", "beta"),
+      wire.openai.toolCallArgumentsDelta(0, '{"a":1}'),
+      wire.openai.toolCallArgumentsDelta(1, '{"b":2}'),
+    ]);
+
+    const starts = events.filter((e) => e.type === "inference.tool_call.start");
+    const deltas = events.filter((e) => e.type === "inference.tool_call.delta");
+    expect(starts).toHaveLength(2);
+    expect(deltas).toHaveLength(2);
+
+    const start0 = starts[0];
+    const start1 = starts[1];
+    if (
+      start0?.type !== "inference.tool_call.start" ||
+      start1?.type !== "inference.tool_call.start"
+    ) {
+      throw new Error("expected two start events");
+    }
+    expect(start0.data.callId).toBe("call_first");
+    expect(start0.data.index).toBe(0);
+    expect(start1.data.callId).toBe("call_second");
+    expect(start1.data.index).toBe(1);
+
+    const delta0 = deltas[0];
+    const delta1 = deltas[1];
+    if (
+      delta0?.type !== "inference.tool_call.delta" ||
+      delta1?.type !== "inference.tool_call.delta"
+    ) {
+      throw new Error("expected two delta events");
+    }
+    expect(delta0.data.index).toBe(0);
+    expect(delta0.data.argumentFragment).toBe('{"a":1}');
+    expect(delta1.data.index).toBe(1);
+    expect(delta1.data.argumentFragment).toBe('{"b":2}');
   });
 
   test("parses usage from final chunk", async () => {

--- a/tests/inference/redacted-thinking-roundtrip.test.ts
+++ b/tests/inference/redacted-thinking-roundtrip.test.ts
@@ -1,0 +1,239 @@
+// End-to-end coverage of the Anthropic redacted_thinking round-trip:
+// SSE `content_block_start` of type `redacted_thinking` arrives →
+// parser emits `inference.thinking.redacted` → harness threads it
+// through and lands the RedactedThinkingBlock in the final
+// `inference.done` turn → the request builder echoes the same
+// opaque `data` bytes back on a follow-up turn.
+//
+// The opaque `data` blob must survive every stage unchanged.
+// Anthropic rejects any follow-up that mutates or omits the blob
+// with a 400 (or worse, with silent context corruption that taints
+// downstream turns), so the round-trip is the load-bearing invariant
+// the adapter exists to preserve.
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  createAnthropicAdapter,
+  runInference,
+  type Dependencies,
+  type Scheduler,
+} from "@intx/inference";
+import { wire } from "@intx/inference-testing";
+import type {
+  AssistantTurn,
+  ConversationTurn,
+  InferenceEvent,
+  InferenceSource,
+} from "@intx/types/runtime";
+
+// Adversarial payload: includes characters that an over-eager
+// normalizer would touch (newlines, padding, internal whitespace,
+// escape-sensitive bytes). The byte-identical round-trip is the
+// invariant — a `JSON.stringify`-of-already-stringified bug, a
+// whitespace strip, or a Unicode normalization would all corrupt
+// this payload.
+const SYNTHETIC_REDACTED_DATA = 'Opaque\nBytes\r\n  ==\tFromAnthropic\\"AAAA==';
+
+const SOURCE: InferenceSource = {
+  id: "anthropic:claude-test",
+  provider: "anthropic",
+  baseURL: "https://test.invalid/v1",
+  apiKey: "test",
+  model: "claude-test",
+};
+
+const inertScheduler: Scheduler = {
+  setTimeout: () => () => {
+    /* tests do not exercise timer firing */
+  },
+};
+
+async function drain(
+  stream: AsyncIterable<InferenceEvent>,
+): Promise<InferenceEvent[]> {
+  const out: InferenceEvent[] = [];
+  for await (const event of stream) {
+    out.push(event);
+  }
+  return out;
+}
+
+function streamingFetch(chunks: Uint8Array[]): Dependencies["fetch"] {
+  return () => {
+    return Promise.resolve(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            for (const chunk of chunks) controller.enqueue(chunk);
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+  };
+}
+
+describe("runInference — Anthropic redacted_thinking round-trip", () => {
+  test("emits inference.thinking.redacted and lands the block in the final turn", async () => {
+    const chunks: Uint8Array[] = [
+      wire.anthropic.messageStart({
+        usage: { inputTokens: 5, outputTokens: 0 },
+      }),
+      ...wire.anthropic.redactedThinkingBlock(SYNTHETIC_REDACTED_DATA, 0),
+      wire.anthropic.messageDelta({ stopReason: "end_turn", outputTokens: 1 }),
+      wire.anthropic.messageStop(),
+    ];
+
+    const deps: Dependencies = {
+      fetch: streamingFetch(chunks),
+      scheduler: inertScheduler,
+    };
+    const turns: ConversationTurn[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Tell me something the classifier hits." },
+        ],
+        timestamp: 0,
+      },
+    ];
+
+    let seq = 0;
+    const events = await drain(
+      runInference({
+        turns,
+        source: SOURCE,
+        nextSeq: () => seq++,
+        deps,
+      }),
+    );
+
+    // The streaming event lands with the opaque data and the source
+    // index — downstream consumers (event collector, audit store) see
+    // it before inference.done.
+    const redactedEvents = events.filter(
+      (e) => e.type === "inference.thinking.redacted",
+    );
+    expect(redactedEvents).toHaveLength(1);
+    const redactedEv = redactedEvents[0];
+    if (redactedEv?.type !== "inference.thinking.redacted") {
+      throw new Error("expected inference.thinking.redacted event");
+    }
+    expect(redactedEv.data.redactedThinking.data).toBe(SYNTHETIC_REDACTED_DATA);
+    expect(redactedEv.data.index).toBe(0);
+
+    // The final turn carries the RedactedThinkingBlock — that's what
+    // gets persisted to history and echoed back next turn.
+    const doneEvent = events.find((e) => e.type === "inference.done");
+    if (doneEvent?.type !== "inference.done") {
+      throw new Error("expected inference.done event");
+    }
+    const finalTurn: AssistantTurn = doneEvent.data.turn;
+    const blocksOfKind = finalTurn.content.filter(
+      (b) => b.type === "redacted_thinking",
+    );
+    expect(blocksOfKind).toHaveLength(1);
+    const finalBlock = blocksOfKind[0];
+    if (finalBlock?.type !== "redacted_thinking") {
+      throw new Error("expected redacted_thinking block in final turn");
+    }
+    expect(finalBlock.data).toBe(SYNTHETIC_REDACTED_DATA);
+  });
+
+  test("data survives the full round-trip back into a follow-up request body", async () => {
+    // Drive a redacted_thinking response through the harness, take the
+    // final assistant turn, and feed it back into the request builder
+    // as conversation history. The opaque data must land in the
+    // outbound request's messages[].content[] verbatim. This is the
+    // actual invariant Anthropic checks on every follow-up turn.
+    const chunks: Uint8Array[] = [
+      wire.anthropic.messageStart({
+        usage: { inputTokens: 5, outputTokens: 0 },
+      }),
+      ...wire.anthropic.redactedThinkingBlock(SYNTHETIC_REDACTED_DATA, 0),
+      wire.anthropic.messageDelta({ stopReason: "end_turn", outputTokens: 1 }),
+      wire.anthropic.messageStop(),
+    ];
+    const deps: Dependencies = {
+      fetch: streamingFetch(chunks),
+      scheduler: inertScheduler,
+    };
+
+    let seq = 0;
+    const events = await drain(
+      runInference({
+        turns: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "round-trip" }],
+            timestamp: 0,
+          },
+        ],
+        source: SOURCE,
+        nextSeq: () => seq++,
+        deps,
+      }),
+    );
+
+    const doneEvent = events.find((e) => e.type === "inference.done");
+    if (doneEvent?.type !== "inference.done") {
+      throw new Error("expected inference.done event");
+    }
+    const assistantTurn: ConversationTurn = doneEvent.data.turn;
+
+    // Build the next request with the assistant turn back in history.
+    const adapter = createAnthropicAdapter();
+    const req = adapter.buildRequest(
+      [
+        {
+          role: "user",
+          content: [{ type: "text", text: "first" }],
+          timestamp: 0,
+        },
+        assistantTurn,
+        {
+          role: "user",
+          content: [{ type: "text", text: "follow-up" }],
+          timestamp: 1,
+        },
+      ],
+      "claude-test",
+      {},
+    );
+
+    // Decode the body and locate the assistant message's
+    // redacted_thinking block to assert byte-exact equality on the
+    // opaque data. A substring match (toContain) would still pass on
+    // a buggy adapter that surrounded the data with whitespace,
+    // padding, or a BOM — Anthropic rejects such mutations, so the
+    // test must be just as strict.
+    const parsed: unknown = JSON.parse(req.body);
+    if (!isRecord(parsed)) {
+      throw new Error("expected request body to be a JSON object");
+    }
+    const messages = parsed["messages"];
+    if (!Array.isArray(messages)) {
+      throw new Error("expected body.messages to be an array");
+    }
+    let observedData: unknown;
+    for (const msg of messages) {
+      if (!isRecord(msg)) continue;
+      if (msg["role"] !== "assistant") continue;
+      const content = msg["content"];
+      if (!Array.isArray(content)) continue;
+      for (const block of content) {
+        if (!isRecord(block)) continue;
+        if (block["type"] === "redacted_thinking") {
+          observedData = block["data"];
+        }
+      }
+    }
+    expect(observedData).toBe(SYNTHETIC_REDACTED_DATA);
+  });
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

- Extends `@intx/types` with new `ContentBlock` variants (audio, video, document, citation, code-execution request/result, redacted thinking), a `MediaSource` discriminated union for media payloads, and new `InferenceEvent` variants for citation, redacted thinking, image output, and code execution.
- Replaces the inference harness's single-buffer accumulators with per-index block tracking. `requireIndex` enforces the per-index discipline uniformly at the harness boundary; provider adapters synthesize an index when the wire shape doesn't carry one.
- Adds compat-replay infrastructure that walks the full discovery `SUPPORT_MATRIX` and applies a typed `Invariant[]` list to each captured fixture. A multi-turn integration test against the `function-calling-with-thinking-streaming` corpus proves the thinking-signature round-trip byte-identical against real captured wire bytes.

## Changes

- `packages/types/src/runtime.ts` — new ContentBlock variants, MediaSource union, InferenceEvent extensions, optional `index` on delta variants, PartialMessage docstring clarifying cumulative-concat semantics.
- `packages/inference/src/harness.ts` — per-index `Map<number, BlockState>` block tracking, `requireIndex` enforcement across all five per-index delta variants, cumulative-usage emission, redacted-thinking and citation accumulation into the finalized turn.
- `packages/inference/src/providers/anthropic.ts` — `redacted_thinking` end-to-end (parser + request builder), file-reference media sources, document input via `MediaSource`, citation streaming via `citations_delta`, per-index propagation on every delta, `toAnthropicMediaSource` helper.
- `packages/inference/src/providers/openai.ts` — per-request indexer that allocates content-block indices for text/thinking/tool_calls in arrival order, file-reference image rejection with operator-friendly messaging, document input deferred with explicit rationale, citation drop documented as cross-provider degradation policy.
- `packages/inference-testing/src/invariants.ts` — typed `Invariant[]` with payload-elided violation messages.
- `packages/inference-testing/src/compat-replay.ts` — single-fixture replay plus full-corpus iteration that filters on `outcome === 'captured'`, handles multi-turn (`turn-1/turn-2`) and files-api (`upload/generate`) layouts, and reports structured skip reasons.
- `packages/inference-testing/src/matchers.ts` — `expectMediaBlock` matcher with byte-length assertions that elide raw base64 payload from failure messages.
- `packages/inference-testing/src/wire/anthropic.ts` — wire DSL helpers for new content block variants.
- `tests/inference/multi-turn-thinking-roundtrip.test.ts` — load-bearing integration proof against the captured corpus.
- `tests/inference/per-index-blocks.test.ts` — per-index harness behavior including signature-after-next-block, empty thinking with signature only, and kind-collision protocol errors.
- `tests/inference/redacted-thinking-roundtrip.test.ts` — synthesized-fixture proof for the redacted_thinking parse + builder echo.
- `docs/INFERENCE.md` — Generalized Multimodal Taxonomy section covering MediaSource, per-index block tracking, and the InferenceEvent extensions; Cross-Provider Message Transformation policy now includes citation handling.

## Testing

- `make all` passes (lint + `tsc -b` + 2001 tests across 120 files + 9 serialized rerun tests).
- Full-corpus compat-replay walks every captured fixture in the discovery `SUPPORT_MATRIX` through `runInference` with the canonical Invariant list applied; all replays clean or skip with a structured reason (`no_adapter_registered`, `non_streaming_capture`, `raw_bytes_upload`, `non_captured_outcome`).
- The multi-turn integration test consumes turn-1 of `function-calling-with-thinking-streaming`, runs it through the harness, takes the finalized assistant turn, builds turn-2's request via the production builder, and asserts the rebuilt body's thinking-block signature is byte-identical to the captured turn-2 wire body.
- Per-commit bisectability: every commit independently passes `make all`. Verified during the Pattern 4 rebase that folded the citation-docs work into the citation-introducing commit, and at all subsequent rebase stops.

## Follow-up issues filed

- INTR-115 — Validate Anthropic `redacted_thinking` against a real wire capture
- INTR-116 — Extend `DocumentBlock` with `title` and `context` fields
- INTR-117 — Add a URL variant to `MediaSource`
- INTR-118 — Wire OpenAI document input through the Chat Completions `file` content type
- INTR-119 — Attribute citations to source content block index in the final turn

Closes INTR-79