### PR TITLE
Refactor harness connector routing into a testable unit

### DIFF
--- a/packages/harness/src/connector-router.test.ts
+++ b/packages/harness/src/connector-router.test.ts
@@ -1,0 +1,301 @@
+import { describe, test, expect } from "bun:test";
+
+import { createInboundMessage } from "@intx/mime";
+import type { ConnectorThreadState, InboundMessage } from "@intx/types/runtime";
+
+import {
+  createConnectorRouter,
+  NoActiveConnectorThreadError,
+} from "./connector-router";
+
+function startMessage(opts?: { subject?: string }): InboundMessage {
+  return createInboundMessage({
+    from: "user@example.com",
+    to: ["agent@example.com"],
+    content: "hello",
+    messageId: "<root@example.com>",
+    ...(opts?.subject !== undefined ? { subject: opts.subject } : {}),
+  });
+}
+
+function continuationByReferences(
+  threadRoot: string,
+  opts?: { from?: string; messageId?: string },
+): InboundMessage {
+  return createInboundMessage({
+    from: opts?.from ?? "user@example.com",
+    to: ["agent@example.com"],
+    content: "more",
+    messageId: opts?.messageId ?? "<reply-1@example.com>",
+    references: [threadRoot],
+  });
+}
+
+function continuationByInReplyTo(
+  lastMessageId: string,
+  opts?: { from?: string; messageId?: string },
+): InboundMessage {
+  return createInboundMessage({
+    from: opts?.from ?? "user@example.com",
+    to: ["agent@example.com"],
+    content: "more",
+    messageId: opts?.messageId ?? "<reply-2@example.com>",
+    inReplyTo: lastMessageId,
+  });
+}
+
+function unrelatedMessage(): InboundMessage {
+  return createInboundMessage({
+    from: "stranger@example.com",
+    to: ["agent@example.com"],
+    content: "unrelated",
+    messageId: "<other@example.com>",
+  });
+}
+
+describe("createConnectorRouter", () => {
+  describe("route + commit (inbound)", () => {
+    test("no active thread: any message starts a new thread", () => {
+      const router = createConnectorRouter();
+      const message = startMessage({ subject: "Hello" });
+
+      const decision = router.route(message);
+      expect(decision.kind).toBe("start");
+
+      router.commit(decision);
+
+      expect(router.snapshot()).toEqual({
+        threadRoot: "<root@example.com>",
+        lastMessageId: "<root@example.com>",
+        replyTo: "user@example.com",
+        subject: "Hello",
+      });
+    });
+
+    test("active thread + references includes threadRoot: continue", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage({ subject: "Hello" })));
+
+      const followup = continuationByReferences("<root@example.com>", {
+        from: "user@example.com",
+        messageId: "<follow-1@example.com>",
+      });
+      const decision = router.route(followup);
+      expect(decision.kind).toBe("continue");
+
+      router.commit(decision);
+
+      expect(router.snapshot()).toEqual({
+        threadRoot: "<root@example.com>",
+        lastMessageId: "<follow-1@example.com>",
+        replyTo: "user@example.com",
+        subject: "Hello",
+      });
+    });
+
+    test("active thread + inReplyTo equals lastMessageId: continue", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage()));
+
+      const followup = continuationByInReplyTo("<root@example.com>", {
+        messageId: "<follow-2@example.com>",
+      });
+      const decision = router.route(followup);
+      expect(decision.kind).toBe("continue");
+
+      router.commit(decision);
+
+      expect(router.snapshot()).toEqual({
+        threadRoot: "<root@example.com>",
+        lastMessageId: "<follow-2@example.com>",
+        replyTo: "user@example.com",
+      });
+    });
+
+    test("active thread + neither header rule matches: passthrough leaves state unchanged", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage({ subject: "Hello" })));
+      const before = router.snapshot();
+
+      const decision = router.route(unrelatedMessage());
+      expect(decision.kind).toBe("passthrough");
+
+      router.commit(decision);
+
+      expect(router.snapshot()).toEqual(before);
+    });
+
+    test("continue preserves threadRoot and subject from initial state", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage({ subject: "Important" })));
+
+      // Continuation from a different sender — replyTo should advance, but
+      // threadRoot and subject must carry through unchanged.
+      const followup = continuationByReferences("<root@example.com>", {
+        from: "other@example.com",
+        messageId: "<follow-3@example.com>",
+      });
+      router.commit(router.route(followup));
+
+      const snap = router.snapshot();
+      expect(snap?.threadRoot).toBe("<root@example.com>");
+      expect(snap?.subject).toBe("Important");
+      expect(snap?.replyTo).toBe("other@example.com");
+      expect(snap?.lastMessageId).toBe("<follow-3@example.com>");
+    });
+
+    test("commit on a foreign decision throws", () => {
+      const router = createConnectorRouter();
+      // A `start` decision the router did not produce.
+      expect(() => {
+        router.commit({ kind: "start" });
+      }).toThrow();
+    });
+  });
+
+  describe("composeReply (outbound)", () => {
+    test("active thread with subject: emits to, inReplyTo, subject", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage({ subject: "Hello" })));
+
+      const parts = router.composeReply();
+      expect(parts).toEqual({
+        to: "user@example.com",
+        inReplyTo: "<root@example.com>",
+        subject: "Hello",
+      });
+    });
+
+    test("active thread without subject: subject key absent (not undefined)", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage()));
+
+      const parts = router.composeReply();
+      expect(parts.to).toBe("user@example.com");
+      expect(parts.inReplyTo).toBe("<root@example.com>");
+      expect("subject" in parts).toBe(false);
+    });
+
+    test("no active thread: throws NoActiveConnectorThreadError", () => {
+      const router = createConnectorRouter();
+      expect(() => {
+        router.composeReply();
+      }).toThrow(NoActiveConnectorThreadError);
+    });
+
+    test("onReplySent advances lastMessageId", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage({ subject: "Hello" })));
+
+      router.onReplySent({
+        messageId: "<sent-1@example.com>",
+        status: "delivered",
+      });
+
+      expect(router.snapshot()).toEqual({
+        threadRoot: "<root@example.com>",
+        lastMessageId: "<sent-1@example.com>",
+        replyTo: "user@example.com",
+        subject: "Hello",
+      });
+
+      // A subsequent inbound message whose inReplyTo matches the new
+      // lastMessageId must route as continue.
+      const followup = continuationByInReplyTo("<sent-1@example.com>", {
+        messageId: "<follow-after-send@example.com>",
+      });
+      expect(router.route(followup).kind).toBe("continue");
+    });
+
+    test("onReplySent with no active thread throws", () => {
+      const router = createConnectorRouter();
+      expect(() => {
+        router.onReplySent({
+          messageId: "<sent@example.com>",
+          status: "delivered",
+        });
+      }).toThrow(NoActiveConnectorThreadError);
+    });
+  });
+
+  describe("snapshot/restore round-trip", () => {
+    test("a router restored from a snapshot decides identically", () => {
+      const a = createConnectorRouter();
+      a.commit(a.route(startMessage({ subject: "Hello" })));
+      a.commit(
+        a.route(
+          continuationByReferences("<root@example.com>", {
+            messageId: "<follow-A@example.com>",
+          }),
+        ),
+      );
+
+      const snap = a.snapshot();
+
+      const b = createConnectorRouter();
+      b.restore(snap);
+
+      // Snapshots match.
+      expect(b.snapshot()).toEqual(snap);
+
+      // Same message → same decision kind from both routers.
+      const probe = continuationByInReplyTo("<follow-A@example.com>", {
+        messageId: "<probe@example.com>",
+      });
+      expect(b.route(probe).kind).toBe(a.route(probe).kind);
+
+      // Outbound parts also match.
+      expect(b.composeReply()).toEqual(a.composeReply());
+    });
+
+    test("restore(null) clears active thread", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage()));
+      expect(router.snapshot()).not.toBeNull();
+
+      router.restore(null);
+      expect(router.snapshot()).toBeNull();
+
+      // After clear, the next inbound starts a new thread.
+      expect(router.route(unrelatedMessage()).kind).toBe("start");
+    });
+
+    test("snapshot is a copy, not the live state", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage({ subject: "Hello" })));
+
+      const snap = router.snapshot();
+      if (snap === null) throw new Error("expected non-null snapshot");
+
+      // Advance router state, then verify the prior snapshot is unaffected.
+      router.commit(
+        router.route(
+          continuationByReferences("<root@example.com>", {
+            messageId: "<follow-snap@example.com>",
+          }),
+        ),
+      );
+
+      expect(snap.lastMessageId).toBe("<root@example.com>");
+      expect(router.snapshot()?.lastMessageId).toBe(
+        "<follow-snap@example.com>",
+      );
+    });
+
+    test("restore takes a defensive copy of the input state", () => {
+      const router = createConnectorRouter();
+      const input: ConnectorThreadState = {
+        threadRoot: "<x@example.com>",
+        lastMessageId: "<x@example.com>",
+        replyTo: "x@example.com",
+        subject: "S",
+      };
+      router.restore(input);
+
+      // Mutating the input after restore must not affect router state.
+      input.lastMessageId = "<mutated@example.com>";
+
+      expect(router.snapshot()?.lastMessageId).toBe("<x@example.com>");
+    });
+  });
+});

