### PR TITLE
Thread user mail into the agent's active connector when present

### DIFF
--- a/apps/sidecar/src/main.ts
+++ b/apps/sidecar/src/main.ts
@@ -1,6 +1,6 @@
 import { setup, getLogger } from "@intx/log";
 import { createInMemoryTransport } from "@intx/mail-memory";
-import type { InferenceEvent } from "@intx/types/runtime";
+import type { ConnectorThreadState, InferenceEvent } from "@intx/types/runtime";
 
 import { createSessionManager } from "./session-manager";
 import { createWsClient } from "./ws-client";
@@ -41,12 +41,21 @@ let forwardEvent: (a: string, s: string, e: InferenceEvent) => void = (
 ) => {
   // Replaced after ws-client is constructed.
 };
+let forwardConnectorState: (
+  a: string,
+  state: ConnectorThreadState | null,
+) => void = (_a, _state) => {
+  // Replaced after ws-client is constructed.
+};
 
 const sessions = createSessionManager({
   transport,
   dataDir,
   onEvent(agentAddress, sessionId, event) {
     forwardEvent(agentAddress, sessionId, event);
+  },
+  onConnectorStateChanged(agentAddress, state) {
+    forwardConnectorState(agentAddress, state);
   },
 });
 
@@ -59,6 +68,7 @@ const client = createWsClient({
 });
 
 forwardEvent = client.sendEvent;
+forwardConnectorState = client.sendConnectorState;
 client.connect();
 
 log.info("Sidecar {sidecarId} connecting to {hubUrl}", { sidecarId, hubUrl });

--- a/apps/sidecar/src/session-manager.ts
+++ b/apps/sidecar/src/session-manager.ts
@@ -38,6 +38,7 @@ import {
 import type { InMemoryTransport } from "@intx/mail-memory";
 import type { GrantRule } from "@intx/types/authz";
 import type {
+  ConnectorThreadState,
   InboundMessage,
   InferenceEvent,
   InferenceSource,
@@ -74,10 +75,16 @@ export type SessionEventSink = (
   event: InferenceEvent,
 ) => void;
 
+export type ConnectorStateSink = (
+  agentAddress: string,
+  state: ConnectorThreadState | null,
+) => void;
+
 export type SessionManagerConfig = {
   transport: InMemoryTransport;
   dataDir: string;
   onEvent: SessionEventSink;
+  onConnectorStateChanged: ConnectorStateSink;
 };
 
 // Sanitize an agent address into a safe directory name.
@@ -187,7 +194,7 @@ export function buildToolDispatch(
 export function createSessionManager(
   config: SessionManagerConfig,
 ): SessionManager {
-  const { transport, dataDir, onEvent } = config;
+  const { transport, dataDir, onEvent, onConnectorStateChanged } = config;
   const sessions = new Map<string, AgentSession>();
   const provisioned = new Map<string, ProvisionedAgent>();
   const pending = new Set<string>();
@@ -375,6 +382,9 @@ export function createSessionManager(
             lastCheckpointHashes.set(agentAddress, event.data.checkpointHash);
           }
           onEvent(agentAddress, sessionId, event);
+        },
+        onConnectorStateChanged(state) {
+          onConnectorStateChanged(agentAddress, state);
         },
       });
 

--- a/apps/sidecar/src/ws-client.ts
+++ b/apps/sidecar/src/ws-client.ts
@@ -28,7 +28,11 @@ import {
 } from "@intx/types/sidecar";
 import type { KeyPair } from "@intx/types/runtime";
 
-import type { SessionManager, SessionEventSink } from "./session-manager";
+import type {
+  ConnectorStateSink,
+  SessionManager,
+  SessionEventSink,
+} from "./session-manager";
 import { createPackReceiver, chunkPack } from "@intx/pack-transport";
 import { hexDecode, hexEncode } from "@intx/types";
 
@@ -49,6 +53,7 @@ export type WsClient = {
   connect(): void;
   close(): void;
   sendEvent: SessionEventSink;
+  sendConnectorState: ConnectorStateSink;
 };
 
 export function createWsClient(config: WsClientConfig): WsClient {
@@ -661,7 +666,18 @@ export function createWsClient(config: WsClientConfig): WsClient {
     });
   };
 
