### PR TITLE
Install a default stderr sink at @intx/log module load

### DIFF
--- a/packages/log/src/default-sink-routing.test.ts
+++ b/packages/log/src/default-sink-routing.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { getLogger, resetSync, installDefaultConsoleSink } from "./index";
+
+// Locks down two design contracts of the module-load default sink that
+// default-sink.test.ts does not currently exercise:
+//
+//   1. Threshold is "warning" — info/debug must be suppressed; warning,
+//      error, and fatal must be routed.
+//   2. Formatter selection follows NODE_ENV — production yields JSON Lines,
+//      anything else yields ANSI-colored text.
+//
+// Both behaviors are contracts a future refactor could accidentally break
+// (e.g., bumping threshold to "info" or flipping the env heuristic).
+
+/* eslint-disable no-console -- intentional spies on console methods */
+describe("default console sink routing contract", () => {
+  const warnCaptured: string[] = [];
+  const errorCaptured: string[] = [];
+  const infoCaptured: string[] = [];
+  const debugCaptured: string[] = [];
+  let originalWarn: typeof console.warn;
+  let originalError: typeof console.error;
+  let originalInfo: typeof console.info;
+  let originalDebug: typeof console.debug;
+  let originalNodeEnv: string | undefined;
+
+  function joinArgs(args: unknown[]): string {
+    return args.map((a) => String(a)).join(" ");
+  }
+
+  beforeEach(() => {
+    warnCaptured.length = 0;
+    errorCaptured.length = 0;
+    infoCaptured.length = 0;
+    debugCaptured.length = 0;
+    originalWarn = console.warn;
+    originalError = console.error;
+    originalInfo = console.info;
+    originalDebug = console.debug;
+    console.warn = (...args: unknown[]) => {
+      warnCaptured.push(joinArgs(args));
+    };
+    console.error = (...args: unknown[]) => {
+      errorCaptured.push(joinArgs(args));
+    };
+    console.info = (...args: unknown[]) => {
+      infoCaptured.push(joinArgs(args));
+    };
+    console.debug = (...args: unknown[]) => {
+      debugCaptured.push(joinArgs(args));
+    };
+    originalNodeEnv = process.env["NODE_ENV"];
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+    console.error = originalError;
+    console.info = originalInfo;
+    console.debug = originalDebug;
+    if (originalNodeEnv === undefined) delete process.env["NODE_ENV"];
+    else process.env["NODE_ENV"] = originalNodeEnv;
+  });
+
+  test("info is suppressed (threshold is warning)", () => {
+    resetSync();
+    installDefaultConsoleSink();
+    getLogger(["probe"]).info`info-msg`;
+    expect(infoCaptured.some((w) => w.includes("info-msg"))).toBe(false);
+    expect(warnCaptured.some((w) => w.includes("info-msg"))).toBe(false);
+  });
+
+  test("debug is suppressed (threshold is warning)", () => {
+    resetSync();
+    installDefaultConsoleSink();
+    getLogger(["probe"]).debug`debug-msg`;
+    expect(debugCaptured.some((w) => w.includes("debug-msg"))).toBe(false);
+    expect(warnCaptured.some((w) => w.includes("debug-msg"))).toBe(false);
+  });
+
+  test("error is routed to console.error", () => {
+    resetSync();
+    installDefaultConsoleSink();
+    getLogger(["probe"]).error`error-msg`;
+    expect(errorCaptured.some((w) => w.includes("error-msg"))).toBe(true);
+  });
+
+  test("fatal is routed to console.error", () => {
+    resetSync();
+    installDefaultConsoleSink();
+    getLogger(["probe"]).fatal`fatal-msg`;
+    expect(errorCaptured.some((w) => w.includes("fatal-msg"))).toBe(true);
+  });
+
+  test("NODE_ENV=production yields JSON Lines output", () => {
+    process.env["NODE_ENV"] = "production";
+    resetSync();
+    installDefaultConsoleSink();
+    getLogger(["probe"]).warn`hello-prod`;
+    const joined = warnCaptured.join("");
+    expect(joined).toContain("hello-prod");
+    expect(joined.includes("\x1b[")).toBe(false);
+    expect(() => JSON.parse(joined.trim())).not.toThrow();
+  });
+
+  test("non-production NODE_ENV yields ANSI-colored text output", () => {
+    process.env["NODE_ENV"] = "development";
+    resetSync();
+    installDefaultConsoleSink();
+    getLogger(["probe"]).warn`hello-dev`;
+    const joined = warnCaptured.join("");
+    expect(joined).toContain("hello-dev");
+    expect(joined.includes("\x1b[")).toBe(true);
+  });
+});
+/* eslint-enable no-console */

