### PR TITLE
Add afterInferenceDone policy hook for state-aware inference gating

### DIFF
--- a/packages/harness/src/harness.test.ts
+++ b/packages/harness/src/harness.test.ts
@@ -29,6 +29,7 @@ import type {
   ToolCall,
   ToolResult,
   InferenceEvent,
+  LastCycleSource,
 } from "@intx/types/runtime";
 import type { AuditRecord, ErrorRecord } from "@intx/types/audit";
 import type { AuthzCallResult } from "@intx/inference";
@@ -52,6 +53,12 @@ import type { HarnessConfig } from "./config";
 function emptyUsage(): TokenUsage {
   return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, thinking: 0 };
 }
+
+const TEST_SOURCE: LastCycleSource = {
+  sourceId: "test-source",
+  provider: "test-provider",
+  model: "test-model",
+};
 
 function makeContextStore(
   opts: { blobs?: Map<string, Uint8Array> } = {},
@@ -1008,6 +1015,7 @@ describe("Default director", () => {
       activeGates: [],
       tokenUsage: emptyUsage(),
       lastCycleUsage: null,
+      lastCycleSource: null,
       sessionId: "test-session",
     };
   }
@@ -1049,6 +1057,7 @@ describe("Default director", () => {
         timestamp: 1000,
       },
       usage: emptyUsage(),
+      source: TEST_SOURCE,
     };
 
     const actions = await director.decide(event, state, caps);
@@ -1071,6 +1080,7 @@ describe("Default director", () => {
         timestamp: 1000,
       },
       usage: emptyUsage(),
+      source: TEST_SOURCE,
     };
 
     const actions = await director.decide(doneEvent, state, caps);
@@ -1156,6 +1166,7 @@ describe("Default director", () => {
         timestamp: 1000,
       },
       usage: emptyUsage(),
+      source: TEST_SOURCE,
     };
 
     const actions = await director.decide(event, state, caps);
@@ -1187,6 +1198,7 @@ describe("Default director", () => {
         timestamp: 1000,
       },
       usage: emptyUsage(),
+      source: TEST_SOURCE,
     };
 
     const actions = await director.decide(event, state, caps);
@@ -1214,6 +1226,7 @@ describe("Default director", () => {
         timestamp: 1000,
       },
       usage: emptyUsage(),
+      source: TEST_SOURCE,
     };
 
     const actions = await director.decide(event, state, caps);
@@ -1240,6 +1253,7 @@ describe("Default director", () => {
         timestamp: 1000,
       },
       usage: emptyUsage(),
+      source: TEST_SOURCE,
     };
 
     const actions = await director.decide(event, state, caps);
@@ -1295,6 +1309,7 @@ describe("Default director", () => {
         timestamp: 1000,
       },
       usage: emptyUsage(),
+      source: TEST_SOURCE,
     };
     await director.decide(inferDone, state, caps);
 

--- a/packages/hub-client/src/session.test.ts
+++ b/packages/hub-client/src/session.test.ts
@@ -1391,6 +1391,11 @@ describe("activity state machine", () => {
           cacheWrite: 0,
           thinking: 0,
         },
+        source: {
+          sourceId: "test-source",
+          provider: "test-provider",
+          model: "gpt-4",
+        },
       },
     });
     expect(session.activity).toBeNull();

--- a/packages/inference-testing/src/invariants.test.ts
+++ b/packages/inference-testing/src/invariants.test.ts
@@ -3,6 +3,7 @@ import { describe, test, expect } from "bun:test";
 import type {
   ContentBlock,
   InferenceEvent,
+  LastCycleSource,
   PartialMessage,
   TokenUsage,
 } from "@intx/types/runtime";
@@ -16,6 +17,11 @@ const ZERO_USAGE: TokenUsage = {
   cacheRead: 0,
   cacheWrite: 0,
   thinking: 0,
+};
+const TEST_SOURCE: LastCycleSource = {
+  sourceId: "test-source",
+  provider: "test-provider",
+  model: "test-model",
 };
 
 function findInvariant(name: string): Invariant {
@@ -39,6 +45,7 @@ function doneEvent(
     data: {
       turn: { role: "assistant", content, model: "test", timestamp: 0 },
       usage,
+      source: TEST_SOURCE,
     },
   };
 }
@@ -55,7 +62,7 @@ function errorEvent(seq: number): InferenceEvent {
 }
 
 function usageEvent(seq: number, usage: TokenUsage): InferenceEvent {
-  return { type: "inference.usage", seq, data: { usage } };
+  return { type: "inference.usage", seq, data: { usage, source: TEST_SOURCE } };
 }
 
 function textDelta(seq: number, token: string, index?: number): InferenceEvent {
@@ -470,6 +477,7 @@ describe("recognized_content_blocks invariant", () => {
           timestamp: 0,
         },
         usage: ZERO_USAGE,
+        source: TEST_SOURCE,
       },
     } as unknown as InferenceEvent;
     const violations = inv.check([event]);

--- a/packages/inference-testing/src/matchers.test.ts
+++ b/packages/inference-testing/src/matchers.test.ts
@@ -1,6 +1,10 @@
 import { describe, test, expect } from "bun:test";
 
-import type { InferenceEvent, PartialMessage } from "@intx/types/runtime";
+import type {
+  InferenceEvent,
+  LastCycleSource,
+  PartialMessage,
+} from "@intx/types/runtime";
 
 import {
   expectEvents,
@@ -11,6 +15,11 @@ import {
 } from "./matchers";
 
 const EMPTY_PARTIAL: PartialMessage = { text: "" };
+const TEST_SOURCE: LastCycleSource = {
+  sourceId: "test-source",
+  provider: "test-provider",
+  model: "test-model",
+};
 
 function startEvent(seq: number): InferenceEvent {
   return {
@@ -59,6 +68,7 @@ function doneEvent(seq: number): InferenceEvent {
         cacheWrite: 0,
         thinking: 0,
       },
+      source: TEST_SOURCE,
     },
   };
 }

--- a/packages/inference-testing/src/wire/agnostic.test.ts
+++ b/packages/inference-testing/src/wire/agnostic.test.ts
@@ -5,7 +5,19 @@ import {
   createOpenAIAdapter,
   parseSSE,
 } from "@intx/inference";
-import type { InferenceEvent } from "@intx/types/runtime";
+import type { InferenceEvent, LastCycleSource } from "@intx/types/runtime";
+
+const ANTHROPIC_SOURCE: LastCycleSource = {
+  sourceId: "test-anthropic",
+  provider: "anthropic",
+  model: "test-anthropic-model",
+};
+
+const OPENAI_SOURCE: LastCycleSource = {
+  sourceId: "test-openai",
+  provider: "openai",
+  model: "test-openai-model",
+};
 
 import { assistantText, completeResponse, toolCall, usage } from "./agnostic";
 
@@ -16,7 +28,7 @@ async function driveAnthropic(chunks: Uint8Array[]): Promise<InferenceEvent[]> {
       controller.close();
     },
   });
-  const adapter = createAnthropicAdapter();
+  const adapter = createAnthropicAdapter(ANTHROPIC_SOURCE);
   const events: InferenceEvent[] = [];
   for await (const sseData of parseSSE(stream)) {
     for (const evt of adapter.parseResponse(sseData)) {
@@ -33,7 +45,7 @@ async function driveOpenAI(chunks: Uint8Array[]): Promise<InferenceEvent[]> {
       controller.close();
     },
   });