--- a/packages/harness/src/connector-router.ts
+++ b/packages/harness/src/connector-router.ts
@@ -1,0 +1,201 @@
+// Connector-thread routing for the agent harness.
+//
+// Two-phase decision: route() is pure and returns a discriminated kind
+// plus an opaque carrier of the next state; commit() advances router
+// state from that carrier. Separating the decision from the mutation
+// lets the harness sequence the side effects (deliver, INBOX
+// expunge) around the state change however it needs to.
+
+import type {
+  ConnectorThreadState,
+  InboundMessage,
+  SendReceipt,
+} from "@intx/types/runtime";
+
+export type RouteDecision =
+  | { kind: "start" }
+  | { kind: "continue" }
+  | { kind: "passthrough" };
+
+export type ConnectorReplyParts = {
+  to: string;
+  inReplyTo: string;
+  subject?: string;
+};
+
+export class NoActiveConnectorThreadError extends Error {
+  constructor() {
+    super("no active connector thread");
+    this.name = "NoActiveConnectorThreadError";
+  }
+}
+
+export interface ConnectorRouter {
+  /**
+   * Classify an inbound message against the current connector state. Pure:
+   * does not mutate router state. The returned decision must be passed to
+   * `commit()` to take effect.
+   */
+  route(message: InboundMessage): RouteDecision;
+
+  /**
+   * Advance router state per a decision produced by `route()`. No-op for
+   * `passthrough`. For `start` and `continue`, throws if the decision was
+   * not produced by this router instance.
+   */
+  commit(decision: RouteDecision): void;
+
+  /**
+   * Produce the threading headers needed to send a reply on the active
+   * connector thread. The caller composes the full outbound message by
+   * adding its own `content` and `type` fields. Throws
+   * `NoActiveConnectorThreadError` when no thread is active.
+   */
+  composeReply(): ConnectorReplyParts;
+
+  /**
+   * Update `lastMessageId` after a successful outbound reply send.
+   * Throws when called with no active thread — outbound state advance
+   * has no meaning without a thread.
+   */
+  onReplySent(receipt: SendReceipt): void;
+
+  /**
+   * Return the current connector state as a serializable snapshot, or
+   * `null` when no thread is active. Matches the
+   * `ConnectorThreadState | null` shape used by the storage layer.
+   */
+  snapshot(): ConnectorThreadState | null;
+
+  /**
+   * Install a snapshot as the router's current state. Used at startup
+   * to restore from the persisted context store, and in tests to set
+   * up scenarios. Passing `null` clears the active thread.
+   */
+  restore(state: ConnectorThreadState | null): void;
+}
+
+export function createConnectorRouter(): ConnectorRouter {
+  let state: ConnectorThreadState | null = null;
+
+  // Pending state per decision is held off the decision object via a
+  // WeakMap so callers see only `{ kind }` — no path to inspect or
+  // mutate the next state, even via type assertions.
+  const pendingStates = new WeakMap<RouteDecision, ConnectorThreadState>();
+
+  function isContinuation(message: InboundMessage): boolean {
+    if (state === null) return false;
+
+    const { inReplyTo, references } = message.headers;
+
+    if (references !== undefined && references.includes(state.threadRoot)) {
+      return true;
+    }
+
+    if (inReplyTo !== undefined && inReplyTo === state.lastMessageId) {
+      return true;
+    }
+
+    return false;
+  }
+
+  function route(message: InboundMessage): RouteDecision {
+    if (state === null) {
+      const nextState: ConnectorThreadState = {
+        threadRoot: message.headers.messageId,
+        lastMessageId: message.headers.messageId,
+        replyTo: message.headers.from,
+        ...(message.headers.subject !== undefined
+          ? { subject: message.headers.subject }
+          : {}),
+      };
+      const decision: RouteDecision = { kind: "start" };
+      pendingStates.set(decision, nextState);
+      return decision;
+    }
+
+    if (isContinuation(message)) {
+      const nextState: ConnectorThreadState = {
+        threadRoot: state.threadRoot,
+        lastMessageId: message.headers.messageId,
+        replyTo: message.headers.from,
+        ...(state.subject !== undefined ? { subject: state.subject } : {}),
+      };
+      const decision: RouteDecision = { kind: "continue" };
+      pendingStates.set(decision, nextState);
+      return decision;
+    }
+
+    return { kind: "passthrough" };
+  }
+
+  function commit(decision: RouteDecision): void {
+    if (decision.kind === "passthrough") return;
+
+    const nextState = pendingStates.get(decision);
+    if (nextState === undefined) {
+      throw new Error(
+        "commit() called with a decision from a different router instance",
+      );
+    }
+
+    state = nextState;
+    pendingStates.delete(decision);
+  }
+
+  function composeReply(): ConnectorReplyParts {
+    if (state === null) {
+      throw new NoActiveConnectorThreadError();
+    }
+
+    return {
+      to: state.replyTo,
+      inReplyTo: state.lastMessageId,
+      ...(state.subject !== undefined ? { subject: state.subject } : {}),
+    };
+  }
+
+  function onReplySent(receipt: SendReceipt): void {
+    if (state === null) {
+      throw new NoActiveConnectorThreadError();
+    }
+    state = {
+      threadRoot: state.threadRoot,
+      lastMessageId: receipt.messageId,
+      replyTo: state.replyTo,
+      ...(state.subject !== undefined ? { subject: state.subject } : {}),
+    };
+  }
+
+  function snapshot(): ConnectorThreadState | null {
+    if (state === null) return null;
+    return {
+      threadRoot: state.threadRoot,
+      lastMessageId: state.lastMessageId,
+      replyTo: state.replyTo,
+      ...(state.subject !== undefined ? { subject: state.subject } : {}),
+    };
+  }
+
+  function restore(next: ConnectorThreadState | null): void {
+    if (next === null) {
+      state = null;
+      return;
+    }
+    state = {
+      threadRoot: next.threadRoot,
+      lastMessageId: next.lastMessageId,
+      replyTo: next.replyTo,
+      ...(next.subject !== undefined ? { subject: next.subject } : {}),
+    };
+  }
+
+  return {
+    route,
+    commit,
+    composeReply,
+    onReplySent,
+    snapshot,
+    restore,
+  };
+}