--- a/packages/log/src/default-sink.test.ts
+++ b/packages/log/src/default-sink.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  getConfig,
+  getLogger,
+  resetSync,
+  installDefaultConsoleSink,
+  setup,
+} from "./index";
+
+// Snapshot taken at test-file load, before any beforeEach hooks run. This is
+// the only point at which we can observe the side effect at the bottom of
+// `default-sink.ts` directly; the hooks below reset and reinstall manually
+// for the per-test scenarios.
+//
+// Order-sensitive: any future test file in this directory that calls
+// `resetSync()` at top level *before* this file imports will null this
+// snapshot. The "importing the module installs a config" test below would
+// then throw with a misleading error pointing at this file rather than the
+// real cause.
+const moduleLoadConfig = getConfig();
+
+describe("default console sink", () => {
+  const warnCaptured: string[] = [];
+  /* eslint-disable no-console -- intentional spy on console.warn */
+  let originalWarn: typeof console.warn;
+
+  beforeEach(() => {
+    warnCaptured.length = 0;
+    originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnCaptured.push(args.map((a) => String(a)).join(" "));
+    };
+
+    resetSync();
+    installDefaultConsoleSink();
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+  });
+  /* eslint-enable no-console */
+
+  test("importing the module installs a config with the default sink", () => {
+    if (!moduleLoadConfig) {
+      throw new Error(
+        "default-sink module-load side effect did not populate getConfig()",
+      );
+    }
+    expect(Object.keys(moduleLoadConfig.sinks)).toEqual(["default"]);
+  });
+
+  test("warn lands on console.warn through the default sink", () => {
+    getLogger(["test-default-sink-probe"]).warn`probe`;
+    expect(warnCaptured.some((w) => w.includes("probe"))).toBe(true);
+  });
+
+  test("setup() replaces the default sink and routes warns through the new sink", async () => {
+    const before = getConfig();
+    if (!before) {
+      throw new Error("default sink installer left getConfig() null");
+    }
+    expect(Object.keys(before.sinks)).toEqual(["default"]);
+
+    await setup();
+
+    const after = getConfig();
+    if (!after) {
+      throw new Error("setup() left getConfig() null");
+    }
+    expect(Object.keys(after.sinks)).toEqual(["console"]);
+
+    warnCaptured.length = 0;
+    getLogger(["test-default-sink-probe"]).warn`post-setup-probe`;
+    expect(warnCaptured.some((w) => w.includes("post-setup-probe"))).toBe(true);
+  });
+
+  test("installDefaultConsoleSink is idempotent when a config is present", () => {
+    const before = getConfig();
+    installDefaultConsoleSink();
+    expect(getConfig()).toBe(before);
+  });
+});

--- a/packages/log/src/default-sink.ts
+++ b/packages/log/src/default-sink.ts
@@ -1,0 +1,61 @@
+import {
+  configureSync,
+  getConfig,
+  getConsoleSink,
+  ansiColorFormatter,
+  getJsonLinesFormatter,
+  type TextFormatter,
+} from "@logtape/logtape";
+
+/**
+ * Installs a default console sink when no LogTape configuration is present.
+ *
+ * Without this, a consumer that imports `getLogger` and emits diagnostics
+ * before calling `setup()` will silently discard those records. The default
+ * sink routes through `console.warn`/`console.error`, which lands on stderr
+ * in Node and Bun and on the devtools console in browsers, until `setup()`
+ * replaces the configuration.
+ *
+ * Formatter selection follows the same dev/prod heuristic as `setup()`,
+ * but only reads `process.env["NODE_ENV"]`; the caller-facing `dev`/`prod`
+ * options on `setup()` cannot influence this default because no options are
+ * passed at module load.
+ *
+ * This is normally invoked once at module load (see the bottom of this
+ * file). It is also exported so tests can reinstall the default sink after
+ * a `resetSync()`. Every entry point in `package.json` must side-effect
+ * import this module (see `./index.ts` and `./hono.ts`); a new entry point
+ * that skips that import silently regresses to the pre-default-sink
+ * behavior.
+ *
+ * Idempotent: returns immediately if a configuration is already installed.
+ */
+export function installDefaultConsoleSink(): void {
+  if (getConfig() !== null) return;
+
+  const isDev = process.env["NODE_ENV"] !== "production";
+  const formatter: TextFormatter = isDev
+    ? ansiColorFormatter
+    : getJsonLinesFormatter();
+
+  configureSync({
+    sinks: { default: getConsoleSink({ formatter }) },
+    loggers: [
+      {
+        category: ["logtape", "meta"],
+        lowestLevel: "warning",
+        sinks: ["default"],
+      },
+      {
+        category: [],
+        lowestLevel: "warning",
+        sinks: ["default"],
+      },
+    ],
+  });
+}
+
+// Module-load entry: every side-effect import of this file installs the
+// default sink. The export above is for tests that need to reinstall after
+// `resetSync()`.
+installDefaultConsoleSink();

