### PR TITLE
Pluggable mechanical retry policy for runInference

### DIFF
--- a/docs/INFERENCE.md
+++ b/docs/INFERENCE.md
@@ -70,6 +70,10 @@ The harness is the shared infrastructure that all provider adapters build on:
 
 Provider adapters never touch SSE parsing, connection lifecycle, abort handling, or event emission. They translate request/response shapes. The harness does everything else.
 
+`runInference` wraps each call in a retry layer that buffers an attempt's events until the attempt terminates with `inference.done` or `inference.error`. On `inference.error` the wrapper consults a `RetryPolicy` (see §Retry Behavior); on a retry decision the wrapper discards the failed attempt's buffered events, emits one `inference.retry` event between attempts, and re-issues the underlying HTTP request after the policy-chosen delay. On `inference.done` or an abort decision the buffered events flush to the caller in order. The buffer is per-call and bounded by the size of one attempt's event stream.
+
+The buffer-and-flush model guarantees the caller sees a single clean event stream — exactly one `inference.start`, no orphaned partial deltas, no leaked `inference.error`s from attempts the policy chose to retry. The cost is that no events reach the caller until the wrapper knows the attempt's terminal shape: a consumer that uses `for await ... break` to abandon a call mid-stream will not observe partial deltas because the wrapper holds them in the buffer until commit. Consumers that need token-by-token partials must pin a custom non-buffering wrapper at the inference layer — no streaming-partials emission API exists today.
+
 ## Event Protocol
 
 All inference activity — streaming tokens, tool execution, reactor state changes — emits events on a single protocol. This protocol is what session channel subscribers receive. There is no internal event format.
@@ -87,6 +91,7 @@ inference.tool_call.end   — Tool call complete (full args)
 inference.usage           — Token accounting for this call (fires before inference.done)
 inference.done            — Model call completed normally (carries final message and usage summary)
 inference.error           — Model call failed (carries error classification and partial message)
+inference.retry           — Retry-policy decision between attempts (carries failed attempt #, chosen delayMs, previous error)
 
 tool.start                — Tool execution begins
 tool.update               — Partial tool output (streaming tools)
@@ -780,7 +785,21 @@ The classifier inspects HTTP status codes, error response bodies, and provider-s
 
 ### Retry Behavior
 
-Retryable errors use exponential backoff: `baseDelay * 2^attempt`. The director controls maximum attempts and total budget. Failed attempts are removed from the message history before retrying — the model should not see its own error responses.
+Mechanical retry of a transient failure (the same HTTP call re-issued with the identical body) lives in the inference layer's `runInference` wrapper, not in the director. The wrapper consults a per-call `RetryPolicy` on every `inference.error`; the director sees an error only after the policy has decided the call is not worth re-issuing. This keeps the boundary clear: the inference layer handles transport flakes (TCP resets, 5xx, rate-limit jitter, half-streamed connection drops); the agent layer handles semantic recovery (continuation prompts, role-specific escalation, model swaps).
+
+`InferenceOptions.retryPolicy?: RetryPolicy` overrides the default; when omitted the harness applies `createDefaultRetryPolicy()`. The policy receives a `RetrySituation` carrying the classified `InferenceError`, a 1-indexed attempt counter (the first failure has `attempt: 1`), and `elapsedMs` measured from the first attempt against the harness `Scheduler`. The policy returns `{ kind: "abort" }` to surface the error or `{ kind: "retry", delayMs }` to re-issue after waiting `delayMs`. Async policies are supported.
+
+The default policy's per-category behaviour:
+
+- **`credential_failure`, `context_overflow`, `fatal`, `aborted`, `protocol_mismatch`** — always abort. These categories describe a deterministic per-call failure that re-issuing the identical request cannot resolve.
+- **`retryable`, `timeout`** — up to 3 attempts total. 500 ms before attempt 2, then 1000 ms before attempt 3, then abort.
+- **`quota_exhausted`** — up to 3 attempts total. The delay is taken from the error's `retryAfterMs` when the provider returned one (the server told us when it would be ready); otherwise a flat 1000 ms baseline that does not grow across retries.
+
+The retry delay is awaited against `Dependencies.scheduler.setTimeout`; the caller-supplied `signal` short-circuits the delay so an abort during the wait wakes the wrapper immediately and the next attempt surfaces `inference.error` of category `"aborted"` from its entry-time signal check. Virtual-clock test harnesses advance the delay without sleeping real wall-clock.
+
+Between attempts the wrapper emits one `inference.retry` event carrying the failed attempt's number, the policy-chosen `delayMs`, and the classified error. Consumers that want telemetry on retry frequency or tuning data subscribe to this event; consumers that do not care can ignore it.
+
+If a custom policy throws synchronously or its returned Promise rejects, the wrapper treats the failure as `{ kind: "abort" }` and surfaces the original `inference.error` to the caller. The policy's own exception is logged at `warn` (so a misbehaving custom policy is not invisible) and dropped — the inference error is what the caller needs to act on, not the bug in the policy callback.
 
 ## Per-Call Timeouts
 

--- a/packages/inference-testing/src/harness.test.ts
+++ b/packages/inference-testing/src/harness.test.ts
@@ -146,7 +146,10 @@ describe("setupHarness", () => {
   test("assertDeps throws when [HarnessId] is missing entirely", () => {
     const a = setupHarness();
     try {
-      const untagged: Dependencies = { fetch: a.deps.fetch };
+      const untagged: Dependencies = {
+        fetch: a.deps.fetch,
+        scheduler: a.deps.scheduler,
+      };
       let caught: unknown;
       try {
         a.assertDeps(untagged);

--- a/packages/inference-testing/src/harness.ts
+++ b/packages/inference-testing/src/harness.ts
@@ -819,8 +819,18 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
   const noopCanceller = (): void => {
     /* no scheduled work to cancel */
   };
+  // The inert scheduler intentionally exposes an asymmetric pair:
+  // `setTimeout` is a no-op (production timers are suppressed when
+  // `enableInferenceTimers` is left at its default `false`), but
+  // `now()` still reflects the virtual clock. A test that doesn't
+  // exercise inference timers may still advance the clock for other
+  // purposes; reading wall-clock or a frozen `0` here would silently
+  // diverge `now()` from the test's authoritative time source. The
+  // asymmetry is deliberate — every test gets a coherent time
+  // reading even when it has opted out of production-timer firing.
   const inertScheduler: Scheduler = {
     setTimeout: () => noopCanceller,
+    now: () => clock.now(),
   };
   const scheduler: Scheduler =
     opts.enableInferenceTimers === true
@@ -835,6 +845,7 @@ export function setupHarness(opts: SetupHarnessOpts = {}): Harness {
               cancelled = true;
             };
           },
+          now: () => clock.now(),
         }
       : inertScheduler;
 

--- a/packages/inference-testing/src/session-recording.ts
+++ b/packages/inference-testing/src/session-recording.ts
@@ -436,6 +436,9 @@ export function createRecordingHarness(
           clearTimeout(handle);
         };
       },
+      // Recording runs against real providers on the wall clock; the
+      // monotonic source matches the `setTimeout` domain above.
+      now: () => performance.now(),
     },
     [HarnessId]: harnessSymbol,
   };

--- a/packages/inference-testing/src/session-recording.ts
+++ b/packages/inference-testing/src/session-recording.ts
@@ -423,9 +423,7 @@ export function createRecordingHarness(
 
   // Production scheduler — recording drives real fetch on the real
   // wall clock, so production `runInference` timers should fire
-  // normally. (The default scheduler created by `runInference` when
-  // `deps.scheduler` is omitted would work too, but providing it
-  // explicitly here keeps the dependency surface visible.)
+  // normally.
   const harnessSymbol = Symbol("RecordingHarnessInstance");
   const deps: Dependencies = {
     fetch: recordingFetch,

--- a/packages/inference-testing/src/session-replay.ts
+++ b/packages/inference-testing/src/session-replay.ts
@@ -579,6 +579,14 @@ export async function createReplayHarness(
         source,
         nextSeq,
         signal: inferenceController.signal,
+        // Replay is deterministic: every captured exchange has a
+        // one-to-one matcher, and a fetch that fails to bind has no
+        // semantically-meaningful "retry the same prompt" outcome —
+        // the next attempt would just hit the same bound-or-unbound
+        // result. Pin an abort-only policy so the inert scheduler
+        // does not deadlock the wrapper on the retry-delay setTimeout
+        // when an unmatched-fetch error surfaces through the harness.
+        inferenceOptions: { retryPolicy: () => ({ kind: "abort" }) },
       })) {
         events.push(ev);
       }

--- a/packages/inference/src/harness.test.ts
+++ b/packages/inference/src/harness.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "bun:test";
 
 import {
   createDefaultDependencies,
+  createDefaultScheduler,
   HarnessId,
   runInference,
   type Dependencies,
@@ -69,6 +70,7 @@ describe("runInference — Dependencies parameter", () => {
           }),
         );
       },
+      scheduler: createDefaultScheduler(),
     };
 
     const originalFetch = globalThis.fetch;
@@ -110,6 +112,7 @@ describe("runInference — Dependencies parameter", () => {
   test("propagates errors from deps.fetch without falling back to globalThis.fetch", async () => {
     const deps: Dependencies = {
       fetch: () => Promise.reject(new Error("simulated network failure")),
+      scheduler: createDefaultScheduler(),
     };
 
     const originalFetch = globalThis.fetch;
@@ -304,6 +307,7 @@ describe("runInference — source.defaults merge precedence", () => {
           }),
         );
       },
+      scheduler: createDefaultScheduler(),
     };
     let seq = 0;
     await collect(
@@ -404,6 +408,7 @@ describe("runInference — providerOptions merge precedence", () => {
             headers: { "content-type": "text/event-stream" },
           }),
         ),
+      scheduler: createDefaultScheduler(),
     };
 
     let seq = 0;
@@ -459,6 +464,7 @@ describe("Dependencies — reflective exposure of HarnessId", () => {
   function stampedDeps(): Dependencies {
     return {
       fetch: () => Promise.resolve(new Response("")),
+      scheduler: createDefaultScheduler(),
       [HarnessId]: Symbol("test-harness"),
     };
   }
@@ -509,6 +515,7 @@ describe("runInference — source-identity stamping", () => {
             headers: { "content-type": "text/event-stream" },
           }),
         ),
+      scheduler: createDefaultScheduler(),
     };
     let seq = 0;
     const events = await collect(
@@ -552,6 +559,7 @@ describe("runInference — source-identity stamping", () => {
             headers: { "content-type": "text/event-stream" },
           }),
         ),
+      scheduler: createDefaultScheduler(),
     };
 
     let seq = 0;
@@ -623,6 +631,7 @@ describe("runInference — source-identity stamping", () => {
           }),
         );
       },
+      scheduler: createDefaultScheduler(),
     };
 
     let seq = 0;

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -99,10 +99,14 @@ export type Dependencies = {
  * Minimal scheduling abstraction. `setTimeout` returns a canceller; the
  * canceller is idempotent (multiple calls are safe). The harness uses
  * this for both the inactivity timer (which is re-armed on every event)
- * and the total wall-clock cap.
+ * and the total wall-clock cap. `now()` is a monotonic time source in
+ * the same `delayMs` units `setTimeout` accepts — deltas across two
+ * `now()` reads describe elapsed time the same way `setTimeout(...,
+ * delta)` would have measured it.
  */
 export type Scheduler = {
   setTimeout(callback: () => void, delayMs: number): () => void;
+  now(): number;
 };
 
 export function createDefaultScheduler(): Scheduler {
@@ -112,6 +116,14 @@ export function createDefaultScheduler(): Scheduler {
       return () => {
         clearTimeout(handle);
       };
+    },
+    // `performance.now()` is monotonic and survives wall-clock
+    // adjustments (NTP, daylight-saving) that could otherwise make a
+    // long-running interval read as negative against `Date.now()`. The
+    // epoch differs from `Date.now()`, but consumers only ever read
+    // deltas across two `now()` calls from the same Scheduler instance.
+    now() {
+      return performance.now();
     },
   };
 }

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -33,6 +33,8 @@ import type {
   ContentBlock,
 } from "@intx/types/runtime";
 
+import { getLogger } from "@intx/log";
+
 import { parseSSE } from "./sse";
 import { lookupProvider } from "./providers/registry";
 import { injectCredentials } from "./auth";
@@ -45,6 +47,8 @@ import {
   ProtocolMismatchError,
 } from "./errors";
 import { createDefaultRetryPolicy } from "./retry-policy";
