### PR TITLE
Refactor agent-repo into a kind-keyed repo store

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "check": "tsc -b --noEmit",
     "lint": "prettier -c . && eslint --cache . && bun run check:docs",
     "format": "prettier -w .",
-    "test": "bun test && bun test tests/sidecar/deploy-flow.test.ts tests/inference/transform-cutover.test.ts",
+    "test": "bun test && bun test tests/hub-agent/deploy-flow.test.ts tests/inference/transform-cutover.test.ts",
     "docs": "bun bin/gen-api-docs.ts",
     "check:docs": "bun bin/gen-api-docs.ts --check"
   },

--- a/packages/hub-sessions/src/agent-repo.ts
+++ b/packages/hub-sessions/src/agent-repo.ts
@@ -1,22 +1,12 @@
-import fs from "node:fs";
-import path from "node:path";
-import git from "isomorphic-git";
-import { createSSHSignature } from "@intx/crypto-node";
+import { createRepoStore, SAFE_REPO_ID } from "./repo-store";
+import type { RepoId } from "./repo-store";
 import {
-  initRepo,
-  createDeployPack,
-  receivePackObjects,
-} from "@intx/storage-isogit";
-import { hasCode } from "@intx/types";
-
-const AUTHOR = {
-  name: "interchange-hub",
-  email: "hub@interchange.local",
-};
-
-const SAFE_AGENT_ID = /^[a-zA-Z0-9_-]+$/;
-
-const DEPLOY_REF = "refs/heads/deploy";
+  agentStateKindHandler,
+  agentStateAuthorize,
+  AGENT_STATE_DEPLOY_REF,
+  type AgentStateHubPrincipal,
+  type AgentStateSidecarPrincipal,
+} from "./agent-state-kind";
 
 export type DeployContent = {
   systemPrompt: string;
@@ -66,161 +56,66 @@ export function createAgentRepoStore(config: {
 }): AgentRepoStore {
   const { dataDir, signingKey } = config;
 
-  function validateAgentId(agentId: string): void {
-    if (!SAFE_AGENT_ID.test(agentId)) {
+  const store = createRepoStore({
+    dataDir,
+    signingKey,
+    handlers: { "agent-state": agentStateKindHandler },
+    authorize: agentStateAuthorize,
+  });
+
+  const hub: AgentStateHubPrincipal = { kind: "hub" };
+
+  // The substrate enforces the same SAFE_REPO_ID rule with a different
+  // error prefix; we throw the legacy message here so existing callers
+  // and tests that match on it continue to work.
+  function repoId(agentId: string): RepoId {
+    if (!SAFE_REPO_ID.test(agentId)) {
       throw new Error(
         `agentId contains unsafe characters: ${JSON.stringify(agentId)}`,
       );
     }
-  }
-
-  function repoDir(agentId: string): string {
-    validateAgentId(agentId);
-    return path.join(dataDir, "agents", agentId);
-  }
-
-  async function ensureRepo(agentId: string): Promise<string> {
-    const dir = repoDir(agentId);
-    await initRepo(dir);
-    return dir;
-  }
-
-  /**
-   * Collect all files tracked in the git index under a given prefix.
-   */
-  async function indexedPaths(dir: string, prefix: string): Promise<string[]> {
-    const matrix = await git.statusMatrix({ fs, dir });
-    return matrix
-      .filter(([filepath]) => filepath.startsWith(prefix))
-      .map(([filepath]) => filepath as string);
-  }
-
-  async function writeDeployTree(
-    agentId: string,
-    content: DeployContent,
-  ): Promise<{ commitSha: string }> {
-    const dir = await ensureRepo(agentId);
-
-    // Remove all tracked deploy/ paths from the index so stale entries
-    // from a previous writeDeployTree call don't survive.
-    const oldPaths = await indexedPaths(dir, "deploy/");
-    for (const filepath of oldPaths) {
-      await git.remove({ fs, dir, filepath });
-    }
-
-    const deployDir = path.join(dir, "deploy");
-    await fs.promises.rm(deployDir, { recursive: true, force: true });
-    await fs.promises.mkdir(deployDir, { recursive: true });
-
-    await fs.promises.writeFile(
-      path.join(deployDir, "prompt.md"),
-      content.systemPrompt,
-    );
-    await git.add({ fs, dir, filepath: "deploy/prompt.md" });
-
-    for (const skill of content.skills) {
-      const skillDir = path.join(deployDir, "skills", skill.name);
-      await fs.promises.mkdir(skillDir, { recursive: true });
-      await fs.promises.writeFile(
-        path.join(skillDir, "tool.json"),
-        JSON.stringify(skill.definition, null, 2),
-      );
-      await git.add({
-        fs,
-        dir,
-        filepath: `deploy/skills/${skill.name}/tool.json`,
-      });
-    }
-
-    // Resolve the parent from the deploy ref if it exists, otherwise
-    // fall back to HEAD. This keeps deploy history on its own lineage
-    // separate from refs/heads/main.
-    let parent: string[];
-    try {
-      parent = [await git.resolveRef({ fs, dir, ref: DEPLOY_REF })];
-    } catch {
-      parent = [await git.resolveRef({ fs, dir, ref: "HEAD" })];
-    }
-
-    const commitSha = await git.commit({
-      fs,
-      dir,
-      message: "Update deploy tree",
-      author: AUTHOR,
-      parent,
-      ref: DEPLOY_REF,
-      signingKey: "sshsig",
-      onSign: async ({ payload }) => ({
-        signature: createSSHSignature(
-          payload,
-          signingKey.privateKey,
-          signingKey.publicKey,
-        ),
-      }),
-    });
-
-    return { commitSha };
-  }
-
-  async function makeDeployPack(
-    agentId: string,
-  ): Promise<{ pack: Uint8Array; commitSha: string; ref: string }> {
-    const dir = repoDir(agentId);
-    const { pack, commitSha } = await createDeployPack(dir, DEPLOY_REF);
-    return { pack, commitSha, ref: DEPLOY_REF };
-  }
-
-  async function receiveStatePack(
-    agentId: string,
-    pack: Uint8Array,
-    ref: string,
-    commitSha: string,
-  ): Promise<void> {
-    const dir = await ensureRepo(agentId);
-    const transferId = crypto.randomUUID().replace(/-/g, "");
-    // Allow the per-cycle working-tree files written by the reactor at the
-    // repository root alongside `state/` and `.gitignore`. Anything outside
-    // this allowlist (notably `deploy/`) is rejected. The pack must contain
-    // at least one state-bearing path beyond `.gitignore`.
-    const allowedTopLevel = new Set([
-      "state",
-      ".gitignore",
-      "turns.jsonl",
-      "prompt.jsonl",
-      "response.jsonl",
-      "manifest.jsonl",
-      "metadata.json",
-      "tool-output",
-    ]);
-    await receivePackObjects(
-      dir,
-      pack,
-      ref,
-      commitSha,
-      transferId,
-      (paths) =>
-        paths.every((p) => allowedTopLevel.has(p)) &&
-        paths.some((p) => p !== ".gitignore"),
-    );
-  }
-
-  async function getDeployRef(agentId: string): Promise<string | null> {
-    const dir = repoDir(agentId);
-    try {
-      return await git.resolveRef({ fs, dir, ref: DEPLOY_REF });
-    } catch (err: unknown) {
-      if (hasCode(err) && err.code === "NotFoundError") {
-        return null;
-      }
-      throw err;
-    }
+    return { kind: "agent-state", id: agentId };
   }
 
   return {
-    writeDeployTree,
-    createDeployPack: makeDeployPack,
-    receiveStatePack,
-    getDeployRef,
-    getSigningPublicKey: () => signingKey.publicKey,
+    async writeDeployTree(agentId, content) {
+      const id = repoId(agentId);
+      const files: Record<string, string> = {
+        "deploy/prompt.md": content.systemPrompt,
+      };
+      for (const skill of content.skills) {
+        files[`deploy/skills/${skill.name}/tool.json`] = JSON.stringify(
+          skill.definition,
+          null,
+          2,
+        );
+      }
+      return store.writeTree(hub, id, AGENT_STATE_DEPLOY_REF, {
+        files,
+        clearPrefix: "deploy/",
+        message: "Update deploy tree",
+      });
+    },
+
+    async createDeployPack(agentId) {
+      return store.createPack(hub, repoId(agentId), AGENT_STATE_DEPLOY_REF);
+    },
+
+    async receiveStatePack(agentId, pack, ref, commitSha) {
+      const id = repoId(agentId);
+      const principal: AgentStateSidecarPrincipal = {
+        kind: "sidecar",
+        agentId,
+      };
+      await store.receivePack(principal, id, ref, pack, commitSha);
+    },
+
+    async getDeployRef(agentId) {
+      return store.resolveRef(hub, repoId(agentId), AGENT_STATE_DEPLOY_REF);
+    },
+
+    getSigningPublicKey() {
+      return signingKey.publicKey;
+    },
   };
 }

--- a/packages/hub-sessions/src/agent-state-kind.ts
+++ b/packages/hub-sessions/src/agent-state-kind.ts
@@ -1,0 +1,129 @@
+import { type } from "arktype";
+import type {
+  AuthorizeFn,
+  KindHandler,
+  Principal,
+  ValidatePushResult,
+} from "./repo-store";
+
+export type AgentStateHubPrincipal = { readonly kind: "hub" };
+
+export type AgentStateSidecarPrincipal = {
+  readonly kind: "sidecar";
+  readonly agentId: string;
+};
+
+export type AgentStatePrincipal =
+  | AgentStateHubPrincipal
+  | AgentStateSidecarPrincipal;
+
+const SidecarPrincipal = type({
+  kind: "'sidecar'",
+  agentId: "string",
+});
+
+export const AGENT_STATE_DEPLOY_REF = "refs/heads/deploy";
+
+const ALLOWED_STATE_TOP_LEVEL = new Set([
+  "state",
+  ".gitignore",
+  "turns.jsonl",
+  "prompt.jsonl",
+  "response.jsonl",
+  "manifest.jsonl",
+  "metadata.json",
+  "tool-output",
+]);
+
+export const agentStateKindHandler: KindHandler = {
+  kind: "agent-state",
+  directoryPrefix: "agents",
+  validatePush: ({ topLevelTreePaths }): ValidatePushResult => {
+    const offender = topLevelTreePaths.find(
+      (p) => !ALLOWED_STATE_TOP_LEVEL.has(p),
+    );
+    if (offender !== undefined) {
+      return {
+        ok: false,
+        reason: `tree contains disallowed top-level path: ${offender}`,
+      };
+    }
+    if (!topLevelTreePaths.some((p) => p !== ".gitignore")) {
+      return {
+        ok: false,
+        reason: "tree must include at least one state-bearing top-level entry",
+      };
+    }
+    return { ok: true };
+  },
+  onRefUpdated: () => {
+    // No consumer at this kind today; the substrate's hook surface is
+    // uniform across kinds and future kinds will use it.
+  },
+};
+
+export const agentStateAuthorize: AuthorizeFn = (
+  principal: Principal,
+  repoId,
+  ref,
+  action,
+) => {
+  if (principal.kind === "hub") {
+    // Full access at this kind. Hub-side reads (getDeployRef,
+    // createDeployPack) and writes (writeDeployTree) all flow through
+    // here, so changing this branch tightens behavior in non-obvious
+    // places.
+    return { allowed: true };
+  }
+
+  if (principal.kind === "sidecar") {
+    const parsed = SidecarPrincipal(principal);
+    if (parsed instanceof type.errors) {
+      return {
+        allowed: false,
+        reason: `sidecar principal is malformed: ${parsed.summary}`,
+      };
+    }
+    if (repoId.kind !== "agent-state" || repoId.id !== parsed.agentId) {
+      return {
+        allowed: false,
+        reason: `sidecar ${parsed.agentId} cannot access ${repoId.kind}/${repoId.id}`,
+      };
+    }
+    switch (action) {
+      case "receivePack":
+        return { allowed: true };
+      case "createPack":
+      case "resolveRef":
+        if (ref !== AGENT_STATE_DEPLOY_REF) {
+          return {
+            allowed: false,
+            reason: `sidecar may only read ${AGENT_STATE_DEPLOY_REF}, not ${ref}`,
+          };
+        }
+        return { allowed: true };
+      case "init":
+        return {
+          allowed: false,
+          reason: "init is not authorize-gated for agent-state",
+        };
+      case "writeTree":
+        return {
+          allowed: false,
+          reason: `action ${action} is hub-only for agent-state`,
+        };
+      default: {
+        const _exhaustive: never = action;
+        return {
+          allowed: false,
+          reason: `unhandled action: ${String(_exhaustive)}`,
+        };
+      }
+    }
+  }
+
+  return {
+    allowed: false,
+    reason: `unknown principal kind: ${principal.kind}`,
+  };
+};

--- a/packages/hub-sessions/src/repo-store/index.ts
+++ b/packages/hub-sessions/src/repo-store/index.ts
@@ -1,0 +1,13 @@
+export type {
+  AuthorizeFn,
+  KindHandler,
+  Principal,
+  RepoAction,
+  RepoId,
+  RepoKind,
+  RepoStore,
+  TreeContent,
+  ValidatePushResult,
+} from "./types";
+export { SAFE_REPO_ID } from "./types";
+export { createRepoStore, type CreateRepoStoreConfig } from "./store";

--- a/packages/hub-sessions/src/repo-store/store.test.ts
+++ b/packages/hub-sessions/src/repo-store/store.test.ts
@@ -1,0 +1,534 @@
+import { describe, test, expect, afterAll, beforeAll } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import git from "isomorphic-git";
+import { generateKeyPair } from "@intx/crypto-node";
+import type { KeyPair } from "@intx/types/runtime";
+import { createRepoStore } from "./store";
+import type {
+  AuthorizeFn,
+  KindHandler,
+  Principal,
+  RepoAction,
+  RepoId,
+  ValidatePushResult,
+} from "./types";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const d = await fs.promises.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(d);
+  return d;
+}
+
+let signingKey: KeyPair;
+
+beforeAll(async () => {
+  signingKey = await generateKeyPair();
+});
+
+afterAll(async () => {
+  for (const d of tempDirs.splice(0)) {
+    await fs.promises.rm(d, { recursive: true, force: true }).catch((_e) => {
+      /* best effort cleanup */
+    });
+  }
+});
+
+type RefUpdateRecord = {
+  repoId: RepoId;
+  ref: string;
+  oldSha: string | null;
+  newSha: string;
+};
+
+type TestHandler = KindHandler & {
+  onRefUpdatedCalls: RefUpdateRecord[];
+};
+
+function createTestHandler(opts?: {
+  allowTopLevelPaths?: (topLevelTreePaths: string[]) => boolean;
+}): TestHandler {
+  const onRefUpdatedCalls: RefUpdateRecord[] = [];
+  const allowFn = opts?.allowTopLevelPaths;
+  return {
+    kind: "agent-state",
+    directoryPrefix: "repos-under-test",
+    validatePush({ topLevelTreePaths }): ValidatePushResult {
+      if (allowFn === undefined) {
+        return { ok: true };
+      }
+      if (allowFn(topLevelTreePaths)) {
+        return { ok: true };
+      }
+      return { ok: false, reason: "stub rejected push" };
+    },
+    onRefUpdated(args) {
+      onRefUpdatedCalls.push(args);
+    },
+    onRefUpdatedCalls,
+  };
+}
+
+const allowAll: AuthorizeFn = () => ({ allowed: true });
+
+const principal: Principal = { kind: "test" };
+
+const repoId: RepoId = { kind: "agent-state", id: "subject" };
+
+const REF = "refs/heads/test";
+
+async function readTreePaths(dir: string, treeOid: string): Promise<string[]> {
+  const { tree } = await git.readTree({ fs, dir, oid: treeOid });
+  return tree.map((e) => e.path);
+}
+
+describe("RepoStore", () => {
+  test("initRepo is idempotent", async () => {
+    const dataDir = await makeTempDir("repo-store-init-");
+    const handler = createTestHandler();
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: allowAll,
+    });
+
+    await store.initRepo(repoId);
+    await store.initRepo(repoId);
+
+    const gitDir = path.join(
+      dataDir,
+      handler.directoryPrefix,
+      repoId.id,
+      ".git",
+    );
+    const stat = await fs.promises.stat(gitDir);
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  test("writeTree writes files, signs the commit, advances the ref, calls onRefUpdated", async () => {
+    const dataDir = await makeTempDir("repo-store-write-");
+    const handler = createTestHandler();
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: allowAll,
+    });
+
+    const { commitSha } = await store.writeTree(principal, repoId, REF, {
+      files: {
+        "deploy/prompt.md": "hello",
+        "deploy/skills/greet/tool.json": '{"name":"greet"}',
+      },
+      message: "initial",
+    });
+
+    expect(commitSha).toMatch(/^[0-9a-f]{40}$/);
+
+    const dir = path.join(dataDir, handler.directoryPrefix, repoId.id);
+    const resolved = await git.resolveRef({ fs, dir, ref: REF });
+    expect(resolved).toBe(commitSha);
+
+    const { commit } = await git.readCommit({ fs, dir, oid: commitSha });
+    expect(commit.gpgsig).toBeDefined();
+    expect(commit.gpgsig).toContain("-----BEGIN SSH SIGNATURE-----");
+
+    expect(handler.onRefUpdatedCalls).toHaveLength(1);
+    const call = handler.onRefUpdatedCalls[0];
+    if (!call) throw new Error("unreachable");
+    expect(call.ref).toBe(REF);
+    expect(call.oldSha).toBeNull();
+    expect(call.newSha).toBe(commitSha);
+    expect(call.repoId).toEqual(repoId);
+  });
+
+  test("writeTree on an existing ref advances from that ref", async () => {
+    const dataDir = await makeTempDir("repo-store-advance-");
+    const handler = createTestHandler();
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: allowAll,
+    });
+
+    const first = await store.writeTree(principal, repoId, REF, {
+      files: { "deploy/a.md": "v1" },
+      message: "first",
+    });
+    const second = await store.writeTree(principal, repoId, REF, {
+      files: { "deploy/a.md": "v2" },
+      message: "second",
+    });
+
+    expect(second.commitSha).not.toBe(first.commitSha);
+
+    const dir = path.join(dataDir, handler.directoryPrefix, repoId.id);
+    const { commit } = await git.readCommit({
+      fs,
+      dir,
+      oid: second.commitSha,
+    });
+    expect(commit.parent).toContain(first.commitSha);
+
+    expect(handler.onRefUpdatedCalls).toHaveLength(2);
+    const secondCall = handler.onRefUpdatedCalls[1];
+    if (!secondCall) throw new Error("unreachable");
+    expect(secondCall.oldSha).toBe(first.commitSha);
+    expect(secondCall.newSha).toBe(second.commitSha);
+  });
+
+  test("writeTree with clearPrefix clears stale tracked files under that prefix", async () => {
+    const dataDir = await makeTempDir("repo-store-clear-");
+    const handler = createTestHandler();
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: allowAll,
+    });
+
+    await store.writeTree(principal, repoId, REF, {
+      files: { "deploy/a.md": "A", "deploy/b.md": "B" },
+      clearPrefix: "deploy/",
+      message: "first",
+    });
+    const second = await store.writeTree(principal, repoId, REF, {
+      files: { "deploy/a.md": "A2" },
+      clearPrefix: "deploy/",
+      message: "second",
+    });
+
+    const dir = path.join(dataDir, handler.directoryPrefix, repoId.id);
+    const { commit } = await git.readCommit({
+      fs,
+      dir,
+      oid: second.commitSha,
+    });
+    const rootEntries = await readTreePaths(dir, commit.tree);
+    expect(rootEntries).toContain("deploy");
+
+    const { tree: rootTree } = await git.readTree({
+      fs,
+      dir,
+      oid: commit.tree,
+    });
+    const deployEntry = rootTree.find((e) => e.path === "deploy");
+    if (!deployEntry) throw new Error("deploy subtree missing");
+    const deployPaths = await readTreePaths(dir, deployEntry.oid);
+    expect(deployPaths).toContain("a.md");
+    expect(deployPaths).not.toContain("b.md");
+  });
+
+  test("writeTree without clearPrefix is purely additive", async () => {
+    const dataDir = await makeTempDir("repo-store-additive-");
+    const handler = createTestHandler();
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: allowAll,
+    });
+
+    await store.writeTree(principal, repoId, REF, {
+      files: { "x/a": "1" },
+      message: "first",
+    });
+    const second = await store.writeTree(principal, repoId, REF, {
+      files: { "x/b": "2" },
+      message: "second",
+    });
+
+    const dir = path.join(dataDir, handler.directoryPrefix, repoId.id);
+    const { commit } = await git.readCommit({
+      fs,
+      dir,
+      oid: second.commitSha,
+    });
+    const { tree: rootTree } = await git.readTree({
+      fs,
+      dir,
+      oid: commit.tree,
+    });
+    const xEntry = rootTree.find((e) => e.path === "x");
+    if (!xEntry) throw new Error("x subtree missing");
+    const xPaths = await readTreePaths(dir, xEntry.oid);
+    expect(xPaths).toContain("a");
+    expect(xPaths).toContain("b");
+  });
+
+  test("receivePack accepts a valid pack and rejects one failing validatePush", async () => {
+    const sourceDataDir = await makeTempDir("repo-store-pack-source-");
+    const sourceHandler = createTestHandler();
+    const sourceStore = createRepoStore({
+      dataDir: sourceDataDir,
+      signingKey,
+      handlers: { "agent-state": sourceHandler },
+      authorize: allowAll,
+    });
+    await sourceStore.writeTree(principal, repoId, REF, {
+      files: { "deploy/a.md": "from-source" },
+      message: "source content",
+    });
+    const { pack, commitSha } = await sourceStore.createPack(
+      principal,
+      repoId,
+      REF,
+    );
+
+    const acceptDir = await makeTempDir("repo-store-pack-accept-");
+    const acceptHandler = createTestHandler({
+      allowTopLevelPaths: () => true,
+    });
+    const acceptStore = createRepoStore({
+      dataDir: acceptDir,
+      signingKey,
+      handlers: { "agent-state": acceptHandler },
+      authorize: allowAll,
+    });
+    await acceptStore.receivePack(principal, repoId, REF, pack, commitSha);
+    expect(await acceptStore.resolveRef(principal, repoId, REF)).toBe(
+      commitSha,
+    );
+    expect(acceptHandler.onRefUpdatedCalls).toHaveLength(1);
+
+    const rejectDir = await makeTempDir("repo-store-pack-reject-");
+    const rejectHandler = createTestHandler({
+      allowTopLevelPaths: () => false,
+    });
+    const rejectStore = createRepoStore({
+      dataDir: rejectDir,
+      signingKey,
+      handlers: { "agent-state": rejectHandler },
+      authorize: allowAll,
+    });
+    await expect(
+      rejectStore.receivePack(principal, repoId, REF, pack, commitSha),
+    ).rejects.toThrow(/^path_violation/);
+    expect(await rejectStore.resolveRef(principal, repoId, REF)).toBeNull();
+  });
+
+  test("createPack and receivePack round-trip", async () => {
+    const sourceDir = await makeTempDir("repo-store-rt-source-");
+    const sourceHandler = createTestHandler();
+    const sourceStore = createRepoStore({
+      dataDir: sourceDir,
+      signingKey,
+      handlers: { "agent-state": sourceHandler },
+      authorize: allowAll,
+    });
+    const { commitSha } = await sourceStore.writeTree(principal, repoId, REF, {
+      files: { "deploy/payload.txt": "round-trip body" },
+      message: "rt",
+    });
+    const { pack } = await sourceStore.createPack(principal, repoId, REF);
+
+    const targetDir = await makeTempDir("repo-store-rt-target-");
+    const targetHandler = createTestHandler({
+      allowTopLevelPaths: () => true,
+    });
+    const targetStore = createRepoStore({
+      dataDir: targetDir,
+      signingKey,
+      handlers: { "agent-state": targetHandler },
+      authorize: allowAll,
+    });
+
+    await targetStore.receivePack(principal, repoId, REF, pack, commitSha);
+    const resolved = await targetStore.resolveRef(principal, repoId, REF);
+    expect(resolved).toBe(commitSha);
+  });
+
+  test("resolveRef returns null for a missing ref", async () => {
+    const dataDir = await makeTempDir("repo-store-resolve-missing-");
+    const handler = createTestHandler();
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: allowAll,
+    });
+    await store.initRepo(repoId);
+    const resolved = await store.resolveRef(
+      principal,
+      repoId,
+      "refs/heads/nonexistent",
+    );
+    expect(resolved).toBeNull();
+  });
+
+  test("authorize gates each authorize-gated operation", async () => {
+    const sourceDir = await makeTempDir("repo-store-authz-source-");
+    const sourceHandler = createTestHandler();
+    const sourceStore = createRepoStore({
+      dataDir: sourceDir,
+      signingKey,
+      handlers: { "agent-state": sourceHandler },
+      authorize: allowAll,
+    });
+    const { commitSha: existingSha, ...rest } = await sourceStore.writeTree(
+      principal,
+      repoId,
+      REF,
+      {
+        files: { "deploy/a.md": "pack-source" },
+        message: "source",
+      },
+    );
+    void rest;
+    const { pack: validPack } = await sourceStore.createPack(
+      principal,
+      repoId,
+      REF,
+    );
+
+    const denyDir = await makeTempDir("repo-store-authz-deny-");
+    let denyCallCount = 0;
+    const denyAuthorize: AuthorizeFn = () => {
+      denyCallCount += 1;
+      return { allowed: false, reason: "denied" };
+    };
+    const denyHandler = createTestHandler({ allowTopLevelPaths: () => true });
+    const denyStore = createRepoStore({
+      dataDir: denyDir,
+      signingKey,
+      handlers: { "agent-state": denyHandler },
+      authorize: denyAuthorize,
+    });
+
+    await denyStore.initRepo(repoId);
+    expect(denyCallCount).toBe(0);
+
+    await expect(
+      denyStore.writeTree(principal, repoId, REF, {
+        files: { a: "1" },
+        message: "x",
+      }),
+    ).rejects.toThrow(/^authorize_denied:.*denied/);
+    await expect(
+      denyStore.receivePack(principal, repoId, REF, validPack, existingSha),
+    ).rejects.toThrow(/^authorize_denied:.*denied/);
+    await expect(denyStore.createPack(principal, repoId, REF)).rejects.toThrow(
+      /^authorize_denied:.*denied/,
+    );
+    await expect(denyStore.resolveRef(principal, repoId, REF)).rejects.toThrow(
+      /^authorize_denied:.*denied/,
+    );
+
+    const partialDir = await makeTempDir("repo-store-authz-partial-");
+    let partialCallCount = 0;
+    const allowOnlyResolve: AuthorizeFn = (
+      _p,
+      _r,
+      _ref,
+      action: RepoAction,
+    ) => {
+      partialCallCount += 1;
+      if (action === "resolveRef") return { allowed: true };
+      return { allowed: false, reason: "denied" };
+    };
+    const partialHandler = createTestHandler({
+      allowTopLevelPaths: () => true,
+    });
+    const partialStore = createRepoStore({
+      dataDir: partialDir,
+      signingKey,
+      handlers: { "agent-state": partialHandler },
+      authorize: allowOnlyResolve,
+    });
+
+    await partialStore.initRepo(repoId);
+    expect(partialCallCount).toBe(0);
+
+    const resolvedMissing = await partialStore.resolveRef(
+      principal,
+      repoId,
+      REF,
+    );
+    expect(resolvedMissing).toBeNull();
+    expect(partialCallCount).toBe(1);
+
+    await expect(
+      partialStore.writeTree(principal, repoId, REF, {
+        files: { a: "1" },
+        message: "x",
+      }),
+    ).rejects.toThrow(/^authorize_denied/);
+    await expect(
+      partialStore.receivePack(principal, repoId, REF, validPack, existingSha),
+    ).rejects.toThrow(/^authorize_denied/);
+    await expect(
+      partialStore.createPack(principal, repoId, REF),
+    ).rejects.toThrow(/^authorize_denied/);
+  });
+
+  test("onRefUpdated is not called on a failed receivePack", async () => {
+    const sourceDir = await makeTempDir("repo-store-fail-source-");
+    const sourceHandler = createTestHandler();
+    const sourceStore = createRepoStore({
+      dataDir: sourceDir,
+      signingKey,
+      handlers: { "agent-state": sourceHandler },
+      authorize: allowAll,
+    });
+    const { commitSha } = await sourceStore.writeTree(principal, repoId, REF, {
+      files: { "deploy/a.md": "pack-source" },
+      message: "source",
+    });
+    const { pack } = await sourceStore.createPack(principal, repoId, REF);
+
+    const targetDir = await makeTempDir("repo-store-fail-target-");
+    const targetHandler = createTestHandler({
+      allowTopLevelPaths: () => false,
+    });
+    const targetStore = createRepoStore({
+      dataDir: targetDir,
+      signingKey,
+      handlers: { "agent-state": targetHandler },
+      authorize: allowAll,
+    });
+
+    await expect(
+      targetStore.receivePack(principal, repoId, REF, pack, commitSha),
+    ).rejects.toThrow(/^path_violation/);
+
+    expect(targetHandler.onRefUpdatedCalls).toHaveLength(0);
+    const resolved = await targetStore.resolveRef(principal, repoId, REF);
+    expect(resolved).toBeNull();
+  });
+
+  test("validatePush runs on receivePack regardless of authorize verdict", async () => {
+    const sourceDir = await makeTempDir("repo-store-bypass-source-");
+    const sourceHandler = createTestHandler();
+    const sourceStore = createRepoStore({
+      dataDir: sourceDir,
+      signingKey,
+      handlers: { "agent-state": sourceHandler },
+      authorize: allowAll,
+    });
+    const { commitSha } = await sourceStore.writeTree(principal, repoId, REF, {
+      files: { "deploy/a.md": "pack-source" },
+      message: "source",
+    });
+    const { pack } = await sourceStore.createPack(principal, repoId, REF);
+
+    const targetDir = await makeTempDir("repo-store-bypass-target-");
+    const targetHandler = createTestHandler({
+      allowTopLevelPaths: () => false,
+    });
+    const targetStore = createRepoStore({
+      dataDir: targetDir,
+      signingKey,
+      handlers: { "agent-state": targetHandler },
+      authorize: allowAll,
+    });
+
+    await expect(
+      targetStore.receivePack(principal, repoId, REF, pack, commitSha),
+    ).rejects.toThrow(/^path_violation/);
+  });
+});