-  const adapter = createOpenAIAdapter();
+  const adapter = createOpenAIAdapter(OPENAI_SOURCE);
   const events: InferenceEvent[] = [];
   for await (const sseData of parseSSE(stream)) {
     for (const evt of adapter.parseResponse(sseData)) {

--- a/packages/inference-testing/src/wire/anthropic.test.ts
+++ b/packages/inference-testing/src/wire/anthropic.test.ts
@@ -1,7 +1,13 @@
 import { describe, test, expect } from "bun:test";
 
 import { createAnthropicAdapter, parseSSE } from "@intx/inference";
-import type { InferenceEvent } from "@intx/types/runtime";
+import type { InferenceEvent, LastCycleSource } from "@intx/types/runtime";
+
+const TEST_SOURCE: LastCycleSource = {
+  sourceId: "test-anthropic",
+  provider: "anthropic",
+  model: "test-anthropic-model",
+};
 
 import * as anthropic from "./anthropic";
 
@@ -17,7 +23,7 @@ async function drive(chunks: Uint8Array[]): Promise<InferenceEvent[]> {
       controller.close();
     },
   });
-  const adapter = createAnthropicAdapter();
+  const adapter = createAnthropicAdapter(TEST_SOURCE);
   const events: InferenceEvent[] = [];
   for await (const sseData of parseSSE(stream)) {
     for (const evt of adapter.parseResponse(sseData)) {

--- a/packages/inference-testing/src/wire/openai.test.ts
+++ b/packages/inference-testing/src/wire/openai.test.ts
@@ -1,7 +1,13 @@
 import { describe, test, expect } from "bun:test";
 
 import { createOpenAIAdapter, parseSSE } from "@intx/inference";
-import type { InferenceEvent } from "@intx/types/runtime";
+import type { InferenceEvent, LastCycleSource } from "@intx/types/runtime";
+
+const TEST_SOURCE: LastCycleSource = {
+  sourceId: "test-openai",
+  provider: "openai",
+  model: "test-openai-model",
+};
 
 import * as openai from "./openai";
 
@@ -12,7 +18,7 @@ async function drive(chunks: Uint8Array[]): Promise<InferenceEvent[]> {
       controller.close();
     },
   });