-  return { connect, close, sendEvent };
+  const sendConnectorState: ConnectorStateSink = (
+    agentAddress,
+    connectorState,
+  ) => {
+    send({
+      type: "connector.state.changed",
+      agentAddress,
+      connectorState,
+    });
+  };
+
+  return { connect, close, sendEvent, sendConnectorState };
 }
 
 function uint8ArrayToBase64(bytes: Uint8Array): string {

--- a/bun.lock
+++ b/bun.lock
@@ -255,11 +255,9 @@
       "dependencies": {
         "@intx/inference": "workspace:*",
         "@intx/log": "workspace:*",
+        "@intx/mime": "workspace:*",
         "@intx/types": "workspace:*",
         "arktype": "catalog:",
-      },
-      "devDependencies": {
-        "@intx/mime": "workspace:*",
       },
     },
     "packages/hub-api": {

--- a/docs/HARNESS_DESIGN.md
+++ b/docs/HARNESS_DESIGN.md
@@ -106,6 +106,33 @@ The sidecar manages agents, not user sessions. When the hub deploys an agent to 
 
 The hub maintains a sidecar-to-agent mapping in its database. This mapping determines where to route messages for a given agent address. When a sidecar disconnects, the hub knows which agents are affected and queues messages for them until the sidecar reconnects.
 
+### Connector threads and user sessions
+
+The connector is **one durable thread per agent**. Anyone who sends conversational mail to the agent — a human via a hub session, a parent agent that launched this one as a sub-agent, a peer agent that initiates a conversation — joins the thread by stamping threading headers the harness recognizes. Participants accumulate; no one is displaced. The thread persists for the lifetime of the agent.
+
+The connector router classifies each inbound message as:
+
+- **`start`** when no thread is active. The sender becomes the first participant; the message-id becomes `threadRoot`; the subject is recorded and preserved for the life of the thread.
+- **`continue`** when the message's `references` includes the active `threadRoot`, or its `inReplyTo` equals the active `lastMessageId`. The sender is added to the participant set; the previous most-recent speaker moves into `cc` (deduplicated against re-entry).
+- **`passthrough`** for everything else — non-conversational mail (structured payloads, system notifications) and conversational mail without threading headers while a thread is active. The reactor still sees it, but the harness leaves it in the INBOX and the connector state is untouched.
+
+Connector state has four parts: `threadRoot` (the first message's id), `lastMessageId` (the most recent message in either direction), `replyTo` (the most recent speaker — the primary recipient on the next outbound reply), and `cc` (every other participant who has spoken on the thread, deduplicated, in arrival order). When the reactor emits `connector.reply`, the outbound mail is addressed to `replyTo` with `cc` carrying everyone else — whoever spoke most recently gets the direct reply and the rest stay in the loop.
+
+When a hub user composes mail to an agent, the hub decides what threading headers to stamp:
+
+1. **Session history wins.** If the user already has prior mail in this session, the hub stamps `inReplyTo` and `references` from that session-history chain. The harness routes the message as `continue` against whatever thread the user's prior session message was part of.
+2. **Connector cache fallback.** With no session history, the hub looks up the agent's cached connector state. If a thread is active, the hub stamps `inReplyTo = lastMessageId` and `references = [threadRoot]` — regardless of who else is on the thread. The user joins whatever conversation is in progress.
+3. **No threading.** With no session history and no active connector, the hub sends the message threading-less. The harness routes it as `start`, establishing this user as the first participant on a new thread.
+
+The hub learns the cached connector state from a `connector.state.changed` frame the sidecar emits whenever the router's state mutates. Cache entries are dropped on sidecar disconnect.
+
+On reconnect, agents whose persisted state is non-null re-bootstrap the cache automatically: the router's `restore()` call from the reactor's `wrappedStore.load()` fires `onStateChanged` because the state transitions from the cold-start `null` to the persisted value, and the sidecar lifts that callback onto a wire frame. Agents whose persisted state is null emit no frame — the cache stays absent until the harness produces its first real state change. The route handler treats absent and null identically.
+
+Two observable windows where the cache may be empty or stale, both of which fall through to threading-less mail and self-heal on the next state change:
+
+1. **Between WebSocket connection and the reactor's first `wrappedStore.load()`.** A user message composed in this window finds an absent cache entry. After the load, a bootstrap frame populates the cache.
+2. **Between a sidecar disconnect and the same sidecar's next `wrappedStore.load()` on reconnect.** The disconnect clears the cache. A user message composed in this window also finds an absent entry. If the cache was ahead of the persisted store at disconnect (a state mutation fired between the last `writeMetadata` cycle and the drop), the bootstrap will restore the persisted snapshot rather than the prior in-memory cache value. The cache reflects the freshest source of truth available, not a continuous history.
+
 ## Registration
 
 On first connection (no restorable agents in `SIDECAR_DATA_DIR`), the sidecar sends a `register` frame to identify itself to the hub. The hub responds by sending `agent.deploy` frames for any agents assigned to this sidecar.

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -12,10 +12,8 @@
   "dependencies": {
     "@intx/inference": "workspace:*",
     "@intx/log": "workspace:*",
+    "@intx/mime": "workspace:*",
     "@intx/types": "workspace:*",
     "arktype": "catalog:"
-  },
-  "devDependencies": {
-    "@intx/mime": "workspace:*"
   }
 }

--- a/packages/harness/src/config.ts
+++ b/packages/harness/src/config.ts
@@ -1,6 +1,7 @@
 import type {
   MessageTransport,
   CryptoProvider,
+  ConnectorThreadState,
   ContextStore,
   AuditStore,
   ToolRunner,
@@ -43,6 +44,15 @@ export type HarnessConfig = {
 
   /** Callback invoked for every inference event emitted by the reactor. */
   onEvent: (event: InferenceEvent) => void;
+
+  /**
+   * Optional callback invoked whenever the connector router's state changes
+   * (commit of a start/continue decision, an outbound reply send advancing
+   * lastMessageId, or load-time restore from the context store). Fires only
+   * on a real state change, not on no-op operations. Used by the sidecar to
+   * lift connector-state updates onto the hub-bound event channel.
+   */
+  onConnectorStateChanged?: (state: ConnectorThreadState | null) => void;
 
   /**
    * Optional custom director. When omitted, the default conversational director

--- a/packages/harness/src/connector-router.test.ts
+++ b/packages/harness/src/connector-router.test.ts
@@ -55,61 +55,154 @@ function unrelatedMessage(): InboundMessage {
 
 describe("createConnectorRouter", () => {
   describe("route + commit (inbound)", () => {
-    test("no active thread: any message starts a new thread", () => {
+    test("no active thread: start initializes with empty cc", () => {
       const router = createConnectorRouter();
-      const message = startMessage({ subject: "Hello" });
 
-      const decision = router.route(message);
-      expect(decision.kind).toBe("start");
-
-      router.commit(decision);
+      router.commit(router.route(startMessage({ subject: "Hello" })));
 
       expect(router.snapshot()).toEqual({
         threadRoot: "<root@example.com>",
         lastMessageId: "<root@example.com>",
         replyTo: "user@example.com",
+        cc: [],
         subject: "Hello",
       });
     });
 
-    test("active thread + references includes threadRoot: continue", () => {
+    test("active thread + references includes threadRoot: continue from the same sender keeps cc empty", () => {
       const router = createConnectorRouter();
       router.commit(router.route(startMessage({ subject: "Hello" })));
 
-      const followup = continuationByReferences("<root@example.com>", {
-        from: "user@example.com",
-        messageId: "<follow-1@example.com>",
-      });
-      const decision = router.route(followup);
-      expect(decision.kind).toBe("continue");
-
-      router.commit(decision);
+      router.commit(
+        router.route(
+          continuationByReferences("<root@example.com>", {
+            from: "user@example.com",
+            messageId: "<follow-1@example.com>",
+          }),
+        ),
+      );
 
       expect(router.snapshot()).toEqual({
         threadRoot: "<root@example.com>",
         lastMessageId: "<follow-1@example.com>",
         replyTo: "user@example.com",
+        cc: [],
         subject: "Hello",
       });
     });
 
-    test("active thread + inReplyTo equals lastMessageId: continue", () => {
+    test("active thread + inReplyTo equals lastMessageId: continue from the same sender keeps cc empty", () => {
       const router = createConnectorRouter();
       router.commit(router.route(startMessage()));
 
-      const followup = continuationByInReplyTo("<root@example.com>", {
-        messageId: "<follow-2@example.com>",
-      });
-      const decision = router.route(followup);
-      expect(decision.kind).toBe("continue");
-
-      router.commit(decision);
+      router.commit(
+        router.route(
+          continuationByInReplyTo("<root@example.com>", {
+            messageId: "<follow-2@example.com>",
+          }),
+        ),
+      );
 
       expect(router.snapshot()).toEqual({
         threadRoot: "<root@example.com>",
         lastMessageId: "<follow-2@example.com>",
         replyTo: "user@example.com",
+        cc: [],
       });
+    });
+
+    test("continue from a different sender moves the prior replyTo into cc", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage({ subject: "Important" })));
+
+      router.commit(
+        router.route(
+          continuationByReferences("<root@example.com>", {
+            from: "other@example.com",
+            messageId: "<follow-3@example.com>",
+          }),
+        ),
+      );
+
+      expect(router.snapshot()).toEqual({
+        threadRoot: "<root@example.com>",
+        lastMessageId: "<follow-3@example.com>",
+        replyTo: "other@example.com",
+        cc: ["user@example.com"],
+        subject: "Important",
+      });
+    });
+
+    test("continue accumulates participants across multiple distinct senders", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage({ subject: "Important" })));
+
+      router.commit(
+        router.route(
+          continuationByReferences("<root@example.com>", {
+            from: "second@example.com",
+            messageId: "<follow-a@example.com>",
+          }),
+        ),
+      );
+      router.commit(
+        router.route(
+          continuationByReferences("<root@example.com>", {
+            from: "third@example.com",
+            messageId: "<follow-b@example.com>",
+          }),
+        ),
+      );
+
+      const snap = router.snapshot();
+      expect(snap?.replyTo).toBe("third@example.com");
+      expect(snap?.cc).toEqual(["user@example.com", "second@example.com"]);
+    });
+
+    test("continue from a sender already in cc does not duplicate them", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage()));
+      router.commit(
+        router.route(
+          continuationByReferences("<root@example.com>", {
+            from: "second@example.com",
+            messageId: "<follow-a@example.com>",
+          }),
+        ),
+      );
+      // Now: replyTo=second, cc=[user]. The original user returns.
+      router.commit(
+        router.route(
+          continuationByReferences("<root@example.com>", {
+            from: "user@example.com",
+            messageId: "<follow-b@example.com>",
+          }),
+        ),
+      );
+
+      const snap = router.snapshot();
+      expect(snap?.replyTo).toBe("user@example.com");
+      // user is now the most recent speaker; second is the only other
+      // participant. user must not appear in cc.
+      expect(snap?.cc).toEqual(["second@example.com"]);
+    });
+
+    test("subject is preserved across many continues from different senders", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage({ subject: "Important" })));
+
+      for (const from of ["b@example.com", "c@example.com", "d@example.com"]) {
+        router.commit(
+          router.route(
+            continuationByReferences("<root@example.com>", {
+              from,
+              messageId: `<follow-${from}>`,
+            }),
+          ),
+        );
+      }
+
+      expect(router.snapshot()?.subject).toBe("Important");
     });
 
     test("active thread + neither header rule matches: passthrough leaves state unchanged", () => {
@@ -125,28 +218,8 @@ describe("createConnectorRouter", () => {
       expect(router.snapshot()).toEqual(before);
     });
 
-    test("continue preserves threadRoot and subject from initial state", () => {
-      const router = createConnectorRouter();
-      router.commit(router.route(startMessage({ subject: "Important" })));
-
-      // Continuation from a different sender — replyTo should advance, but
-      // threadRoot and subject must carry through unchanged.
-      const followup = continuationByReferences("<root@example.com>", {
-        from: "other@example.com",
-        messageId: "<follow-3@example.com>",
-      });
-      router.commit(router.route(followup));
-
-      const snap = router.snapshot();
-      expect(snap?.threadRoot).toBe("<root@example.com>");
-      expect(snap?.subject).toBe("Important");
-      expect(snap?.replyTo).toBe("other@example.com");
-      expect(snap?.lastMessageId).toBe("<follow-3@example.com>");
-    });
-
     test("commit on a foreign decision throws", () => {
       const router = createConnectorRouter();
-      // A `start` decision the router did not produce.
       expect(() => {
         router.commit({ kind: "start" });
       }).toThrow();
@@ -154,15 +227,45 @@ describe("createConnectorRouter", () => {
   });
 
   describe("composeReply (outbound)", () => {
-    test("active thread with subject: emits to, inReplyTo, subject", () => {
+    test("single-participant thread: cc is empty", () => {
       const router = createConnectorRouter();
       router.commit(router.route(startMessage({ subject: "Hello" })));
 
       const parts = router.composeReply();
       expect(parts).toEqual({
         to: "user@example.com",
+        cc: [],
         inReplyTo: "<root@example.com>",
         subject: "Hello",
+      });
+    });
+
+    test("multi-participant thread: cc contains all prior speakers", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage({ subject: "Important" })));
+      router.commit(
+        router.route(
+          continuationByReferences("<root@example.com>", {
+            from: "second@example.com",
+            messageId: "<follow-a@example.com>",
+          }),
+        ),
+      );
+      router.commit(
+        router.route(
+          continuationByReferences("<root@example.com>", {
+            from: "third@example.com",
+            messageId: "<follow-b@example.com>",
+          }),
+        ),
+      );
+
+      const parts = router.composeReply();
+      expect(parts).toEqual({
+        to: "third@example.com",
+        cc: ["user@example.com", "second@example.com"],
+        inReplyTo: "<follow-b@example.com>",
+        subject: "Important",
       });
     });
 
@@ -172,8 +275,28 @@ describe("createConnectorRouter", () => {
 
       const parts = router.composeReply();
       expect(parts.to).toBe("user@example.com");
+      expect(parts.cc).toEqual([]);
       expect(parts.inReplyTo).toBe("<root@example.com>");
       expect("subject" in parts).toBe(false);
+    });
+
+    test("composeReply returns a copy of cc, not the live array", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage()));
+      router.commit(
+        router.route(
+          continuationByReferences("<root@example.com>", {
+            from: "second@example.com",
+            messageId: "<follow-a@example.com>",
+          }),
+        ),
+      );
+
+      const parts = router.composeReply();
+      parts.cc.push("injected@example.com");
+
+      // Subsequent state must not include the injected value.
+      expect(router.snapshot()?.cc).toEqual(["user@example.com"]);
     });
 
     test("no active thread: throws NoActiveConnectorThreadError", () => {
@@ -183,9 +306,17 @@ describe("createConnectorRouter", () => {
       }).toThrow(NoActiveConnectorThreadError);
     });
 
-    test("onReplySent advances lastMessageId", () => {
+    test("onReplySent advances lastMessageId and preserves cc", () => {
       const router = createConnectorRouter();
       router.commit(router.route(startMessage({ subject: "Hello" })));
+      router.commit(
+        router.route(
+          continuationByReferences("<root@example.com>", {
+            from: "second@example.com",
+            messageId: "<follow-a@example.com>",
+          }),
+        ),
+      );
 
       router.onReplySent({
         messageId: "<sent-1@example.com>",
@@ -195,13 +326,15 @@ describe("createConnectorRouter", () => {
       expect(router.snapshot()).toEqual({
         threadRoot: "<root@example.com>",
         lastMessageId: "<sent-1@example.com>",
-        replyTo: "user@example.com",
+        replyTo: "second@example.com",
+        cc: ["user@example.com"],
         subject: "Hello",
       });
 
-      // A subsequent inbound message whose inReplyTo matches the new
+      // A subsequent inbound whose inReplyTo matches the new
       // lastMessageId must route as continue.
       const followup = continuationByInReplyTo("<sent-1@example.com>", {
+        from: "second@example.com",
         messageId: "<follow-after-send@example.com>",
       });
       expect(router.route(followup).kind).toBe("continue");
@@ -225,6 +358,7 @@ describe("createConnectorRouter", () => {
       a.commit(
         a.route(
           continuationByReferences("<root@example.com>", {
+            from: "other@example.com",
             messageId: "<follow-A@example.com>",
           }),
         ),
@@ -235,16 +369,14 @@ describe("createConnectorRouter", () => {
       const b = createConnectorRouter();
       b.restore(snap);
 
-      // Snapshots match.
       expect(b.snapshot()).toEqual(snap);
 
-      // Same message → same decision kind from both routers.
       const probe = continuationByInReplyTo("<follow-A@example.com>", {
         messageId: "<probe@example.com>",
       });
       expect(b.route(probe).kind).toBe(a.route(probe).kind);
 
-      // Outbound parts also match.
+      // Outbound parts also match (including cc).
       expect(b.composeReply()).toEqual(a.composeReply());
     });
 
@@ -256,7 +388,6 @@ describe("createConnectorRouter", () => {
       router.restore(null);
       expect(router.snapshot()).toBeNull();
 
-      // After clear, the next inbound starts a new thread.
       expect(router.route(unrelatedMessage()).kind).toBe("start");
     });
 
@@ -267,7 +398,6 @@ describe("createConnectorRouter", () => {
       const snap = router.snapshot();
       if (snap === null) throw new Error("expected non-null snapshot");
 
-      // Advance router state, then verify the prior snapshot is unaffected.
       router.commit(
         router.route(
           continuationByReferences("<root@example.com>", {
@@ -282,20 +412,307 @@ describe("createConnectorRouter", () => {
       );
     });
 
-    test("restore takes a defensive copy of the input state", () => {
+    test("restore takes a defensive copy of the input state and its cc", () => {
       const router = createConnectorRouter();
       const input: ConnectorThreadState = {
         threadRoot: "<x@example.com>",
         lastMessageId: "<x@example.com>",
         replyTo: "x@example.com",
+        cc: ["a@example.com"],
         subject: "S",
       };
       router.restore(input);
 
-      // Mutating the input after restore must not affect router state.
       input.lastMessageId = "<mutated@example.com>";
+      input.cc.push("injected@example.com");
 
-      expect(router.snapshot()?.lastMessageId).toBe("<x@example.com>");
+      const snap = router.snapshot();
+      expect(snap?.lastMessageId).toBe("<x@example.com>");
+      expect(snap?.cc).toEqual(["a@example.com"]);
+    });
+  });
+
+  describe("replyTo normalization", () => {
+    // These tests bypass createInboundMessage because its `from` validator
+    // requires a bare addr-spec, but on the production fetch path
+    // (mail-memory's buildMessageHeaders) the `from` header is copied
+    // verbatim from the wire and may contain a display name. The router
+    // is the layer that has to handle that, so the test exercises it
+    // with wire-shaped values.
+    function inboundWith(
+      fromHeader: string,
+      messageId: string,
+    ): InboundMessage {
+      return {
+        ref: { uid: 1, mailbox: "INBOX" },
+        headers: {
+          from: fromHeader,
+          to: ["agent@example.com"],
+          date: new Date().toISOString(),
+          messageId,
+        },
+        flags: [],
+        content: "x",
+        signatureStatus: "missing",
+      };
+    }
+
+    test("strips display name and lowercases when storing replyTo on start", () => {
+      const router = createConnectorRouter();
+
+      router.commit(
+        router.route(
+          inboundWith('"Alice Doe" <Alice@Example.COM>', "<root@example.com>"),
+        ),
+      );
+
+      expect(router.snapshot()?.replyTo).toBe("alice@example.com");
+    });
+
+    test("strips display name when advancing replyTo on continue", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage({ subject: "Hello" })));
+
+      const followup: InboundMessage = {
+        ref: { uid: 2, mailbox: "INBOX" },
+        headers: {
+          from: '"Other User" <Other@Example.com>',
+          to: ["agent@example.com"],
+          date: new Date().toISOString(),
+          messageId: "<follow-norm@example.com>",
+          references: ["<root@example.com>"],
+        },
+        flags: [],
+        content: "more",
+        signatureStatus: "missing",
+      };
+      router.commit(router.route(followup));
+
+      expect(router.snapshot()?.replyTo).toBe("other@example.com");
+    });
+
+    test("route() throws when the from header is unparseable on start", () => {
+      const router = createConnectorRouter();
+      const message = inboundWith("not-an-address", "<bad@example.com>");
+
+      expect(() => router.route(message)).toThrow();
+    });
+
+    test("route() throws when the from header is unparseable on continue", () => {
+      const router = createConnectorRouter();
+      router.commit(router.route(startMessage()));
+
+      const malformedContinuation: InboundMessage = {
+        ref: { uid: 99, mailbox: "INBOX" },
+        headers: {
+          from: "not-an-address",
+          to: ["agent@example.com"],
+          date: new Date().toISOString(),
+          messageId: "<follow-bad@example.com>",
+          references: ["<root@example.com>"],
+        },
+        flags: [],
+        content: "more",
+        signatureStatus: "missing",
+      };
+
+      expect(() => router.route(malformedContinuation)).toThrow();
+    });
+  });
+
+  describe("onStateChanged callback", () => {
+    test("fires after a start decision commits", () => {
+      const events: (ConnectorThreadState | null)[] = [];
+      const router = createConnectorRouter({
+        onStateChanged: (s) => events.push(s),
+      });
+
+      router.commit(router.route(startMessage({ subject: "Hello" })));
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        threadRoot: "<root@example.com>",
+        lastMessageId: "<root@example.com>",
+        replyTo: "user@example.com",
+        cc: [],
+        subject: "Hello",
+      });
+    });
+
+    test("fires after continue advances the thread", () => {
+      const events: (ConnectorThreadState | null)[] = [];
+      const router = createConnectorRouter({
+        onStateChanged: (s) => events.push(s),
+      });
+      router.commit(router.route(startMessage()));
+      events.length = 0;
+
+      router.commit(
+        router.route(
+          continuationByReferences("<root@example.com>", {
+            from: "second@example.com",
+            messageId: "<follow-cb@example.com>",
+          }),
+        ),
+      );
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.lastMessageId).toBe("<follow-cb@example.com>");
+      expect(events[0]?.replyTo).toBe("second@example.com");
+      expect(events[0]?.cc).toEqual(["user@example.com"]);
+    });
+
+    test("does not fire for passthrough commits", () => {
+      const events: (ConnectorThreadState | null)[] = [];
+      const router = createConnectorRouter({
+        onStateChanged: (s) => events.push(s),
+      });
+      router.commit(router.route(startMessage()));
+      events.length = 0;
+
+      router.commit(router.route(unrelatedMessage()));
+
+      expect(events).toHaveLength(0);
+    });
+
+    test("fires after onReplySent advances lastMessageId", () => {
+      const events: (ConnectorThreadState | null)[] = [];
+      const router = createConnectorRouter({
+        onStateChanged: (s) => events.push(s),
+      });
+      router.commit(router.route(startMessage()));
+      events.length = 0;
+
+      router.onReplySent({
+        messageId: "<sent-cb@example.com>",
+        status: "delivered",
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.lastMessageId).toBe("<sent-cb@example.com>");
+    });
+
+    test("fires on restore() when state changes from null", () => {
+      const events: (ConnectorThreadState | null)[] = [];
+      const router = createConnectorRouter({
+        onStateChanged: (s) => events.push(s),
+      });
+
+      router.restore({
+        threadRoot: "<r@example.com>",
+        lastMessageId: "<r@example.com>",
+        replyTo: "r@example.com",
+        cc: [],
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.threadRoot).toBe("<r@example.com>");
+    });
+
+    test("does not fire on restore(null) when already null (cold start)", () => {
+      const events: (ConnectorThreadState | null)[] = [];
+      const router = createConnectorRouter({
+        onStateChanged: (s) => events.push(s),
+      });
+
+      router.restore(null);
+
+      expect(events).toHaveLength(0);
+    });
+
+    test("does not fire on restore() into an equal state", () => {
+      const events: (ConnectorThreadState | null)[] = [];
+      const router = createConnectorRouter({
+        onStateChanged: (s) => events.push(s),
+      });
+      const snap: ConnectorThreadState = {
+        threadRoot: "<r@example.com>",
+        lastMessageId: "<r@example.com>",
+        replyTo: "r@example.com",
+        cc: ["a@example.com"],
+        subject: "S",
+      };
+      router.restore(snap);
+      events.length = 0;
+
+      router.restore({ ...snap, cc: [...snap.cc] });
+
+      expect(events).toHaveLength(0);
+    });
+
+    test("fires when cc changes even if replyTo and lastMessageId do not", () => {
+      // Defensive: any field of the state changing is a state change.
+      const events: (ConnectorThreadState | null)[] = [];
+      const router = createConnectorRouter({
+        onStateChanged: (s) => events.push(s),
+      });
+      const snap: ConnectorThreadState = {
+        threadRoot: "<r@example.com>",
+        lastMessageId: "<r@example.com>",
+        replyTo: "r@example.com",
+        cc: [],
+      };
+      router.restore(snap);
+      events.length = 0;
+
+      router.restore({ ...snap, cc: ["a@example.com"] });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.cc).toEqual(["a@example.com"]);
+    });
+
+    test("fires with a snapshot copy, not the live state", () => {
+      const events: (ConnectorThreadState | null)[] = [];
+      const router = createConnectorRouter({
+        onStateChanged: (s) => events.push(s),
+      });
+
+      router.commit(router.route(startMessage()));
+      const captured = events[0];
+      if (captured === null || captured === undefined) {
+        throw new Error("expected non-null captured state");
+      }
+
+      router.onReplySent({
+        messageId: "<later@example.com>",
+        status: "delivered",
+      });
+
+      expect(captured.lastMessageId).toBe("<root@example.com>");
+    });
+
+    test("a throwing subscriber does not propagate out of commit()", () => {
+      const router = createConnectorRouter({
+        onStateChanged: () => {
+          throw new Error("subscriber boom");
+        },
+      });
+
+      const decision = router.route(startMessage());
+      expect(() => router.commit(decision)).not.toThrow();
+      expect(router.snapshot()).not.toBeNull();
+    });
+
+    test("a throwing subscriber does not propagate out of onReplySent()", () => {
+      let firstCall = true;
+      const router = createConnectorRouter({
+        onStateChanged: () => {
+          if (firstCall) {
+            firstCall = false;
+            return;
+          }
+          throw new Error("subscriber boom");
+        },
+      });
+      router.commit(router.route(startMessage()));
+
+      expect(() =>
+        router.onReplySent({
+          messageId: "<sent-throw@example.com>",
+          status: "delivered",
+        }),
+      ).not.toThrow();
+      expect(router.snapshot()?.lastMessageId).toBe("<sent-throw@example.com>");
     });
   });
 });

--- a/packages/harness/src/connector-router.ts
+++ b/packages/harness/src/connector-router.ts
@@ -1,16 +1,26 @@
 // Connector-thread routing for the agent harness.
 //
+// The connector is one durable thread per agent. Participants accumulate
+// as they speak; no one is displaced. `replyTo` tracks the most recent
+// speaker (the primary recipient on the next outbound reply) and `cc`
+// tracks every other participant who has spoken (carried on outbound so
+// everyone stays in the loop).
+//
 // Two-phase decision: route() is pure and returns a discriminated kind
 // plus an opaque carrier of the next state; commit() advances router
 // state from that carrier. Separating the decision from the mutation
-// lets the harness sequence the side effects (deliver, INBOX
-// expunge) around the state change however it needs to.
+// lets the harness sequence the side effects (deliver, INBOX expunge)
+// around the state change however it needs to.
 
+import { getLogger } from "@intx/log";
+import { extractAddrSpec } from "@intx/mime";
 import type {
   ConnectorThreadState,
   InboundMessage,
   SendReceipt,
 } from "@intx/types/runtime";
+
+const logger = getLogger(["interchange", "harness", "connector-router"]);
 
 export type RouteDecision =
   | { kind: "start" }
@@ -19,6 +29,7 @@ export type RouteDecision =
 
 export type ConnectorReplyParts = {
   to: string;
+  cc: string[];
   inReplyTo: string;
   subject?: string;
 };
@@ -30,11 +41,39 @@ export class NoActiveConnectorThreadError extends Error {
   }
 }
 
+export type ConnectorRouterOptions = {
+  /**
+   * Called synchronously after the router's internal state mutates and the
+   * new state is committed to internal storage. Fires only when the new
+   * state differs from the prior state — restore() into the same state,
+   * passthrough commits, and other no-ops do not fire. Single subscriber:
+   * the harness wiring that lifts state changes onto the hub-bound event
+   * channel.
+   *
+   * The router catches and logs any error this callback throws. The cache
+   * the callback feeds is a best-effort projection of router state, and
+   * the authoritative state remains in the router and the persisted
+   * context store. Dropping one notification means the projection stays
+   * stale until the next state change rebuilds it; that is the right
+   * trade-off versus aborting the call chain that invoked the
+   * commit/onReplySent that produced the notification.
+   */
+  onStateChanged?(state: ConnectorThreadState | null): void;
+};
+
 export interface ConnectorRouter {
   /**
    * Classify an inbound message against the current connector state. Pure:
    * does not mutate router state. The returned decision must be passed to
    * `commit()` to take effect.
+   *
+   * Throws when `message.headers.from` is not a parseable bare addr-spec
+   * (per `extractAddrSpec` from `@intx/mime`). The production fetch path
+   * copies the wire `From:` header verbatim, so a malformed sender is a
+   * normal-shape runtime concern, not a programmer error. Callers should
+   * treat the throw as passthrough — deliver the message to the reactor
+   * but do not advance router state or consume the message from the
+   * INBOX.
    */
   route(message: InboundMessage): RouteDecision;
 
@@ -47,9 +86,11 @@ export interface ConnectorRouter {
 
   /**
    * Produce the threading headers needed to send a reply on the active
-   * connector thread. The caller composes the full outbound message by
-   * adding its own `content` and `type` fields. Throws
-   * `NoActiveConnectorThreadError` when no thread is active.
+   * connector thread. `to` is the most recent speaker; `cc` is everyone
+   * else who has spoken on the thread (deduplicated). The caller composes
+   * the full outbound message by adding its own `content` and `type`
+   * fields. Throws `NoActiveConnectorThreadError` when no thread is
+   * active.
    */
   composeReply(): ConnectorReplyParts;
 
@@ -75,13 +116,54 @@ export interface ConnectorRouter {
   restore(state: ConnectorThreadState | null): void;
 }
 
-export function createConnectorRouter(): ConnectorRouter {
+function statesEqual(
+  a: ConnectorThreadState | null,
+  b: ConnectorThreadState | null,
+): boolean {
+  if (a === null || b === null) return a === b;
+  return (
+    a.threadRoot === b.threadRoot &&
+    a.lastMessageId === b.lastMessageId &&
+    a.replyTo === b.replyTo &&
+    a.subject === b.subject &&
+    a.cc.length === b.cc.length &&
+    a.cc.every((v, i) => v === b.cc[i])
+  );
+}
+
+export function createConnectorRouter(
+  options?: ConnectorRouterOptions,
+): ConnectorRouter {
   let state: ConnectorThreadState | null = null;
+  const onStateChanged = options?.onStateChanged;
 
   // Pending state per decision is held off the decision object via a
   // WeakMap so callers see only `{ kind }` — no path to inspect or
   // mutate the next state, even via type assertions.
   const pendingStates = new WeakMap<RouteDecision, ConnectorThreadState>();
+
+  function applyState(next: ConnectorThreadState | null): void {
+    // The null → X transition is what drives bootstrap on restore() — a
+    // future refactor that collapses null into a sentinel "no mutation"
+    // case would silently break the hub-side cache's only fill path
+    // outside live state mutations. Keep the equality check as-is; the
+    // null state is a value, not a non-event.
+    if (statesEqual(state, next)) return;
+    state = next;
+    if (onStateChanged !== undefined) {
+      // The callback feeds a best-effort projection of router state. A
+      // throwing subscriber would otherwise propagate out of commit() or
+      // onReplySent() and abort the caller; catching here drops one
+      // notification (cache stays stale until the next change) instead
+      // of corrupting the call chain. The authoritative state is
+      // already committed to the router by this point.
+      try {
+        onStateChanged(snapshot());
+      } catch (cause) {
+        logger.warn`onStateChanged subscriber threw: ${cause instanceof Error ? cause.message : String(cause)}`;
+      }
+    }
+  }
 
   function isContinuation(message: InboundMessage): boolean {
     if (state === null) return false;
@@ -99,12 +181,21 @@ export function createConnectorRouter(): ConnectorRouter {
     return false;
   }
 
+  // Append `value` to `existing` only when it is not already present.
+  // The thread's participant list is small enough that linear-scan dedup
+  // is the right cost.
+  function appendUnique(existing: readonly string[], value: string): string[] {
+    if (existing.includes(value)) return [...existing];
+    return [...existing, value];
+  }
+
   function route(message: InboundMessage): RouteDecision {
     if (state === null) {
       const nextState: ConnectorThreadState = {
         threadRoot: message.headers.messageId,
         lastMessageId: message.headers.messageId,
-        replyTo: message.headers.from,
+        replyTo: extractAddrSpec(message.headers.from),
+        cc: [],
         ...(message.headers.subject !== undefined
           ? { subject: message.headers.subject }
           : {}),
@@ -115,10 +206,18 @@ export function createConnectorRouter(): ConnectorRouter {
     }
 
     if (isContinuation(message)) {
+      const nextSpeaker = extractAddrSpec(message.headers.from);
+      // The previous most-recent speaker moves into the cc list; the
+      // new speaker becomes replyTo. Dedup so a sender returning after
+      // others have spoken doesn't appear twice.
+      const carriedCc = appendUnique(state.cc, state.replyTo).filter(
+        (addr) => addr !== nextSpeaker,
+      );
       const nextState: ConnectorThreadState = {
         threadRoot: state.threadRoot,
         lastMessageId: message.headers.messageId,
-        replyTo: message.headers.from,
+        replyTo: nextSpeaker,
+        cc: carriedCc,
         ...(state.subject !== undefined ? { subject: state.subject } : {}),
       };
       const decision: RouteDecision = { kind: "continue" };
@@ -139,8 +238,8 @@ export function createConnectorRouter(): ConnectorRouter {
       );
     }
 
-    state = nextState;
     pendingStates.delete(decision);
+    applyState(nextState);
   }
 
   function composeReply(): ConnectorReplyParts {
@@ -150,6 +249,7 @@ export function createConnectorRouter(): ConnectorRouter {
 
     return {
       to: state.replyTo,
+      cc: [...state.cc],
       inReplyTo: state.lastMessageId,
       ...(state.subject !== undefined ? { subject: state.subject } : {}),
     };
@@ -159,12 +259,13 @@ export function createConnectorRouter(): ConnectorRouter {
     if (state === null) {
       throw new NoActiveConnectorThreadError();
     }
-    state = {
+    applyState({
       threadRoot: state.threadRoot,
       lastMessageId: receipt.messageId,
       replyTo: state.replyTo,
+      cc: [...state.cc],
       ...(state.subject !== undefined ? { subject: state.subject } : {}),
-    };
+    });
   }
 
   function snapshot(): ConnectorThreadState | null {
@@ -173,21 +274,23 @@ export function createConnectorRouter(): ConnectorRouter {
       threadRoot: state.threadRoot,
       lastMessageId: state.lastMessageId,
       replyTo: state.replyTo,
+      cc: [...state.cc],
       ...(state.subject !== undefined ? { subject: state.subject } : {}),
     };
   }
 
   function restore(next: ConnectorThreadState | null): void {
-    if (next === null) {
-      state = null;
-      return;
-    }
-    state = {
-      threadRoot: next.threadRoot,
-      lastMessageId: next.lastMessageId,
-      replyTo: next.replyTo,
-      ...(next.subject !== undefined ? { subject: next.subject } : {}),
-    };
+    applyState(
+      next === null
+        ? null
+        : {
+            threadRoot: next.threadRoot,
+            lastMessageId: next.lastMessageId,
+            replyTo: next.replyTo,
+            cc: [...next.cc],
+            ...(next.subject !== undefined ? { subject: next.subject } : {}),
+          },
+    );
   }
 
   return {

--- a/packages/harness/src/harness.ts
+++ b/packages/harness/src/harness.ts
@@ -40,7 +40,7 @@ import {
   getMailToolDefinitions,
 } from "./tools";
 import { createDefaultDirector } from "./director";
-import { createConnectorRouter } from "./connector-router";
+import { createConnectorRouter, type RouteDecision } from "./connector-router";
 import { type } from "arktype";
 
 const logger = getLogger(["interchange", "harness"]);
@@ -322,7 +322,21 @@ export function createHarness(config: HarnessConfig): Harness {
         // Only connector-thread messages are consumed from the INBOX.
         // Everything else is delivered to the reactor and stays in the
         // INBOX so message tools can access it.
-        const decision = connectorRouter.route(message);
+        //
+        // route() can throw on malformed inbound headers (e.g. a From
+        // header that is not a valid RFC 5322 address). Surface the
+        // failure via the logger and fall through to passthrough so
+        // the message still reaches the reactor for inspection, but
+        // do not advance router state or consume.
+        let decision: RouteDecision;
+        try {
+          decision = connectorRouter.route(message);
+        } catch (cause) {
+          logger.warn`Connector router rejected message uid=${message.ref.uid} for agent ${config.address}: ${cause instanceof Error ? cause.message : String(cause)}`;
+          reactor.deliver(message);
+          return;
+        }
+
         if (decision.kind === "passthrough") {
           // Non-connector mail (replies to agent sends, unsolicited
           // inter-agent mail, etc.). Deliver to reactor for notification

--- a/packages/harness/src/harness.ts
+++ b/packages/harness/src/harness.ts
@@ -119,7 +119,11 @@ export function createHarness(config: HarnessConfig): Harness {
   // Connector state: track which thread(s) this reactor owns.
   // -------------------------------------------------------------------------
 
-  const connectorRouter = createConnectorRouter();
+  const connectorRouter = createConnectorRouter(
+    config.onConnectorStateChanged !== undefined
+      ? { onStateChanged: config.onConnectorStateChanged }
+      : undefined,
+  );
 
   // Wrap the context store so load() restores connector state and the reactor's
   // per-cycle writeMetadata picks up the live connector state via the underlying

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -20,5 +20,6 @@ export {
 export type {
   ConnectorRouter,
   ConnectorReplyParts,
+  ConnectorRouterOptions,
   RouteDecision,
 } from "./connector-router";

--- a/packages/hub-api/src/routes/instances.test.ts
+++ b/packages/hub-api/src/routes/instances.test.ts
@@ -3,6 +3,7 @@ import { describe, test, expect } from "bun:test";
 import { createInMemoryGrantStore } from "@intx/authz";
 import type { GrantRule } from "@intx/types/authz";
 import type { SessionStatus } from "@intx/types";
+import type { ConnectorThreadState } from "@intx/types/runtime";
 
 import { createApp } from "../app";
 import {
@@ -98,6 +99,11 @@ type MockDBOpts = {
   instance?: TestInstance | undefined;
   agent?: typeof testAgent | undefined;
   offerings?: Record<string, unknown>[] | undefined;
+  /** Rows returned for the priorMail query used by POST /mail.
+   * Defaults to `[]` (no prior session mail). */
+  sessionMail?: { id: string }[];
+  /** Captured rows passed to db.insert(sessionMail).values(...). */
+  inserts?: Record<string, unknown>[];
 };
 
 function notImplemented(path: string) {
@@ -107,8 +113,14 @@ function notImplemented(path: string) {
 }
 
 function createMockDB(opts: MockDBOpts) {
-  // Builder chain for db.select().from().innerJoin().where().limit()
-  // Simulates the instance+agent join used by the offerings handler.
+  const sessionMailRows = opts.sessionMail ?? [];
+
+  // Builder chain that handles two shapes:
+  //   1. .from().innerJoin().where().{limit | orderBy().limit()} — the
+  //      instance+agent join used by the offerings handler.
+  //   2. .from().where().orderBy().limit() — the priorMail query used by
+  //      POST /:instanceId/mail.
+  // The mock distinguishes them by whether innerJoin is on the path.
   function selectChain() {
     const joinedRows =
       opts.instance && opts.agent
@@ -117,6 +129,7 @@ function createMockDB(opts: MockDBOpts) {
 
     return {
       from: () => ({
+        // join-shaped chain
         innerJoin: () => ({
           where: () => ({
             limit: () => Promise.resolve(joinedRows),
@@ -125,9 +138,18 @@ function createMockDB(opts: MockDBOpts) {
             }),
           }),
         }),
+        // non-join chain (priorMail)
+        where: () => ({
+          orderBy: (..._args: unknown[]) => ({
+            limit: () => Promise.resolve(sessionMailRows),
+          }),
+          limit: () => Promise.resolve(sessionMailRows),
+        }),
       }),
     };
   }
+
+  const insertCapture = opts.inserts;
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- drizzle PgDatabase type cannot be structurally satisfied in tests
   return {
@@ -150,6 +172,14 @@ function createMockDB(opts: MockDBOpts) {
       },
     },
     select: selectChain,
+    insert: () => ({
+      values: (row: Record<string, unknown>) => {
+        if (insertCapture !== undefined) {
+          insertCapture.push(row);
+        }
+        return Promise.resolve();
+      },
+    }),
   } as unknown as Parameters<typeof createApp>[0]["db"];
 }
 
@@ -177,6 +207,7 @@ function createMockGetSession(userId: string): GetSession {
 
 function createMockSidecarRouter(
   routableAddresses: string[] = [],
+  connectorStates = new Map<string, ConnectorThreadState | null>(),
 ): SidecarRouter {
   function notImpl(name: string): never {
     throw new Error(`mock: sidecarRouter.${name} not implemented`);
@@ -222,10 +253,13 @@ function createMockSidecarRouter(
       return notImpl("subscribeAgent");
     },
     dispatchAgentEvent(_addr, _event) {
-      notImpl("dispatchAgentEvent");
+      // No-op default: many routes dispatch events but the tests don't
+      // assert on them. Override at the test boundary if assertion is
+      // needed.
     },
     getConnectedSidecars: () => [],
     getRoutableAddresses: () => routableAddresses,
+    getConnectorState: (addr) => connectorStates.get(addr) ?? null,
     events: createSidecarEmitter(),
   };
 }
@@ -266,6 +300,8 @@ type TestAppOpts = {
   db?: MockDBOpts;
   grants?: GrantRule[];
   routableAddresses?: string[];
+  connectorStates?: Map<string, ConnectorThreadState | null>;
+  sessionService?: SessionService;
   collectorStatuses?: Map<string, SessionStatus>;
 };
 
@@ -284,8 +320,11 @@ function createTestApp(opts: TestAppOpts = {}) {
     authHandler: () => new Response("", { status: 404 }),
     db,
     grantStore: createInMemoryGrantStore(opts.grants ?? [makeGrant()]),
-    sidecarRouter: createMockSidecarRouter(opts.routableAddresses),
-    sessionService: createMockSessionService(),
+    sidecarRouter: createMockSidecarRouter(
+      opts.routableAddresses,
+      opts.connectorStates,
+    ),
+    sessionService: opts.sessionService ?? createMockSessionService(),
     eventCollectors: createMockEventCollectors(opts.collectorStatuses),
   });
 }
@@ -568,5 +607,155 @@ describe("GET /agents/instances/blobs/:blobId", () => {
     expect(res.status).toBe(400);
     const body: unknown = await res.json();
     expect(body).toMatchObject({ error: { code: "bad_request" } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /:instanceId/mail — threading-header policy
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/instances/:instanceId/mail", () => {
+  // The user's bare addr-spec is `${principal.refId}@${tenant.domain}`.
+  const USER_ADDR = `${USER_ID}@${testTenant.domain}`;
+
+  function makeMailGrant(): GrantRule {
+    return makeGrant({ resource: "instance:*", action: "write" });
+  }
+
+  type CapturedSendArgs = {
+    inReplyTo?: string;
+    references?: string[];
+  };
+
+  function captureSendUserMessage(): {
+    service: SessionService;
+    captured: CapturedSendArgs[];
+  } {
+    const captured: CapturedSendArgs[] = [];
+    const service: SessionService = {
+      launchSession() {
+        throw new Error("not implemented");
+      },
+      endSession() {
+        throw new Error("not implemented");
+      },
+      sendUserMessage(params) {
+        captured.push({
+          ...(params.inReplyTo !== undefined
+            ? { inReplyTo: params.inReplyTo }
+            : {}),
+          ...(params.references !== undefined
+            ? { references: params.references }
+            : {}),
+        });
+        return Promise.resolve(new Uint8Array([1, 2, 3]));
+      },
+    };
+    return { service, captured };
+  }
+
+  async function postMail(app: ReturnType<typeof createTestApp>) {
+    return app.request(`${instanceURL()}/mail`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content: "hello agent" }),
+    });
+  }
+
+  test("no active connector → no threading headers", async () => {
+    const { service, captured } = captureSendUserMessage();
+    const app = createTestApp({
+      grants: [makeMailGrant()],
+      sessionService: service,
+      // connectorStates default empty → getConnectorState returns null
+    });
+
+    const res = await postMail(app);
+    expect(res.status).toBe(201);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.inReplyTo).toBeUndefined();
+    expect(captured[0]?.references).toBeUndefined();
+  });
+
+  test("active connector started by the same user → user continues the thread", async () => {
+    const { service, captured } = captureSendUserMessage();
+    const connectorStates = new Map<string, ConnectorThreadState | null>();
+    connectorStates.set(ADDRESS, {
+      threadRoot: "<root@example.com>",
+      lastMessageId: "<last@example.com>",
+      replyTo: USER_ADDR,
+      cc: [],
+    });
+
+    const app = createTestApp({
+      grants: [makeMailGrant()],
+      sessionService: service,
+      connectorStates,
+    });
+
+    const res = await postMail(app);
+    expect(res.status).toBe(201);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.inReplyTo).toBe("<last@example.com>");
+    expect(captured[0]?.references).toEqual(["<root@example.com>"]);
+  });
+
+  test("active connector started by another peer → user joins the same thread", async () => {
+    // The connector is one durable shared thread per agent. A user
+    // opening a session against an agent whose active thread was
+    // started by another peer (a parent agent that launched this one,
+    // a peer agent, a prior session by anyone else) joins that thread
+    // — the agent's next connector.reply will then CC the prior
+    // speaker alongside the user.
+    const { service, captured } = captureSendUserMessage();
+    const connectorStates = new Map<string, ConnectorThreadState | null>();
+    connectorStates.set(ADDRESS, {
+      threadRoot: "<root@example.com>",
+      lastMessageId: "<last@example.com>",
+      replyTo: "someone-else@example.com",
+      cc: [],
+    });
+
+    const app = createTestApp({
+      grants: [makeMailGrant()],
+      sessionService: service,
+      connectorStates,
+    });
+
+    const res = await postMail(app);
+    expect(res.status).toBe(201);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.inReplyTo).toBe("<last@example.com>");
+    expect(captured[0]?.references).toEqual(["<root@example.com>"]);
+  });
+
+  test("session history takes precedence over the connector cache", async () => {
+    const { service, captured } = captureSendUserMessage();
+    const connectorStates = new Map<string, ConnectorThreadState | null>();
+    connectorStates.set(ADDRESS, {
+      threadRoot: "<root@example.com>",
+      lastMessageId: "<connector-last@example.com>",
+      replyTo: USER_ADDR,
+      cc: [],
+    });
+
+    const app = createTestApp({
+      grants: [makeMailGrant()],
+      sessionService: service,
+      connectorStates,
+      db: {
+        tenant: testTenant,
+        principal: testPrincipal,
+        instance: testInstance,
+        agent: testAgent,
+        sessionMail: [{ id: "prior-1" }],
+      },
+    });
+
+    const res = await postMail(app);
+    expect(res.status).toBe(201);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.inReplyTo).toBe(`<prior-1@${testTenant.domain}>`);
+    expect(captured[0]?.references).toEqual([`<prior-1@${testTenant.domain}>`]);
   });
 });

--- a/packages/hub-api/src/routes/instances.ts
+++ b/packages/hub-api/src/routes/instances.ts
@@ -1501,7 +1501,34 @@ export function createInstanceRoutes({
         .limit(100);
 
       const priorIds = priorMail.map((m) => `<${m.id}@${tenant.domain}>`);
-      const lastId = priorIds[priorIds.length - 1];
+      const lastIdFromSession = priorIds[priorIds.length - 1];
+
+      // Threading-header policy:
+      //   1. Session history (the user's prior mail to this instance)
+      //      wins whenever it exists. inReplyTo points at the user's
+      //      most recent message, references lists the chain.
+      //   2. With no session history, fall back to the agent's active
+      //      connector thread. The connector is one durable shared
+      //      thread per agent — anyone with a session joins whatever
+      //      thread is active. Stamp inReplyTo and references from the
+      //      cached state so the harness routes the message as
+      //      `continue` and adds the user to the participant set.
+      //   3. With no session history and no active connector, send
+      //      threading-less mail. The harness routes it as `start`,
+      //      establishing this user as the first participant on a new
+      //      thread.
+      let inReplyTo: string | undefined;
+      let references: string[] | undefined;
+      if (lastIdFromSession !== undefined) {
+        inReplyTo = lastIdFromSession;
+        references = priorIds;
+      } else {
+        const connectorState = sidecarRouter.getConnectorState(row.address);
+        if (connectorState !== null) {
+          inReplyTo = connectorState.lastMessageId;
+          references = [connectorState.threadRoot];
+        }
+      }
 
       const cryptoProvider = await getInstanceCryptoProvider(instanceId);
 
@@ -1513,8 +1540,10 @@ export function createInstanceRoutes({
           messageId: mimeMessageId,
           date: now,
           content: body.content,
-          ...(lastId !== undefined ? { inReplyTo: lastId } : {}),
-          ...(priorIds.length > 0 ? { references: priorIds } : {}),
+          ...(inReplyTo !== undefined ? { inReplyTo } : {}),
+          ...(references !== undefined && references.length > 0
+            ? { references }
+            : {}),
           sessionId: row.sessionId,
           tenantId: tenant.id,
           cryptoProvider,

--- a/packages/hub-sessions/src/session-service.test.ts
+++ b/packages/hub-sessions/src/session-service.test.ts
@@ -62,6 +62,7 @@ function createMockRouter(): SidecarRouter & {
     dispatchAgentEvent: () => undefined,
     getConnectedSidecars: () => [],
     getRoutableAddresses: () => [],
+    getConnectorState: () => null,
     events: createSidecarEmitter(),
   };
   return mock;

--- a/packages/hub-sessions/src/ws/sidecar-events.ts
+++ b/packages/hub-sessions/src/ws/sidecar-events.ts
@@ -20,6 +20,7 @@
 // would silently change failure handling.
 
 import type { PackRejectReason } from "@intx/types/sidecar";
+import type { ConnectorThreadState } from "@intx/types/runtime";
 import { getLogger } from "@intx/log";
 
 const logger = getLogger(["hub", "ws", "sidecar", "events"]);
@@ -76,6 +77,17 @@ export type SidecarEventMap = {
     publicKey: string;
   };
 
+  /** Notification. Emitted when the sidecar reports a change to an
+   * agent's connector-thread state. The wire layer caches the state
+   * per agent so the host can read it via
+   * `router.getConnectorState(agentAddress)`; this event is for hosts
+   * that want to observe transitions directly. `connectorState` is
+   * `null` when the agent has no active connector thread. */
+  "connector.state.changed": {
+    agentAddress: string;
+    connectorState: ConnectorThreadState | null;
+  };
+
   /** Awaited. Emitted per address after challenge verification
    * succeeds and before the disconnect queue is flushed. Rejection
    * rolls that address back from the routing table; earlier listeners
@@ -128,6 +140,7 @@ export function createSidecarEmitter(): SidecarEventEmitter {
     "agent.deploy.ack": new Set(),
     "agent.reconnected": new Set(),
     "deploy.ref.stale": new Set(),
+    "connector.state.changed": new Set(),
   };
 
   function on<T extends SidecarEventType>(

--- a/packages/hub-sessions/src/ws/sidecar-handler.test.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.test.ts
@@ -944,6 +944,178 @@ describe("SidecarRouter", () => {
 
       expect(seen).toEqual([["agent@local"]]);
     });
+
+    test("connector.state.changed populates the cache and is readable via getConnectorState", () => {
+      const router = createSidecarRouter({});
+      const ws = createMockWs();
+      router.handleOpen(ws);
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "register",
+          sidecarId: "sc-1",
+          token: "tok",
+          agentAddresses: ["agent@local"],
+        }),
+      );
+
+      // Before any state frame, the cache is absent → null.
+      expect(router.getConnectorState("agent@local")).toBeNull();
+
+      const state = {
+        threadRoot: "<root@example.com>",
+        lastMessageId: "<last@example.com>",
+        replyTo: "user@example.com",
+        cc: [],
+      };
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "connector.state.changed",
+          agentAddress: "agent@local",
+          connectorState: state,
+        }),
+      );
+
+      expect(router.getConnectorState("agent@local")).toEqual(state);
+
+      // An explicit-null frame clears the cached state.
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "connector.state.changed",
+          agentAddress: "agent@local",
+          connectorState: null,
+        }),
+      );
+
+      expect(router.getConnectorState("agent@local")).toBeNull();
+    });
+
+    test("connector.state.changed is emitted on router.events", () => {
+      const router = createSidecarRouter({});
+      const seen: { addr: string; state: unknown }[] = [];
+      router.events.on(
+        "connector.state.changed",
+        ({ agentAddress, connectorState }) => {
+          seen.push({ addr: agentAddress, state: connectorState });
+        },
+      );
+
+      const ws = createMockWs();
+      router.handleOpen(ws);
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "register",
+          sidecarId: "sc-1",
+          token: "tok",
+          agentAddresses: ["agent@local"],
+        }),
+      );
+
+      const state = {
+        threadRoot: "<root@example.com>",
+        lastMessageId: "<last@example.com>",
+        replyTo: "user@example.com",
+        cc: [],
+        subject: "Hi",
+      };
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "connector.state.changed",
+          agentAddress: "agent@local",
+          connectorState: state,
+        }),
+      );
+
+      expect(seen).toEqual([{ addr: "agent@local", state }]);
+    });
+
+    test("live takeover via register evicts the prior owner's cached connector state", () => {
+      const router = createSidecarRouter({});
+
+      // First sidecar registers and reports connector state.
+      const ws1 = createMockWs();
+      router.handleOpen(ws1);
+      router.handleMessage(
+        ws1,
+        JSON.stringify({
+          type: "register",
+          sidecarId: "sc-1",
+          token: "tok",
+          agentAddresses: ["agent@local"],
+        }),
+      );
+      router.handleMessage(
+        ws1,
+        JSON.stringify({
+          type: "connector.state.changed",
+          agentAddress: "agent@local",
+          connectorState: {
+            threadRoot: "<root@example.com>",
+            lastMessageId: "<last@example.com>",
+            replyTo: "user@example.com",
+            cc: [],
+          },
+        }),
+      );
+      expect(router.getConnectorState("agent@local")).not.toBeNull();
+
+      // A second sidecar registers claiming the same address without
+      // the first having disconnected. The prior cache must be evicted
+      // so it cannot mis-thread mail in the window before the new
+      // owner bootstraps.
+      const ws2 = createMockWs();
+      router.handleOpen(ws2);
+      router.handleMessage(
+        ws2,
+        JSON.stringify({
+          type: "register",
+          sidecarId: "sc-2",
+          token: "tok",
+          agentAddresses: ["agent@local"],
+        }),
+      );
+
+      expect(router.getConnectorState("agent@local")).toBeNull();
+    });
+
+    test("disconnect clears cached connector state for affected agents", () => {
+      const router = createSidecarRouter({});
+      const ws = createMockWs();
+      router.handleOpen(ws);
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "register",
+          sidecarId: "sc-1",
+          token: "tok",
+          agentAddresses: ["agent@local"],
+        }),
+      );
+
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "connector.state.changed",
+          agentAddress: "agent@local",
+          connectorState: {
+            threadRoot: "<root@example.com>",
+            lastMessageId: "<last@example.com>",
+            replyTo: "user@example.com",
+            cc: [],
+          },
+        }),
+      );
+
+      expect(router.getConnectorState("agent@local")).not.toBeNull();
+
+      router.handleClose(ws);
+
+      expect(router.getConnectorState("agent@local")).toBeNull();
+    });
   });
 
   describe("session subscriptions", () => {

--- a/packages/hub-sessions/src/ws/sidecar-handler.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.ts
@@ -18,6 +18,7 @@ import {
 } from "@intx/types/sidecar";
 import type {
   AbortReason,
+  ConnectorThreadState,
   HarnessConfig,
   InferenceSource,
 } from "@intx/types/runtime";
@@ -51,6 +52,16 @@ export type SidecarRouter = {
   handleClose(ws: WsHandle): void;
 
   routeMail(agentAddress: string, rawMessage: string): boolean;
+  /**
+   * Returns the current connector-thread state for the named agent, or
+   * `null` if the agent has no active connector thread (or if the
+   * sidecar has not yet reported any state — e.g. mid-reconnect, before
+   * the harness has loaded its context store). The state is cached
+   * from `connector.state.changed` frames; callers should treat `null`
+   * as "no threading info available" and fall through to whatever
+   * default the calling path uses.
+   */
+  getConnectorState(agentAddress: string): ConnectorThreadState | null;
   sendAgentDeploy(agentAddress: string, config: HarnessConfig): Promise<void>;
   sendAgentUndeploy(agentAddress: string, reason: string): Promise<void>;
   sendSessionStart(agentAddress: string): Promise<void>;
@@ -167,6 +178,12 @@ export function createSidecarRouter(
   const disconnectedAgents = new Map<string, DisconnectedAgent>();
   // agentAddress → set of subscriber callbacks for agent events
   const agentSubscribers = new Map<string, Set<(event: unknown) => void>>();
+  // agentAddress → cached connector-thread state, populated by
+  // connector.state.changed frames. Hub-side mail composition reads this
+  // to set threading headers on user-originated mail. Absent entries mean
+  // "no state reported yet" (e.g. mid-reconnect); callers must treat that
+  // identically to a null entry (no active thread).
+  const connectorStates = new Map<string, ConnectorThreadState | null>();
   // ws handle → liveness timer (reset on each ping from the sidecar)
   const livenessTimers = new Map<WsHandle, ReturnType<typeof setTimeout>>();
 
@@ -339,6 +356,20 @@ export function createSidecarRouter(
         });
         dispatchToSubscribers(frame.agentAddress, frame.event);
         break;
+      case "connector.state.changed":
+        // Gate the cache write on the sending sidecar actually owning
+        // the named agent. A misbehaving sidecar that knows another
+        // agent's address could otherwise poison the cached state.
+        if (addressIndex.get(frame.agentAddress) !== ws) {
+          logger.warn`Dropping connector.state.changed for ${frame.agentAddress}: not registered to this sidecar`;
+          break;
+        }
+        connectorStates.set(frame.agentAddress, frame.connectorState);
+        events.emit("connector.state.changed", {
+          agentAddress: frame.agentAddress,
+          connectorState: frame.connectorState,
+        });
+        break;
       case "session.ack":
         resolvePending(frame.requestId);
         break;
@@ -379,6 +410,10 @@ export function createSidecarRouter(
     if (existing !== undefined) {
       for (const addr of existing.agentAddresses) {
         addressIndex.delete(addr);
+        // The harness on this ws is restarting; the cached connector
+        // state from its previous incarnation is now stale. The new
+        // harness will bootstrap via restore-fires-callback.
+        connectorStates.delete(addr);
       }
     }
 
@@ -393,6 +428,10 @@ export function createSidecarRouter(
         if (prevConn !== undefined) {
           prevConn.agentAddresses.delete(addr);
         }
+        // The new owner is about to take over; the prior owner's
+        // cached state must not survive into the new owner's window
+        // before its bootstrap frame arrives.
+        connectorStates.delete(addr);
       }
 
       // Cancel any in-flight deploy for this address since the
@@ -610,6 +649,14 @@ export function createSidecarRouter(
     // (e.g. sendGrantsUpdate). Addresses that fail governance are
     // rolled back from the routing table afterward.
     for (const addr of verified) {
+      // If a different ws still owns this address (live takeover via
+      // verified reconnect), evict its cached connector state before
+      // routing flips. The new owner's harness will bootstrap via
+      // restore-fires-callback.
+      const prevWs = addressIndex.get(addr);
+      if (prevWs !== undefined && prevWs !== ws) {
+        connectorStates.delete(addr);
+      }
       conn.agentAddresses.add(addr);
       addressIndex.set(addr, ws);
     }
@@ -775,6 +822,12 @@ export function createSidecarRouter(
       // owns the address. A reconnected sidecar may have already claimed it.
       if (addressIndex.get(addr) === ws) {
         addressIndex.delete(addr);
+        // Drop cached connector state for the same reason: a takeover
+        // sidecar's state lives in connectorStates under the same key,
+        // and only this owner's close should evict it. The next
+        // reconnect re-bootstraps via the router's
+        // restore-fires-callback path.
+        connectorStates.delete(addr);
         const deployReq = pendingDeploys.get(addr);
         if (deployReq !== undefined && deployReq.ws === ws) {
           clearTimeout(deployReq.timer);
@@ -1410,6 +1463,12 @@ export function createSidecarRouter(
     return Array.from(addressIndex.keys());
   }
 
+  function getConnectorState(
+    agentAddress: string,
+  ): ConnectorThreadState | null {
+    return connectorStates.get(agentAddress) ?? null;
+  }
+
   async function sendGrantsUpdate(
     agentAddress: string,
     grants: GrantRule[],
@@ -1471,6 +1530,7 @@ export function createSidecarRouter(
     dispatchAgentEvent: dispatchToSubscribers,
     getConnectedSidecars,
     getRoutableAddresses,
+    getConnectorState,
     events,
   };
 }

--- a/packages/mime/src/index.test.ts
+++ b/packages/mime/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   assembleSignedContent,
   assembleMessage,
   createDetachedSignatureFromProvider,
+  extractAddrSpec,
   formatRFC2822Date,
   generateMessageId,
   parseHeaderSection,
@@ -78,6 +79,68 @@ describe("generateMessageId", () => {
 // ---------------------------------------------------------------------------
 // formatRFC2822Date
 // ---------------------------------------------------------------------------
+
+describe("extractAddrSpec", () => {
+  test("strips quoted display name and angle brackets", () => {
+    expect(extractAddrSpec('"Alice Doe" <alice@example.com>')).toBe(
+      "alice@example.com",
+    );
+  });
+
+  test("strips unquoted display name and angle brackets", () => {
+    expect(extractAddrSpec("Alice Doe <alice@example.com>")).toBe(
+      "alice@example.com",
+    );
+  });
+
+  test("strips bare angle brackets", () => {
+    expect(extractAddrSpec("<alice@example.com>")).toBe("alice@example.com");
+  });
+
+  test("passes through a bare addr-spec", () => {
+    expect(extractAddrSpec("alice@example.com")).toBe("alice@example.com");
+  });
+
+  test("lowercases local-part and domain", () => {
+    expect(extractAddrSpec("Alice@Example.COM")).toBe("alice@example.com");
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(extractAddrSpec("   Alice@Example.com   ")).toBe(
+      "alice@example.com",
+    );
+  });
+
+  test("throws on empty input", () => {
+    expect(() => extractAddrSpec("   ")).toThrow();
+  });
+
+  test("throws on input with no '@'", () => {
+    expect(() => extractAddrSpec("Alice Doe")).toThrow();
+  });
+
+  test("throws on missing local-part", () => {
+    expect(() => extractAddrSpec("<@example.com>")).toThrow();
+  });
+
+  test("throws on missing domain", () => {
+    expect(() => extractAddrSpec("<alice@>")).toThrow();
+  });
+
+  test("throws on trailing content after the closing '>'", () => {
+    expect(() =>
+      extractAddrSpec("Alice <alice@example.com> (comment)"),
+    ).toThrow();
+  });
+
+  test("throws on a quoted local-part", () => {
+    expect(() => extractAddrSpec('"a@b"@example.com')).toThrow();
+  });
+
+  test("throws on multiple '@' in an unquoted form", () => {
+    expect(() => extractAddrSpec("a@b@example.com")).toThrow();
+  });
+});
 
 describe("formatRFC2822Date", () => {
   test("formats a known date correctly", () => {

--- a/packages/mime/src/index.ts
+++ b/packages/mime/src/index.ts
@@ -1,6 +1,7 @@
 export {
   assembleSignedContent,
   assembleMessage,
+  extractAddrSpec,
   formatRFC2822Date,
   generateMessageId,
   parseHeaderSection,

--- a/packages/mime/src/mime.ts
+++ b/packages/mime/src/mime.ts
@@ -121,6 +121,95 @@ export function generateMessageId(address: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Address normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the bare addr-spec (local-part@domain) from a single RFC 5322
+ * address value. Strips any display name and surrounding angle brackets,
+ * then lowercases the result so case-insensitive comparison falls out
+ * naturally.
+ *
+ * Accepted inputs (single-address only — do not pass comma-separated lists):
+ *   `"Display Name" <user@host>`  → `user@host`
+ *   `Display Name <user@host>`    → `user@host`
+ *   `<user@host>`                 → `user@host`
+ *   `user@host`                   → `user@host`
+ *   `  User@Host  `               → `user@host`
+ *
+ * Rejected (throws) inputs:
+ *   - empty or whitespace-only
+ *   - input with no `@`
+ *   - input that produces an empty local-part or domain
+ *   - quoted local-parts (e.g. `"a@b"@host`) — technically valid per RFC
+ *     5321 §4.1.2 but rare in practice; the simple split below would
+ *     misinterpret the inner `@`, so we refuse rather than guess
+ *   - content after the closing `>` in an angle-bracketed form
+ *     (e.g. `Name <a@b> (comment)`) — would silently fall through to a
+ *     misparsed bare-form attempt, so we refuse instead
+ *
+ * Per RFC 5321 §2.4 the local-part is technically case-sensitive, but no
+ * production system honors that; matching case-insensitively is the
+ * correct call for routing and identity checks.
+ */
+export function extractAddrSpec(addressLine: string): string {
+  const trimmed = addressLine.trim();
+  if (trimmed === "") {
+    throw new Error("extractAddrSpec: address is empty");
+  }
+
+  let candidate: string;
+  const angleOpen = trimmed.lastIndexOf("<");
+  if (angleOpen !== -1) {
+    // Angle-bracketed form. Require the `>` to be the trailing
+    // non-whitespace character so that input like `Name <a@b> (comment)`
+    // is refused rather than re-parsed as a bare addr-spec.
+    if (!trimmed.endsWith(">")) {
+      throw new Error(
+        `extractAddrSpec: trailing content after '>' in ${JSON.stringify(addressLine)}`,
+      );
+    }
+    candidate = trimmed.slice(angleOpen + 1, -1).trim();
+  } else {
+    candidate = trimmed;
+  }
+
+  // Reject quoted local-parts: the parser below splits on the first `@`,
+  // which would corrupt a quoted form whose local-part contains `@`.
+  if (candidate.includes('"')) {
+    throw new Error(
+      `extractAddrSpec: quoted local-parts are not supported: ${JSON.stringify(addressLine)}`,
+    );
+  }
+
+  const atIndex = candidate.indexOf("@");
+  if (atIndex === -1) {
+    throw new Error(
+      `extractAddrSpec: address has no '@': ${JSON.stringify(addressLine)}`,
+    );
+  }
+
+  // Reject any further `@` in the candidate — a well-formed addr-spec
+  // has exactly one. Multiple `@` is either a quoted form (rejected
+  // above) or simply malformed.
+  if (candidate.indexOf("@", atIndex + 1) !== -1) {
+    throw new Error(
+      `extractAddrSpec: multiple '@' in ${JSON.stringify(addressLine)}`,
+    );
+  }
+
+  const local = candidate.slice(0, atIndex);
+  const domain = candidate.slice(atIndex + 1);
+  if (local === "" || domain === "") {
+    throw new Error(
+      `extractAddrSpec: empty local-part or domain in ${JSON.stringify(addressLine)}`,
+    );
+  }
+
+  return `${local.toLowerCase()}@${domain.toLowerCase()}`;
+}
+
+// ---------------------------------------------------------------------------
 // RFC 2822 date formatting
 // ---------------------------------------------------------------------------
 

--- a/packages/storage-isogit/src/store.test.ts
+++ b/packages/storage-isogit/src/store.test.ts
@@ -703,6 +703,7 @@ describe("connector thread state", () => {
       threadRoot: "<root@example.com>",
       lastMessageId: "<last@example.com>",
       replyTo: "user@example.com",
+      cc: ["second@example.com"],
       subject: "Re: Test thread",
     };
 
@@ -726,6 +727,7 @@ describe("connector thread state", () => {
       threadRoot: "<root@example.com>",
       lastMessageId: "<last@example.com>",
       replyTo: "user@example.com",
+      cc: [],
     };
 
     store.setConnectorState(connectorState);

--- a/packages/storage-isogit/src/store.ts
+++ b/packages/storage-isogit/src/store.ts
@@ -46,6 +46,7 @@ const ConnectorThreadStateSchema = type({
   threadRoot: "string",
   lastMessageId: "string",
   replyTo: "string",
+  cc: "string[]",
   "subject?": "string",
 });
 

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -2049,14 +2049,19 @@ export type ContextCommit = {
  * spoken on the thread, deduplicated, in arrival order — they ride as
  * `cc` on the next outbound reply so everyone stays in the loop.
  * `subject` is set when the thread starts and preserved for its life.
+ *
+ * Defined as an arktype so the wire layer (sidecar↔hub frames) and
+ * other parsing boundaries can validate snapshots without
+ * re-declaring the shape.
  */
-export type ConnectorThreadState = {
-  threadRoot: string;
-  lastMessageId: string;
-  replyTo: string;
-  cc: string[];
-  subject?: string;
-};
+export const ConnectorThreadState = type({
+  threadRoot: "string",
+  lastMessageId: "string",
+  replyTo: "string",
+  cc: "string[]",
+  "subject?": "string",
+});
+export type ConnectorThreadState = typeof ConnectorThreadState.infer;
 
 /**
  * The context store interface. Implementations back the store with git

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -2039,13 +2039,22 @@ export type ContextCommit = {
 };
 
 /**
- * The state of an active connector thread. Persisted alongside the
- * conversation context so that reply threading survives sidecar restarts.
+ * The state of an active connector thread. The connector is one durable
+ * thread per agent; participants accumulate as they speak. Persisted
+ * alongside the conversation context so the thread survives sidecar
+ * restarts.
+ *
+ * `replyTo` is the most recent speaker — the primary recipient (`to`)
+ * on the next outbound reply. `cc` is every other participant who has
+ * spoken on the thread, deduplicated, in arrival order — they ride as
+ * `cc` on the next outbound reply so everyone stays in the loop.
+ * `subject` is set when the thread starts and preserved for its life.
  */
 export type ConnectorThreadState = {
   threadRoot: string;
   lastMessageId: string;
   replyTo: string;
+  cc: string[];
   subject?: string;
 };
 

--- a/packages/types/src/sidecar.ts
+++ b/packages/types/src/sidecar.ts
@@ -10,6 +10,7 @@
 import { type } from "arktype";
 import {
   AbortReason,
+  ConnectorThreadState,
   HarnessConfig,
   InferenceEvent,
   InferenceSource,
@@ -112,6 +113,25 @@ export const AgentEventFrame = type({
   event: InferenceEvent,
 });
 export type AgentEventFrame = typeof AgentEventFrame.infer;
+
+/**
+ * Notifies the hub that the agent's connector-thread state has changed.
+ * The sidecar emits this when the harness's connector router commits a
+ * start/continue decision, when an outbound reply advances the
+ * lastMessageId, and when load-time restore brings persisted state into
+ * memory. The hub uses the cached state to set threading headers on
+ * user-originated mail so the harness routes it as `continue` rather
+ * than `passthrough`.
+ *
+ * `connectorState` is `null` when no active thread exists.
+ */
+export const ConnectorStateChangedFrame = type({
+  type: "'connector.state.changed'",
+  agentAddress: "string",
+  connectorState: ConnectorThreadState.or("null"),
+});
+export type ConnectorStateChangedFrame =
+  typeof ConnectorStateChangedFrame.infer;
 
 /**
  * Keepalive ping sent by the sidecar. The hub responds with a pong frame.
@@ -378,6 +398,7 @@ export const SidecarFrame = RegisterFrame.or(ReconnectFrame)
   .or(AgentErrorFrame)
   .or(MailOutboundFrame)
   .or(AgentEventFrame)
+  .or(ConnectorStateChangedFrame)
   .or(PingFrame)
   .or(SessionAckFrame)
   .or(SessionErrorFrame)


### PR DESCRIPTION
## Summary

- The connector is one durable shared thread per agent. Anyone who sends conversational mail to the agent — a human via a hub session, a parent agent that launched this one as a sub-agent, a peer agent — joins the thread. Participants accumulate; no one is displaced.
- When the hub composes mail to an agent and a connector thread is active, the route handler stamps `inReplyTo` and `references` from the cached state so the harness routes the message as a continuation. No per-participant gate at the comparison site: anyone with a session joins whatever thread is in progress.
- `connector.reply` outbound replies address the whole thread (`to: replyTo, cc: rest`) so the agent's response reaches every participant.

## Changes

- `packages/harness/src/connector-router.ts`: multi-participant router. `ConnectorThreadState` carries `replyTo` (most recent speaker — primary recipient) and `cc: string[]` (every other participant who has spoken, deduplicated, in arrival order). `continue` moves the prior `replyTo` into `cc` and sets `replyTo` to the new sender. `composeReply()` returns `{ to: replyTo, cc, inReplyTo, subject? }`. `onStateChanged` fires on any real state change (including `cc`); the router catches and logs subscriber throws so the call chain that invoked `commit`/`onReplySent` is never aborted.
- `packages/mime/src/mime.ts`: new `extractAddrSpec` utility — strips display name and angle brackets, lowercases, throws on inputs it cannot parse safely (quoted local-parts, trailing content after `>`, multiple `@`).
- `packages/harness/src/harness.ts`: watch callback wraps `route()` in try/catch so malformed `From:` headers log and fall through to passthrough.
- `packages/types/src/runtime.ts`: `ConnectorThreadState` promoted to an arktype carrying `cc: string[]`.
- `packages/types/src/sidecar.ts`: new `connector.state.changed` wire frame; uses the arktype directly so the `cc` field flows through.
- `packages/hub-sessions/src/ws/sidecar-handler.ts`: per-agent `connectorStates` map. Cache writes gated on `addressIndex.get(addr) === ws` ownership. Cache eviction inline with `addressIndex.delete` and at all live-takeover sites (`handleRegister` same-ws, ghost cleanup, `handleReconnect` post-challenge verify). New `getConnectorState(addr)` accessor.
- `packages/hub-api/src/routes/instances.ts`: POST `/:instanceId/mail` stamps threading headers from the cache whenever a connector exists — no `replyTo` comparison, no address normalization in the route handler.
- `packages/storage-isogit/src/store.ts`: `ConnectorThreadStateSchema` requires `cc: "string[]"`. Existing on-disk `metadata.json` files written under the previous shape will fail validation and need `bin/db-reset --clean` (acceptable under the current dev-state contract).
- `apps/sidecar/{main,session-manager,ws-client}.ts`: wire the harness `onConnectorStateChanged` option through to the wire frame sender.
- `docs/HARNESS_DESIGN.md`: section "Connector threads and user sessions" describes the shared-thread model, the route handler's precedence rule (session history > connector cache > none), and the two cache-empty windows during reconnect.

## Testing

- `make all` clean against HEAD: 2281 + 9 tests pass, 0 fail.
- Each commit passes `make all` standalone.
- Router tests cover: `cc` accumulation on `continue` from a different sender, dedup on re-entry, multi-sender accumulation in arrival order, subject preservation across many continues, `composeReply` returns a copy of `cc` (not the live array), `cc` carried through `onReplySent`, snapshot/restore round-trip with `cc`, `restore` takes a defensive copy of the input `cc`, `onStateChanged` fires when only `cc` changes, subscriber throws don't propagate out of `commit()` or `onReplySent()`, `route()` throws on unparseable `From:` headers on both `start` and `continue` branches, `replyTo` normalization strips display name and lowercases.
- Route-handler tests cover: no active connector → no threading headers; active connector started by the same user → user continues; active connector started by another peer → user joins the same thread (same headers stamped); session history takes precedence over the connector cache.
- Wire-path tests cover: `connector.state.changed` populates the cache and is readable via `getConnectorState`; the frame emits the matching event; disconnect clears the cache; live takeover via register evicts the prior owner's cached state.
- Storage tests cover: `ConnectorThreadState` with non-empty `cc` and `subject` round-trips through `writeMetadata` + `commit` + `load`; state with empty `cc` and no `subject` also round-trips.
- `extractAddrSpec` tests cover the accepted inputs (quoted display name, bare display name, angle brackets only, bare addr-spec, mixed-case lowercased, trimmed whitespace) and rejected ones (empty, no `@`, missing local-part, missing domain, trailing content after `>`, quoted local-part, multiple `@`).

## Behavior delta

When a user sends mail to an agent that already has an active connector thread — regardless of who started it — the message now threads as a continuation and the user becomes a participant. Today it would route as passthrough and the conversation would silently break. The agent's next `connector.reply` reaches every participant on the thread (most recent speaker as `to:`, rest as `cc:`).

## Out of scope

- Auto-close, idle timeout, or explicit clear of the connector thread. Threads persist for the lifetime of the agent.
- Removing participants from the thread when a session ends. `cc` only grows.
- Migration of existing on-disk `ConnectorThreadState` snapshots; old snapshots may be wiped via `bin/db-reset --clean`.
- Per-peer connector threads. The shared-thread model intentionally maintains one thread per agent.

Closes INTR-77