+
+const logger = getLogger(["interchange", "inference", "harness"]);
 
 /**
  * Default per-call inactivity timeout (ms). Two minutes is conservative
@@ -1169,9 +1173,9 @@ async function* runSingleAttempt(
  * reach the caller until the wrapper knows the attempt's terminal
  * shape, even on a successful first attempt. That trade-off is the
  * deliberate consequence of making "one clean stream" a hard contract
- * rather than a best-effort one; consumers that need token-by-token
- * partials should subscribe further down the agent layer's emission
- * chain rather than to `runInference` directly.
+ * rather than a best-effort one. Consumers that need token-by-token
+ * partials must pin a custom non-buffering wrapper — no streaming-
+ * partials emission API exists today.
  *
  * The buffer is per-call and bounded by the size of one attempt's
  * event stream — no cross-call accumulation.
@@ -1186,26 +1190,28 @@ async function* runSingleAttempt(
  * the failed attempt's number, the policy-chosen `delayMs`, and the
  * classified error that triggered the retry. The `setTimeout` await
  * is driven by `deps.scheduler`, so virtual-clock test harnesses
- * advance retry delays without sleeping real wall-clock.
+ * advance retry delays without sleeping real wall-clock. The
+ * caller-supplied `signal` short-circuits the retry delay: aborting
+ * the signal mid-delay wakes the await immediately and the next
+ * `runSingleAttempt` invocation surfaces `inference.error` of
+ * category `aborted` from its entry-time signal check, which the
+ * default policy aborts on.
  *
  * Policy-failure handling: if the policy throws synchronously or its
  * returned Promise rejects, the wrapper treats the failure as
  * `{ kind: "abort" }` and surfaces the *original* `inference.error`
- * to the caller. The policy's own exception is dropped — the
- * inference error is what the caller needs to act on.
- *
- * `signal`-driven abort during a retry delay surfaces on the next
- * attempt: the awaited `setTimeout` resolves, `runSingleAttempt`
- * checks `signal.aborted` at entry, and emits an `inference.error`
- * of category `aborted`. The default policy aborts on `aborted`, so
- * the caller sees the abort error and the wrapper returns.
+ * to the caller. The policy's own exception is logged at `warn` so
+ * operators can see when a custom policy is failing under load, and
+ * dropped — the inference error is what the caller needs to act on,
+ * not the bug in the policy callback.
  *
  * Synchronous throws from `runSingleAttempt` (`ProtocolMismatchError`
  * raised by the streaming parse or the finalization walk, etc.)
- * propagate untouched out of `runInference`. Those represent protocol
- * bugs the policy mechanism is not equipped to absorb — the caller's
- * `for await` rejects so the failure surfaces rather than being
- * silently buffered.
+ * propagate out of `runInference`. The current attempt's buffered
+ * events are discarded along with the throw — those represent
+ * protocol bugs the policy mechanism is not equipped to absorb, and
+ * the caller's `for await` rejects so the failure surfaces rather
+ * than being silently buffered.
  */
 export async function* runInference(
   opts: InferenceHarnessOptions,
@@ -1223,14 +1229,22 @@ export async function* runInference(
     );
   }
   if (typeof opts.deps.scheduler?.now !== "function") {
+    const schedulerType = typeof opts.deps.scheduler;
+    const detail =
+      schedulerType === "object"
+        ? "scheduler is missing the now() method"
+        : `got ${schedulerType}`;
     throw new Error(
-      `runInference: deps.scheduler must implement now() (got ${typeof opts.deps.scheduler}); pass createDefaultDependencies() or a test harness Dependencies object`,
+      `runInference: deps.scheduler must implement now() (${detail}); pass createDefaultDependencies() or a test harness Dependencies object`,
     );
   }
   const policy =
     opts.inferenceOptions?.retryPolicy ?? createDefaultRetryPolicy();
+  // The guards above proved `opts.deps.scheduler` is well-formed; the
+  // rest of the wrapper reads it directly without the `?.` ceremony.
   const scheduler = opts.deps.scheduler;
   const startedAtMs = scheduler.now();