--- a/packages/log/src/hono.ts
+++ b/packages/log/src/hono.ts
@@ -1,3 +1,7 @@
+// Install the default console sink so consumers that import only
+// @intx/log/hono still get diagnostics before they call setup().
+import "./default-sink";
+
 // Re-export Hono middleware from @logtape/hono
 export {
   honoLogger,

--- a/packages/log/src/index.ts
+++ b/packages/log/src/index.ts
@@ -1,3 +1,6 @@
+// Install the default console sink before any caller can get a logger.
+import "./default-sink";
+
 // Re-export core LogTape functionality
 export {
   // Logger creation and usage
@@ -75,3 +78,7 @@ export {
 
 // Re-export our setup helper
 export { setup, type SetupOptions } from "./setup";
+
+// Re-export the default sink installer for tests that need to reinstall
+// after `resetSync()`.
+export { installDefaultConsoleSink } from "./default-sink";

--- a/packages/log/src/setup.ts
+++ b/packages/log/src/setup.ts
@@ -38,6 +38,12 @@ type LoggerConfigEntry = {
  * - Production: JSON Lines console output, info level
  *
  * Call this once at application startup (app entry point, CLI script).
+ *
+ * `setup()` passes `reset: true` to LogTape's `configure()`, so each call
+ * unconditionally replaces the current configuration — including the
+ * module-load default console sink and any prior `setup()` call. A second
+ * invocation with different options silently wins rather than erroring;
+ * callers that need to detect double-configuration must guard externally.
  */
 export async function setup(options: SetupOptions = {}): Promise<void> {
   const isDev =
@@ -69,6 +75,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   }
 
   await configure({
+    reset: true,
     sinks: {
       console: getConsoleSink({
         formatter: isDev ? ansiColorFormatter : getJsonLinesFormatter(),


### PR DESCRIPTION
## Summary

- `@intx/log` now installs a default sync console sink at module load when no LogTape config is present, so diagnostics emitted before `setup()` is called no longer silently disappear.
- `setup()` passes `reset: true` so its `configure()` cleanly replaces the default — and any prior `setup()` call — without throwing.
- Both `@intx/log` and `@intx/log/hono` entry points side-effect-import the installer so consumers of either get the default behavior.

## Changes

- `packages/log/src/default-sink.ts`: new module. `installDefaultConsoleSink()` returns early when a config already exists; otherwise registers `getConsoleSink({ formatter })` with `ansiColorFormatter` (non-production) or `getJsonLinesFormatter()` (production), threshold `warning`. Called at module load.
- `packages/log/src/index.ts`: side-effect import of `./default-sink` at the top; re-exports `installDefaultConsoleSink` for tests that need to reinstall after `resetSync()`.
- `packages/log/src/hono.ts`: side-effect import of `./default-sink` so the `/hono` entry point installs the default too.
- `packages/log/src/setup.ts`: pass `reset: true` to `configure()`; document the re-entry semantics in the JSDoc.
- `packages/log/src/default-sink.test.ts`: new tests — module-load capture, pre-setup routing, sink-swap on `setup()` with post-setup routing assertion, idempotency.
- `packages/log/src/default-sink-routing.test.ts`: new tests pinning the `warning` threshold and the `NODE_ENV`-driven formatter selection.

## Implementation notes

The issue's pseudocode suggested `getStreamSink({ stream: process.stderr, formatter })`, but LogTape 2.x's `getStreamSink` requires a Web `WritableStream` and returns an `AsyncDisposable` that `configureSync` rejects. `getConsoleSink` is sync, takes the same formatters, and routes through `console.warn`/`console.error` — which lands on stderr in Node and Bun and on the devtools console in browsers. Same default destination in every runtime, no `process.stderr` dependency.

## Testing

- [x] `make all` passes.
- [x] 10 new tests in `packages/log/src/` covering install, swap, idempotency, threshold, formatter selection.

Closes INTR-91