### PR TITLE
Type-check the bin scripts with tsc -b

### DIFF
--- a/bin/seed.ts
+++ b/bin/seed.ts
@@ -15,7 +15,11 @@ import {
 
 const AuthResponse = type({ "user?": { id: "string" } });
 
-function parse<T>(schema: Type<T>, data: unknown, label: string): T {
+function parse<T extends Type>(
+  schema: T,
+  data: unknown,
+  label: string,
+): T["infer"] {
   const result = schema(data);
   if (result instanceof type.errors) {
     console.error(`Seed validation failed for ${label}: ${result.summary}`);

--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["**/*.ts"]
+}

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -49,7 +49,6 @@ export default defineConfig(
           allowDefaultProject: [
             "eslint.config.ts",
             "apps/admin-ui/vite.config.ts",
-            "bin/*.ts",
             "packages/db/drizzle.config.ts",
             "tests/inference/transform-cutover.test.ts",
             "tests/agent/*.ts",
@@ -64,7 +63,7 @@ export default defineConfig(
             "tests/agent-rich-tool/*.ts",
             "tests/agent-structured-payload/*.ts",
           ],
-          maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 25,
+          maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 18,
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/packages/types/src/common.ts
+++ b/packages/types/src/common.ts
@@ -21,7 +21,7 @@ export const PaginatedList = type({
  * Creates a typed paginated response schema for use with OpenAPI.
  * Wraps an item array schema in `{ data: T[], nextCursor: string | null }`.
  */
-export function paginatedSchema(itemSchema: Type) {
+export function paginatedSchema<T>(itemSchema: Type<T>) {
   return type({
     data: itemSchema.array(),
     nextCursor: "string | null",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
     { "path": "examples/agent-gemini-image" },
     { "path": "examples/posix-demo" },
     { "path": "examples/ring-demo" },
-    { "path": "tests/hub-agent" }
+    { "path": "tests/hub-agent" },
+    { "path": "bin" }
   ]
 }


### PR DESCRIPTION
## Summary

- The `bin/*.ts` scripts join the `tsc -b` project graph and the typescript-eslint `allowDefaultProject` escape hatch they had been relying on is retired.
- `paginatedSchema` is generic so callers preserve the element type — required so `bin/seed.ts` can type-check `.data.find(...)` lookups without casts.
- The `maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING` cap drops from 25 to 18, one slot of headroom over the 17 files the remaining `allowDefaultProject` patterns match.

## Changes

- `bin/tsconfig.json` (new): leaf-project config extending `tsconfig.base.json`, includes `**/*.ts`.
- `tsconfig.json`: adds `{ "path": "bin" }` to the project references array.
- `eslint.config.ts`: removes `"bin/*.ts"` from `allowDefaultProject`; lowers the file-match cap from 25 to 18.
- `bin/seed.ts`: parse helper takes its schema as `T extends Type` and returns `T["infer"]` so the narrowed result of `paginatedSchema(...)` flows through it without losing the element type.
- `packages/types/src/common.ts`: `paginatedSchema<T>(itemSchema: Type<T>)` so the returned schema's `.data` carries the element type into callers.

## Testing

- [x] `make all` exits 0 (build, lint, 2412 tests pass)
- [x] Pre-commit hook (cold `.eslintcache`) and live `make lint` (warm cache) produce identical verdicts on a clean tree
- [x] All five `bin/*.ts` files appear in `tsc -b bin --listFiles`

Closes INTR-82