+  const signal = opts.signal;
 
   for (let attempt = 1; ; attempt++) {
     const buffered: InferenceEvent[] = [];
@@ -1269,7 +1283,10 @@ export async function* runInference(
 
     // Consult the policy. Sync throws and Promise rejections both
     // resolve to an abort decision; the original inference.error
-    // surfaces to the caller, not the policy's exception.
+    // surfaces to the caller, not the policy's exception. The
+    // exception is logged at warn so a custom policy that
+    // misbehaves under load is not invisible — swallowing the
+    // failure silently would hide the bug from operators.
     let decision: RetryDecision;
     try {
       decision = await Promise.resolve(
@@ -1279,7 +1296,8 @@ export async function* runInference(
           elapsedMs: scheduler.now() - startedAtMs,
         }),
       );
-    } catch {
+    } catch (cause) {
+      logger.warn`Retry policy threw at attempt ${String(attempt)}; treating as abort. error=${cause instanceof Error ? cause.message : String(cause)}`;
       decision = { kind: "abort" };
     }
 
@@ -1304,10 +1322,40 @@ export async function* runInference(
     };
 
     const retryDelayMs = decision.delayMs;
+    // Wire the caller-supplied signal into the delay so an abort
+    // during the wait short-circuits to the next attempt within a
+    // single virtual tick rather than blocking until the full
+    // `retryDelayMs` elapses. A 60-second `retryAfterMs` on a quota
+    // error would otherwise pin the wrapper for the full minute
+    // before honouring cancellation. The shape is the standard one
+    // for racing a scheduled timeout against an abort listener: a
+    // single `settled` flag plus a `settle()` helper that cancels
+    // whichever side did not fire and removes the listener so the
+    // caller signal does not accumulate one stale entry per call.
     await new Promise<void>((resolve) => {
-      scheduler.setTimeout(() => {
+      let settled = false;
+      const settle = (): void => {
+        if (settled) return;
+        settled = true;
+        cancelTimer();
+        if (signal !== undefined) {
+          signal.removeEventListener("abort", onAbort);
+        }
         resolve();
+      };
+      const onAbort = (): void => {
+        settle();
+      };
+      const cancelTimer = scheduler.setTimeout(() => {
+        settle();
       }, retryDelayMs);
+      if (signal !== undefined) {
+        if (signal.aborted) {
+          settle();
+        } else {
+          signal.addEventListener("abort", onAbort, { once: true });
+        }
+      }
     });
   }
 }

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -88,10 +88,11 @@ export type Dependencies = {
    * passes the default wrapper around `setTimeout` / `clearTimeout`; the
    * deterministic test harness injects a scheduler that wraps its virtual
    * clock so timeout tests fire at virtual-time-N without sleeping real
-   * wall-clock. Optional for backward compatibility — when omitted the
-   * harness substitutes the production default.
+   * wall-clock. Required — every caller must make an explicit choice
+   * between the production scheduler and a virtual one. Use
+   * `createDefaultScheduler()` for the production default.
    */
-  readonly scheduler?: Scheduler;
+  readonly scheduler: Scheduler;
   readonly [HarnessId]?: symbol;
 };
 
@@ -295,7 +296,7 @@ export async function* runInference(
     effectiveOptions.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
   const totalTimeoutMs =
     effectiveOptions.totalTimeoutMs ?? DEFAULT_TOTAL_TIMEOUT_MS;
-  const scheduler = deps.scheduler ?? createDefaultScheduler();
+  const scheduler = deps.scheduler;
   const timeoutAbort = new AbortController();
   let timeoutReason: "inactivity" | "total" | null = null;
   let cancelInactivity: (() => void) | null = null;

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -21,11 +21,13 @@ import type {
   CodeExecutionResultBlock,
   ConversationTurn,
   ImageBlock,
+  InferenceError,
   InferenceEvent,
   InferenceOptions,
   InferenceSource,
   LastCycleSource,
   PartialMessage,
+  RetryDecision,
   TokenUsage,
   AssistantTurn,
   ContentBlock,
@@ -42,6 +44,7 @@ import {
   classifyTimeoutError,
   ProtocolMismatchError,
 } from "./errors";
+import { createDefaultRetryPolicy } from "./retry-policy";
 
 /**
  * Default per-call inactivity timeout (ms). Two minutes is conservative
@@ -146,7 +149,17 @@ export type InferenceHarnessOptions = {
   deps: Dependencies;
 };
 
-export async function* runInference(
+/**
+ * Run one fetch lifecycle and yield its events. Ends on the first
+ * `inference.error` or `inference.done`. The outer `runInference`
+ * consumes this generator, decides retry vs flush per the configured
+ * `RetryPolicy`, and either flushes the buffered events to the caller
+ * or discards them and re-enters this generator with the same opts.
+ *
+ * Not exported — the wrapper is the public entry point; calling this
+ * directly would bypass retry handling.
+ */
+async function* runSingleAttempt(
   opts: InferenceHarnessOptions,
 ): AsyncIterable<InferenceEvent> {
   const { turns, source, inferenceOptions, signal, nextSeq, deps } = opts;
@@ -183,17 +196,6 @@ export async function* runInference(
     provider: source.provider,
     model,
   };
-
-  // Defensive guard for callers that bypass the type system (JS, `any`,
-  // unchecked casts). Missing or malformed `deps.fetch` is a programmer
-  // bug — surface it as an unhandled throw before any `yield`, so it does
-  // not get caught by the network try/catch below and misclassified as a
-  // retryable transport failure that callers might paper over with retries.
-  if (typeof deps?.fetch !== "function") {
-    throw new Error(
-      `runInference: deps.fetch must be a function (got ${typeof deps?.fetch}); pass createDefaultDependencies() or a test harness Dependencies object`,
-    );
-  }
 
   // Emit inference.start immediately.
   yield { type: "inference.start", seq: nextSeq(), data: { model } };
@@ -1148,6 +1150,165 @@ export async function* runInference(
     // finally). Both cleanups are idempotent.
     cleanupTimers();
     cleanupSignal();
+  }
+}
+
+/**
+ * Run a single inference call with mechanical retry. Wraps
+ * `runSingleAttempt` and consults the configured `RetryPolicy` (or the
+ * default from `createDefaultRetryPolicy`) on every `inference.error`.
+ *
+ * Events from each attempt are buffered until the attempt terminates;
+ * the wrapper only flushes them to the caller once it knows whether
+ * the attempt resolved (`inference.done` or a policy-approved abort)
+ * or whether the attempt's events should be discarded in favour of a
+ * retry. The buffer-and-flush model is what guarantees the caller
+ * sees a single clean event stream — exactly one `inference.start`,
+ * no orphaned partial deltas, no leaked `inference.error`s from
+ * attempts the policy chose to retry. The cost is that no events
+ * reach the caller until the wrapper knows the attempt's terminal
+ * shape, even on a successful first attempt. That trade-off is the
+ * deliberate consequence of making "one clean stream" a hard contract
+ * rather than a best-effort one; consumers that need token-by-token
+ * partials should subscribe further down the agent layer's emission
+ * chain rather than to `runInference` directly.
+ *
+ * The buffer is per-call and bounded by the size of one attempt's
+ * event stream — no cross-call accumulation.
+ *
+ * Caller-visible seqs stay contiguous across retries. Each attempt
+ * runs against a private seq allocator; on flush the wrapper
+ * re-stamps the buffered events with seqs from the caller's
+ * `nextSeq`, so a retry that discards an attempt does not leave a
+ * gap in the consumer's seq stream.
+ *
+ * Between attempts the wrapper emits one `inference.retry` event with
+ * the failed attempt's number, the policy-chosen `delayMs`, and the
+ * classified error that triggered the retry. The `setTimeout` await
+ * is driven by `deps.scheduler`, so virtual-clock test harnesses
+ * advance retry delays without sleeping real wall-clock.
+ *
+ * Policy-failure handling: if the policy throws synchronously or its
+ * returned Promise rejects, the wrapper treats the failure as
+ * `{ kind: "abort" }` and surfaces the *original* `inference.error`
+ * to the caller. The policy's own exception is dropped — the
+ * inference error is what the caller needs to act on.
+ *
+ * `signal`-driven abort during a retry delay surfaces on the next
+ * attempt: the awaited `setTimeout` resolves, `runSingleAttempt`
+ * checks `signal.aborted` at entry, and emits an `inference.error`
+ * of category `aborted`. The default policy aborts on `aborted`, so
+ * the caller sees the abort error and the wrapper returns.
+ *
+ * Synchronous throws from `runSingleAttempt` (`ProtocolMismatchError`
+ * raised by the streaming parse or the finalization walk, etc.)
+ * propagate untouched out of `runInference`. Those represent protocol
+ * bugs the policy mechanism is not equipped to absorb — the caller's
+ * `for await` rejects so the failure surfaces rather than being
+ * silently buffered.
+ */
+export async function* runInference(
+  opts: InferenceHarnessOptions,
+): AsyncIterable<InferenceEvent> {
+  // Crash-loudly guards. The wrapper accesses both `deps.fetch`
+  // (passed into each `runSingleAttempt` invocation) and
+  // `deps.scheduler` (read here for the monotonic time source) before
+  // any event yields. A malformed `deps` from a JS caller would
+  // otherwise surface as a confusing `Cannot read properties of
+  // undefined`. The wrapper is the single public entrypoint to the
+  // harness; this is the right layer to own the `deps` shape check.
+  if (typeof opts.deps?.fetch !== "function") {
+    throw new Error(
+      `runInference: deps.fetch must be a function (got ${typeof opts.deps?.fetch}); pass createDefaultDependencies() or a test harness Dependencies object`,
+    );
+  }
+  if (typeof opts.deps.scheduler?.now !== "function") {
+    throw new Error(
+      `runInference: deps.scheduler must implement now() (got ${typeof opts.deps.scheduler}); pass createDefaultDependencies() or a test harness Dependencies object`,
+    );
+  }
+  const policy =
+    opts.inferenceOptions?.retryPolicy ?? createDefaultRetryPolicy();
+  const scheduler = opts.deps.scheduler;
+  const startedAtMs = scheduler.now();
+
+  for (let attempt = 1; ; attempt++) {
+    const buffered: InferenceEvent[] = [];
+    let terminalError: InferenceError | undefined;
+
+    // Per-attempt private allocator. `runSingleAttempt` allocates a
+    // seq for every event it yields; if the attempt is discarded on
+    // retry, any caller-visible seq it had consumed would leave a
+    // gap in the consumer's stream — indistinguishable from the
+    // "missed events during brief disconnection" the seq stream is
+    // documented to expose. Allocate from a private counter here and
+    // re-stamp the buffer with caller-visible seqs at flush time.
+    let attemptSeq = 0;
+    const attemptOpts: InferenceHarnessOptions = {
+      ...opts,
+      nextSeq: () => attemptSeq++,
+    };
+    for await (const event of runSingleAttempt(attemptOpts)) {
+      buffered.push(event);
+      if (event.type === "inference.error") {
+        terminalError = event.data.error;
+        break;
+      }
+      if (event.type === "inference.done") {
+        break;
+      }
+    }
+
+    if (terminalError === undefined) {
+      // Successful attempt. Re-stamp the buffer with caller-visible
+      // seqs (the private allocator's values are discarded) and
+      // flush in order.
+      for (const event of buffered) yield { ...event, seq: opts.nextSeq() };
+      return;
+    }
+
+    // Consult the policy. Sync throws and Promise rejections both
+    // resolve to an abort decision; the original inference.error
+    // surfaces to the caller, not the policy's exception.
+    let decision: RetryDecision;
+    try {
+      decision = await Promise.resolve(
+        policy({
+          error: terminalError,
+          attempt,
+          elapsedMs: scheduler.now() - startedAtMs,
+        }),
+      );
+    } catch {
+      decision = { kind: "abort" };
+    }
+
+    if (decision.kind === "abort") {
+      // Flush the buffer (including the terminal inference.error)
+      // with re-stamped caller-visible seqs and return. No
+      // `inference.retry` event is emitted on the abort path.
+      for (const event of buffered) yield { ...event, seq: opts.nextSeq() };
+      return;
+    }
+
+    // Retry: discard the failed attempt's events, emit a single
+    // inference.retry, await the delay, and re-enter the loop.
+    yield {
+      type: "inference.retry",
+      seq: opts.nextSeq(),
+      data: {
+        attempt,
+        delayMs: decision.delayMs,
+        previousError: terminalError,
+      },
+    };
+
+    const retryDelayMs = decision.delayMs;
+    await new Promise<void>((resolve) => {
+      scheduler.setTimeout(() => {
+        resolve();
+      }, retryDelayMs);
+    });
   }
 }
 

--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -33,6 +33,11 @@ export {
 export { transformMessages, createIDNormalizer } from "./transform";
 export type { TransformOptions, IDNormalizer } from "./transform";
 export { createDefaultRetryPolicy } from "./retry-policy";
+export type {
+  RetryPolicy,
+  RetrySituation,
+  RetryDecision,
+} from "@intx/types/runtime";
 export { createAnthropicAdapter } from "./providers/anthropic";
 export { createOpenAIAdapter } from "./providers/openai";
 export { createGoogleGenAIAdapter } from "./providers/google-genai";

--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -32,6 +32,7 @@ export {
 } from "./errors";
 export { transformMessages, createIDNormalizer } from "./transform";
 export type { TransformOptions, IDNormalizer } from "./transform";
+export { createDefaultRetryPolicy } from "./retry-policy";
 export { createAnthropicAdapter } from "./providers/anthropic";
 export { createOpenAIAdapter } from "./providers/openai";
 export { createGoogleGenAIAdapter } from "./providers/google-genai";

--- a/packages/inference/src/retry-policy.ts
+++ b/packages/inference/src/retry-policy.ts
@@ -15,8 +15,11 @@ import type {
 } from "@intx/types/runtime";
 
 const MAX_ATTEMPTS = 3;
-const RETRYABLE_BACKOFF_BEFORE_ATTEMPT_2_MS = 500;
-const RETRYABLE_BACKOFF_BEFORE_ATTEMPT_3_MS = 1000;
+// Indexed by the failed attempt number (1-indexed): the delay BEFORE
+// the attempt-after-this-one starts. Length must be `MAX_ATTEMPTS - 1`
+// because after the final attempt fails the policy aborts. Drives the
+// `retryable` and `timeout` schedules.
+const RETRYABLE_BACKOFF_BY_FAILED_ATTEMPT_MS: readonly number[] = [500, 1000];
 const QUOTA_DEFAULT_DELAY_MS = 1000;
 
 /**
@@ -61,15 +64,18 @@ export function createDefaultRetryPolicy(): RetryPolicy {
         return { kind: "abort" };
 
       case "retryable":
-      case "timeout":
+      case "timeout": {
         if (attempt >= MAX_ATTEMPTS) return { kind: "abort" };
-        return {
-          kind: "retry",
-          delayMs:
-            attempt === 1
-              ? RETRYABLE_BACKOFF_BEFORE_ATTEMPT_2_MS
-              : RETRYABLE_BACKOFF_BEFORE_ATTEMPT_3_MS,
-        };
+        const delayMs = RETRYABLE_BACKOFF_BY_FAILED_ATTEMPT_MS[attempt - 1];
+        if (delayMs === undefined) {
+          // Unreachable in practice given the `attempt >= MAX_ATTEMPTS`
+          // guard above, but the explicit narrowing keeps the schedule
+          // table and the cap from drifting silently if anyone bumps
+          // `MAX_ATTEMPTS` without extending the table.
+          return { kind: "abort" };
+        }
+        return { kind: "retry", delayMs };
+      }
 
       case "quota_exhausted":
         if (attempt >= MAX_ATTEMPTS) return { kind: "abort" };
@@ -77,6 +83,17 @@ export function createDefaultRetryPolicy(): RetryPolicy {
           kind: "retry",
           delayMs: error.retryAfterMs ?? QUOTA_DEFAULT_DELAY_MS,
         };
+
+      default: {
+        // Exhaustiveness: if a new InferenceError.category lands
+        // without a clause here, the never-assignment fails at
+        // compile time rather than silently returning undefined
+        // from the policy callback.
+        const exhaustive: never = error.category;
+        throw new Error(
+          `createDefaultRetryPolicy: unhandled error category ${String(exhaustive)}`,
+        );
+      }
     }
   };
 }

--- a/packages/inference/src/retry-policy.ts
+++ b/packages/inference/src/retry-policy.ts
@@ -1,0 +1,82 @@
+// The default per-call mechanical retry policy. See `RetryPolicy` /
+// `RetrySituation` / `RetryDecision` in `@intx/types/runtime` for the
+// public contract. This module ships the opinionated defaults the
+// harness substitutes when `InferenceOptions.retryPolicy` is omitted.
+//
+// The defaults are deliberately conservative: enough to absorb the
+// transient-flake surface (TCP resets, 5xx, rate-limit jitter, half-
+// streamed connection drops) without masking a genuinely persistent
+// failure under a retry loop a human would never notice.
+
+import type {
+  RetryPolicy,
+  RetrySituation,
+  RetryDecision,
+} from "@intx/types/runtime";
+
+const MAX_ATTEMPTS = 3;
+const RETRYABLE_BACKOFF_BEFORE_ATTEMPT_2_MS = 500;
+const RETRYABLE_BACKOFF_BEFORE_ATTEMPT_3_MS = 1000;
+const QUOTA_DEFAULT_DELAY_MS = 1000;
+
+/**
+ * The default retry policy bundled with `@intx/inference`. Behaviour by
+ * `InferenceError.category`:
+ *
+ * - `credential_failure`, `context_overflow`, `fatal`, `aborted`,
+ *   `protocol_mismatch` — never retry. These categories describe a
+ *   deterministic per-call failure that re-issuing the identical
+ *   request cannot resolve: bad credentials stay bad, a too-large
+ *   context stays too large, a caller-driven abort is intentional,
+ *   and a wire-shape mismatch will repeat on the next response.
+ * - `retryable`, `timeout` — up to 3 attempts total. 500ms before
+ *   attempt 2, then 1000ms before attempt 3. Exponential rather than
+ *   constant so a server taking longer than usual to recover gets a
+ *   slightly larger window each time without compounding into a long
+ *   tail.
+ * - `quota_exhausted` — up to 3 attempts total. The delay is taken
+ *   from `error.retryAfterMs` when the provider returned one (the
+ *   server told us when it would be ready); otherwise a flat
+ *   `1000`ms baseline. The baseline does NOT grow across attempts —
+ *   if 1s isn't long enough for a rate limit to clear, exponential
+ *   backoff on top of the provider's own pacing instructions is more
+ *   likely to mask a config problem than help. Operators who need
+ *   exponential pacing for rate limits should supply a custom policy.
+ *
+ * The 3-attempt cap is the same across every retryable category: a
+ * single transient flake is plausible, two is rare, and a third
+ * failure across the backoff schedule is a real signal that the call
+ * is not going to succeed on its own.
+ */
+export function createDefaultRetryPolicy(): RetryPolicy {
+  return (situation: RetrySituation): RetryDecision => {
+    const { error, attempt } = situation;
+
+    switch (error.category) {
+      case "credential_failure":
+      case "context_overflow":
+      case "fatal":
+      case "aborted":
+      case "protocol_mismatch":
+        return { kind: "abort" };
+
+      case "retryable":
+      case "timeout":
+        if (attempt >= MAX_ATTEMPTS) return { kind: "abort" };
+        return {
+          kind: "retry",
+          delayMs:
+            attempt === 1
+              ? RETRYABLE_BACKOFF_BEFORE_ATTEMPT_2_MS
+              : RETRYABLE_BACKOFF_BEFORE_ATTEMPT_3_MS,
+        };
+
+      case "quota_exhausted":
+        if (attempt >= MAX_ATTEMPTS) return { kind: "abort" };
+        return {
+          kind: "retry",
+          delayMs: error.retryAfterMs ?? QUOTA_DEFAULT_DELAY_MS,
+        };
+    }
+  };
+}

--- a/packages/inference/src/scheduler.test.ts
+++ b/packages/inference/src/scheduler.test.ts
@@ -1,0 +1,41 @@
+// Tests for the `Scheduler` time source. The harness reads
+// `scheduler.now()` to time deltas across multiple operations within a
+// single call; the contract that matters is monotonicity and the same
+// time domain as `setTimeout`. We do not assert specific values — the
+// production default uses `performance.now()` which is sub-ms and
+// floating-point.
+
+import { describe, test, expect } from "bun:test";
+
+import { createDefaultScheduler } from "./harness";
+
+describe("createDefaultScheduler", () => {
+  test("now() returns a finite number", () => {
+    const scheduler = createDefaultScheduler();
+    const value = scheduler.now();
+    expect(Number.isFinite(value)).toBe(true);
+  });
+
+  test("now() is monotonic: a second read is not less than the first", () => {
+    const scheduler = createDefaultScheduler();
+    const a = scheduler.now();
+    const b = scheduler.now();
+    expect(b).toBeGreaterThanOrEqual(a);
+  });
+
+  test("now() advances across a setTimeout that fires", async () => {
+    const scheduler = createDefaultScheduler();
+    const before = scheduler.now();
+    await new Promise<void>((resolve) => {
+      scheduler.setTimeout(() => {
+        resolve();
+      }, 5);
+    });
+    const after = scheduler.now();
+    // Real wall-clock time elapsed across the await must be reflected
+    // in `now()` — the time domain of `setTimeout` and `now()` is the
+    // contract that lets the retry wrapper compute `elapsedMs` from
+    // two `now()` reads sandwiching a `setTimeout`-driven delay.
+    expect(after - before).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -1131,6 +1131,15 @@ export const InferenceEvent = type({
     data: { error: InferenceError, partial: PartialMessage },
   })
   .or({
+    type: "'inference.retry'",
+    seq: "number",
+    data: {
+      attempt: "number",
+      delayMs: "number",
+      previousError: InferenceError,
+    },
+  })
+  .or({
     type: "'inference.citation'",
     seq: "number",
     // `index`, when present, names the source content block (typically
@@ -1348,6 +1357,24 @@ export type InferenceEvent =
       type: "inference.error";
       seq: number;
       data: { error: InferenceError; partial: PartialMessage };
+    }
+  | {
+      /**
+       * Emitted between attempts when the per-call retry policy decides
+       * to retry after an error. `attempt` is the 1-indexed number of
+       * the attempt that just **failed** — the same value the policy
+       * saw on its `RetrySituation.attempt` reading. `delayMs` is the
+       * delay the wrapper will apply before the next attempt starts;
+       * `previousError` carries the classified error that triggered
+       * the retry. The event is not emitted when the policy aborts.
+       */
+      type: "inference.retry";
+      seq: number;
+      data: {
+        attempt: number;
+        delayMs: number;
+        previousError: InferenceError;
+      };
     }
   | {
       type: "inference.citation";
@@ -1979,6 +2006,59 @@ export function applyInferenceSourceFields(
 }
 
 /**
+ * Outcome of a `RetryPolicy` consultation. Either abort the call
+ * (surface the most recent `inference.error` to the caller), or retry
+ * after `delayMs` milliseconds, measured against the harness Scheduler.
+ *
+ * (INFERENCE.md § Providers › Streaming Harness)
+ */
+export type RetryDecision =
+  | { kind: "abort" }
+  | { kind: "retry"; delayMs: number };
+
+/**
+ * Context supplied to a `RetryPolicy` each time an attempt produces an
+ * `inference.error`.
+ *
+ * (INFERENCE.md § Providers › Streaming Harness)
+ */
+export type RetrySituation = {
+  /** The classified error the most recent attempt produced. */
+  readonly error: InferenceError;
+  /**
+   * 1-indexed attempt counter. The first failure has `attempt: 1`;
+   * the second failure (after one retry) has `attempt: 2`; and so on.
+   */
+  readonly attempt: number;
+  /**
+   * Milliseconds since the *first* attempt of this call started,
+   * measured via the harness `Scheduler.now()`. The default Scheduler
+   * uses `performance.now()` (sub-millisecond resolution), so the
+   * value may be fractional; virtual-clock test schedulers report
+   * integer virtual time. Both are valid; policies that compare
+   * against integer thresholds should `Math.floor` if they need that.
+   */
+  readonly elapsedMs: number;
+};
+
+/**
+ * Per-call retry policy. The harness invokes the policy once per
+ * `inference.error` an attempt produces, in 1-indexed attempt order.
+ * Returning `{ kind: "abort" }` ends the call by surfacing the most
+ * recent error to the caller; returning `{ kind: "retry", delayMs }`
+ * causes the harness to discard the failed attempt's events, sleep
+ * `delayMs` milliseconds against the Scheduler, and re-issue the
+ * underlying HTTP request with the identical body. The policy may be
+ * async; the harness awaits the returned `Promise<RetryDecision>` if
+ * it is a thenable.
+ *
+ * (INFERENCE.md § Providers › Streaming Harness)
+ */
+export type RetryPolicy = (
+  situation: RetrySituation,
+) => RetryDecision | Promise<RetryDecision>;
+
+/**
  * Options for a single inference call. Override the defaults from the agent
  * configuration on a per-call basis.
  *
@@ -2066,6 +2146,12 @@ export type InferenceOptions = {
    * `0` arms the timer to fire on the next tick.
    */
   totalTimeoutMs?: number;
+  /**
+   * Per-call mechanical retry policy. Consulted once per attempt that
+   * ends in `inference.error`; see `RetryPolicy` for the contract. If
+   * omitted, a built-in default policy is applied.
+   */
+  retryPolicy?: RetryPolicy;
 };
 
 // ---------------------------------------------------------------------------

--- a/tests/inference/citation-interleave.test.ts
+++ b/tests/inference/citation-interleave.test.ts
@@ -41,6 +41,7 @@ const inertScheduler: Scheduler = {
   setTimeout: () => () => {
     /* tests do not exercise timer firing */
   },
+  now: () => 0,
 };
 
 async function drain(

--- a/tests/inference/error-body.test.ts
+++ b/tests/inference/error-body.test.ts
@@ -40,6 +40,7 @@ const inertScheduler: Scheduler = {
   setTimeout: () => () => {
     /* tests do not exercise timer firing */
   },
+  now: () => 0,
 };
 
 async function drain(

--- a/tests/inference/error-body.test.ts
+++ b/tests/inference/error-body.test.ts
@@ -62,6 +62,15 @@ async function runAgainstFetch(
     runInference({
       turns: makeTurns(),
       source: SOURCE,
+      // These tests verify how the harness extracts `error.message`
+      // from various non-OK response body shapes. Retry behaviour is
+      // tested elsewhere; pin an abort-only policy so a single fetch
+      // call still produces a single terminal `inference.error` even
+      // when the response classifies as a retry-eligible category
+      // (5xx → retryable, 429 → quota_exhausted) that the default
+      // policy would otherwise re-issue against the same single-use
+      // fetch stub and deadlock on the inert scheduler.
+      inferenceOptions: { retryPolicy: () => ({ kind: "abort" }) },
       nextSeq: () => seq++,
       deps,
     }),

--- a/tests/inference/lifecycle.test.ts
+++ b/tests/inference/lifecycle.test.ts
@@ -55,6 +55,7 @@ function recordingScheduler(): {
         entry.cancelled = true;
       };
     },
+    now: () => 0,
   };
   return { scheduler, entries };
 }
@@ -193,6 +194,7 @@ describe("runInference — caller-signal listener accounting", () => {
       setTimeout: () => () => {
         /* no-op: tests do not exercise the timer firing */
       },
+      now: () => 0,
     };
     const successfulFetch: Dependencies["fetch"] = () => {
       const enc = new TextEncoder();

--- a/tests/inference/lifecycle.test.ts
+++ b/tests/inference/lifecycle.test.ts
@@ -71,6 +71,14 @@ async function drain(
 }
 
 describe("runInference — timer cancellation on non-streaming exit paths", () => {
+  // Both tests pin an abort-only retry policy: they assert that the
+  // per-attempt timers are cancelled when the attempt exits before
+  // streaming begins. The default policy retries on `retryable` (5xx)
+  // and would block the wrapper on the recording scheduler's
+  // setTimeout — which records but never fires. Abort-only keeps the
+  // per-attempt invariant assertion focused.
+  const ABORT_ONLY_POLICY = { retryPolicy: () => ({ kind: "abort" as const }) };
+
   test("non-OK HTTP response cancels the total timer", async () => {
     const { scheduler, entries } = recordingScheduler();
     const fetchStub: Dependencies["fetch"] = () =>
@@ -87,6 +95,7 @@ describe("runInference — timer cancellation on non-streaming exit paths", () =
       runInference({
         turns: makeTurns(),
         source: SOURCE,
+        inferenceOptions: ABORT_ONLY_POLICY,
         nextSeq: () => seq++,
         deps,
       }),
@@ -110,6 +119,7 @@ describe("runInference — timer cancellation on non-streaming exit paths", () =
       runInference({
         turns: makeTurns(),
         source: SOURCE,
+        inferenceOptions: ABORT_ONLY_POLICY,
         nextSeq: () => seq++,
         deps,
       }),
@@ -124,22 +134,36 @@ describe("runInference — timer cancellation on non-streaming exit paths", () =
 });
 
 describe("runInference — timer cancellation on consumer abandonment", () => {
-  test("consumer abandoning the iterator mid-stream cancels every timer", async () => {
+  test("aborting the caller signal mid-stream cancels every timer", async () => {
+    // Earlier the consumer abandoned the iterator by `break`ing on the
+    // first `inference.text.delta`. The retry wrapper buffers every
+    // attempt's events until a terminal event arrives, so deltas no
+    // longer reach the caller incrementally — there is no observable
+    // event to break on while the upstream stream is still parked.
+    // The same invariant (timer cleanup on a mid-stream exit path)
+    // still holds via the caller-supplied `signal`: aborting it after
+    // the fetch has resolved but before the stream completes flows
+    // through `runSingleAttempt`'s try/finally and cancels both
+    // timers via the recorded canceller.
     const { scheduler, entries } = recordingScheduler();
+    let firstByteResolved: () => void = () => undefined;
+    const firstByteEmitted = new Promise<void>((resolve) => {
+      firstByteResolved = resolve;
+    });
     const fetchStub: Dependencies["fetch"] = () => {
       const enc = new TextEncoder();
       return Promise.resolve(
         new Response(
           new ReadableStream({
-            start(controller) {
+            async start(controller) {
               controller.enqueue(
                 enc.encode(
                   'data: {"choices":[{"index":0,"delta":{"content":"a"}}]}\n\n',
                 ),
               );
-              // Stream never closes. The consumer is expected to `break`
-              // out below; without the generator's `finally`, the
-              // timers stay armed.
+              firstByteResolved();
+              // Stream never closes. Caller aborts after the first
+              // chunk; the generator's finally must cancel the timers.
             },
           }),
           { status: 200, headers: { "content-type": "text/event-stream" } },
@@ -148,17 +172,32 @@ describe("runInference — timer cancellation on consumer abandonment", () => {
     };
     const deps: Dependencies = { fetch: fetchStub, scheduler };
 
+    const controller = new AbortController();
     let seq = 0;
-    const iter = runInference({
-      turns: makeTurns(),
-      source: SOURCE,
-      nextSeq: () => seq++,
-      deps,
-    });
+    const collector = (async () => {
+      // Drain the iterator until it ends; with buffering the only
+      // way out is the abort flowing through to `runSingleAttempt`
+      // and yielding the terminal `inference.error` from the catch
+      // block (category `aborted`), which the abort-only retry
+      // policy then surfaces.
+      for await (const _ev of runInference({
+        turns: makeTurns(),
+        source: SOURCE,
+        signal: controller.signal,
+        inferenceOptions: {
+          retryPolicy: () => ({ kind: "abort" as const }),
+        },
+        nextSeq: () => seq++,
+        deps,
+      })) {
+        // Discard — the assertion is downstream of the iteration
+        // ending, not on any specific event.
+      }
+    })();
 
-    for await (const ev of iter) {
-      if (ev.type === "inference.text.delta") break;
-    }
+    await firstByteEmitted;
+    controller.abort();
+    await collector;
 
     const armed = entries.filter((e) => !e.cancelled).length;
     expect(armed).toBe(0);

--- a/tests/inference/multi-turn-thinking-roundtrip.test.ts
+++ b/tests/inference/multi-turn-thinking-roundtrip.test.ts
@@ -52,6 +52,7 @@ const inertScheduler: Scheduler = {
   setTimeout: () => () => {
     /* tests do not exercise timer firing */
   },
+  now: () => 0,
 };
 
 async function drain(

--- a/tests/inference/per-index-blocks.test.ts
+++ b/tests/inference/per-index-blocks.test.ts
@@ -48,6 +48,7 @@ const inertScheduler: Scheduler = {
   setTimeout: () => () => {
     /* tests do not exercise timer firing */
   },
+  now: () => 0,
 };
 
 async function drain(

--- a/tests/inference/protocol-mismatch.test.ts
+++ b/tests/inference/protocol-mismatch.test.ts
@@ -28,6 +28,7 @@ const inertScheduler: Scheduler = {
   setTimeout: () => () => {
     /* tests do not exercise timer firing */
   },
+  now: () => 0,
 };
 
 function makeTurns(): ConversationTurn[] {

--- a/tests/inference/providers/google-genai-live-drift.test.ts
+++ b/tests/inference/providers/google-genai-live-drift.test.ts
@@ -30,6 +30,7 @@ describe("Google GenAI adapter: live drift", () => {
     setTimeout: () => () => {
       /* tests do not exercise timer firing */
     },
+    now: () => 0,
   };
 
   test.skipIf(GEMINI_API_KEY === undefined || GEMINI_API_KEY === "")(

--- a/tests/inference/providers/google-genai.test.ts
+++ b/tests/inference/providers/google-genai.test.ts
@@ -1649,6 +1649,7 @@ describe("Google GenAI adapter: harness round trip", () => {
     setTimeout: () => () => {
       /* tests do not exercise timer firing */
     },
+    now: () => 0,
   };
 
   const SOURCE: InferenceSource = {
@@ -2674,6 +2675,7 @@ describe("Google GenAI adapter: harness round trip with thinking + tool_call", (
     setTimeout: () => () => {
       /* tests do not exercise timer firing */
     },
+    now: () => 0,
   };
 
   const SOURCE: InferenceSource = {
@@ -3050,6 +3052,7 @@ describe("Google GenAI adapter: harness round trip with image output", () => {
     setTimeout: () => () => {
       /* tests do not exercise timer firing */
     },
+    now: () => 0,
   };
 
   const SOURCE: InferenceSource = {
@@ -3405,6 +3408,7 @@ describe("Google GenAI adapter: harness round trip with grounding", () => {
     setTimeout: () => () => {
       /* tests do not exercise timer firing */
     },
+    now: () => 0,
   };
 
   const SOURCE: InferenceSource = {
@@ -3837,6 +3841,7 @@ describe("Google GenAI adapter: harness round trip with code execution", () => {
     setTimeout: () => () => {
       /* tests do not exercise timer firing */
     },
+    now: () => 0,
   };
 
   const SOURCE: InferenceSource = {

--- a/tests/inference/reactor-streaming.test.ts
+++ b/tests/inference/reactor-streaming.test.ts
@@ -676,7 +676,13 @@ describe("createReactor — inference path [wire-driven]", () => {
         deps: harness.deps,
         source: ANTHROPIC_SOURCE,
         director: directorFromTable({
-          "message.received": (_e, _s, caps) => caps.infer(),
+          // Pin an abort-only retry policy: the test asserts error
+          // classification and partial-text capture on a single
+          // scripted stream. Default policy would retry on
+          // `retryable` and deadlock against the inert harness
+          // scheduler with no second stream registered.
+          "message.received": (_e, _s, caps) =>
+            caps.infer({ retryPolicy: () => ({ kind: "abort" }) }),
           "inference.error": (e, _s, caps) => {
             capturedError = {
               category: e.error.category,
@@ -719,7 +725,9 @@ describe("createReactor — inference path [wire-driven]", () => {
         deps: harness.deps,
         source: OPENAI_SOURCE,
         director: directorFromTable({
-          "message.received": (_e, _s, caps) => caps.infer(),
+          // See the matching test above; same rationale.
+          "message.received": (_e, _s, caps) =>
+            caps.infer({ retryPolicy: () => ({ kind: "abort" }) }),
           "inference.error": (e, _s, caps) => {
             capturedError = {
               category: e.error.category,
@@ -945,7 +953,12 @@ describe("createReactor — inference path [wire-driven]", () => {
         deps: harness.deps,
         source: ANTHROPIC_SOURCE,
         director: directorFromTable({
-          "message.received": (_e, _s, caps) => caps.infer(),
+          // Pin an abort-only retry policy: this test asserts the HTTP
+          // 5xx → category=retryable classification path. The default
+          // policy would retry on retryable and deadlock against the
+          // inert harness scheduler with no second stream registered.
+          "message.received": (_e, _s, caps) =>
+            caps.infer({ retryPolicy: () => ({ kind: "abort" }) }),
           "inference.error": (e, _s, caps) => {
             capturedError = {
               category: e.error.category,

--- a/tests/inference/redacted-thinking-roundtrip.test.ts
+++ b/tests/inference/redacted-thinking-roundtrip.test.ts
@@ -47,6 +47,7 @@ const inertScheduler: Scheduler = {
   setTimeout: () => () => {
     /* tests do not exercise timer firing */
   },
+  now: () => 0,
 };
 
 async function drain(

--- a/tests/inference/refusal-harness.test.ts
+++ b/tests/inference/refusal-harness.test.ts
@@ -44,6 +44,7 @@ const inertScheduler: Scheduler = {
   setTimeout: () => () => {
     /* tests do not exercise timer firing */
   },
+  now: () => 0,
 };
 
 async function drain(

--- a/tests/inference/retry.test.ts
+++ b/tests/inference/retry.test.ts
@@ -1,0 +1,775 @@
+// Pluggable mechanical retry policy for the inference harness — INTR-88.
+//
+// The wrapper exposed as `runInference` buffers each attempt's events
+// until the attempt terminates with `inference.done` or
+// `inference.error`. On `inference.error` the wrapper consults the
+// configured `RetryPolicy` (or `createDefaultRetryPolicy()` when none
+// is supplied) and either flushes the buffered events to the caller
+// or discards them, emits one `inference.retry` event between
+// attempts, awaits a Scheduler-driven delay, and re-issues the same
+// HTTP request.
+//
+// These tests drive the wrapper against the deterministic test
+// harness's virtual clock (`enableInferenceTimers: true`) so every
+// retry delay is asserted exactly without sleeping real wall-clock,
+// and so the scheduler the wrapper awaits is the one whose firing
+// timing the test controls.
+
+import { describe, test, expect } from "bun:test";
+
+import { runInference, createDefaultRetryPolicy } from "@intx/inference";
+import type {
+  InferenceEvent,
+  InferenceError,
+  ConversationTurn,
+  InferenceSource,
+  RetryPolicy,
+  RetrySituation,
+} from "@intx/types/runtime";
+import { setupHarness } from "@intx/inference-testing";
+import type { Harness } from "@intx/inference-testing";
+
+async function withHarness<T>(body: (h: Harness) => Promise<T>): Promise<T> {
+  // `enableInferenceTimers: true` is required: the wrapper awaits the
+  // scheduler-driven retry delay and the inert default scheduler's
+  // setTimeout is a no-op (deliberately, to keep tests that do not
+  // exercise timers from advancing virtual time through ten-minute
+  // defaults). Without virtual-clock firing the retry delay would
+  // never resolve.
+  const harness = setupHarness({ enableInferenceTimers: true });
+  try {
+    return await body(harness);
+  } finally {
+    harness.dispose();
+  }
+}
+
+const SOURCE: InferenceSource = {
+  id: "openai:test-model",
+  provider: "openai",
+  baseURL: "https://test.invalid/v1",
+  apiKey: "test",
+  model: "test-model",
+};
+
+function makeTurns(): ConversationTurn[] {
+  return [
+    { role: "user", content: [{ type: "text", text: "hi" }], timestamp: 0 },
+  ];
+}
+
+async function collect(
+  stream: AsyncIterable<InferenceEvent>,
+): Promise<InferenceEvent[]> {
+  const out: InferenceEvent[] = [];
+  for await (const event of stream) {
+    out.push(event);
+  }
+  return out;
+}
+
+function startConsumer(events: AsyncIterable<InferenceEvent>): {
+  done: Promise<InferenceEvent[]>;
+} {
+  return { done: collect(events) };
+}
+
+function findError(events: InferenceEvent[]): InferenceError | undefined {
+  const errorEvent = events.find((e) => e.type === "inference.error");
+  if (errorEvent?.type !== "inference.error") return undefined;
+  return errorEvent.data.error;
+}
+
+function retryEvents(
+  events: InferenceEvent[],
+): { attempt: number; delayMs: number; previousError: InferenceError }[] {
+  const out: {
+    attempt: number;
+    delayMs: number;
+    previousError: InferenceError;
+  }[] = [];
+  for (const e of events) {
+    if (e.type === "inference.retry") out.push(e.data);
+  }
+  return out;
+}
+
+// Register N single-use 5xx responses with a small JSON body. Each
+// classifies as `retryable` through `classifyHTTPError`. Used by tests
+// that target `category: "retryable"` without depending on timeout
+// semantics.
+function registerRetryable5xx(harness: Harness, count: number): void {
+  const encoder = new TextEncoder();
+  for (let i = 0; i < count; i++) {
+    const stream = harness.scenario.createStream();
+    harness.scenario.whenRequestMatches(() => true, stream, { status: 503 });
+    stream.enqueueAt(
+      1,
+      encoder.encode('{"error":{"message":"upstream unavailable"}}'),
+    );
+    stream.closeAt(2);
+  }
+}
+
+describe("runInference — default retry policy", () => {
+  test("makes up to 3 attempts on `retryable` with documented backoff before surfacing", async () => {
+    await withHarness(async (harness) => {
+      registerRetryable5xx(harness, 3);
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+
+      const before = harness.clock.now();
+      await harness.run();
+      const after = harness.clock.now();
+
+      const events = await consumer.done;
+      const retries = retryEvents(events);
+      expect(retries).toHaveLength(2);
+      expect(retries[0]?.attempt).toBe(1);
+      expect(retries[0]?.delayMs).toBe(500);
+      expect(retries[1]?.attempt).toBe(2);
+      expect(retries[1]?.delayMs).toBe(1000);
+
+      // The wrapper waited the documented backoff between attempts:
+      // 500ms before attempt 2 plus 1000ms before attempt 3.
+      expect(after - before).toBeGreaterThanOrEqual(1500);
+
+      const err = findError(events);
+      expect(err?.category).toBe("retryable");
+      expect(harness.scenario.matchedRequests()).toHaveLength(3);
+    });
+  });
+
+  test("never retries `credential_failure`, `context_overflow`, `fatal`, or `aborted`", async () => {
+    const cases: {
+      status: number;
+      expectedCategory: InferenceError["category"];
+    }[] = [
+      { status: 401, expectedCategory: "credential_failure" },
+      { status: 403, expectedCategory: "credential_failure" },
+      { status: 400, expectedCategory: "fatal" },
+    ];
+    for (const { status, expectedCategory } of cases) {
+      await withHarness(async (harness) => {
+        const encoder = new TextEncoder();
+        const stream = harness.scenario.createStream();
+        harness.scenario.whenRequestMatches(() => true, stream, { status });
+        stream.enqueueAt(1, encoder.encode('{"error":{"message":"nope"}}'));
+        stream.closeAt(2);
+
+        let seq = 0;
+        const consumer = startConsumer(
+          runInference({
+            turns: makeTurns(),
+            source: SOURCE,
+            nextSeq: () => seq++,
+            deps: harness.deps,
+          }),
+        );
+        await harness.run();
+        const events = await consumer.done;
+
+        expect(retryEvents(events)).toHaveLength(0);
+        expect(findError(events)?.category).toBe(expectedCategory);
+        expect(harness.scenario.matchedRequests()).toHaveLength(1);
+      });
+    }
+
+    // `context_overflow` is the 400-with-context-length-message branch.
+    await withHarness(async (harness) => {
+      const encoder = new TextEncoder();
+      const stream = harness.scenario.createStream();
+      harness.scenario.whenRequestMatches(() => true, stream, { status: 400 });
+      stream.enqueueAt(
+        1,
+        encoder.encode(
+          '{"error":{"message":"prompt is too long: maximum context length is 8192 tokens"}}',
+        ),
+      );
+      stream.closeAt(2);
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+      await harness.run();
+      const events = await consumer.done;
+      expect(retryEvents(events)).toHaveLength(0);
+      expect(findError(events)?.category).toBe("context_overflow");
+    });
+
+    // `aborted` — caller signal raised before any attempt produces.
+    await withHarness(async (harness) => {
+      harness.scenario.stall();
+      const controller = new AbortController();
+      controller.abort();
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          signal: controller.signal,
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+      await harness.run();
+      const events = await consumer.done;
+      expect(retryEvents(events)).toHaveLength(0);
+      expect(findError(events)?.category).toBe("aborted");
+    });
+  });
+});
+
+describe("runInference — custom retry policy", () => {
+  test("single-attempt policy: `retryable` error surfaces immediately", async () => {
+    await withHarness(async (harness) => {
+      registerRetryable5xx(harness, 1);
+
+      let policyCalls = 0;
+      const policy: RetryPolicy = () => {
+        policyCalls += 1;
+        return { kind: "abort" };
+      };
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          inferenceOptions: { retryPolicy: policy },
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+      await harness.run();
+      const events = await consumer.done;
+
+      expect(policyCalls).toBe(1);
+      expect(retryEvents(events)).toHaveLength(0);
+      expect(findError(events)?.category).toBe("retryable");
+      expect(harness.scenario.matchedRequests()).toHaveLength(1);
+    });
+  });
+
+  test("unlimited retries on `retryable`: success on attempt N produces a single clean event stream", async () => {
+    await withHarness(async (harness) => {
+      // Two failures then one success. The custom policy retries
+      // indefinitely with delayMs: 0 so the test does not need to
+      // advance virtual time through real backoff.
+      registerRetryable5xx(harness, 2);
+      // Third matcher: a successful 200 response with a short payload.
+      // The OpenAI adapter accepts a single text delta followed by the
+      // SSE `[DONE]` sentinel; we serialise both inline rather than
+      // building a wire helper since the test only needs one well-
+      // formed reply.
+      const encoder = new TextEncoder();
+      const okStream = harness.scenario.createStream();
+      harness.scenario.whenRequestMatches(() => true, okStream);
+      okStream.enqueueAt(
+        1,
+        encoder.encode(
+          'data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hi"}}]}\n\n',
+        ),
+      );
+      okStream.enqueueAt(2, encoder.encode("data: [DONE]\n\n"));
+      okStream.closeAt(3);
+
+      const policy: RetryPolicy = () => ({ kind: "retry", delayMs: 0 });
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          inferenceOptions: { retryPolicy: policy },
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+      await harness.run();
+      const events = await consumer.done;
+
+      // Single inference.start, exactly two inference.retry events,
+      // a successful tail (no inference.error visible to caller).
+      const starts = events.filter((e) => e.type === "inference.start");
+      const retries = retryEvents(events);
+      const dones = events.filter((e) => e.type === "inference.done");
+      const errors = events.filter((e) => e.type === "inference.error");
+
+      expect(starts).toHaveLength(1);
+      expect(retries).toHaveLength(2);
+      expect(dones).toHaveLength(1);
+      expect(errors).toHaveLength(0);
+      expect(retries[0]?.attempt).toBe(1);
+      expect(retries[1]?.attempt).toBe(2);
+    });
+  });
+
+  test("custom policy reads `attempt` and can override the default's category", async () => {
+    await withHarness(async (harness) => {
+      // Default would retry 3 times on `retryable`; custom policy
+      // aborts after the second failure regardless of category.
+      registerRetryable5xx(harness, 3);
+
+      const seen: number[] = [];
+      const policy: RetryPolicy = (situation: RetrySituation) => {
+        seen.push(situation.attempt);
+        if (situation.attempt >= 2) return { kind: "abort" };
+        return { kind: "retry", delayMs: 10 };
+      };
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          inferenceOptions: { retryPolicy: policy },
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+      await harness.run();
+      const events = await consumer.done;
+
+      expect(seen).toEqual([1, 2]);
+      expect(retryEvents(events)).toHaveLength(1);
+      expect(harness.scenario.matchedRequests()).toHaveLength(2);
+      expect(findError(events)?.category).toBe("retryable");
+    });
+  });
+});
+
+describe("runInference — quota_exhausted handling", () => {
+  test("uses error.retryAfterMs when present and fires the next attempt at exactly that delay", async () => {
+    await withHarness(async (harness) => {
+      const encoder = new TextEncoder();
+      const headers = { "retry-after-ms": "750" } as const;
+
+      // Two single-use 429s carrying retry-after-ms = 750. The default
+      // policy retries on quota_exhausted; the second 429 surfaces.
+      for (let i = 0; i < 2; i++) {
+        const stream = harness.scenario.createStream();
+        harness.scenario.whenRequestMatches(() => true, stream, {
+          status: 429,
+          headers,
+        });
+        stream.enqueueAt(
+          1,
+          encoder.encode('{"error":{"message":"rate limited"}}'),
+        );
+        stream.closeAt(2);
+      }
+      // Third 429 to satisfy the third attempt; default policy then
+      // exhausts and surfaces the error.
+      {
+        const stream = harness.scenario.createStream();
+        harness.scenario.whenRequestMatches(() => true, stream, {
+          status: 429,
+          headers,
+        });
+        stream.enqueueAt(
+          1,
+          encoder.encode('{"error":{"message":"rate limited"}}'),
+        );
+        stream.closeAt(2);
+      }
+
+      const before = harness.clock.now();
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+      await harness.run();
+      const after = harness.clock.now();
+      const events = await consumer.done;
+
+      const retries = retryEvents(events);
+      expect(retries).toHaveLength(2);
+      // Both retries use the provider-supplied retry-after-ms.
+      expect(retries[0]?.delayMs).toBe(750);
+      expect(retries[1]?.delayMs).toBe(750);
+      // Virtual clock advanced at least 2 * 750 ms across the two
+      // delays (plus the fetch turnaround).
+      expect(after - before).toBeGreaterThanOrEqual(1500);
+      expect(findError(events)?.category).toBe("quota_exhausted");
+    });
+  });
+
+  test("falls back to the 1000ms flat baseline when retry-after-ms is absent", async () => {
+    await withHarness(async (harness) => {
+      const encoder = new TextEncoder();
+      for (let i = 0; i < 3; i++) {
+        const stream = harness.scenario.createStream();
+        harness.scenario.whenRequestMatches(() => true, stream, {
+          status: 429,
+        });
+        stream.enqueueAt(
+          1,
+          encoder.encode('{"error":{"message":"rate limited"}}'),
+        );
+        stream.closeAt(2);
+      }
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+      await harness.run();
+      const events = await consumer.done;
+      const retries = retryEvents(events);
+      expect(retries).toHaveLength(2);
+      expect(retries[0]?.delayMs).toBe(1000);
+      expect(retries[1]?.delayMs).toBe(1000);
+    });
+  });
+});
+
+describe("runInference — inference.retry event payload", () => {
+  test("carries attempt, delayMs, and previousError matching the most recent error", async () => {
+    await withHarness(async (harness) => {
+      registerRetryable5xx(harness, 3);
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+      await harness.run();
+      const events = await consumer.done;
+      const retries = retryEvents(events);
+      expect(retries).toHaveLength(2);
+      for (const r of retries) {
+        expect(r.previousError.category).toBe("retryable");
+        expect(typeof r.previousError.message).toBe("string");
+        expect(r.previousError.message.length).toBeGreaterThan(0);
+        expect(r.previousError.statusCode).toBe(503);
+      }
+    });
+  });
+});
+
+describe("runInference — policy failure handling", () => {
+  test("policy that throws synchronously: caller sees the original inference.error", async () => {
+    await withHarness(async (harness) => {
+      registerRetryable5xx(harness, 1);
+      const policy: RetryPolicy = () => {
+        throw new Error("policy boom");
+      };
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          inferenceOptions: { retryPolicy: policy },
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+      await harness.run();
+      const events = await consumer.done;
+
+      // No retry was emitted, the original retryable error surfaces,
+      // and no `policy boom` text leaks through.
+      expect(retryEvents(events)).toHaveLength(0);
+      const err = findError(events);
+      expect(err?.category).toBe("retryable");
+      expect(err?.message).not.toContain("policy boom");
+    });
+  });
+
+  test("policy that returns a rejected Promise: caller sees the original inference.error", async () => {
+    await withHarness(async (harness) => {
+      registerRetryable5xx(harness, 1);
+      const policy: RetryPolicy = () =>
+        Promise.reject(new Error("policy rejected"));
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          inferenceOptions: { retryPolicy: policy },
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+      await harness.run();
+      const events = await consumer.done;
+
+      expect(retryEvents(events)).toHaveLength(0);
+      const err = findError(events);
+      expect(err?.category).toBe("retryable");
+      expect(err?.message).not.toContain("policy rejected");
+    });
+  });
+
+  test("policy throw does not allocate an extra seq for a phantom inference.retry", async () => {
+    // The wrapper allocates one new seq via nextSeq() per
+    // inference.retry it actually emits. A policy that throws and
+    // gets coerced to abort must NOT call nextSeq() for the abort
+    // path — the seq counter should match what a non-throwing
+    // abort-only policy produces.
+    async function seqsConsumed(policy: RetryPolicy): Promise<number> {
+      return await withHarness(async (harness) => {
+        registerRetryable5xx(harness, 1);
+        let seq = 0;
+        const consumer = startConsumer(
+          runInference({
+            turns: makeTurns(),
+            source: SOURCE,
+            inferenceOptions: { retryPolicy: policy },
+            nextSeq: () => seq++,
+            deps: harness.deps,
+          }),
+        );
+        await harness.run();
+        await consumer.done;
+        return seq;
+      });
+    }
+
+    const cleanAbort = await seqsConsumed(() => ({ kind: "abort" }));
+    const throwingPolicy = await seqsConsumed(() => {
+      throw new Error("policy boom");
+    });
+    expect(throwingPolicy).toBe(cleanAbort);
+  });
+
+  test("caller-visible seqs stay contiguous across a retry that discards an attempt", async () => {
+    // The seq stream is documented as supporting gap detection for
+    // missed events. A retry that discards a failed attempt's
+    // buffered events must NOT leak the discarded attempt's seq
+    // allocations into the caller's counter — otherwise the
+    // consumer's first event arrives at a non-zero seq, looking
+    // exactly like a network drop.
+    await withHarness(async (harness) => {
+      registerRetryable5xx(harness, 2);
+      const encoder = new TextEncoder();
+      const okStream = harness.scenario.createStream();
+      harness.scenario.whenRequestMatches(() => true, okStream);
+      okStream.enqueueAt(
+        1,
+        encoder.encode(
+          'data: {"choices":[{"index":0,"delta":{"content":"hi"}}]}\n\n',
+        ),
+      );
+      okStream.enqueueAt(2, encoder.encode("data: [DONE]\n\n"));
+      okStream.closeAt(3);
+
+      const policy: RetryPolicy = () => ({ kind: "retry", delayMs: 0 });
+
+      let nextSeq = 0;
+      const eventsP = collect(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          inferenceOptions: { retryPolicy: policy },
+          nextSeq: () => nextSeq++,
+          deps: harness.deps,
+        }),
+      );
+      await harness.run();
+      const events = await eventsP;
+
+      // First event the caller sees starts at seq 0; the sequence
+      // is strictly monotonically increasing by 1 across the entire
+      // run (including the two `inference.retry` events between the
+      // three attempts).
+      expect(events[0]?.seq).toBe(0);
+      for (let i = 1; i < events.length; i++) {
+        expect(events[i]?.seq).toBe(i);
+      }
+    });
+  });
+});
+
+describe("runInference — retry delay scheduling", () => {
+  test("retry delay is honoured via the harness scheduler — virtual-clock advance is sufficient", async () => {
+    await withHarness(async (harness) => {
+      registerRetryable5xx(harness, 2);
+      // Third matcher: a healthy response so the wrapper exits via
+      // inference.done after the policy-driven retry.
+      const okStream = harness.scenario.createStream();
+      harness.scenario.whenRequestMatches(() => true, okStream);
+      const encoder = new TextEncoder();
+      okStream.enqueueAt(
+        1,
+        encoder.encode(
+          'data: {"choices":[{"index":0,"delta":{"content":"a"}}]}\n\n',
+        ),
+      );
+      okStream.enqueueAt(2, encoder.encode("data: [DONE]\n\n"));
+      okStream.closeAt(3);
+
+      const policy: RetryPolicy = () => ({ kind: "retry", delayMs: 250 });
+
+      const before = harness.clock.now();
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          inferenceOptions: { retryPolicy: policy },
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+      await harness.run();
+      const after = harness.clock.now();
+      const events = await consumer.done;
+
+      // Two retries → virtual clock advanced at least 2 * 250 ms.
+      // We assert greater-than-or-equal because the fetch chunks
+      // themselves consume a small amount of virtual time on top.
+      expect(retryEvents(events)).toHaveLength(2);
+      expect(after - before).toBeGreaterThanOrEqual(500);
+    });
+  });
+
+  test("aborting the caller signal partway through a retry delay surfaces an aborted error on the next attempt", async () => {
+    await withHarness(async (harness) => {
+      registerRetryable5xx(harness, 1);
+      // The retry policy asks for a 1000ms delay before attempt 2.
+      // The test schedules `controller.abort()` to fire at virtual
+      // time +500ms — squarely inside the delay window — so the
+      // wrapper is awaiting `scheduler.setTimeout` when the signal
+      // aborts. When the delay's setTimeout fires the wrapper
+      // re-enters `runSingleAttempt`, which checks `signal.aborted`
+      // at entry and yields `inference.error` of category `aborted`.
+      // The default policy aborts on that category; no further
+      // attempts are issued.
+
+      const controller = new AbortController();
+      let policyCalls = 0;
+      const policy: RetryPolicy = () => {
+        policyCalls += 1;
+        if (policyCalls === 1) {
+          // First failure (the registered 503): schedule the abort
+          // to fire mid-delay, then return a long-enough delay that
+          // the abort lands well before the next attempt would
+          // start. The scheduling is done against the harness clock
+          // directly so the abort is settled in virtual time.
+          harness.clock.schedule(harness.clock.now() + 500, () => {
+            controller.abort();
+          });
+          return { kind: "retry", delayMs: 1000 };
+        }
+        return { kind: "abort" };
+      };
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          signal: controller.signal,
+          inferenceOptions: { retryPolicy: policy },
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+      await harness.run();
+      const events = await consumer.done;
+
+      // One retry emitted before the signal-aborted error surfaces.
+      expect(retryEvents(events)).toHaveLength(1);
+      expect(findError(events)?.category).toBe("aborted");
+    });
+  });
+});
+
+describe("createDefaultRetryPolicy — direct unit coverage", () => {
+  function situation(
+    overrides: Partial<RetrySituation> & { error: InferenceError },
+  ): RetrySituation {
+    return {
+      attempt: 1,
+      elapsedMs: 0,
+      ...overrides,
+    };
+  }
+  function err(
+    category: InferenceError["category"],
+    extra: Partial<InferenceError> = {},
+  ): InferenceError {
+    return { category, message: `${category} error`, ...extra };
+  }
+
+  test("non-retryable categories always abort", async () => {
+    const policy = createDefaultRetryPolicy();
+    for (const category of [
+      "credential_failure",
+      "context_overflow",
+      "fatal",
+      "aborted",
+      "protocol_mismatch",
+    ] as const) {
+      const decision = await policy(situation({ error: err(category) }));
+      expect(decision).toEqual({ kind: "abort" });
+    }
+  });
+
+  test("retryable + timeout: 500ms / 1000ms backoff, abort on 3rd failure", async () => {
+    const policy = createDefaultRetryPolicy();
+    for (const category of ["retryable", "timeout"] as const) {
+      const e = err(category);
+      const a1 = await policy(situation({ error: e, attempt: 1 }));
+      const a2 = await policy(situation({ error: e, attempt: 2 }));
+      const a3 = await policy(situation({ error: e, attempt: 3 }));
+      expect(a1).toEqual({ kind: "retry", delayMs: 500 });
+      expect(a2).toEqual({ kind: "retry", delayMs: 1000 });
+      expect(a3).toEqual({ kind: "abort" });
+    }
+  });
+
+  test("quota_exhausted: prefers retryAfterMs, falls back to flat 1000ms", async () => {
+    const policy = createDefaultRetryPolicy();
+    const withHeader = await policy(
+      situation({
+        error: err("quota_exhausted", { retryAfterMs: 1234 }),
+        attempt: 1,
+      }),
+    );
+    expect(withHeader).toEqual({ kind: "retry", delayMs: 1234 });
+
+    const noHeader = await policy(
+      situation({ error: err("quota_exhausted"), attempt: 1 }),
+    );
+    expect(noHeader).toEqual({ kind: "retry", delayMs: 1000 });
+
+    const exhausted = await policy(
+      situation({ error: err("quota_exhausted"), attempt: 3 }),
+    );
+    expect(exhausted).toEqual({ kind: "abort" });
+  });
+});

--- a/tests/inference/retry.test.ts
+++ b/tests/inference/retry.test.ts
@@ -68,12 +68,6 @@ async function collect(
   return out;
 }
 
-function startConsumer(events: AsyncIterable<InferenceEvent>): {
-  done: Promise<InferenceEvent[]>;
-} {
-  return { done: collect(events) };
-}
-
 function findError(events: InferenceEvent[]): InferenceError | undefined {
   const errorEvent = events.find((e) => e.type === "inference.error");
   if (errorEvent?.type !== "inference.error") return undefined;
@@ -117,7 +111,7 @@ describe("runInference — default retry policy", () => {
       registerRetryable5xx(harness, 3);
 
       let seq = 0;
-      const consumer = startConsumer(
+      const eventsP = collect(
         runInference({
           turns: makeTurns(),
           source: SOURCE,
@@ -130,7 +124,7 @@ describe("runInference — default retry policy", () => {
       await harness.run();
       const after = harness.clock.now();
 
-      const events = await consumer.done;
+      const events = await eventsP;
       const retries = retryEvents(events);
       expect(retries).toHaveLength(2);
       expect(retries[0]?.attempt).toBe(1);
@@ -166,7 +160,7 @@ describe("runInference — default retry policy", () => {
         stream.closeAt(2);
 
         let seq = 0;
-        const consumer = startConsumer(
+        const eventsP = collect(
           runInference({
             turns: makeTurns(),
             source: SOURCE,
@@ -175,7 +169,7 @@ describe("runInference — default retry policy", () => {
           }),
         );
         await harness.run();
-        const events = await consumer.done;
+        const events = await eventsP;
 
         expect(retryEvents(events)).toHaveLength(0);
         expect(findError(events)?.category).toBe(expectedCategory);
@@ -197,7 +191,7 @@ describe("runInference — default retry policy", () => {
       stream.closeAt(2);
 
       let seq = 0;
-      const consumer = startConsumer(
+      const eventsP = collect(
         runInference({
           turns: makeTurns(),
           source: SOURCE,
@@ -206,7 +200,7 @@ describe("runInference — default retry policy", () => {
         }),
       );
       await harness.run();
-      const events = await consumer.done;
+      const events = await eventsP;
       expect(retryEvents(events)).toHaveLength(0);
       expect(findError(events)?.category).toBe("context_overflow");
     });
@@ -218,7 +212,7 @@ describe("runInference — default retry policy", () => {
       controller.abort();
 
       let seq = 0;
-      const consumer = startConsumer(
+      const eventsP = collect(
         runInference({
           turns: makeTurns(),
           source: SOURCE,
@@ -228,7 +222,7 @@ describe("runInference — default retry policy", () => {
         }),
       );
       await harness.run();
-      const events = await consumer.done;
+      const events = await eventsP;
       expect(retryEvents(events)).toHaveLength(0);
       expect(findError(events)?.category).toBe("aborted");
     });
@@ -247,7 +241,7 @@ describe("runInference — custom retry policy", () => {
       };
 
       let seq = 0;
-      const consumer = startConsumer(
+      const eventsP = collect(
         runInference({
           turns: makeTurns(),
           source: SOURCE,
@@ -257,7 +251,7 @@ describe("runInference — custom retry policy", () => {
         }),
       );
       await harness.run();
-      const events = await consumer.done;
+      const events = await eventsP;
 
       expect(policyCalls).toBe(1);
       expect(retryEvents(events)).toHaveLength(0);
@@ -292,7 +286,7 @@ describe("runInference — custom retry policy", () => {
       const policy: RetryPolicy = () => ({ kind: "retry", delayMs: 0 });
 
       let seq = 0;
-      const consumer = startConsumer(
+      const eventsP = collect(
         runInference({
           turns: makeTurns(),
           source: SOURCE,
@@ -302,7 +296,7 @@ describe("runInference — custom retry policy", () => {
         }),
       );
       await harness.run();
-      const events = await consumer.done;
+      const events = await eventsP;
 
       // Single inference.start, exactly two inference.retry events,
       // a successful tail (no inference.error visible to caller).
@@ -334,7 +328,7 @@ describe("runInference — custom retry policy", () => {
       };
 
       let seq = 0;
-      const consumer = startConsumer(
+      const eventsP = collect(
         runInference({
           turns: makeTurns(),
           source: SOURCE,
@@ -344,7 +338,7 @@ describe("runInference — custom retry policy", () => {
         }),
       );
       await harness.run();
-      const events = await consumer.done;
+      const events = await eventsP;
 
       expect(seen).toEqual([1, 2]);
       expect(retryEvents(events)).toHaveLength(1);
@@ -391,7 +385,7 @@ describe("runInference — quota_exhausted handling", () => {
 
       const before = harness.clock.now();
       let seq = 0;
-      const consumer = startConsumer(
+      const eventsP = collect(
         runInference({
           turns: makeTurns(),
           source: SOURCE,
@@ -401,7 +395,7 @@ describe("runInference — quota_exhausted handling", () => {
       );
       await harness.run();
       const after = harness.clock.now();
-      const events = await consumer.done;
+      const events = await eventsP;
 
       const retries = retryEvents(events);
       expect(retries).toHaveLength(2);
@@ -431,7 +425,7 @@ describe("runInference — quota_exhausted handling", () => {
       }
 
       let seq = 0;
-      const consumer = startConsumer(
+      const eventsP = collect(
         runInference({
           turns: makeTurns(),
           source: SOURCE,
@@ -440,7 +434,7 @@ describe("runInference — quota_exhausted handling", () => {
         }),
       );
       await harness.run();
-      const events = await consumer.done;
+      const events = await eventsP;
       const retries = retryEvents(events);
       expect(retries).toHaveLength(2);
       expect(retries[0]?.delayMs).toBe(1000);
@@ -455,7 +449,7 @@ describe("runInference — inference.retry event payload", () => {
       registerRetryable5xx(harness, 3);
 
       let seq = 0;
-      const consumer = startConsumer(
+      const eventsP = collect(
         runInference({
           turns: makeTurns(),
           source: SOURCE,
@@ -464,7 +458,7 @@ describe("runInference — inference.retry event payload", () => {
         }),
       );
       await harness.run();
-      const events = await consumer.done;
+      const events = await eventsP;
       const retries = retryEvents(events);
       expect(retries).toHaveLength(2);
       for (const r of retries) {
@@ -486,7 +480,7 @@ describe("runInference — policy failure handling", () => {
       };
 
       let seq = 0;
-      const consumer = startConsumer(
+      const eventsP = collect(
         runInference({
           turns: makeTurns(),
           source: SOURCE,
@@ -496,7 +490,7 @@ describe("runInference — policy failure handling", () => {
         }),
       );
       await harness.run();
-      const events = await consumer.done;
+      const events = await eventsP;
 
       // No retry was emitted, the original retryable error surfaces,
       // and no `policy boom` text leaks through.
@@ -514,7 +508,7 @@ describe("runInference — policy failure handling", () => {
         Promise.reject(new Error("policy rejected"));
 
       let seq = 0;
-      const consumer = startConsumer(
+      const eventsP = collect(
         runInference({
           turns: makeTurns(),
           source: SOURCE,
@@ -524,7 +518,7 @@ describe("runInference — policy failure handling", () => {
         }),
       );
       await harness.run();
-      const events = await consumer.done;
+      const events = await eventsP;
 
       expect(retryEvents(events)).toHaveLength(0);
       const err = findError(events);
@@ -543,7 +537,7 @@ describe("runInference — policy failure handling", () => {
       return await withHarness(async (harness) => {
         registerRetryable5xx(harness, 1);
         let seq = 0;
-        const consumer = startConsumer(
+        const eventsP = collect(
           runInference({
             turns: makeTurns(),
             source: SOURCE,
@@ -553,7 +547,7 @@ describe("runInference — policy failure handling", () => {
           }),
         );
         await harness.run();
-        await consumer.done;
+        await eventsP;
         return seq;
       });
     }
@@ -635,7 +629,7 @@ describe("runInference — retry delay scheduling", () => {
 
       const before = harness.clock.now();
       let seq = 0;
-      const consumer = startConsumer(
+      const eventsP = collect(
         runInference({
           turns: makeTurns(),
           source: SOURCE,
@@ -646,7 +640,7 @@ describe("runInference — retry delay scheduling", () => {
       );
       await harness.run();
       const after = harness.clock.now();
-      const events = await consumer.done;
+      const events = await eventsP;
 
       // Two retries → virtual clock advanced at least 2 * 250 ms.
       // We assert greater-than-or-equal because the fetch chunks
@@ -688,7 +682,7 @@ describe("runInference — retry delay scheduling", () => {
       };
 
       let seq = 0;
-      const consumer = startConsumer(
+      const eventsP = collect(
         runInference({
           turns: makeTurns(),
           source: SOURCE,
@@ -699,7 +693,7 @@ describe("runInference — retry delay scheduling", () => {
         }),
       );
       await harness.run();
-      const events = await consumer.done;
+      const events = await eventsP;
 
       // One retry emitted before the signal-aborted error surfaces.
       expect(retryEvents(events)).toHaveLength(1);
@@ -738,7 +732,7 @@ describe("runInference — retry delay scheduling", () => {
       };
 
       let seq = 0;
-      const consumer = startConsumer(
+      const eventsP = collect(
         runInference({
           turns: makeTurns(),
           source: SOURCE,
@@ -749,7 +743,7 @@ describe("runInference — retry delay scheduling", () => {
         }),
       );
       await harness.run();
-      const events = await consumer.done;
+      const events = await eventsP;
 
       expect(policyCalls).toBe(2);
       // The second policy call (the aborted error from the next
@@ -774,7 +768,7 @@ describe("runInference — retry delay scheduling", () => {
       };
 
       let seq = 0;
-      const consumer = startConsumer(
+      const eventsP = collect(
         runInference({
           turns: makeTurns(),
           source: SOURCE,
@@ -784,7 +778,7 @@ describe("runInference — retry delay scheduling", () => {
         }),
       );
       await harness.run();
-      const events = await consumer.done;
+      const events = await eventsP;
 
       // Exactly one policy invocation (the throw → abort path does
       // not loop), no retry event leaks out, original retryable

--- a/tests/inference/retry.test.ts
+++ b/tests/inference/retry.test.ts
@@ -1,4 +1,4 @@
-// Pluggable mechanical retry policy for the inference harness — INTR-88.
+// Pluggable mechanical retry policy for the inference harness.
 //
 // The wrapper exposed as `runInference` buffers each attempt's events
 // until the attempt terminates with `inference.done` or
@@ -704,6 +704,94 @@ describe("runInference — retry delay scheduling", () => {
       // One retry emitted before the signal-aborted error surfaces.
       expect(retryEvents(events)).toHaveLength(1);
       expect(findError(events)?.category).toBe("aborted");
+    });
+  });
+
+  test("aborting during the retry delay short-circuits the await within the delay window", async () => {
+    await withHarness(async (harness) => {
+      registerRetryable5xx(harness, 1);
+      // The retry policy asks for a long delay; the abort fires
+      // early in that window. If the wrapper honours `signal`
+      // during the delay, the policy's second invocation — which
+      // sees the aborted-category error from the next attempt —
+      // reads an `elapsedMs` shortly after `ABORT_AT_MS`, not
+      // after the full delay. Reading from the policy callback
+      // is the precise signal: virtual time elsewhere may still
+      // advance to drain the cancelled-but-still-heap retry
+      // setTimeout entry, which has no bearing on whether the
+      // wrapper resumed promptly.
+      const controller = new AbortController();
+      const RETRY_DELAY_MS = 5_000;
+      const ABORT_AT_MS = 100;
+      let policyCalls = 0;
+      let secondCallElapsedMs: number | undefined;
+      const policy: RetryPolicy = (situation) => {
+        policyCalls += 1;
+        if (policyCalls === 1) {
+          harness.clock.schedule(harness.clock.now() + ABORT_AT_MS, () => {
+            controller.abort();
+          });
+          return { kind: "retry", delayMs: RETRY_DELAY_MS };
+        }
+        secondCallElapsedMs = situation.elapsedMs;
+        return { kind: "abort" };
+      };
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          signal: controller.signal,
+          inferenceOptions: { retryPolicy: policy },
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+      await harness.run();
+      const events = await consumer.done;
+
+      expect(policyCalls).toBe(2);
+      // The second policy call (the aborted error from the next
+      // attempt) happens shortly after the abort fired, not after
+      // the configured retry delay. Bound the assertion well
+      // below the retry delay — the order-of-magnitude separation
+      // makes this robust without pinning exact timing.
+      expect(secondCallElapsedMs).toBeDefined();
+      expect(secondCallElapsedMs).toBeLessThan(RETRY_DELAY_MS / 5);
+      expect(retryEvents(events)).toHaveLength(1);
+      expect(findError(events)?.category).toBe("aborted");
+    });
+  });
+
+  test("policy that throws is invoked once, logs warn, and aborts cleanly", async () => {
+    await withHarness(async (harness) => {
+      registerRetryable5xx(harness, 1);
+      let policyCalls = 0;
+      const policy: RetryPolicy = () => {
+        policyCalls += 1;
+        throw new Error("policy boom");
+      };
+
+      let seq = 0;
+      const consumer = startConsumer(
+        runInference({
+          turns: makeTurns(),
+          source: SOURCE,
+          inferenceOptions: { retryPolicy: policy },
+          nextSeq: () => seq++,
+          deps: harness.deps,
+        }),
+      );
+      await harness.run();
+      const events = await consumer.done;
+
+      // Exactly one policy invocation (the throw → abort path does
+      // not loop), no retry event leaks out, original retryable
+      // error surfaces.
+      expect(policyCalls).toBe(1);
+      expect(retryEvents(events)).toHaveLength(0);
+      expect(findError(events)?.category).toBe("retryable");
     });
   });
 });

--- a/tests/inference/scheduler.test.ts
+++ b/tests/inference/scheduler.test.ts
@@ -1,0 +1,85 @@
+// Tests for the `Scheduler` exposed by `setupHarness` via `deps.scheduler`.
+// Both modes (`enableInferenceTimers: false` and `true`) report `now()`
+// from the harness's virtual clock so the harness's authoritative time
+// source agrees with whatever a consumer reads through the injected
+// Scheduler. The inert-mode scheduler additionally guarantees that
+// `setTimeout` is a no-op — only `now()` follows the clock.
+
+import { describe, test, expect } from "bun:test";
+
+import { setupHarness } from "@intx/inference-testing";
+import type { Scheduler } from "@intx/inference";
+
+// `Dependencies.scheduler` is structurally optional, but `setupHarness`
+// always populates it; pulling it out through a tiny helper keeps the
+// tests focused on the behaviour, not the optional-chain ceremony.
+function getScheduler(harness: { deps: { scheduler?: Scheduler } }): Scheduler {
+  const scheduler = harness.deps.scheduler;
+  if (scheduler === undefined) {
+    throw new Error("setupHarness did not populate deps.scheduler");
+  }
+  return scheduler;
+}
+
+describe("inference-testing Scheduler.now() (inert mode)", () => {
+  test("starts at the virtual clock's current value", () => {
+    const harness = setupHarness();
+    try {
+      expect(getScheduler(harness).now()).toBe(harness.clock.now());
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("tracks virtual time advanced by harness.advanceTo()", async () => {
+    const harness = setupHarness();
+    try {
+      const scheduler = getScheduler(harness);
+      const before = scheduler.now();
+      await harness.advanceTo(250);
+      const after = scheduler.now();
+      expect(after - before).toBe(250);
+      expect(after).toBe(harness.clock.now());
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("setTimeout remains a no-op even though now() tracks the clock", async () => {
+    // The asymmetry is deliberate: production timers are suppressed,
+    // but a test that advances the clock for unrelated reasons still
+    // sees `now()` move. The callback handed to `setTimeout` must
+    // not fire even after the clock advances well past `delayMs`.
+    const harness = setupHarness();
+    try {
+      const scheduler = getScheduler(harness);
+      let fired = false;
+      scheduler.setTimeout(() => {
+        fired = true;
+      }, 10);
+      await harness.advanceTo(1000);
+      expect(fired).toBe(false);
+    } finally {
+      harness.dispose();
+    }
+  });
+});
+
+describe("inference-testing Scheduler.now() (enableInferenceTimers)", () => {
+  test("tracks virtual time and fires setTimeout at virtualMs delayMs later", async () => {
+    const harness = setupHarness({ enableInferenceTimers: true });
+    try {
+      const scheduler = getScheduler(harness);
+      expect(scheduler.now()).toBe(harness.clock.now());
+      const firings: number[] = [];
+      scheduler.setTimeout(() => {
+        firings.push(harness.clock.now());
+      }, 100);
+      await harness.advanceTo(100);
+      expect(firings).toEqual([100]);
+      expect(scheduler.now()).toBe(100);
+    } finally {
+      harness.dispose();
+    }
+  });
+});

--- a/tests/inference/scheduler.test.ts
+++ b/tests/inference/scheduler.test.ts
@@ -8,24 +8,12 @@
 import { describe, test, expect } from "bun:test";
 
 import { setupHarness } from "@intx/inference-testing";
-import type { Scheduler } from "@intx/inference";
-
-// `Dependencies.scheduler` is structurally optional, but `setupHarness`
-// always populates it; pulling it out through a tiny helper keeps the
-// tests focused on the behaviour, not the optional-chain ceremony.
-function getScheduler(harness: { deps: { scheduler?: Scheduler } }): Scheduler {
-  const scheduler = harness.deps.scheduler;
-  if (scheduler === undefined) {
-    throw new Error("setupHarness did not populate deps.scheduler");
-  }
-  return scheduler;
-}
 
 describe("inference-testing Scheduler.now() (inert mode)", () => {
   test("starts at the virtual clock's current value", () => {
     const harness = setupHarness();
     try {
-      expect(getScheduler(harness).now()).toBe(harness.clock.now());
+      expect(harness.deps.scheduler.now()).toBe(harness.clock.now());
     } finally {
       harness.dispose();
     }
@@ -34,10 +22,9 @@ describe("inference-testing Scheduler.now() (inert mode)", () => {
   test("tracks virtual time advanced by harness.advanceTo()", async () => {
     const harness = setupHarness();
     try {
-      const scheduler = getScheduler(harness);
-      const before = scheduler.now();
+      const before = harness.deps.scheduler.now();
       await harness.advanceTo(250);
-      const after = scheduler.now();
+      const after = harness.deps.scheduler.now();
       expect(after - before).toBe(250);
       expect(after).toBe(harness.clock.now());
     } finally {
@@ -52,9 +39,8 @@ describe("inference-testing Scheduler.now() (inert mode)", () => {
     // not fire even after the clock advances well past `delayMs`.
     const harness = setupHarness();
     try {
-      const scheduler = getScheduler(harness);
       let fired = false;
-      scheduler.setTimeout(() => {
+      harness.deps.scheduler.setTimeout(() => {
         fired = true;
       }, 10);
       await harness.advanceTo(1000);
@@ -69,15 +55,14 @@ describe("inference-testing Scheduler.now() (enableInferenceTimers)", () => {
   test("tracks virtual time and fires setTimeout at virtualMs delayMs later", async () => {
     const harness = setupHarness({ enableInferenceTimers: true });
     try {
-      const scheduler = getScheduler(harness);
-      expect(scheduler.now()).toBe(harness.clock.now());
+      expect(harness.deps.scheduler.now()).toBe(harness.clock.now());
       const firings: number[] = [];
-      scheduler.setTimeout(() => {
+      harness.deps.scheduler.setTimeout(() => {
         firings.push(harness.clock.now());
       }, 100);
       await harness.advanceTo(100);
       expect(firings).toEqual([100]);
-      expect(scheduler.now()).toBe(100);
+      expect(harness.deps.scheduler.now()).toBe(100);
     } finally {
       harness.dispose();
     }

--- a/tests/inference/timeout.test.ts
+++ b/tests/inference/timeout.test.ts
@@ -78,6 +78,15 @@ function startConsumer(events: AsyncIterable<InferenceEvent>): {
   return { done: collect(events) };
 }
 
+// Pin a one-attempt policy in the tests below whose intent is per-
+// attempt timeout-firing rather than retry behaviour. The retry path
+// is exercised by the inactivity-and-stall test that registers three
+// stalls. Defined once so the rationale and the literal stay in one
+// place.
+const ABORT_ONLY_RETRY_POLICY = {
+  retryPolicy: () => ({ kind: "abort" as const }),
+};
+
 describe("runInference — per-call timeouts (virtual clock)", () => {
   test("inactivity timeout fires on each of the default policy's three attempts, then surfaces", async () => {
     await withHarness(async (harness) => {
@@ -193,16 +202,14 @@ describe("runInference — per-call timeouts (virtual clock)", () => {
           inferenceOptions: {
             inactivityTimeoutMs: 5_000,
             totalTimeoutMs: 200,
-            // The retry behaviour under category `timeout` is exercised
-            // by the inactivity-and-stall test above. Pin an abort-only
-            // policy here so the single scripted long-trickle stream is
-            // sufficient to drive the total-timeout assertion; without
-            // it the default policy would retry into a fetch with no
-            // matcher registered, and the chunk-pre-scheduling makes
-            // adding three trickle streams behave nondeterministically
-            // (all chunks fire in virtual time before the second and
-            // third attempts even start).
-            retryPolicy: () => ({ kind: "abort" }),
+            // The chunk-pre-scheduling pattern (chunks scheduled at
+            // setup time, not at fetch time) would make multi-attempt
+            // trickle streams behave nondeterministically — all
+            // chunks fire in virtual time before the second and third
+            // attempts even start. Pinning the abort-only policy
+            // keeps the total-timeout assertion focused on the single
+            // first-attempt fire.
+            ...ABORT_ONLY_RETRY_POLICY,
           },
           nextSeq: () => seq++,
           deps: harness.deps,
@@ -332,14 +339,10 @@ describe("runInference — per-call timeouts (virtual clock)", () => {
             inferenceOptions: {
               inactivityTimeoutMs: 50,
               totalTimeoutMs: 10_000,
-              // The retry behaviour under category `timeout` is
-              // exercised by the inactivity-and-stall test above; this
-              // test asserts the per-call inactivity-threshold override
-              // narrowly. The scripted-gap stream is pre-scheduled in
-              // virtual time, so a default-policy retry would re-issue
-              // against a fetch with no matcher; abort-only keeps the
-              // per-override assertion narrow.
-              retryPolicy: () => ({ kind: "abort" }),
+              // Per-call inactivity-threshold override assertion only;
+              // see the ABORT_ONLY_RETRY_POLICY rationale above for why
+              // we pin a single-attempt policy on these tests.
+              ...ABORT_ONLY_RETRY_POLICY,
             },
             nextSeq: () => seq++,
             deps: harness.deps,

--- a/tests/inference/timeout.test.ts
+++ b/tests/inference/timeout.test.ts
@@ -79,12 +79,16 @@ function startConsumer(events: AsyncIterable<InferenceEvent>): {
 }
 
 describe("runInference — per-call timeouts (virtual clock)", () => {
-  test("inactivity timeout fires when SSE stream goes silent past the threshold", async () => {
+  test("inactivity timeout fires on each of the default policy's three attempts, then surfaces", async () => {
     await withHarness(async (harness) => {
-      // `scenario.stall()` routes the fetch to a stream that never
-      // emits anything. The SSE iterator's first read parks forever in
-      // real time; in virtual time we advance past the inactivity
-      // threshold and the timer aborts the fetch.
+      // Three single-use stalls — one per attempt under the default
+      // policy. Each `scenario.stall()` registers a fresh matcher that
+      // routes the next fetch to a never-emitting stream. The
+      // inactivity timer trips on each attempt; the wrapper consults
+      // the default policy, retries up to the 3-attempt cap, then
+      // surfaces the terminal `inference.error`.
+      harness.scenario.stall();
+      harness.scenario.stall();
       harness.scenario.stall();
 
       let seq = 0;
@@ -101,12 +105,27 @@ describe("runInference — per-call timeouts (virtual clock)", () => {
         }),
       );
 
-      // Advance virtual clock past the inactivity threshold. Drains
-      // every scheduled callback (including the timeout), settles
+      // Advance virtual clock through all three attempts plus the
+      // 500ms + 1000ms backoff between them. Drains every scheduled
+      // callback (timeouts and the retry-delay setTimeouts), settles
       // microtasks, returns when the heap is empty + quiescent.
       await harness.run();
 
       const events = await consumer.done;
+
+      // The retry sequence: two `inference.retry` events between the
+      // three attempts, with the right per-attempt numbers and
+      // backoff delays. The terminal error surfaces from the third
+      // attempt with category `"timeout"`.
+      const retries = events.filter((e) => e.type === "inference.retry");
+      expect(retries).toHaveLength(2);
+      expect(
+        retries[0]?.type === "inference.retry" ? retries[0].data : null,
+      ).toMatchObject({ attempt: 1, delayMs: 500 });
+      expect(
+        retries[1]?.type === "inference.retry" ? retries[1].data : null,
+      ).toMatchObject({ attempt: 2, delayMs: 1000 });
+
       const err = findError(events);
       expect(err).toBeDefined();
       expect(err?.category).toBe("timeout");
@@ -174,6 +193,16 @@ describe("runInference — per-call timeouts (virtual clock)", () => {
           inferenceOptions: {
             inactivityTimeoutMs: 5_000,
             totalTimeoutMs: 200,
+            // The retry behaviour under category `timeout` is exercised
+            // by the inactivity-and-stall test above. Pin an abort-only
+            // policy here so the single scripted long-trickle stream is
+            // sufficient to drive the total-timeout assertion; without
+            // it the default policy would retry into a fetch with no
+            // matcher registered, and the chunk-pre-scheduling makes
+            // adding three trickle streams behave nondeterministically
+            // (all chunks fire in virtual time before the second and
+            // third attempts even start).
+            retryPolicy: () => ({ kind: "abort" }),
           },
           nextSeq: () => seq++,
           deps: harness.deps,
@@ -213,7 +242,7 @@ describe("runInference — per-call timeouts (virtual clock)", () => {
     });
   });
 
-  test("underlying fetch AbortController fires on timeout", async () => {
+  test("underlying fetch AbortController fires on timeout for each attempt", async () => {
     await withHarness(async (harness) => {
       // Direct assertion on abort propagation: `stall.aborted` flips
       // and `stall.awaitAbort` resolves the moment the matched fetch's
@@ -221,8 +250,17 @@ describe("runInference — per-call timeouts (virtual clock)", () => {
       // names explicitly — the downstream `inference.error` event the
       // other tests look at is downstream of the abort, but this test
       // proves the abort actually fired at the fetch boundary.
-      const stall = harness.scenario.stall();
-      expect(stall.aborted).toBe(false);
+      //
+      // The default policy retries on timeout up to three attempts;
+      // we register one stall per attempt and assert the abort fires
+      // on each so a fix that broke the abort plumbing on retried
+      // attempts would not slip past this test.
+      const stalls = [
+        harness.scenario.stall(),
+        harness.scenario.stall(),
+        harness.scenario.stall(),
+      ];
+      for (const stall of stalls) expect(stall.aborted).toBe(false);
 
       let seq = 0;
       const consumer = startConsumer(
@@ -239,15 +277,21 @@ describe("runInference — per-call timeouts (virtual clock)", () => {
       );
 
       await harness.run();
-      await stall.awaitAbort;
-      expect(stall.aborted).toBe(true);
+      for (const stall of stalls) {
+        await stall.awaitAbort;
+        expect(stall.aborted).toBe(true);
+      }
 
-      // Sanity: the run also surfaced a timeout error, so this is a
-      // genuine timeout-driven abort and not some other path.
+      // Sanity: the run also surfaced a timeout error after the third
+      // attempt, so this is a genuine timeout-driven abort sequence
+      // and not some other path.
       const events = await consumer.done;
       const err = findError(events);
       expect(err?.category).toBe("timeout");
       expect(err?.message).toMatch(/inactivity/i);
+      expect(events.filter((e) => e.type === "inference.retry")).toHaveLength(
+        2,
+      );
     });
   });
 
@@ -288,6 +332,14 @@ describe("runInference — per-call timeouts (virtual clock)", () => {
             inferenceOptions: {
               inactivityTimeoutMs: 50,
               totalTimeoutMs: 10_000,
+              // The retry behaviour under category `timeout` is
+              // exercised by the inactivity-and-stall test above; this
+              // test asserts the per-call inactivity-threshold override
+              // narrowly. The scripted-gap stream is pre-scheduled in
+              // virtual time, so a default-policy retry would re-issue
+              // against a fetch with no matcher; abort-only keeps the
+              // per-override assertion narrow.
+              retryPolicy: () => ({ kind: "abort" }),
             },
             nextSeq: () => seq++,
             deps: harness.deps,


### PR DESCRIPTION
## Summary

- `runInference` in `@intx/inference` wraps each call in a mechanical retry layer: per-attempt event buffer, a `RetryPolicy` consulted on `inference.error`, and one `inference.retry` event emitted between attempts carrying the failed attempt's number, the policy-chosen `delayMs`, and the classified error.
- `createDefaultRetryPolicy()` ships conservative defaults: up to 3 attempts with 500/1000 ms backoff on `retryable` and `timeout`; up to 3 attempts on `quota_exhausted` honoring `retryAfterMs ?? 1000 ms`; immediate abort on `credential_failure`, `context_overflow`, `fatal`, `aborted`, and `protocol_mismatch`.
- The caller-supplied `AbortSignal` short-circuits the retry delay so a 60-second `retryAfterMs` on a quota error wakes the wrapper immediately on cancellation rather than blocking the full minute.
- Caller-visible event seqs stay contiguous across retries: each attempt runs against a private allocator and the buffer is re-stamped from `opts.nextSeq` at flush, so a discarded attempt does not leave gaps in the consumer's seq stream.
- `Dependencies.scheduler` is now required and exposes a `now()` method alongside the existing `setTimeout`, giving the wrapper a monotonic time source for `RetrySituation.elapsedMs`. The production default uses `performance.now()`; the test harness wires `now()` to its virtual clock in both inert and timer-enabled modes.
- `InferenceOptions.retryPolicy?: RetryPolicy` lets callers override per call. The contract types (`RetryPolicy`, `RetrySituation`, `RetryDecision`) live in `@intx/types/runtime` and are re-exported from `@intx/inference` for ergonomic imports.
- The retry contract is documented in the inference docs alongside the existing event protocol and per-call timeout sections.

## Test plan

- [x] `make all` clean — 2331 pass / 2 skip / 0 fail across 138 files, plus 9/0 secondary integration suite.
- [x] Retry-policy behavioural suite at `tests/inference/retry.test.ts` covers default 3-attempt cadence, abort-only policy, unlimited-retry success on attempt N, `quota_exhausted` with and without `retryAfterMs`, every non-retryable category, custom-policy `attempt` reading, `inference.retry` payload, policy throws / rejected promises, scheduler-driven delay, signal short-circuit during the delay, abort-vs-retry seq invariants, and contiguous caller-visible seqs across a retry.
- [x] Scheduler unit + harness tests at `packages/inference/src/scheduler.test.ts` and `tests/inference/scheduler.test.ts` cover monotonicity, the inert-mode `setTimeout` no-op / `now()`-tracks-clock asymmetry, and timer firing under virtual clock.
- [x] Timeout suite at `tests/inference/timeout.test.ts` exercises the default policy's three-attempt retry on `timeout` via three single-use stalls plus abort-propagation per attempt.
- [x] Direct unit coverage of `createDefaultRetryPolicy` decisions per category.

Closes INTR-88.