--- a/packages/hub-sessions/src/repo-store/store.ts
+++ b/packages/hub-sessions/src/repo-store/store.ts
@@ -1,0 +1,240 @@
+import fs from "node:fs";
+import path from "node:path";
+import git from "isomorphic-git";
+import { createSSHSignature } from "@intx/crypto-node";
+import {
+  initRepo as storageInitRepo,
+  createDeployPack,
+  receivePackObjects,
+} from "@intx/storage-isogit";
+import { hasCode } from "@intx/types";
+import { getLogger } from "@intx/log";
+import type {
+  AuthorizeFn,
+  KindHandler,
+  Principal,
+  RepoAction,
+  RepoId,
+  RepoKind,
+  RepoStore,
+  TreeContent,
+} from "./types";
+import { SAFE_REPO_ID } from "./types";
+
+const AUTHOR = {
+  name: "interchange-hub",
+  email: "hub@interchange.local",
+};
+
+const logger = getLogger(["hub", "repo-store"]);
+
+type SigningKey = { privateKey: Uint8Array; publicKey: Uint8Array };
+
+export type CreateRepoStoreConfig = {
+  dataDir: string;
+  signingKey: SigningKey;
+  handlers: Record<RepoKind, KindHandler>;
+  authorize: AuthorizeFn;
+};
+
+export function createRepoStore(config: CreateRepoStoreConfig): RepoStore {
+  const { dataDir, signingKey, handlers, authorize } = config;
+
+  function handlerFor(repoId: RepoId): KindHandler {
+    const handler = handlers[repoId.kind];
+    if (handler === undefined) {
+      throw new Error(`no handler registered for kind: ${repoId.kind}`);
+    }
+    return handler;
+  }
+
+  function repoDir(repoId: RepoId): string {
+    if (!SAFE_REPO_ID.test(repoId.id)) {
+      throw new Error(`repo_id_invalid: ${repoId.id}`);
+    }
+    const handler = handlerFor(repoId);
+    return path.join(dataDir, handler.directoryPrefix, repoId.id);
+  }
+
+  function gateAccess(
+    principal: Principal,
+    repoId: RepoId,
+    ref: string,
+    action: RepoAction,
+  ): void {
+    const verdict = authorize(principal, repoId, ref, action);
+    if (!verdict.allowed) {
+      throw new Error(`authorize_denied: ${verdict.reason}`);
+    }
+  }
+
+  function validateClearPrefix(clearPrefix: string): void {
+    const malformed =
+      clearPrefix.length === 0 ||
+      !clearPrefix.endsWith("/") ||
+      clearPrefix.startsWith("/") ||
+      clearPrefix.split("/").includes("..");
+    if (malformed) {
+      throw new Error(`clear_prefix_invalid: ${clearPrefix}`);
+    }
+  }
+
+  async function initRepo(repoId: RepoId): Promise<void> {
+    await storageInitRepo(repoDir(repoId));
+  }
+
+  async function resolveRefSha(
+    dir: string,
+    ref: string,
+  ): Promise<string | null> {
+    try {
+      return await git.resolveRef({ fs, dir, ref });
+    } catch (err: unknown) {
+      if (hasCode(err) && err.code === "NotFoundError") {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  async function clearIndexPrefix(dir: string, prefix: string): Promise<void> {
+    const matrix = await git.statusMatrix({ fs, dir });
+    for (const row of matrix) {
+      const filepath = row[0];
+      if (filepath.startsWith(prefix)) {
+        await git.remove({ fs, dir, filepath });
+      }
+    }
+  }
+
+  async function writeFileEntry(
+    dir: string,
+    relPath: string,
+    contents: string | Uint8Array,
+  ): Promise<void> {
+    const fullPath = path.join(dir, relPath);
+    await fs.promises.mkdir(path.dirname(fullPath), { recursive: true });
+    await fs.promises.writeFile(fullPath, contents);
+    await git.add({ fs, dir, filepath: relPath });
+  }
+
+  async function writeTree(
+    principal: Principal,
+    repoId: RepoId,
+    ref: string,
+    content: TreeContent,
+  ): Promise<{ commitSha: string }> {
+    gateAccess(principal, repoId, ref, "writeTree");
+
+    const dir = repoDir(repoId);
+    await storageInitRepo(dir);
+
+    const handler = handlerFor(repoId);
+
+    if (content.clearPrefix !== undefined) {
+      validateClearPrefix(content.clearPrefix);
+      await clearIndexPrefix(dir, content.clearPrefix);
+      await fs.promises.rm(path.join(dir, content.clearPrefix), {
+        recursive: true,
+        force: true,
+      });
+    }
+
+    for (const [relPath, contents] of Object.entries(content.files)) {
+      await writeFileEntry(dir, relPath, contents);
+    }
+
+    // Resolve the previous ref value for the post-update hook (precise:
+    // null only when the ref truly doesn't exist) and the parent SHA for
+    // the new commit (best-effort: any error falls back to HEAD, so a
+    // first write on a never-touched ref produces a commit parented on
+    // the repo's initial commit instead of failing).
+    const oldSha = await resolveRefSha(dir, ref);
+    let parentSha: string;
+    try {
+      parentSha = await git.resolveRef({ fs, dir, ref });
+    } catch {
+      parentSha = await git.resolveRef({ fs, dir, ref: "HEAD" });
+    }
+
+    const commitSha = await git.commit({
+      fs,
+      dir,
+      message: content.message,
+      author: AUTHOR,
+      parent: [parentSha],
+      ref,
+      signingKey: "sshsig",
+      onSign: async ({ payload }) => ({
+        signature: createSSHSignature(
+          payload,
+          signingKey.privateKey,
+          signingKey.publicKey,
+        ),
+      }),
+    });
+
+    await handler.onRefUpdated({ repoId, ref, oldSha, newSha: commitSha });
+
+    return { commitSha };
+  }
+
+  async function receivePack(
+    principal: Principal,
+    repoId: RepoId,
+    ref: string,
+    pack: Uint8Array,
+    commitSha: string,
+  ): Promise<void> {
+    gateAccess(principal, repoId, ref, "receivePack");
+
+    const dir = repoDir(repoId);
+    await storageInitRepo(dir);
+
+    const handler = handlerFor(repoId);
+    const oldSha = await resolveRefSha(dir, ref);
+    const transferId = crypto.randomUUID().replace(/-/g, "");
+
+    await receivePackObjects(dir, pack, ref, commitSha, transferId, (paths) => {
+      const result = handler.validatePush({
+        repoId,
+        ref,
+        topLevelTreePaths: paths,
+      });
+      if (!result.ok) {
+        logger.debug`validatePush rejected ${repoId.kind}/${repoId.id} on ${ref}: ${result.reason}`;
+        return false;
+      }
+      return true;
+    });
+
+    await handler.onRefUpdated({ repoId, ref, oldSha, newSha: commitSha });
+  }
+
+  async function createPack(
+    principal: Principal,
+    repoId: RepoId,
+    ref: string,
+  ): Promise<{ pack: Uint8Array; commitSha: string; ref: string }> {
+    gateAccess(principal, repoId, ref, "createPack");
+    const { pack, commitSha } = await createDeployPack(repoDir(repoId), ref);
+    return { pack, commitSha, ref };
+  }
+
+  async function resolveRef(
+    principal: Principal,
+    repoId: RepoId,
+    ref: string,
+  ): Promise<string | null> {
+    gateAccess(principal, repoId, ref, "resolveRef");
+    return resolveRefSha(repoDir(repoId), ref);
+  }
+
+  return {
+    initRepo,
+    writeTree,
+    receivePack,
+    createPack,
+    resolveRef,
+  };
+}

--- a/packages/hub-sessions/src/repo-store/types.ts
+++ b/packages/hub-sessions/src/repo-store/types.ts
@@ -1,0 +1,128 @@
+export type RepoKind = "agent-state";
+
+export type RepoId = { kind: RepoKind; id: string };
+
+/**
+ * Regex defining the shape of a valid `RepoId.id`. The substrate
+ * validates against this at every public operation and throws an Error
+ * prefixed with `"repo_id_invalid: "` on mismatch. Exposed so callers
+ * that want to validate ids before constructing a `RepoId` (e.g. shims
+ * that throw their own legacy error messages) can use the same rule.
+ */
+export const SAFE_REPO_ID = /^[a-zA-Z0-9_-]+$/;
+
+export type RepoAction =
+  | "init"
+  | "writeTree"
+  | "receivePack"
+  | "createPack"
+  | "resolveRef";
+
+/**
+ * Principal is a discriminated-union extension point. The substrate
+ * requires only the `kind` discriminant; concrete principal shapes live
+ * in kind-handler packages and are narrowed via `principal.kind === "..."`
+ * checks plus arktype validation in the handler. No index signature is
+ * declared here so that handlers do not need `as Type` casts to access
+ * their own fields.
+ */
+export type Principal = { readonly kind: string };
+
+export type AuthorizeFn = (
+  principal: Principal,
+  repoId: RepoId,
+  ref: string,
+  action: RepoAction,
+) => { allowed: true } | { allowed: false; reason: string };
+
+export type ValidatePushResult = { ok: true } | { ok: false; reason: string };
+
+export type TreeContent = {
+  /**
+   * Map of repo-relative path to file contents. Each entry is written
+   * to the working tree and staged before commit.
+   */
+  files: Record<string, string | Uint8Array>;
+  /**
+   * Optional directory-subtree prefix to clear before staging. When
+   * set, every tracked path beginning with this prefix is removed
+   * from the git index and the corresponding directory on disk is
+   * deleted before `files` is written. Must end with `/` and must
+   * not contain `..` or absolute path components. When unset,
+   * writeTree is purely additive.
+   */
+  clearPrefix?: string;
+  /** Commit message for the resulting commit. */
+  message: string;
+};
+
+export interface KindHandler {
+  kind: RepoKind;
+  /**
+   * On-disk directory under `dataDir` for repos of this kind. Allows
+   * each kind to declare its own layout (e.g. "agents") so the
+   * substrate does not hard-code a `<kind>/<id>` path.
+   */
+  directoryPrefix: string;
+  /**
+   * Inspect the top-level entries of the expected commit's tree
+   * before the ref is advanced. Return `{ ok: false, reason }` to
+   * reject the pack. The substrate translates rejection into a
+   * thrown Error whose message begins with `"path_violation: "`.
+   *
+   * Runs on every `receivePack` independently of the authorize
+   * verdict: authorize gates access, validatePush enforces content
+   * rules.
+   */
+  validatePush: (args: {
+    repoId: RepoId;
+    ref: string;
+    topLevelTreePaths: string[];
+  }) => ValidatePushResult;
+  /**
+   * Fired after a successful ref update from any operation. `oldSha`
+   * is `null` when the ref did not exist before the update.
+   */
+  onRefUpdated: (args: {
+    repoId: RepoId;
+    ref: string;
+    oldSha: string | null;
+    newSha: string;
+  }) => Promise<void> | void;
+}
+
+export interface RepoStore {
+  /**
+   * Bookkeeping primitive. Idempotent. Creates the repo directory
+   * and initializes git when not already present. Not gated by
+   * `authorize`: the only state it can produce is an empty repo, so
+   * the higher-level question of who may mint a new `<kind>/<id>`
+   * lives at the caller. The substrate also calls `initRepo`
+   * internally from `writeTree` and `receivePack`, so first-touch
+   * operations succeed without an explicit init call.
+   */
+  initRepo(repoId: RepoId): Promise<void>;
+  writeTree(
+    principal: Principal,
+    repoId: RepoId,
+    ref: string,
+    content: TreeContent,
+  ): Promise<{ commitSha: string }>;
+  receivePack(
+    principal: Principal,
+    repoId: RepoId,
+    ref: string,
+    pack: Uint8Array,
+    commitSha: string,
+  ): Promise<void>;
+  createPack(
+    principal: Principal,
+    repoId: RepoId,
+    ref: string,
+  ): Promise<{ pack: Uint8Array; commitSha: string; ref: string }>;
+  resolveRef(
+    principal: Principal,
+    repoId: RepoId,
+    ref: string,
+  ): Promise<string | null>;
+}


### PR DESCRIPTION
Closes INTR-94.

## Summary

Generalize the hub's `AgentRepoStore` into a kind-keyed `RepoStore`
substrate so the asset system in INTR-95+ can host any repo kind
(skills, knowledge bases, customer codebases, agent journals) on the
same machinery. Behavior is unchanged — every existing test passes
unchanged.

- A generic substrate at `packages/hub-sessions/src/repo-store/`,
  keyed by `(kind, repoId)`, with `initRepo`, `writeTree`,
  `receivePack`, `createPack`, `resolveRef`, and a single `authorize`
  predicate that gates every public operation except `initRepo`.
- Per-kind hooks (`validatePush`, `onRefUpdated`) and an on-disk
  layout that each kind handler advertises via `directoryPrefix`.
- The `agent-state` kind handler declares `directoryPrefix: "agents"`
  so the existing `$HUB_DATA_DIR/agents/<agentId>/.git` layout is
  preserved bit-for-bit.
- `AgentRepoStore` is now a thin shim over the substrate with the
  agent-state kind registered; its public surface is identical.
- `DeployContent` serialization stays in the shim because it is
  session-layer authoring, not substrate behavior.

A small drive-by fix to the root `package.json` test script lands as
the final commit on this branch: the rerun line pointed at
`tests/sidecar/deploy-flow.test.ts` (does not exist) instead of
`tests/hub-agent/deploy-flow.test.ts`, so the deploy-flow integration
test was silently being skipped by `make test`. Pre-existing, surfaced
during the closeout audit.

## Commits

- `ef1c4f9` Introduce a kind-keyed RepoStore substrate
- `7a21623` Cover the RepoStore substrate with unit tests
- `2739a09` Define the agent-state kind handler
- `9fe46b9` Rewire AgentRepoStore as a shim over the RepoStore
- `0446c3d` Fix the test rerun script's deploy-flow path

## Acceptance criteria

- [x] The agent repo store factors into a generic store keyed by `(kind, repoId)`.
- [x] Operations exposed: `initRepo`, `writeTree`, `receivePack`, `createPack`, `resolveRef`.
- [x] Single `authorize(principal, repoId, ref, action)` predicate gates the substrate's public operations.
- [x] Per-kind hook surface (`validatePush`, `onRefUpdated`); only `agent-state` is registered.
- [x] The agent state repo migrates to the generalized store with no observable behavior change.
- [x] All existing hub-session and harness tests pass unchanged.
- [x] `make all` passes (2359 tests across 141 files, 0 failures, including the deploy-flow integration test that the rerun script now correctly exercises).

## Test plan

- [x] `make all` clean on CI.
- [ ] Spot-check `apps/hub`'s `createAgentRepoStore` call still constructs cleanly.
- [x] Confirm `git diff main -- packages/db/src/schema/agents.ts` and `git diff main -- packages/hub-agent/src/agent-repo-store.ts` are both empty (INTR-94 scope).