### PR TITLE
Move DefaultDirector from harness to inference

### DIFF
--- a/examples/ring-demo/src/cli.ts
+++ b/examples/ring-demo/src/cli.ts
@@ -349,7 +349,7 @@ for (const [i, name] of AGENT_NAMES.entries()) {
     storage,
     tools: createPosixTools({ cwd: process.cwd() }),
     onEvent: makeEventLogger(name),
-    directorPolicy: i !== 0 ? { mode: "reactive" } : {},
+    defaultDirectorPolicy: i !== 0 ? { mode: "reactive" } : {},
   });
   harnesses.push(h);
 }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -10,7 +10,6 @@
     }
   },
   "dependencies": {
-    "@intx/harness": "workspace:*",
     "@intx/inference": "workspace:*",
     "@intx/mime": "workspace:*",
     "@intx/storage-isogit": "workspace:*",

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -28,8 +28,8 @@
 // active source's model is the single source of truth and rotations
 // take effect on the next inference call without any wrapper.
 
-import { createDefaultDirector } from "@intx/harness";
 import {
+  createDefaultDirector,
   createReactorAssembly,
   type AuthzExtensionOptions,
   type Dependencies,

--- a/packages/harness/src/config.ts
+++ b/packages/harness/src/config.ts
@@ -61,8 +61,8 @@ export type HarnessConfig = {
   director?: ReactorDirector;
 
   /**
-   * Policy overrides for the default director. Ignored when a custom director is
-   * provided. Each field controls a specific decision point in the default
+   * Policy overrides for the default director. Mutually exclusive with
+   * `director`. Each field controls a specific decision point in the default
    * director's event handling loop.
    */
   defaultDirectorPolicy?: DefaultDirectorPolicy;
@@ -122,6 +122,14 @@ export function validateConfig(config: HarnessConfig): void {
   }
   if (config.source.baseURL.trim() === "") {
     throw new Error("HarnessConfig.source.baseURL must not be empty");
+  }
+  if (
+    config.director !== undefined &&
+    config.defaultDirectorPolicy !== undefined
+  ) {
+    throw new Error(
+      "HarnessConfig.director and HarnessConfig.defaultDirectorPolicy are mutually exclusive",
+    );
   }
   if (config.auditStore !== undefined && config.authorize === undefined) {
     throw new Error(

--- a/packages/harness/src/config.ts
+++ b/packages/harness/src/config.ts
@@ -11,7 +11,7 @@ import type {
   ReactorDirector,
   BeforeToolExtension,
 } from "@intx/types/runtime";
-import type { AuthzCallResult, DirectorPolicy } from "@intx/inference";
+import type { AuthzCallResult, DefaultDirectorPolicy } from "@intx/inference";
 
 /**
  * Configuration passed to `createHarness`. All required fields must be
@@ -62,10 +62,10 @@ export type HarnessConfig = {
 
   /**
    * Policy overrides for the default director. Ignored when a custom director is
-   * provided. Each field controls a specific decision point in the director's
-   * event handling loop.
+   * provided. Each field controls a specific decision point in the default
+   * director's event handling loop.
    */
-  directorPolicy?: DirectorPolicy;
+  defaultDirectorPolicy?: DefaultDirectorPolicy;
 
   /**
    * Extensions that run before each tool call. Return a string to block the

--- a/packages/harness/src/config.ts
+++ b/packages/harness/src/config.ts
@@ -11,7 +11,7 @@ import type {
   ReactorDirector,
   BeforeToolExtension,
 } from "@intx/types/runtime";
-import type { AuthzCallResult } from "@intx/inference";
+import type { AuthzCallResult, DirectorPolicy } from "@intx/inference";
 
 /**
  * Configuration passed to `createHarness`. All required fields must be
@@ -99,23 +99,6 @@ export type HarnessConfig = {
    * in the director's tool list for inference calls.
    */
   deployTools?: ToolDefinition[];
-};
-
-export type DirectorPolicy = {
-  /**
-   * Controls the agent's behavior after inference completes.
-   *
-   *   "conversational" (default) — The standard agentic loop. After tools
-   *     complete, re-infer so the model can reason about results, issue more
-   *     tool calls, or compose a reply. When inference produces text without
-   *     tool calls, send it as a connector reply.
-   *
-   *   "reactive" — The agent acts on each message by executing tools, then
-   *     returns to the event loop to wait for the next inbound event. It does
-   *     not re-infer after tools complete and does not send connector replies.
-   *     Use this for agents that perform a single action per message.
-   */
-  mode?: "conversational" | "reactive";
 };
 
 export function validateConfig(config: HarnessConfig): void {

--- a/packages/harness/src/harness.test.ts
+++ b/packages/harness/src/harness.test.ts
@@ -1338,6 +1338,25 @@ describe("Config validation", () => {
     ).toThrow("systemPrompt");
   });
 
+  test("throws when both director and defaultDirectorPolicy are provided", () => {
+    const transport = makeMockTransport();
+    const director: ReactorDirector = {
+      async decide(_event, _state, caps) {
+        return caps.wait();
+      },
+    };
+    expect(() =>
+      createHarness(
+        makeConfig(transport, {
+          director,
+          defaultDirectorPolicy: { mode: "reactive" },
+        }),
+      ),
+    ).toThrow(
+      "HarnessConfig.director and HarnessConfig.defaultDirectorPolicy are mutually exclusive",
+    );
+  });
+
   test("throws when auditStore is provided without authorize", () => {
     const transport = makeMockTransport();
     const auditStore: AuditStore = {

--- a/packages/harness/src/harness.test.ts
+++ b/packages/harness/src/harness.test.ts
@@ -42,7 +42,7 @@ import type {
 
 import { createHarness } from "./harness";
 import { buildMailToolHandlers, buildCombinedRunner } from "./tools";
-import { createDefaultDirector } from "./director";
+import { createDefaultDirector } from "@intx/inference";
 import type { HarnessConfig } from "./config";
 
 // ---------------------------------------------------------------------------

--- a/packages/harness/src/harness.ts
+++ b/packages/harness/src/harness.ts
@@ -93,7 +93,7 @@ export function createHarness(config: HarnessConfig): Harness {
     director = createDefaultDirector(
       config.systemPrompt,
       [...getMailToolDefinitions(), ...deployToolDefs],
-      config.directorPolicy ?? {},
+      config.defaultDirectorPolicy ?? {},
     );
   }
 

--- a/packages/harness/src/harness.ts
+++ b/packages/harness/src/harness.ts
@@ -18,7 +18,7 @@
 // (ARCHITECTURE.md § Agent Harness, INFERENCE.md § Relationship to Harness)
 
 import { getLogger } from "@intx/log";
-import { createReactorAssembly } from "@intx/inference";
+import { createReactorAssembly, createDefaultDirector } from "@intx/inference";
 import type { ReactorEmittedEvent } from "@intx/inference";
 import {
   InferenceSource,
@@ -39,7 +39,6 @@ import {
   buildCombinedRunner,
   getMailToolDefinitions,
 } from "./tools";
-import { createDefaultDirector } from "./director";
 import { createConnectorRouter, type RouteDecision } from "./connector-router";
 import { type } from "arktype";
 

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -8,7 +8,7 @@ export type { BeforeToolExtension } from "@intx/types/runtime";
 export {
   createDefaultDirector,
   DefaultDirector,
-  type DirectorPolicy,
+  type DefaultDirectorPolicy,
 } from "@intx/inference";
 
 export { buildMailToolHandlers, buildCombinedRunner } from "./tools";

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -5,7 +5,11 @@ export type { HarnessConfig } from "./config";
 export { validateConfig } from "./config";
 export type { BeforeToolExtension } from "@intx/types/runtime";
 
-export { createDefaultDirector, DefaultDirector } from "./director";
+export {
+  createDefaultDirector,
+  DefaultDirector,
+  type DirectorPolicy,
+} from "@intx/inference";
 
 export { buildMailToolHandlers, buildCombinedRunner } from "./tools";
 export type { MailToolName } from "./tools";

--- a/packages/inference/src/default-director.ts
+++ b/packages/inference/src/default-director.ts
@@ -27,7 +27,7 @@ import type {
 
 const logger = getLogger(["interchange", "inference", "default-director"]);
 
-export type DirectorPolicy = {
+export type DefaultDirectorPolicy = {
   /**
    * Controls the agent's behavior after inference completes.
    *
@@ -106,7 +106,7 @@ function formatInferenceError(error: {
 export class DefaultDirector implements ReactorDirector {
   private readonly systemPrompt: string;
   private readonly toolDefinitions: ToolDefinition[];
-  private readonly policy: DirectorPolicy;
+  private readonly policy: DefaultDirectorPolicy;
 
   // Track outstanding tool results so we only re-infer once per batch.
   private pendingToolResults = 0;
@@ -114,7 +114,7 @@ export class DefaultDirector implements ReactorDirector {
   constructor(
     systemPrompt: string,
     toolDefinitions: ToolDefinition[] = [],
-    policy: DirectorPolicy = {},
+    policy: DefaultDirectorPolicy = {},
   ) {
     this.systemPrompt = systemPrompt;
     this.toolDefinitions = toolDefinitions;
@@ -220,7 +220,7 @@ export class DefaultDirector implements ReactorDirector {
 export function createDefaultDirector(
   systemPrompt: string,
   toolDefinitions: ToolDefinition[] = [],
-  policy: DirectorPolicy = {},
+  policy: DefaultDirectorPolicy = {},
 ): ReactorDirector {
   return new DefaultDirector(systemPrompt, toolDefinitions, policy);
 }

--- a/packages/inference/src/default-director.ts
+++ b/packages/inference/src/default-director.ts
@@ -1,4 +1,4 @@
-// Default conversational director for the agent harness.
+// Default conversational director — reference ReactorDirector implementation.
 //
 // Implements the decision table from INFERENCE.md § Director Decision Function:
 //
@@ -24,9 +24,25 @@ import type {
   ToolCall,
   ToolDefinition,
 } from "@intx/types/runtime";
-import type { DirectorPolicy } from "./config";
 
-const logger = getLogger(["interchange", "harness", "director"]);
+const logger = getLogger(["interchange", "inference", "default-director"]);
+
+export type DirectorPolicy = {
+  /**
+   * Controls the agent's behavior after inference completes.
+   *
+   *   "conversational" (default) — The standard agentic loop. After tools
+   *     complete, re-infer so the model can reason about results, issue more
+   *     tool calls, or compose a reply. When inference produces text without
+   *     tool calls, send it as a connector reply.
+   *
+   *   "reactive" — The agent acts on each message by executing tools, then
+   *     returns to the event loop to wait for the next inbound event. It does
+   *     not re-infer after tools complete and does not send connector replies.
+   *     Use this for agents that perform a single action per message.
+   */
+  mode?: "conversational" | "reactive";
+};
 
 function extractToolCalls(turn: AssistantTurn): ToolCall[] {
   const calls: ToolCall[] = [];

--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -53,6 +53,8 @@ export type { CorrelationRegistry, CorrelationValidator } from "./correlation";
 export { createStateManager } from "./state";
 export type { ReactorStateManager } from "./state";
 export { createCapabilities } from "./director";
+export { DefaultDirector, createDefaultDirector } from "./default-director";
+export type { DirectorPolicy } from "./default-director";
 export { createAuthzExtension } from "./authz-extension";
 export type {
   AuthzCallResult,

--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -54,7 +54,7 @@ export { createStateManager } from "./state";
 export type { ReactorStateManager } from "./state";
 export { createCapabilities } from "./director";
 export { DefaultDirector, createDefaultDirector } from "./default-director";
-export type { DirectorPolicy } from "./default-director";
+export type { DefaultDirectorPolicy } from "./default-director";
 export { createAuthzExtension } from "./authz-extension";
 export type {
   AuthzCallResult,


### PR DESCRIPTION
## Summary

- `DefaultDirector`, `createDefaultDirector`, and `DefaultDirectorPolicy` live in `@intx/inference` next to the reactor that consumes them. `@intx/harness` re-exports them for existing consumers; `@intx/agent` imports directly from `@intx/inference` and no longer depends on `@intx/harness`.
- `HarnessConfig.defaultDirectorPolicy` replaces the former `directorPolicy` field. The type rename and field rename happen in lockstep; no backward-compat alias.
- `validateConfig` rejects configurations that set both `director` and `defaultDirectorPolicy`, turning a previously silent drop (the custom director won, the policy was discarded) into a loud configuration error.

## State of the diff

- `packages/inference/src/default-director.ts` holds the `DefaultDirector` class, `createDefaultDirector` factory, and `DefaultDirectorPolicy` type. Logger scope is `interchange.inference.default-director`.
- `packages/inference/src/index.ts` exports `DefaultDirector`, `createDefaultDirector`, and `DefaultDirectorPolicy`.
- `packages/harness/src/index.ts` re-exports those three names from `@intx/inference` in a single block.
- `packages/harness/src/config.ts` imports `DefaultDirectorPolicy` from `@intx/inference`, defines `HarnessConfig.defaultDirectorPolicy?: DefaultDirectorPolicy`, and the new `validateConfig` check throws ``HarnessConfig.director and HarnessConfig.defaultDirectorPolicy are mutually exclusive`` when both are set.
- `packages/harness/src/harness.ts` imports `createDefaultDirector` from `@intx/inference` and reads `config.defaultDirectorPolicy` when constructing the fallback director.
- `packages/agent/src/agent.ts` imports `createDefaultDirector` from `@intx/inference`; `@intx/harness` is removed from `packages/agent/package.json`.
- `examples/ring-demo/src/cli.ts` passes `defaultDirectorPolicy`.

## Verification

- `make all` exits 0: lint clean, `tsc -b` clean, 2282 + 9 tests pass, 0 fail.
- Per-commit `make build` and `bun test packages/harness packages/inference` both pass on each of the three commits.
- `grep -rn 'DirectorPolicy\|directorPolicy'` excluding the new spellings returns no hits; no stale identifiers in source, docs, or fixtures.
- `grep -rn '"interchange", "harness", "director"'` returns no hits; the old logger scope is fully migrated.
- Subject and body line-length audits (`awk 'length > 72'` against `git log main..HEAD --format='%s'` and `…--format='%b'`) return empty.
- Tracker / series / filename / trailing-punctuation audits against the same input return empty.
- The new test ``"throws when both director and defaultDirectorPolicy are provided"`` in `packages/harness/src/harness.test.ts` asserts the validation error byte-for-byte against the string thrown by `validateConfig`.

## Test plan

- [ ] Reviewer confirms the re-exports through `@intx/harness` cover any out-of-tree consumers
- [ ] Reviewer confirms the new validation message is acceptable wording for an end-user-facing configuration error