-  const adapter = createOpenAIAdapter();
+  const adapter = createOpenAIAdapter(TEST_SOURCE);
   const events: InferenceEvent[] = [];
   for await (const sseData of parseSSE(stream)) {
     for (const evt of adapter.parseResponse(sseData)) {

--- a/packages/inference/src/authz-extension.test.ts
+++ b/packages/inference/src/authz-extension.test.ts
@@ -21,6 +21,7 @@ function makeState(): ReactorState {
     activeGates: [],
     tokenUsage: emptyUsage(),
     lastCycleUsage: null,
+    lastCycleSource: null,
   };
 }
 

--- a/packages/inference/src/default-director.test.ts
+++ b/packages/inference/src/default-director.test.ts
@@ -1,0 +1,314 @@
+import { describe, test, expect } from "bun:test";
+
+import { createInboundMessage } from "@intx/mime";
+import type {
+  AssistantTurn,
+  InferenceError,
+  LastCycleSource,
+  PartialMessage,
+  ReactorAction,
+  ReactorInboundEvent,
+  ReactorState,
+  ToolResult,
+  TokenUsage,
+} from "@intx/types/runtime";
+
+import { createDefaultDirector } from "./default-director";
+import type {
+  AfterInferenceDecision,
+  AfterInferenceHook,
+  DefaultDirectorPolicy,
+} from "./default-director";
+import { createCapabilities } from "./director";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_SOURCE: LastCycleSource = {
+  sourceId: "anthropic:claude-test",
+  provider: "anthropic",
+  model: "claude-test",
+};
+
+const TEST_USAGE: TokenUsage = {
+  input: 100,
+  output: 50,
+  cacheRead: 0,
+  cacheWrite: 0,
+  thinking: 0,
+};
+
+function makeState(overrides: Partial<ReactorState> = {}): ReactorState {
+  return {
+    sessionId: "test-session",
+    turns: [],
+    activeForks: [],
+    pendingOperations: [],
+    activeGates: [],
+    tokenUsage: { ...TEST_USAGE },
+    lastCycleUsage: { ...TEST_USAGE },
+    lastCycleSource: { ...TEST_SOURCE },
+    ...overrides,
+  };
+}
+
+function makeAssistantTurn(text: string): AssistantTurn {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    model: "claude-test",
+    timestamp: 1000,
+  };
+}
+
+function makeAssistantTurnWithToolCall(
+  callId: string,
+  name: string,
+): AssistantTurn {
+  return {
+    role: "assistant",
+    content: [
+      { type: "tool_call", id: callId, name, arguments: { q: "test" } },
+    ],
+    model: "claude-test",
+    timestamp: 1000,
+  };
+}
+
+function makeInferenceDoneEvent(turn: AssistantTurn): ReactorInboundEvent {
+  return {
+    type: "inference.done",
+    turn,
+    usage: TEST_USAGE,
+    source: TEST_SOURCE,
+  };
+}
+
+function makeInferenceErrorEvent(): ReactorInboundEvent {
+  const error: InferenceError = {
+    category: "fatal",
+    message: "test error",
+  };
+  const partial: PartialMessage = { text: "" };
+  return { type: "inference.error", error, partial };
+}
+
+async function decide(
+  policy: DefaultDirectorPolicy,
+  event: ReactorInboundEvent,
+  state: ReactorState = makeState(),
+): Promise<ReactorAction[]> {
+  const director = createDefaultDirector("You are a test agent.", [], policy);
+  const result = await director.decide(event, state, createCapabilities());
+  return Array.isArray(result) ? result : [result];
+}
+
+// ---------------------------------------------------------------------------
+// Hook decisions
+// ---------------------------------------------------------------------------
+
+describe("DefaultDirector — afterInferenceDone hook", () => {
+  test("continue: existing post-inference logic runs unchanged", async () => {
+    let receivedState: ReactorState | undefined;
+    let receivedTurn: AssistantTurn | undefined;
+    const hook: AfterInferenceHook = (state, turn) => {
+      receivedState = state;
+      receivedTurn = turn;
+      return { type: "continue" };
+    };
+    const turn = makeAssistantTurn("Hello from the model");
+    const actions = await decide(
+      { afterInferenceDone: hook },
+      makeInferenceDoneEvent(turn),
+    );
+
+    // The hook saw the post-cycle state and the turn — verifies the
+    // director plumbed both arguments through, not just called the hook.
+    expect(receivedTurn).toEqual(turn);
+    expect(receivedState?.lastCycleSource).toEqual(TEST_SOURCE);
+    expect(receivedState?.lastCycleUsage).toEqual(TEST_USAGE);
+
+    // Continue falls through to the existing reply path.
+    expect(actions).toEqual([
+      { type: "checkpoint", message: "checkpoint: inference-done" },
+      { type: "reply", content: "Hello from the model" },
+    ]);
+  });
+
+  test("abort: returns [checkpoint, reply, done] with the policy reason", async () => {
+    const hook: AfterInferenceHook = () => ({
+      type: "abort",
+      reason: "budget exhausted",
+    });
+    const actions = await decide(
+      { afterInferenceDone: hook },
+      makeInferenceDoneEvent(makeAssistantTurn("ignored")),
+    );
+    expect(actions).toEqual([
+      { type: "checkpoint", message: "checkpoint: after-inference-abort" },
+      { type: "reply", content: "budget exhausted" },
+      { type: "done" },
+    ]);
+  });
+
+  test("halt: returns [checkpoint, reply, wait] with the policy reason", async () => {
+    const hook: AfterInferenceHook = () => ({
+      type: "halt",
+      reason: "paused for top-up",
+    });
+    const actions = await decide(
+      { afterInferenceDone: hook },
+      makeInferenceDoneEvent(makeAssistantTurn("ignored")),
+    );
+    expect(actions).toEqual([
+      { type: "checkpoint", message: "checkpoint: after-inference-halt" },
+      { type: "reply", content: "paused for top-up" },
+      { type: "wait" },
+    ]);
+  });
+
+  test("hook not set: existing behavior preserved", async () => {
+    const actions = await decide(
+      {},
+      makeInferenceDoneEvent(makeAssistantTurn("Hello")),
+    );
+    expect(actions).toEqual([
+      { type: "checkpoint", message: "checkpoint: inference-done" },
+      { type: "reply", content: "Hello" },
+    ]);
+  });
+
+  test("hook throws: caught, routed to abort with synthesized reason", async () => {
+    const hook: AfterInferenceHook = () => {
+      throw new Error("policy died");
+    };
+    const actions = await decide(
+      { afterInferenceDone: hook },
+      makeInferenceDoneEvent(makeAssistantTurn("ignored")),
+    );
+    expect(actions).toEqual([
+      { type: "checkpoint", message: "checkpoint: after-inference-abort" },
+      {
+        type: "reply",
+        content: "afterInferenceDone policy threw: policy died",
+      },
+      { type: "done" },
+    ]);
+  });
+
+  test("hook returning a Promise is awaited", async () => {
+    const hook: AfterInferenceHook = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      const decision: AfterInferenceDecision = {
+        type: "abort",
+        reason: "async abort",
+      };
+      return decision;
+    };
+    const actions = await decide(
+      { afterInferenceDone: hook },
+      makeInferenceDoneEvent(makeAssistantTurn("ignored")),
+    );
+    expect(actions).toEqual([
+      { type: "checkpoint", message: "checkpoint: after-inference-abort" },
+      { type: "reply", content: "async abort" },
+      { type: "done" },
+    ]);
+  });
+
+  test("hook does NOT fire on inference.error", async () => {
+    let hookFired = false;
+    const hook: AfterInferenceHook = () => {
+      hookFired = true;
+      return { type: "abort", reason: "should not run" };
+    };
+    const actions = await decide(
+      { afterInferenceDone: hook },
+      makeInferenceErrorEvent(),
+    );
+    expect(hookFired).toBe(false);
+    // The inference.error branch produces its own checkpoint + reply
+    // shape; the hook is not in that path.
+    expect(actions[0]).toEqual({
+      type: "checkpoint",
+      message: "checkpoint: inference-error",
+    });
+  });
+
+  test("abort fires before tool calls execute (tool calls dropped)", async () => {
+    const hook: AfterInferenceHook = () => ({
+      type: "abort",
+      reason: "stop now",
+    });
+    const turn = makeAssistantTurnWithToolCall("call_1", "search");
+    const actions = await decide(
+      { afterInferenceDone: hook },
+      makeInferenceDoneEvent(turn),
+    );
+    // The model's tool call is on the turn, but the hook's abort
+    // routes to done before execute_tools is reached. The TSDoc warns
+    // policy authors about this; the test pins the behavior.
+    expect(actions).toEqual([
+      { type: "checkpoint", message: "checkpoint: after-inference-abort" },
+      { type: "reply", content: "stop now" },
+      { type: "done" },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Firing boundary: hook fires only on inference.done
+//
+// The "does NOT fire on inference.error" test above pins one negative
+// case; this block exhausts the rest of the ReactorInboundEvent union
+// so a future switch refactor (e.g. extracting a shared post-event
+// helper) can't quietly start invoking the hook on the wrong branch.
+// ---------------------------------------------------------------------------
+
+async function fireHook(event: ReactorInboundEvent): Promise<boolean> {
+  let fired = false;
+  const hook: AfterInferenceHook = () => {
+    fired = true;
+    return { type: "continue" };
+  };
+  await decide({ afterInferenceDone: hook }, event);
+  return fired;
+}
+
+describe("DefaultDirector — afterInferenceDone firing boundary", () => {
+  test("not fired on message.received", async () => {
+    const event: ReactorInboundEvent = {
+      type: "message.received",
+      message: createInboundMessage({
+        from: "test@example.com",
+        to: "agent@example.com",
+        content: "hi",
+      }),
+    };
+    expect(await fireHook(event)).toBe(false);
+  });
+
+  test("not fired on tool.done", async () => {
+    const result: ToolResult = { callId: "c1", content: "ok" };
+    const event: ReactorInboundEvent = { type: "tool.done", result };
+    expect(await fireHook(event)).toBe(false);
+  });
+
+  test("not fired on reactor.gate.cleared", async () => {
+    const event: ReactorInboundEvent = {
+      type: "reactor.gate.cleared",
+      gateId: "g1",
+      reason: "resolved",
+    };
+    expect(await fireHook(event)).toBe(false);
+  });
+
+  test("not fired on abort", async () => {
+    const event: ReactorInboundEvent = {
+      type: "abort",
+      reason: "user_disconnect",
+    };
+    expect(await fireHook(event)).toBe(false);
+  });
+});

--- a/packages/inference/src/default-director.ts
+++ b/packages/inference/src/default-director.ts
@@ -27,6 +27,77 @@ import type {
 
 const logger = getLogger(["interchange", "inference", "default-director"]);
 
+/**
+ * Decision returned by an `afterInferenceDone` policy hook.
+ *
+ *   continue — proceed with the director's normal post-inference logic
+ *              (tool extraction, reply, or wait per the existing flow).
+ *   abort    — terminate the agent. Routes to `[checkpoint, reply, done]`
+ *              and the reactor shuts down. Stronger than the
+ *              `inference.error` branch, which only replies and stays
+ *              alive — `abort` is for "session is over, do not accept
+ *              further inputs."
+ *   halt     — pause the current cycle without terminating. Routes to
+ *              `[checkpoint, reply, wait]`. Reactor stays alive waiting
+ *              for the next inbound event. There is no auto-resume; an
+ *              external event (mail, gate clearance, etc.) must reach
+ *              the reactor for the agent to make progress again.
+ *
+ * `reason` becomes the connector reply text verbatim — policy authors
+ * choose what is safe to surface to the user. There is no separate
+ * private-reason / user-message split today; add one if a real need
+ * appears.
+ */
+export type AfterInferenceDecision =
+  | { type: "continue" }
+  | { type: "abort"; reason: string }
+  | { type: "halt"; reason: string };
+
+/**
+ * Function shape for an after-inference-done policy hook.
+ *
+ * The hook fires only on `inference.done` (a successful cycle). Errored
+ * cycles do not invoke it. `mode: "reactive"` does not change firing —
+ * the hook gates the entire `inference.done` branch, including the
+ * reactive-wait shortcut, so a budget check applies to reactive agents
+ * the same way it does to conversational ones.
+ *
+ * The hook receives the post-cycle `ReactorState` (with `lastCycleSource`
+ * and `lastCycleUsage` populated for the just-completed call) and the
+ * assistant turn. Returns a decision (sync or async) that controls
+ * whether the director continues, terminates the agent, or pauses the
+ * cycle.
+ *
+ * Canonical use case: cost-aware gating. Read `state.lastCycleSource`
+ * + `state.lastCycleUsage`, price the call against user-supplied rate
+ * data, decide whether the budget is exhausted. Token caps, time caps,
+ * wallet checks, and governance triggers fit the same shape; the
+ * type stays policy-agnostic.
+ *
+ * "Downgrade to cheaper model" policies do NOT use this hook to return
+ * a new source. Compose them via an external observer of
+ * `lastCycleSource` / `lastCycleUsage` that calls `setSource` from
+ * outside the director.
+ *
+ * The hook blocks the reactor's inference.done branch: keep its
+ * latency low. The return type admits a Promise, but every await
+ * inside the hook is wall-clock time the agent isn't making progress.
+ * Small lookups (in-memory caches, fast DB reads) are fine; arbitrary
+ * waits are not.
+ *
+ * Tool calls and `halt`: if the model emitted tool calls and the hook
+ * returns `halt` (or `abort`), those tool calls are dropped — the
+ * director never executes them. On resume, the model's next inference
+ * sees an assistant turn with unanswered tool calls; depending on the
+ * provider this is either a validation error or a confused model.
+ * Policy authors that combine `halt` with tool-heavy agents need to
+ * understand this.
+ */
+export type AfterInferenceHook = (
+  state: ReactorState,
+  turn: AssistantTurn,
+) => AfterInferenceDecision | Promise<AfterInferenceDecision>;
+
 export type DefaultDirectorPolicy = {
   /**
    * Controls the agent's behavior after inference completes.
@@ -42,6 +113,18 @@ export type DefaultDirectorPolicy = {
    *     Use this for agents that perform a single action per message.
    */
   mode?: "conversational" | "reactive";
+
+  /**
+   * Optional policy hook fired after every successful `inference.done`.
+   * See `AfterInferenceHook` for the contract: firing boundary, return
+   * shape, composition patterns, and policy-author caveats.
+   *
+   * If the hook throws or rejects, the director catches the error,
+   * routes to `{ type: "abort", reason: "afterInferenceDone policy
+   * threw: <message>" }`, and logs at error level. The director's
+   * never-throws contract is preserved.
+   */
+  afterInferenceDone?: AfterInferenceHook;
 };
 
 function extractToolCalls(turn: AssistantTurn): ToolCall[] {
@@ -123,7 +206,7 @@ export class DefaultDirector implements ReactorDirector {
 
   async decide(
     event: ReactorInboundEvent,
-    _state: ReactorState,
+    state: ReactorState,
     capabilities: ReactorCapabilities,
   ): Promise<ReactorAction | ReactorAction[]> {
     switch (event.type) {
@@ -135,6 +218,41 @@ export class DefaultDirector implements ReactorDirector {
       }
 
       case "inference.done": {
+        // The hook gates the entire inference.done branch (including
+        // tool extraction and the reactive-mode wait shortcut). An
+        // abort/halt from the policy drops any tool calls the model
+        // emitted in this turn; see AfterInferenceHook TSDoc for the
+        // implications.
+        if (this.policy.afterInferenceDone !== undefined) {
+          let decision: AfterInferenceDecision;
+          try {
+            decision = await this.policy.afterInferenceDone(state, event.turn);
+          } catch (cause) {
+            const message =
+              cause instanceof Error ? cause.message : String(cause);
+            logger.error`afterInferenceDone policy threw: ${message}`;
+            decision = {
+              type: "abort",
+              reason: `afterInferenceDone policy threw: ${message}`,
+            };
+          }
+          if (decision.type === "abort") {
+            return [
+              capabilities.checkpoint("after-inference-abort"),
+              capabilities.reply(decision.reason),
+              capabilities.done(),
+            ];
+          }
+          if (decision.type === "halt") {
+            return [
+              capabilities.checkpoint("after-inference-halt"),
+              capabilities.reply(decision.reason),
+              capabilities.wait(),
+            ];
+          }
+          // decision.type === "continue" — fall through.
+        }
+
         const toolCalls = extractToolCalls(event.turn);
         if (toolCalls.length > 0) {
           this.pendingToolResults = toolCalls.length;

--- a/packages/inference/src/harness.test.ts
+++ b/packages/inference/src/harness.test.ts
@@ -486,3 +486,161 @@ describe("Dependencies — reflective exposure of HarnessId", () => {
     expect(Reflect.ownKeys(deps)).toContain(HarnessId);
   });
 });
+
+// ---------------------------------------------------------------------------
+// runInference — source-identity stamping on inference events
+//
+// The harness snapshots `{id, provider, model}` from the active source at
+// the top of the call and stamps that descriptor onto every inference.usage
+// and inference.done event for that call. The snapshot defends against
+// `applyInferenceSourceFields` (or any other in-place mutation of the
+// shared source object) firing between call start and inference.done: the
+// identity stamped onto the events must reflect the source that *began*
+// the call, not whatever the active source happens to be at done-time.
+// ---------------------------------------------------------------------------
+
+describe("runInference — source-identity stamping", () => {
+  test("emits LastCycleSource on inference.done matching the call-start source", async () => {
+    const deps: Dependencies = {
+      fetch: () =>
+        Promise.resolve(
+          new Response("", {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }),
+        ),
+    };
+    let seq = 0;
+    const events = await collect(
+      runInference({
+        turns: [userTurn("hi")],
+        source: SOURCE,
+        nextSeq: () => ++seq,
+        deps,
+      }),
+    );
+
+    const doneEvent = events.find((e) => e.type === "inference.done");
+    if (doneEvent === undefined) throw new Error("missing inference.done");
+    expect(doneEvent.data.source).toEqual({
+      sourceId: SOURCE.id,
+      provider: SOURCE.provider,
+      model: SOURCE.model,
+    });
+  });
+
+  test("two calls with different sources stamp their own descriptor", async () => {
+    const sourceA: InferenceSource = {
+      id: "anthropic:claude-A",
+      provider: "anthropic",
+      baseURL: "https://api.anthropic.com",
+      apiKey: "test",
+      model: "claude-A",
+    };
+    const sourceB: InferenceSource = {
+      id: "openai:gpt-B",
+      provider: "openai",
+      baseURL: "https://api.openai.test/v1",
+      apiKey: "test",
+      model: "gpt-B",
+    };
+    const deps: Dependencies = {
+      fetch: () =>
+        Promise.resolve(
+          new Response("", {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }),
+        ),
+    };
+
+    let seq = 0;
+    const eventsA = await collect(
+      runInference({
+        turns: [userTurn("call-A")],
+        source: sourceA,
+        nextSeq: () => ++seq,
+        deps,
+      }),
+    );
+    const doneA = eventsA.find((e) => e.type === "inference.done");
+    if (doneA === undefined) throw new Error("missing inference.done for A");
+    expect(doneA.data.source).toEqual({
+      sourceId: "anthropic:claude-A",
+      provider: "anthropic",
+      model: "claude-A",
+    });
+
+    seq = 0;
+    const eventsB = await collect(
+      runInference({
+        turns: [userTurn("call-B")],
+        source: sourceB,
+        nextSeq: () => ++seq,
+        deps,
+      }),
+    );
+    const doneB = eventsB.find((e) => e.type === "inference.done");
+    if (doneB === undefined) throw new Error("missing inference.done for B");
+    expect(doneB.data.source).toEqual({
+      sourceId: "openai:gpt-B",
+      provider: "openai",
+      model: "gpt-B",
+    });
+  });
+
+  test("hot-swap mid-call: inference.done reflects the call-start source, not the post-mutation fields", async () => {
+    // Simulate the harness's `setSource` pattern: a single InferenceSource
+    // object is mutated in place via `applyInferenceSourceFields`. If the
+    // call captured a reference to the live object instead of snapshotting
+    // its identifying fields, the descriptor on inference.done would
+    // observe whatever id/provider/model the swap mutated in.
+    const activeSource: InferenceSource = {
+      id: "anthropic:claude-pre",
+      provider: "anthropic",
+      baseURL: "https://api.anthropic.com",
+      apiKey: "test",
+      model: "claude-pre",
+    };
+
+    // Mutate the source between fetch invocation and stream consumption.
+    // The Response body resolves synchronously here, but the harness still
+    // reads `source.*` (model in the request body) on the way out; the
+    // post-mutation values must NOT show up on the inference.done event
+    // because the snapshot at call start already captured the pre-swap
+    // identity.
+    const deps: Dependencies = {
+      fetch: () => {
+        activeSource.id = "openai:gpt-post";
+        activeSource.provider = "openai";
+        activeSource.baseURL = "https://api.openai.test/v1";
+        activeSource.apiKey = "test-post";
+        activeSource.model = "gpt-post";
+        return Promise.resolve(
+          new Response("", {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }),
+        );
+      },
+    };
+
+    let seq = 0;
+    const events = await collect(
+      runInference({
+        turns: [userTurn("hi")],
+        source: activeSource,
+        nextSeq: () => ++seq,
+        deps,
+      }),
+    );
+
+    const doneEvent = events.find((e) => e.type === "inference.done");
+    if (doneEvent === undefined) throw new Error("missing inference.done");
+    expect(doneEvent.data.source).toEqual({
+      sourceId: "anthropic:claude-pre",
+      provider: "anthropic",
+      model: "claude-pre",
+    });
+  });
+});

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -24,6 +24,7 @@ import type {
   InferenceEvent,
   InferenceOptions,
   InferenceSource,
+  LastCycleSource,
   PartialMessage,
   TokenUsage,
   AssistantTurn,
@@ -145,6 +146,30 @@ export async function* runInference(
     ...(inferenceOptions ?? {}),
   };
   const model = source.model;
+  // Snapshot the source identity at call start. The harness reads
+  // `source.*` lazily across the rest of this function (and the adapter
+  // closes over `source` for its parseResponse), so a `setSource`
+  // mid-call would otherwise mutate the identity stamped onto the
+  // inference.usage and inference.done events for this very call.
+  // Capturing into a local LastCycleSource here is the single point
+  // that defends against that hot-swap.
+  //
+  // Scope of the defense: this snapshot protects *identity attribution*
+  // — what the director's policy hook and external event consumers see
+  // for `lastCycleSource` and `event.data.source`. It does NOT isolate
+  // the in-flight HTTP request from the swap: `resolveURL` reads
+  // `source.baseURL` live and `injectCredentials` reads `source.apiKey`
+  // live (both below). A mid-call `setSource` will route the request to
+  // the new endpoint with the new credentials while the resulting
+  // inference.done still carries the pre-swap identity. That is
+  // consistent with `LastCycleSource` deliberately excluding
+  // baseURL/apiKey, but it is worth knowing: the snapshot is
+  // identity-only, not a transactional freeze of the entire source.
+  const lastCycleSource: LastCycleSource = {
+    sourceId: source.id,
+    provider: source.provider,
+    model,
+  };
 
   // Defensive guard for callers that bypass the type system (JS, `any`,
   // unchecked casts). Missing or malformed `deps.fetch` is a programmer
@@ -211,7 +236,7 @@ export async function* runInference(
 
   let adapter;
   try {
-    adapter = lookupProvider(source.provider);
+    adapter = lookupProvider(lastCycleSource.provider, lastCycleSource);
   } catch (cause) {
     yield {
       type: "inference.error",
@@ -222,7 +247,7 @@ export async function* runInference(
           message:
             cause instanceof Error
               ? cause.message
-              : `Unknown provider: ${source.provider}`,
+              : `Unknown provider: ${lastCycleSource.provider}`,
         },
         partial: snapshotPartial(partial),
       },
@@ -827,11 +852,25 @@ export async function* runInference(
               // observably "decrease" input from a real count back
               // to 0 between the two events even though no decrease
               // occurred in the underlying counter.
+              //
+              // The source field uses the call-start `lastCycleSource`
+              // snapshot rather than `raw.data.source`. The adapter
+              // stamps source on its own emit because the InferenceEvent
+              // type requires the field at every producer site, but the
+              // harness owns identity attribution for downstream
+              // consumers: the harness's snapshot is the single source
+              // of truth, the adapter's stamp is type-system overhead
+              // that gets replaced here. Both descriptors are equal by
+              // construction (the registry passes the same snapshot to
+              // the adapter factory), so the override is redundant for
+              // correctness; it exists so a future provider that
+              // synthesizes its own descriptor cannot drift from the
+              // call-start identity the rest of the harness commits to.
               usageSeen = mergeUsage(usageSeen, raw.data.usage);
               yield {
                 type: "inference.usage",
                 seq: nextSeq(),
-                data: { usage: usageSeen },
+                data: { usage: usageSeen, source: lastCycleSource },
               };
               break;
             }
@@ -924,7 +963,7 @@ export async function* runInference(
       yield {
         type: "inference.usage",
         seq: nextSeq(),
-        data: { usage: finalUsage },
+        data: { usage: finalUsage, source: lastCycleSource },
       };
     }
 
@@ -1082,6 +1121,7 @@ export async function* runInference(
       data: {
         turn: finalTurn,
         usage: finalUsage,
+        source: lastCycleSource,
         ...(pacingDelayMs !== undefined && pacingDelayMs > 0
           ? { pacingDelayMs }
           : {}),

--- a/packages/inference/src/providers/anthropic.test.ts
+++ b/packages/inference/src/providers/anthropic.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, test } from "bun:test";
 
-import type { ConversationTurn, InferenceEvent } from "@intx/types/runtime";
+import type {
+  ConversationTurn,
+  InferenceEvent,
+  LastCycleSource,
+} from "@intx/types/runtime";
 
 import { ProtocolMismatchError } from "../errors";
 import { createAnthropicAdapter } from "./anthropic";
+
+const TEST_SOURCE: LastCycleSource = {
+  sourceId: "test-anthropic",
+  provider: "anthropic",
+  model: "test-anthropic-model",
+};
 
 // The parser is exercised through the public adapter rather than imported
 // directly. parseResponse is intentionally not exported — the adapter
@@ -79,7 +89,7 @@ function pickFirstToolCallDelta(
 
 describe("Anthropic parser — index propagation on delta events", () => {
   test("text_delta carries the SSE block index forward as data.index", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     const events = parse(adapter, {
       type: "content_block_delta",
       index: 1,
@@ -92,7 +102,7 @@ describe("Anthropic parser — index propagation on delta events", () => {
   });
 
   test("thinking_delta carries the SSE block index forward as data.index", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     const events = parse(adapter, {
       type: "content_block_delta",
       index: 2,
@@ -105,7 +115,7 @@ describe("Anthropic parser — index propagation on delta events", () => {
   });
 
   test("signature_delta carries the SSE block index forward as data.index", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     const events = parse(adapter, {
       type: "content_block_delta",
       index: 3,
@@ -118,7 +128,7 @@ describe("Anthropic parser — index propagation on delta events", () => {
   });
 
   test("tool_call.start carries the SSE block index forward as data.index", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     const events = parse(adapter, {
       type: "content_block_start",
       index: 4,
@@ -131,7 +141,7 @@ describe("Anthropic parser — index propagation on delta events", () => {
   });
 
   test("tool_call.delta carries the SSE block index forward as data.index", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     parse(adapter, {
       type: "content_block_start",
       index: 5,
@@ -156,7 +166,7 @@ describe("Anthropic parser — multi-tool callId routing across indices", () => 
   // index. Collapsing the indices into one slot would route the second
   // tool's argument fragments to the first tool's callId.
   test("input_json_deltas at distinct indices resolve to distinct callIds", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     parse(adapter, {
       type: "content_block_start",
       index: 0,
@@ -197,7 +207,7 @@ describe("Anthropic parser — required-index schema enforcement", () => {
   // load-bearing on the index being real, not synthesized.
 
   test("content_block_delta without index throws ProtocolMismatchError", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     let thrown: unknown;
     try {
       parse(adapter, {
@@ -214,7 +224,7 @@ describe("Anthropic parser — required-index schema enforcement", () => {
   });
 
   test("content_block_start without index throws ProtocolMismatchError", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     let thrown: unknown;
     try {
       parse(adapter, {
@@ -228,7 +238,7 @@ describe("Anthropic parser — required-index schema enforcement", () => {
   });
 
   test("content_block_stop without index throws ProtocolMismatchError", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     let thrown: unknown;
     try {
       parse(adapter, { type: "content_block_stop" });
@@ -271,7 +281,7 @@ function pickFirstThinkingRedacted(
 
 describe("Anthropic parser — redacted_thinking content_block_start", () => {
   test("emits inference.thinking.redacted carrying the data and source index", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     const events = parse(adapter, {
       type: "content_block_start",
       index: 0,
@@ -288,7 +298,7 @@ describe("Anthropic parser — redacted_thinking content_block_start", () => {
   });
 
   test("preserves the data verbatim — no normalization or transformation", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     // The data is an opaque blob; any mutation breaks the round-trip.
     // Use a string with characters that an over-eager normalizer would
     // touch (newlines, whitespace, base64 padding).
@@ -303,7 +313,7 @@ describe("Anthropic parser — redacted_thinking content_block_start", () => {
   });
 
   test("missing `data` field throws ProtocolMismatchError naming the field", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     let thrown: unknown;
     try {
       parse(adapter, {
@@ -331,7 +341,7 @@ describe("Anthropic adapter — redacted_thinking parser-to-builder round-trip",
   // that carries the same bytes verbatim. That round-trip is the
   // invariant Anthropic requires on every follow-up turn.
   test("data survives parse → reconstruct → buildRequest unchanged", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     const events = parse(adapter, {
       type: "content_block_start",
       index: 0,
@@ -377,7 +387,7 @@ describe("Anthropic parser — citations_delta to inference.citation", () => {
     // Anthropic's web_search citations carry url + title + cited_text +
     // encrypted_index. The encrypted_index has no echo-back target in
     // CitationBlock today and is intentionally dropped at the adapter.
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     const events = parse(adapter, {
       type: "content_block_delta",
       index: 3,
@@ -412,7 +422,7 @@ describe("Anthropic parser — citations_delta to inference.citation", () => {
     // Catches a regression where the parser caches the most recent
     // content_block_delta.index across subsequent citation events
     // instead of reading it fresh for each.
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     const events = [
       ...parse(adapter, {
         type: "content_block_delta",
@@ -453,7 +463,7 @@ describe("Anthropic parser — citations_delta to inference.citation", () => {
   });
 
   test("page_location maps to location.kind=page with start/end page numbers", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     const events = parse(adapter, {
       type: "content_block_delta",
       index: 0,
@@ -481,7 +491,7 @@ describe("Anthropic parser — citations_delta to inference.citation", () => {
   });
 
   test("char_location maps to location.kind=char with character offsets", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     const events = parse(adapter, {
       type: "content_block_delta",
       index: 1,
@@ -507,7 +517,7 @@ describe("Anthropic parser — citations_delta to inference.citation", () => {
   });
 
   test("content_block_location maps to location.kind=content-block", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     const events = parse(adapter, {
       type: "content_block_delta",
       index: 0,
@@ -533,7 +543,7 @@ describe("Anthropic parser — citations_delta to inference.citation", () => {
   });
 
   test("unrecognized citation variant throws ProtocolMismatchError naming the variant", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     let thrown: unknown;
     try {
       parse(adapter, {
@@ -558,7 +568,7 @@ describe("Anthropic parser — citations_delta to inference.citation", () => {
   });
 
   test("citations_delta missing citation payload throws ProtocolMismatchError", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     let thrown: unknown;
     try {
       parse(adapter, {
@@ -581,7 +591,7 @@ describe("Anthropic parser — citations_delta to inference.citation", () => {
     // — runtime.ts). Surfacing a missing wire field as a thrown error
     // is the load-bearing alternative to coalescing to an empty
     // string and silently emitting a content-free citation.
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     let thrown: unknown;
     try {
       parse(adapter, {
@@ -614,7 +624,7 @@ describe("Anthropic parser — citations_delta to inference.citation", () => {
     // the parser-emitted event stream must preserve the wire order
     // exactly. Feed a mixed sequence and assert the emitted events
     // come out in the same order they went in.
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     const events: InferenceEvent[] = [];
     events.push(
       ...parse(adapter, {
@@ -685,7 +695,7 @@ describe("Anthropic parser — citations_delta to inference.citation", () => {
   });
 
   test("page_location missing start_page_number throws ProtocolMismatchError", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     let thrown: unknown;
     try {
       parse(adapter, {
@@ -721,7 +731,7 @@ describe("Anthropic adapter — responseFormat boundary", () => {
   ];
 
   test("omitted responseFormat builds a request without throwing", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     const req = adapter.buildRequest(conversation, "claude-sonnet-4", {});
     expect(req.url).toBe("/v1/messages");
   });
@@ -730,7 +740,7 @@ describe("Anthropic adapter — responseFormat boundary", () => {
     // Free-form text is Anthropic's default; the option is a no-op
     // here rather than a throw so the cross-provider call site can
     // pass `{ kind: "text" }` uniformly without conditional logic.
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     const req = adapter.buildRequest(conversation, "claude-sonnet-4", {
       responseFormat: { kind: "text" },
     });
@@ -738,7 +748,7 @@ describe("Anthropic adapter — responseFormat boundary", () => {
   });
 
   test("responseFormat.kind=json throws at the marshaling boundary", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     expect(() =>
       adapter.buildRequest(conversation, "claude-sonnet-4", {
         responseFormat: { kind: "json" },
@@ -747,7 +757,7 @@ describe("Anthropic adapter — responseFormat boundary", () => {
   });
 
   test("responseFormat.kind=json-schema throws and names the kind", () => {
-    const adapter = createAnthropicAdapter();
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
     expect(() =>
       adapter.buildRequest(conversation, "claude-sonnet-4", {
         responseFormat: {

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -5,6 +5,7 @@ import type {
   ContentBlock,
   InferenceEvent,
   InferenceOptions,
+  LastCycleSource,
   MediaSource,
   PartialMessage,
   TokenUsage,
@@ -509,6 +510,7 @@ const AnthropicSSEEvent = ContentBlockDelta.or(ContentBlockStart)
 function parseResponse(
   sseData: string,
   blockIndexToCallId: Map<number, string>,
+  source: LastCycleSource,
 ): InferenceEvent[] {
   // Same protocol-mismatch posture as the openai adapter: a JSON parse
   // failure or arktype rejection means the upstream emitted bytes that
@@ -724,7 +726,11 @@ function parseResponse(
         thinking: 0,
       };
       return [
-        { type: "inference.usage", seq, data: { usage: inferenceUsage } },
+        {
+          type: "inference.usage",
+          seq,
+          data: { usage: inferenceUsage, source },
+        },
       ];
     }
 
@@ -741,7 +747,11 @@ function parseResponse(
         thinking: 0,
       };
       return [
-        { type: "inference.usage", seq, data: { usage: inferenceUsage } },
+        {
+          type: "inference.usage",
+          seq,
+          data: { usage: inferenceUsage, source },
+        },
       ];
     }
 
@@ -785,12 +795,15 @@ function extractPacingDelayMs(headers: Headers): number | undefined {
   return delays.length > 0 ? Math.max(...delays) : undefined;
 }
 
-export function createAnthropicAdapter(): ProviderAdapter {
+export function createAnthropicAdapter(
+  source: LastCycleSource,
+): ProviderAdapter {
   const blockIndexToCallId = new Map<number, string>();
 
   return {
     buildRequest,
-    parseResponse: (sseData) => parseResponse(sseData, blockIndexToCallId),
+    parseResponse: (sseData) =>
+      parseResponse(sseData, blockIndexToCallId, source),
     extractRetryAfterMs,
     extractPacingDelayMs,
   };

--- a/packages/inference/src/providers/google-genai.ts
+++ b/packages/inference/src/providers/google-genai.ts
@@ -7,6 +7,7 @@ import type {
   ContentBlock,
   InferenceEvent,
   InferenceOptions,
+  LastCycleSource,
   MediaSource,
   PartialMessage,
   TokenUsage,
@@ -1382,6 +1383,7 @@ function consumeSignature(
 function parseResponse(
   sseData: string,
   state: GeminiParserState,
+  source: LastCycleSource,
 ): InferenceEvent[] {
   let parsed: unknown;
   try {
@@ -1479,7 +1481,7 @@ function parseResponse(
     out.push({
       type: "inference.usage",
       seq,
-      data: { usage: tokenUsage },
+      data: { usage: tokenUsage, source },
     });
 
     // Terminal events seal the response. A still-pending
@@ -1502,13 +1504,15 @@ function parseResponse(
   return out;
 }
 
-export function createGoogleGenAIAdapter(): ProviderAdapter {
+export function createGoogleGenAIAdapter(
+  source: LastCycleSource,
+): ProviderAdapter {
   // Per-request state lives in the closure: block-index allocation
   // and signature-anchor pairing both need to span SSE events.
   // `buildRequest` does not touch state; only `parseResponse` does.
   const state = createParserState();
   return {
     buildRequest,
-    parseResponse: (sseData) => parseResponse(sseData, state),
+    parseResponse: (sseData) => parseResponse(sseData, state, source),
   };
 }

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -5,6 +5,7 @@ import type {
   ContentBlock,
   InferenceEvent,
   InferenceOptions,
+  LastCycleSource,
   PartialMessage,
   TokenUsage,
 } from "@intx/types/runtime";
@@ -427,6 +428,7 @@ function getOrAssignToolCallIndex(
 function parseResponse(
   sseData: string,
   indexer: OpenAIBlockIndexer,
+  source: LastCycleSource,
 ): InferenceEvent[] {
   // parseSSE strips the `[DONE]` sentinel before yielding payloads, so
   // anything that reaches us here is supposed to be a JSON chunk. A
@@ -471,7 +473,9 @@ function parseResponse(
         cacheWrite: 0,
         thinking: usage.completion_tokens_details?.reasoning_tokens ?? 0,
       };
-      return [{ type: "inference.usage", seq, data: { usage: tokenUsage } }];
+      return [
+        { type: "inference.usage", seq, data: { usage: tokenUsage, source } },
+      ];
     }
     return [];
   }
@@ -631,7 +635,11 @@ function parseResponse(
       cacheWrite: 0,
       thinking: 0,
     };
-    events.push({ type: "inference.usage", seq, data: { usage: tokenUsage } });
+    events.push({
+      type: "inference.usage",
+      seq,
+      data: { usage: tokenUsage, source },
+    });
   }
 
   return events;
@@ -690,7 +698,7 @@ function parseDuration(value: string): number | undefined {
   return total > 0 ? Math.ceil(total) : undefined;
 }
 
-export function createOpenAIAdapter(): ProviderAdapter {
+export function createOpenAIAdapter(source: LastCycleSource): ProviderAdapter {
   // Per-request indexer state. Adapter instances are created per
   // request (see `adapter.ts`), so each call to `createOpenAIAdapter`
   // gets a fresh counter for assigning block indices to reasoning vs.
@@ -704,7 +712,7 @@ export function createOpenAIAdapter(): ProviderAdapter {
   };
   return {
     buildRequest,
-    parseResponse: (sseData) => parseResponse(sseData, indexer),
+    parseResponse: (sseData) => parseResponse(sseData, indexer, source),
     extractRetryAfterMs,
     extractPacingDelayMs,
   };

--- a/packages/inference/src/providers/registry.ts
+++ b/packages/inference/src/providers/registry.ts
@@ -1,9 +1,10 @@
+import type { LastCycleSource } from "@intx/types/runtime";
 import type { ProviderAdapter } from "../adapter";
 import { createAnthropicAdapter } from "./anthropic";
 import { createGoogleGenAIAdapter } from "./google-genai";
 import { createOpenAIAdapter } from "./openai";
 
-type AdapterFactory = () => ProviderAdapter;
+type AdapterFactory = (source: LastCycleSource) => ProviderAdapter;
 
 const registry = new Map<string, AdapterFactory>();
 
@@ -20,10 +21,13 @@ export function hasProvider(id: string): boolean {
   return registry.has(id);
 }
 
-export function lookupProvider(id: string): ProviderAdapter {
+export function lookupProvider(
+  id: string,
+  source: LastCycleSource,
+): ProviderAdapter {
   const factory = registry.get(id);
   if (factory === undefined) {
     throw new Error(`Unknown inference provider: ${id}`);
   }
-  return factory();
+  return factory(source);
 }

--- a/packages/inference/src/reactor.test.ts
+++ b/packages/inference/src/reactor.test.ts
@@ -26,6 +26,7 @@ import type {
   PartialMessage,
   BeforeToolExtension,
   Compactor,
+  LastCycleSource,
 } from "@intx/types/runtime";
 
 import type { ReactorConfig, Reactor, ReactorEmittedEvent } from "./reactor";
@@ -39,6 +40,12 @@ import type { CorrelationValidator } from "./correlation";
 function emptyUsage(): TokenUsage {
   return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, thinking: 0 };
 }
+
+const TEST_SOURCE: LastCycleSource = {
+  sourceId: "test-source",
+  provider: "test-provider",
+  model: "test-model",
+};
 
 function makeContextStore(turns: ConversationTurn[] = []): ContextStore {
   async function commit(
@@ -2312,7 +2319,7 @@ function makeInferenceRunner(
       const event: InferenceEvent = {
         type: "inference.done",
         seq: opts.nextSeq(),
-        data: { turn: result.turn, usage: result.usage },
+        data: { turn: result.turn, usage: result.usage, source: TEST_SOURCE },
       };
       yield event;
     } else {
@@ -3228,7 +3235,7 @@ function mockInferenceRunner(
     yield {
       type: "inference.done",
       seq: opts.nextSeq(),
-      data: { turn, usage },
+      data: { turn, usage, source: TEST_SOURCE },
     };
   };
 }
@@ -3374,6 +3381,7 @@ describe("createReactor — transform chain ordering and compact action", () => 
         data: {
           turn,
           usage: emptyUsage(),
+          source: TEST_SOURCE,
         },
       };
     };
@@ -3508,7 +3516,7 @@ describe("createReactor — transform chain ordering and compact action", () => 
       yield {
         type: "inference.done",
         seq: opts.nextSeq(),
-        data: { turn, usage: emptyUsage() },
+        data: { turn, usage: emptyUsage(), source: TEST_SOURCE },
       };
     };
 

--- a/packages/inference/src/reactor.ts
+++ b/packages/inference/src/reactor.ts
@@ -418,6 +418,7 @@ export function createReactor(config: ReactorConfig): Reactor {
             stateManager.appendTurn(lastDone.data.turn);
             stateManager.accumUsage(lastDone.data.usage);
             stateManager.setLastCycleUsage(lastDone.data.usage);
+            stateManager.setLastCycleSource(lastDone.data.source);
           }
           cycleInferred = true;
           try {
@@ -438,6 +439,7 @@ export function createReactor(config: ReactorConfig): Reactor {
             type: "inference.done",
             turn: lastDone.data.turn,
             usage: lastDone.data.usage,
+            source: lastDone.data.source,
           });
           return;
         }

--- a/packages/inference/src/state.ts
+++ b/packages/inference/src/state.ts
@@ -8,6 +8,7 @@
 
 import type {
   ConversationTurn,
+  LastCycleSource,
   PendingOperation,
   TokenUsage,
   ReactorState,
@@ -32,6 +33,7 @@ export function createStateManager(
   );
   const tokenUsage: TokenUsage = { ...initialUsage };
   let lastCycleUsage: TokenUsage | null = null;
+  let lastCycleSource: LastCycleSource | null = null;
   let activeGatesSnapshot: GateSnapshot[] = [];
   const activeForks: { forkId: string; mode: "independent" | "child" }[] = [];
 
@@ -61,6 +63,10 @@ export function createStateManager(
 
   function setLastCycleUsage(usage: TokenUsage): void {
     lastCycleUsage = { ...usage };
+  }
+
+  function setLastCycleSource(source: LastCycleSource): void {
+    lastCycleSource = { ...source };
   }
 
   function setGatesSnapshot(gates: GateSnapshot[]): void {
@@ -106,6 +112,7 @@ export function createStateManager(
       activeForks: activeForks.map((f) => ({ ...f })),
       tokenUsage: { ...tokenUsage },
       lastCycleUsage: lastCycleUsage !== null ? { ...lastCycleUsage } : null,
+      lastCycleSource: lastCycleSource !== null ? { ...lastCycleSource } : null,
     };
   }
 
@@ -116,6 +123,7 @@ export function createStateManager(
     removePendingOperation,
     accumUsage,
     setLastCycleUsage,
+    setLastCycleSource,
     setGatesSnapshot,
     addFork,
     removeFork,

--- a/packages/inference/src/transforms/size-cap.test.ts
+++ b/packages/inference/src/transforms/size-cap.test.ts
@@ -23,6 +23,7 @@ function emptyState(): ReactorState {
       thinking: 0,
     },
     lastCycleUsage: null,
+    lastCycleSource: null,
     sessionId: "test-session",
   };
 }

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -606,6 +606,32 @@ export const TokenUsage = type({
 });
 export type TokenUsage = typeof TokenUsage.infer;
 
+/**
+ * Slim source descriptor stamped onto `inference.usage` / `inference.done`
+ * events and onto `ReactorState.lastCycleSource`.
+ *
+ * Carries enough identity for state-aware policies (cost gating, budget
+ * caps, governance triggers, audit) to attribute usage to a specific
+ * inference source without re-reading the live, mutable `InferenceSource`
+ * the harness owns.
+ *
+ * Deliberately a strict subset of `InferenceSource` — `apiKey` and
+ * `baseURL` are intentionally excluded. Credentials and endpoints must
+ * not leak to director-side policy code or to external event consumers.
+ * Any code path that needs the full source obtains it through the
+ * harness's source registry, not through this descriptor.
+ *
+ * `sourceId` aliases `InferenceSource.id` to disambiguate from message
+ * ids, turn ids, and session ids in director-side code where `id` alone
+ * would be ambiguous.
+ */
+export const LastCycleSource = type({
+  sourceId: "string",
+  provider: "string",
+  model: "string",
+});
+export type LastCycleSource = typeof LastCycleSource.infer;
+
 // ---------------------------------------------------------------------------
 // Internal Turn Format (INFERENCE.md § Message Format)
 // ---------------------------------------------------------------------------
@@ -1087,7 +1113,7 @@ export const InferenceEvent = type({
   .or({
     type: "'inference.usage'",
     seq: "number",
-    data: { usage: TokenUsage },
+    data: { usage: TokenUsage, source: LastCycleSource },
   })
   .or({
     type: "'inference.done'",
@@ -1095,6 +1121,7 @@ export const InferenceEvent = type({
     data: {
       turn: AssistantTurn,
       usage: TokenUsage,
+      source: LastCycleSource,
       "pacingDelayMs?": "number",
     },
   })
@@ -1305,12 +1332,17 @@ export type InferenceEvent =
   | {
       type: "inference.usage";
       seq: number;
-      data: { usage: TokenUsage };
+      data: { usage: TokenUsage; source: LastCycleSource };
     }
   | {
       type: "inference.done";
       seq: number;
-      data: { turn: AssistantTurn; usage: TokenUsage; pacingDelayMs?: number };
+      data: {
+        turn: AssistantTurn;
+        usage: TokenUsage;
+        source: LastCycleSource;
+        pacingDelayMs?: number;
+      };
     }
   | {
       type: "inference.error";
@@ -1438,11 +1470,20 @@ export type PendingOperation = {
 /**
  * Complete reactor state visible to the director decision function.
  *
- * `tokenUsage` is the cumulative usage across the session; `lastCycleUsage`
- * is the usage reported by the most recent inference call, or null if no
- * inference call has completed yet. The per-cycle value supports
- * compaction triggers that key off recent input cost rather than session
- * totals.
+ * `tokenUsage` is the cumulative usage across the session.
+ *
+ * `lastCycleUsage` and `lastCycleSource` describe the most recent
+ * *successful* inference call. They move together: both null before the
+ * first completion; every `inference.done` sets both atomically.
+ * `inference.error` does not clear either — the pair always reflects the
+ * last cycle that produced a well-defined turn and usage. The director's
+ * `afterInferenceDone` hook fires only on `inference.done`, so policy
+ * code never observes a torn or stale-vs-fresh window.
+ *
+ * The per-cycle values support compaction triggers that key off recent
+ * input cost rather than session totals, and state-aware policies (cost
+ * gating, budget caps, governance triggers) that need to attribute
+ * usage to the source that produced it.
  *
  * (INFERENCE.md § Agent Reactor › Director Decision Function)
  */
@@ -1453,6 +1494,7 @@ export type ReactorState = {
   activeGates: { gateId: string; type: GateType; timeoutAt: number }[];
   tokenUsage: TokenUsage;
   lastCycleUsage: TokenUsage | null;
+  lastCycleSource: LastCycleSource | null;
   sessionId: string;
 };
 
@@ -1538,7 +1580,12 @@ export type ReactorCapabilities = {
  */
 export type ReactorInboundEvent =
   | { type: "message.received"; message: InboundMessage }
-  | { type: "inference.done"; turn: AssistantTurn; usage: TokenUsage }
+  | {
+      type: "inference.done";
+      turn: AssistantTurn;
+      usage: TokenUsage;
+      source: LastCycleSource;
+    }
   | { type: "inference.error"; error: InferenceError; partial: PartialMessage }
   | { type: "tool.done"; result: ToolResult }
   | {


### PR DESCRIPTION
## Summary

- `DefaultDirector` gains an optional `afterInferenceDone` policy hook on `DefaultDirectorPolicy`. The hook fires after every successful `inference.done`, reads post-cycle state, and returns `continue`, `abort` (terminate the agent), or `halt` (pause this cycle).
- `inference.usage` and `inference.done` event payloads, and `ReactorState.lastCycleSource`, now carry a slim `LastCycleSource = { sourceId, provider, model }` descriptor — derived from `InferenceSource` but deliberately excluding `apiKey`/`baseURL` so credentials never reach director-side policy code or external event consumers.
- The harness snapshots source identity at call start and stamps the descriptor onto every emit. Provider adapters take the snapshot at factory construction. This defends against `setSource` / `applyInferenceSourceFields` firing mid-call: the identity stamped on `inference.done` reflects the source that began the call, not whatever was active at done-time.

## Changes

- `packages/types/src/runtime.ts`: adds `LastCycleSource` (arktype + TS); extends `ReactorState` with `lastCycleSource`; documents the atomic invariant pairing it with `lastCycleUsage`; adds `source: LastCycleSource` to `inference.usage` and `inference.done` arms of `InferenceEvent` (TS union + arktype validator) and to `ReactorInboundEvent.inference.done`.
- `packages/inference/src/harness.ts`: snapshots `{sourceId, provider, model}` into a `lastCycleSource` local at the top of `runInference` and stamps it on every `inference.usage` and `inference.done` emit.
- `packages/inference/src/providers/{anthropic,openai,google-genai}.ts`: factories take `source: LastCycleSource` and close over it; `parseResponse` stamps source on usage emits.
- `packages/inference/src/providers/registry.ts`: `lookupProvider(id, source)` forwards source to the factory.
- `packages/inference/src/reactor.ts`: calls `stateManager.setLastCycleSource(lastDone.data.source)` alongside `setLastCycleUsage`; forwards `source` on the enqueued `ReactorInboundEvent.inference.done`.
- `packages/inference/src/state.ts`: adds `lastCycleSource` to the state manager mirror, with a `setLastCycleSource` setter and inclusion in `snapshot()`.
- `packages/inference/src/default-director.ts`: adds `AfterInferenceDecision` (continue/abort/halt) and `AfterInferenceHook` types; extends `DefaultDirectorPolicy` with `afterInferenceDone?`; invokes the hook at the top of the `inference.done` branch inside try/catch (throws route to `abort` with synthesized reason); stops underscoring `_state`.
- `packages/inference/src/default-director.test.ts`: new file. Twelve tests covering `continue`/`abort`/`halt`/hook-unset/throws/async/firing-boundary (one test per non-`inference.done` event variant)/tool-calls-dropped-on-abort.
- `packages/inference/src/harness.test.ts`: three new tests in a `runInference — source-identity stamping` block, including the hot-swap-mid-call defense.
- Other test files (harness, hub-client, inference-testing, authz-extension, transforms/size-cap, reactor, anthropic adapter): seed the new fields on existing event/state literals.

## Testing

- `make all` green: lint clean, `tsc -b --noEmit` clean, 2295 + 9 tests pass (12 new for the hook, 3 new for source-identity stamping, 4 new for the firing boundary).
- Whole-branch self-review via the `code-review` skill returned no findings (commit-message style, coherence, convention compliance, scope all clean).
- Per-commit critique passes addressed all VERIFIED/HIGH findings; remaining items were informational observations.

Closes INTR-129