--- a/packages/harness/src/harness.ts
+++ b/packages/harness/src/harness.ts
@@ -25,7 +25,6 @@ import {
   applyInferenceSourceFields,
   type BlobReader,
   type ContextStore,
-  type ConnectorThreadState,
   type InboundMessage,
   type Unsubscribe,
   type ReactorDirector,
@@ -41,6 +40,7 @@ import {
   getMailToolDefinitions,
 } from "./tools";
 import { createDefaultDirector } from "./director";
+import { createConnectorRouter } from "./connector-router";
 import { type } from "arktype";
 
 const logger = getLogger(["interchange", "harness"]);
@@ -119,40 +119,7 @@ export function createHarness(config: HarnessConfig): Harness {
   // Connector state: track which thread(s) this reactor owns.
   // -------------------------------------------------------------------------
 
-  let connectorThreadRoot: string | undefined = undefined;
-  let connectorLastMessageId: string | undefined = undefined;
-  let connectorReplyTo: string | undefined = undefined;
-  let connectorSubject: string | undefined = undefined;
-
-  function currentConnectorState(): ConnectorThreadState | null {
-    if (
-      connectorThreadRoot === undefined ||
-      connectorLastMessageId === undefined ||
-      connectorReplyTo === undefined
-    ) {
-      return null;
-    }
-    return {
-      threadRoot: connectorThreadRoot,
-      lastMessageId: connectorLastMessageId,
-      replyTo: connectorReplyTo,
-      ...(connectorSubject !== undefined ? { subject: connectorSubject } : {}),
-    };
-  }
-
-  function restoreConnectorState(state: ConnectorThreadState | null): void {
-    if (state === null) {
-      connectorThreadRoot = undefined;
-      connectorLastMessageId = undefined;
-      connectorReplyTo = undefined;
-      connectorSubject = undefined;
-    } else {
-      connectorThreadRoot = state.threadRoot;
-      connectorLastMessageId = state.lastMessageId;
-      connectorReplyTo = state.replyTo;
-      connectorSubject = state.subject;
-    }
-  }
+  const connectorRouter = createConnectorRouter();
 
   // Wrap the context store so load() restores connector state and the reactor's
   // per-cycle writeMetadata picks up the live connector state via the underlying
@@ -161,7 +128,7 @@ export function createHarness(config: HarnessConfig): Harness {
   const wrappedStore: ContextStore = {
     async load(signal) {
       const loaded = await storage.load(signal);
-      restoreConnectorState(loaded.connectorState);
+      connectorRouter.restore(loaded.connectorState);
       return loaded;
     },
     setConnectorState(state) {
@@ -202,54 +169,13 @@ export function createHarness(config: HarnessConfig): Harness {
       // buffer so writeMetadata picks it up alongside pendingOperations and
       // tokenUsage. This is the reactor's per-cycle moment to durably record
       // connector thread state.
-      storage.setConnectorState(currentConnectorState());
+      storage.setConnectorState(connectorRouter.snapshot());
       return storage.writeMetadata(metadata, signal);
     },
     async readManifestHistory(limit, signal) {
       return storage.readManifestHistory(limit, signal);
     },
   };
-
-  /**
-   * Determine whether a message belongs to the active connector thread.
-   */
-  function isConnectorMessage(message: InboundMessage): boolean {
-    if (connectorThreadRoot === undefined) return false;
-
-    const { inReplyTo, references } = message.headers;
-
-    if (references !== undefined && references.includes(connectorThreadRoot)) {
-      return true;
-    }
-
-    if (
-      inReplyTo !== undefined &&
-      connectorLastMessageId !== undefined &&
-      inReplyTo === connectorLastMessageId
-    ) {
-      return true;
-    }
-
-    return false;
-  }
-
-  /**
-   * Start tracking a new connector thread from an initial inbound message.
-   */
-  function initConnectorThread(message: InboundMessage): void {
-    connectorThreadRoot = message.headers.messageId;
-    connectorLastMessageId = message.headers.messageId;
-    connectorReplyTo = message.headers.from;
-    connectorSubject = message.headers.subject;
-  }
-
-  /**
-   * Update connector state when a new message arrives in the thread.
-   */
-  function advanceConnectorThread(message: InboundMessage): void {
-    connectorLastMessageId = message.headers.messageId;
-    connectorReplyTo = message.headers.from;
-  }
 
   /**
    * Delete a message from the INBOX after it has been delivered to the reactor.
@@ -269,26 +195,18 @@ export function createHarness(config: HarnessConfig): Harness {
 
   function handleEvent(event: ReactorEmittedEvent): void {
     // Handle connector.reply: send the reply via transport.
-    if (
-      event.type === "connector.reply" &&
-      connectorReplyTo !== undefined &&
-      connectorLastMessageId !== undefined
-    ) {
+    if (event.type === "connector.reply") {
       const replyContent = event.data.content;
-      const replyTo = connectorReplyTo;
-      const inReplyTo = connectorLastMessageId;
-      const subject = connectorSubject;
 
       void (async () => {
         try {
+          const parts = connectorRouter.composeReply();
           const receipt = await transport.send({
-            to: replyTo,
+            ...parts,
             content: replyContent,
             type: "conversation.message",
-            inReplyTo,
-            ...(subject !== undefined ? { subject } : {}),
           });
-          connectorLastMessageId = receipt.messageId;
+          connectorRouter.onReplySent(receipt);
         } catch (cause) {
           logger.error`Failed to send connector reply: ${cause}`;
         }
@@ -404,22 +322,21 @@ export function createHarness(config: HarnessConfig): Harness {
         // Only connector-thread messages are consumed from the INBOX.
         // Everything else is delivered to the reactor and stays in the
         // INBOX so message tools can access it.
-        if (connectorThreadRoot === undefined) {
-          // No active conversation — this message starts one.
-          initConnectorThread(message);
-          reactor.deliver(message);
-          await consumeFromInbox(message);
-        } else if (isConnectorMessage(message)) {
-          // Continues the active connector thread.
-          advanceConnectorThread(message);
-          reactor.deliver(message);
-          await consumeFromInbox(message);
-        } else {
+        const decision = connectorRouter.route(message);
+        if (decision.kind === "passthrough") {
           // Non-connector mail (replies to agent sends, unsolicited
           // inter-agent mail, etc.). Deliver to reactor for notification
           // but leave in INBOX for message tools.
           reactor.deliver(message);
+          return;
         }
+
+        // start or continue: commit router state synchronously before
+        // any await so that a concurrent watch callback fired during
+        // consumeFromInbox observes the updated state.
+        connectorRouter.commit(decision);
+        reactor.deliver(message);
+        await consumeFromInbox(message);
       })();
     });
 

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -12,3 +12,13 @@ export type { MailToolName } from "./tools";
 
 export { readDeployTree } from "./deploy-tree";
 export type { DeployTree, DeployToolInfo } from "./deploy-tree";
+
+export {
+  createConnectorRouter,
+  NoActiveConnectorThreadError,
+} from "./connector-router";
+export type {
+  ConnectorRouter,
+  ConnectorReplyParts,
+  RouteDecision,
+} from "./connector-router";


### PR DESCRIPTION
## Summary

- Extract the connector-thread routing decision out of `createHarness` into a self-contained `createConnectorRouter` unit with a pure `route()`, a separate `commit()`, and a matched `snapshot()`/`restore()` pair for storage round-trips.
- Drive `createHarness` through the router; delete the four loose state bindings, the partial-state guards, and the three inline helpers they were paired with.

## Changes

- `packages/harness/src/connector-router.ts`: new — router factory, `RouteDecision` discriminated union, `ConnectorReplyParts`, `NoActiveConnectorThreadError`.
- `packages/harness/src/connector-router.test.ts`: new — 15 unit tests covering inbound start/continue/passthrough, outbound `composeReply` with and without an active thread, `onReplySent` advance, snapshot/restore round-trip, and defensive copying.
- `packages/harness/src/harness.ts`: switch INBOX watch and `connector.reply` reactor-event handler to the router; remove inline routing helpers; route persistence through `router.snapshot()`.
- `packages/harness/src/index.ts`: re-export router factory, types, and the named error class.

## Testing

- `make all` clean against HEAD: 2238 + 9 tests pass, 0 fail.
- Each commit passes `make all` standalone (bisect-friendly).

## Behavior delta

One intentional, observable change, documented in commit 2: the `connector.reply` outbound handler previously no-opped silently when state was missing; it now throws `NoActiveConnectorThreadError`, which the existing fire-and-forget IIFE catches and surfaces via `logger.error`. There is no legitimate path where `connector.reply` fires without an active thread, so loud-log is the correct shape.

Closes INTR-76