### PR TITLE
Clean up the codebase ahead of the v0.1.0 tag

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -8,6 +8,12 @@
 
 ## Quick Start
 
+After cloning, install workspace dependencies. The Makefile does not run this for you, and `make build` will fail with `TS2307: Cannot find module '@intx/...'` for any workspace package whose symlink under `node_modules/@intx/` has not been materialized yet:
+
+```bash
+bun install
+```
+
 If env files are already configured (see Environment Setup below):
 
 ```bash

--- a/DEV.md
+++ b/DEV.md
@@ -152,6 +152,7 @@ All scripts live in `bin/`. The bash scripts source the bundled [opsh](https://g
 | `bin/add-package`     | `bin/add-package <name>`                         | Scaffold a new `@intx/<name>` package                                                                   |
 | `bin/check-env`       | `bin/check-env`                                  | Verify git hooks are configured                                                                         |
 | `bin/audit`           | `bin/audit --dir <path> --session <id> [--json]` | Inspect an agent's tool authorization audit trail                                                       |
+| `bin/discover.ts`     | `bun bin/discover.ts --provider <name> [flags]`  | Run the wire-capture rig against a registered inference provider (needs provider credentials in env)    |
 | `bin/gen-api-docs.ts` | `bun bin/gen-api-docs.ts`                        | Generate API documentation from route schemas                                                           |
 | `bin/posix-demo`      | `bin/posix-demo`                                 | Run the POSIX (alpha/beta) agent demo (auto-loads `.env`; reads `ALPHA_*`/`BETA_*`)                     |
 | `bin/ring-demo`       | `bin/ring-demo`                                  | Run the ring agent demo (auto-loads `.env`; reads `RING_*`)                                             |

--- a/LAYOUT.md
+++ b/LAYOUT.md
@@ -72,6 +72,7 @@ Each package implements an interface defined in `@intx/types`. The harness accep
 | ------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@intx/tools-posix` | Server      | File read/write/edit, shell execution, git operations. Requires filesystem and process spawning.                                            |
 | `@intx/tools-lsp`   | Server      | Language-server diagnostics. Composes with `tools-posix` and spawns LSP servers over JSON-RPC. Requires process spawning and `which` shell. |
+| `@intx/tools-mail`  | Any         | Mail send/read/search/reply/wait operations on the agent's inbox. Composes with any `MessageTransport` implementation.                      |
 
 ### Why the splits exist
 

--- a/apps/admin-ui/src/lib/queries/tenants.ts
+++ b/apps/admin-ui/src/lib/queries/tenants.ts
@@ -55,7 +55,7 @@ type GrantRequirement = {
 export type AgentResponse = {
   id: string;
   tenantId: string;
-  creatorPrincipalId?: string | null;
+  creatorPrincipalId: string;
   name: string;
   description: string | null;
   systemPrompt: string | null;

--- a/apps/admin-ui/src/pages/tenant-agent-detail.tsx
+++ b/apps/admin-ui/src/pages/tenant-agent-detail.tsx
@@ -417,7 +417,7 @@ export function TenantAgentDetailPage() {
             </Row>
             <Row label="Creator Principal">
               <span className="font-mono text-xs">
-                {agent.creatorPrincipalId ?? "\u2014"}
+                {agent.creatorPrincipalId}
               </span>
             </Row>
             {agent.systemPrompt && (

--- a/bun.lock
+++ b/bun.lock
@@ -312,6 +312,9 @@
     "packages/hub-common": {
       "name": "@intx/hub-common",
       "version": "0.0.0",
+      "dependencies": {
+        "@intx/types": "workspace:*",
+      },
     },
     "packages/hub-sessions": {
       "name": "@intx/hub-sessions",

--- a/docs/API.md
+++ b/docs/API.md
@@ -1049,7 +1049,7 @@ Source: packages/types/src/agents.ts
 Source: packages/types/src/agents.ts
 
 ### AgentResponse
-`{ createdAt: string, currentVersion: string, id: string, name: string, status: "deployed" | "stopped", tenantId: string, updatedAt: string, capabilities?: { [string]: unknown }, contextConfig?: { [string]: unknown }, creatorPrincipalId?: string | null, credentialRequirements?: { providerName: string, source: "creator" | "invoker" | "tenant", name?: string, scopes?: string[] }[], description?: string | null, grantRequirements?: { action: string, resource: string, source: "creator" | "invoker", conditions?: { [string]: unknown } | null, effect?: "allow" | "ask" | "deny" }[], initialState?: { [string]: unknown }, modelConfig?: { [string]: unknown }, roles?: { id: string, name: string }[], systemPrompt?: string | null }`
+`{ createdAt: string, creatorPrincipalId: string, currentVersion: string, id: string, name: string, status: "deployed" | "stopped", tenantId: string, updatedAt: string, capabilities?: { [string]: unknown }, contextConfig?: { [string]: unknown }, credentialRequirements?: { providerName: string, source: "creator" | "invoker" | "tenant", name?: string, scopes?: string[] }[], description?: string | null, grantRequirements?: { action: string, resource: string, source: "creator" | "invoker", conditions?: { [string]: unknown } | null, effect?: "allow" | "ask" | "deny" }[], initialState?: { [string]: unknown }, modelConfig?: { [string]: unknown }, roles?: { id: string, name: string }[], systemPrompt?: string | null }`
 Source: packages/types/src/agents.ts
 
 **creatorPrincipalId**: Identifies the definition author's principal (definitions have no principalId of their own). Used for resolving creator-sourced grant and credential requirements.

--- a/packages/authz/README.md
+++ b/packages/authz/README.md
@@ -1,0 +1,49 @@
+# @intx/authz
+
+Grant evaluation engine. Given a principal, a tenant, a resource,
+and an action, `authorize` collects the relevant grants from a
+`GrantStore`, picks the most specific match, applies condition
+evaluators, and returns the resolved effect.
+
+Pattern matching uses colon-segmented patterns with `*` and `**`
+wildcards; specificity scoring picks the most specific matching
+grant; condition evaluators gate matches on runtime facts such as
+time windows. An in-memory grant store is included for tests and
+single-process deployments; `@intx/db` provides the database-backed
+implementation.
+
+Consumed by `@intx/hub-api` for HTTP request authorization and by
+`@intx/harness` for tool-call gating.
+
+```ts
+import { authorize, createInMemoryGrantStore } from "@intx/authz";
+
+const store = createInMemoryGrantStore([
+  {
+    id: "g1",
+    principalId: "user-1",
+    roleId: null,
+    effect: "allow",
+    origin: "system",
+    resource: "tenant:*:agent:*",
+    action: "read",
+    conditions: null,
+    expiresAt: null,
+  },
+]);
+
+const result = await authorize(
+  store,
+  "user-1",
+  "acme",
+  "tenant:acme:agent:abc",
+  "read",
+);
+
+if (result.effect !== "allow") throw new Error("forbidden");
+```
+
+`authorize` returns an `AuthzResult` whose `effect` is one of
+`allow`, `deny`, `ask`, or `null` when no grant matches. Callers
+translate `null` into a refusal (HTTP 403, tool-call block) because
+evaluation is fail-closed.

--- a/packages/crypto-node/README.md
+++ b/packages/crypto-node/README.md
@@ -1,0 +1,21 @@
+# @intx/crypto-node
+
+Node-backed cryptographic provider. Ed25519 key generation,
+import, sign, and verify; canonicalisation of text and byte
+payloads; SSH and PGP detached signature formats; ASCII armoring.
+
+The exported `NodeCrypto` implements the `CryptoProvider` contract
+that the mail and storage layers depend on. Consumed by
+`@intx/mime` (detached PGP signatures on outbound mail),
+`@intx/storage-isogit` (commit signing), `@intx/mail-memory`
+(per-address keys for the in-process transport), and
+`@intx/hub-sessions` (per-agent key material).
+
+```ts
+import { generateKeyPair, createNodeCrypto } from "@intx/crypto-node";
+
+const keyPair = await generateKeyPair();
+const provider = createNodeCrypto(keyPair);
+
+const signature = await provider.sign(new TextEncoder().encode("hello"));
+```

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,37 @@
+# @intx/db
+
+Drizzle ORM client, schema, migrations, and row parsers for the
+hub's PostgreSQL database. Owns the database-backed `GrantStore`,
+the tenant hierarchy walk, the credential resolution layer, and
+the `parseRow` family that validates `jsonb` columns at the
+database boundary so internal code never re-checks them.
+
+Consumed by `@intx/hub-api` (HTTP request handlers and grant
+middleware) and `@intx/hub-sessions` (session orchestration and
+agent repo metadata).
+
+## Surface
+
+- `@intx/db` — the client (`createDB`), config validator, migration
+  runner, grant store, credential resolution, tenant hierarchy
+  helpers, and the `parseRow` functions.
+- `@intx/db/schema` — the Drizzle table exports, used by callers
+  that compose queries against the schema directly.
+
+```ts
+import { createDB } from "@intx/db";
+import { agent } from "@intx/db/schema";
+import { eq } from "drizzle-orm";
+
+const { db } = createDB(process.env);
+
+const row = await db.query.agent.findFirst({
+  where: eq(agent.id, agentId),
+});
+```
+
+The `parseRow` functions (`parseAgentRow`, `parseGrantRow`, and so
+on) validate each table's `jsonb` columns once and return fully
+typed values; downstream code uses those values without
+re-casting. See `CONVENTIONS.md` for the project-wide rule against
+cast-at-callsite in DB consumers.

--- a/packages/db/migrations/0028_wet_sugar_man.sql
+++ b/packages/db/migrations/0028_wet_sugar_man.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agent" ALTER COLUMN "creator_principal_id" SET NOT NULL;

--- a/packages/db/migrations/meta/0028_snapshot.json
+++ b/packages/db/migrations/meta/0028_snapshot.json
@@ -1,0 +1,2657 @@
+{
+  "id": "28016fda-202f-4943-92d1-ee459239ef69",
+  "prevId": "453912ac-d646-4705-b0a1-63f0232269a6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.federation_trust": {
+      "name": "federation_trust",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_tenant_id": {
+          "name": "target_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "federation_trust_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "federation_trust_target_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_target_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "tableTo": "tenant",
+          "columnsFrom": ["target_tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federation_trust_tenant_id_target_tenant_id_unique": {
+          "name": "federation_trust_tenant_id_target_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "target_tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant": {
+      "name": "tenant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_parent_id_tenant_id_fk": {
+          "name": "tenant_parent_id_tenant_id_fk",
+          "tableFrom": "tenant",
+          "tableTo": "tenant",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_slug_unique": {
+          "name": "tenant_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "tenant_domain_unique": {
+          "name": "tenant_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": ["domain"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal": {
+      "name": "principal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_tenant_id_tenant_id_fk": {
+          "name": "principal_tenant_id_tenant_id_fk",
+          "tableFrom": "principal",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "principal_tenant_id_kind_ref_id_unique": {
+          "name": "principal_tenant_id_kind_ref_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "kind", "ref_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_role": {
+      "name": "agent_role",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_role_agent_id_agent_id_fk": {
+          "name": "agent_role_agent_id_agent_id_fk",
+          "tableFrom": "agent_role",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_role_role_id_role_id_fk": {
+          "name": "agent_role_role_id_role_id_fk",
+          "tableFrom": "agent_role",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_role_agent_id_role_id_pk": {
+          "name": "agent_role_agent_id_role_id_pk",
+          "columns": ["agent_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal_role": {
+      "name": "principal_role",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_role_principal_id_principal_id_fk": {
+          "name": "principal_role_principal_id_principal_id_fk",
+          "tableFrom": "principal_role",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "principal_role_role_id_role_id_fk": {
+          "name": "principal_role_role_id_role_id_fk",
+          "tableFrom": "principal_role",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "principal_role_principal_id_role_id_pk": {
+          "name": "principal_role_principal_id_role_id_pk",
+          "columns": ["principal_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_tenant_id_tenant_id_fk": {
+          "name": "role_tenant_id_tenant_id_fk",
+          "tableFrom": "role",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grant": {
+      "name": "grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grant_tenant_id_tenant_id_fk": {
+          "name": "grant_tenant_id_tenant_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grant_role_id_role_id_fk": {
+          "name": "grant_role_id_role_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grant_principal_id_principal_id_fk": {
+          "name": "grant_principal_id_principal_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_config": {
+          "name": "context_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_state": {
+          "name": "initial_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_config": {
+          "name": "model_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_requirements": {
+          "name": "credential_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_requirements": {
+          "name": "grant_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_tenant_id_tenant_id_fk": {
+          "name": "agent_tenant_id_tenant_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_creator_principal_id_principal_id_fk": {
+          "name": "agent_creator_principal_id_principal_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "principal",
+          "columnsFrom": ["creator_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version": {
+      "name": "agent_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_agent_id_agent_id_fk": {
+          "name": "agent_version_agent_id_agent_id_fk",
+          "tableFrom": "agent_version",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_info_url": {
+          "name": "user_info_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_tenant_id_tenant_id_fk": {
+          "name": "provider_tenant_id_tenant_id_fk",
+          "tableFrom": "provider",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_tenant_name": {
+          "name": "provider_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_scopes": {
+          "name": "default_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_tenant_id_tenant_id_fk": {
+          "name": "oauth_client_tenant_id_tenant_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_client_provider_id_provider_id_fk": {
+          "name": "oauth_client_provider_id_provider_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_tenant_provider": {
+          "name": "oauth_client_tenant_provider",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "provider_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credential": {
+      "name": "credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_secret": {
+          "name": "refresh_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credential_tenant_id_tenant_id_fk": {
+          "name": "credential_tenant_id_tenant_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_principal_id_principal_id_fk": {
+          "name": "credential_principal_id_principal_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credential_provider_id_provider_id_fk": {
+          "name": "credential_provider_id_provider_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_oauth_client_id_oauth_client_id_fk": {
+          "name": "credential_oauth_client_id_oauth_client_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "credential_tenant_name": {
+          "name": "credential_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset": {
+      "name": "asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_tenant_id_tenant_id_fk": {
+          "name": "asset_tenant_id_tenant_id_fk",
+          "tableFrom": "asset",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "asset_creator_principal_id_principal_id_fk": {
+          "name": "asset_creator_principal_id_principal_id_fk",
+          "tableFrom": "asset",
+          "tableTo": "principal",
+          "columnsFrom": ["creator_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_tenant_kind_name": {
+          "name": "asset_tenant_kind_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "kind", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_asset": {
+      "name": "agent_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_mode": {
+          "name": "access_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read-only'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_asset_agent_id_agent_id_fk": {
+          "name": "agent_asset_agent_id_agent_id_fk",
+          "tableFrom": "agent_asset",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_asset_asset_id_asset_id_fk": {
+          "name": "agent_asset_asset_id_asset_id_fk",
+          "tableFrom": "agent_asset",
+          "tableTo": "asset",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_asset_agent_asset": {
+          "name": "agent_asset_agent_asset",
+          "nullsNotDistinct": false,
+          "columns": ["agent_id", "asset_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_wallet_id_wallet_id_fk": {
+          "name": "transaction_wallet_id_wallet_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_agent_id_agent_id_fk": {
+          "name": "transaction_agent_id_agent_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet": {
+      "name": "wallet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend_type": {
+          "name": "backend_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallet_tenant_id_tenant_id_fk": {
+          "name": "wallet_tenant_id_tenant_id_fk",
+          "tableFrom": "wallet",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offering": {
+      "name": "offering",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "offering_agent_id_agent_id_fk": {
+          "name": "offering_agent_id_agent_id_fk",
+          "tableFrom": "offering",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "offering_tenant_id_tenant_id_fk": {
+          "name": "offering_tenant_id_tenant_id_fk",
+          "tableFrom": "offering",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidecar": {
+      "name": "sidecar",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_session": {
+      "name": "agent_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_session_tenant_id_tenant_id_fk": {
+          "name": "agent_session_tenant_id_tenant_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_agent_id_agent_id_fk": {
+          "name": "agent_session_agent_id_agent_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_principal_id_principal_id_fk": {
+          "name": "agent_session_principal_id_principal_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_instance": {
+      "name": "agent_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployed'"
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kernel_id": {
+          "name": "kernel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_instance_agent_id_agent_id_fk": {
+          "name": "agent_instance_agent_id_agent_id_fk",
+          "tableFrom": "agent_instance",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_instance_tenant_id_tenant_id_fk": {
+          "name": "agent_instance_tenant_id_tenant_id_fk",
+          "tableFrom": "agent_instance",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_instance_principal_id_principal_id_fk": {
+          "name": "agent_instance_principal_id_principal_id_fk",
+          "tableFrom": "agent_instance",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_instance_version_id_agent_version_id_fk": {
+          "name": "agent_instance_version_id_agent_version_id_fk",
+          "tableFrom": "agent_instance",
+          "tableTo": "agent_version",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_instance_session_id_agent_session_id_fk": {
+          "name": "agent_instance_session_id_agent_session_id_fk",
+          "tableFrom": "agent_instance",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_instance_sidecar_id_sidecar_id_fk": {
+          "name": "agent_instance_sidecar_id_sidecar_id_fk",
+          "tableFrom": "agent_instance",
+          "tableTo": "sidecar",
+          "columnsFrom": ["sidecar_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_instance_address_unique": {
+          "name": "agent_instance_address_unique",
+          "nullsNotDistinct": false,
+          "columns": ["address"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_asset": {
+      "name": "session_asset",
+      "schema": "",
+      "columns": {
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_asset_id": {
+          "name": "agent_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mount_path": {
+          "name": "mount_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_pack_sha": {
+          "name": "asset_pack_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "materialized_at": {
+          "name": "materialized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_asset_pack_sha_idx": {
+          "name": "session_asset_pack_sha_idx",
+          "columns": [
+            {
+              "expression": "asset_pack_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_asset_instance_id_agent_instance_id_fk": {
+          "name": "session_asset_instance_id_agent_instance_id_fk",
+          "tableFrom": "session_asset",
+          "tableTo": "agent_instance",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_asset_agent_asset_id_agent_asset_id_fk": {
+          "name": "session_asset_agent_asset_id_agent_asset_id_fk",
+          "tableFrom": "session_asset",
+          "tableTo": "agent_asset",
+          "columnsFrom": ["agent_asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_asset_instance_id_agent_asset_id_pk": {
+          "name": "session_asset_instance_id_agent_asset_id_pk",
+          "columns": ["instance_id", "agent_asset_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inference_turn": {
+      "name": "inference_turn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "inference_turn_instance_id_started_at_idx": {
+          "name": "inference_turn_instance_id_started_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inference_turn_session_id_agent_session_id_fk": {
+          "name": "inference_turn_session_id_agent_session_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inference_turn_instance_id_agent_instance_id_fk": {
+          "name": "inference_turn_instance_id_agent_instance_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "agent_instance",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inference_turn_tenant_id_tenant_id_fk": {
+          "name": "inference_turn_tenant_id_tenant_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_mail": {
+      "name": "session_mail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "raw": {
+          "name": "raw",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_mail_instance_id_created_at_idx": {
+          "name": "session_mail_instance_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_mail_session_id_agent_session_id_fk": {
+          "name": "session_mail_session_id_agent_session_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_mail_instance_id_agent_instance_id_fk": {
+          "name": "session_mail_instance_id_agent_instance_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "agent_instance",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "session_mail_tenant_id_tenant_id_fk": {
+          "name": "session_mail_tenant_id_tenant_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turn_part": {
+      "name": "turn_part",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "turn_part_turn_id_inference_turn_id_fk": {
+          "name": "turn_part_turn_id_inference_turn_id_fk",
+          "tableFrom": "turn_part",
+          "tableTo": "inference_turn",
+          "columnsFrom": ["turn_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_part_session_id_agent_session_id_fk": {
+          "name": "turn_part_session_id_agent_session_id_fk",
+          "tableFrom": "turn_part",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_token": {
+      "name": "git_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash_sha256": {
+          "name": "token_hash_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_pattern": {
+          "name": "ref_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "git_token_user_id_name_active_idx": {
+          "name": "git_token_user_id_name_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"git_token\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "git_token_tenant_id_tenant_id_fk": {
+          "name": "git_token_tenant_id_tenant_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "git_token_user_id_user_id_fk": {
+          "name": "git_token_user_id_user_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_token_principal_id_principal_id_fk": {
+          "name": "git_token_principal_id_principal_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "git_token_token_hash_sha256_unique": {
+          "name": "git_token_token_hash_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash_sha256"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1780377246076,
       "tag": "0027_git_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1780502952568,
+      "tag": "0028_wet_sugar_man",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/credential-resolution.ts
+++ b/packages/db/src/credential-resolution.ts
@@ -235,6 +235,12 @@ export async function resolveOneCredential(
   invokerPrincipalId: string | null,
   defaultModel: string,
 ): Promise<CredentialOutcome> {
+  // Reject requirements whose targeted principal does not exist. Without
+  // these guards a null creator or invoker would fall through to
+  // `resolveCredentialRequirement`, where the principal filter becomes
+  // `isNull(credential.principalId)` — the tenant-credential lookup — and
+  // a tenant credential would be returned as if it satisfied the
+  // creator- or invoker-source requirement.
   if (req.source === "creator" && !creatorPrincipalId) {
     return { ok: false, reason: "skipped", requirement: req };
   }

--- a/packages/db/src/schema/agents.ts
+++ b/packages/db/src/schema/agents.ts
@@ -10,9 +10,9 @@ export const agent = pgTable("agent", {
     .references(() => tenant.id, { onDelete: "cascade" }),
   // Tracks the definition author's principal for resolving source:"creator"
   // grant requirements at launch. See AUTH.md § Grant Requirements on Definitions.
-  creatorPrincipalId: text("creator_principal_id").references(
-    () => principal.id,
-  ),
+  creatorPrincipalId: text("creator_principal_id")
+    .notNull()
+    .references(() => principal.id),
   name: text("name").notNull(),
   description: text("description"),
   systemPrompt: text("system_prompt"),

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -1,0 +1,38 @@
+# @intx/harness
+
+Agent harness runtime. Composes the inference reactor, tool
+runners, deploy-tree reader, default director, runtime
+capabilities, and connector router into a single supervisor that
+sits between the message transport and the reactor.
+
+The harness watches the agent's INBOX, routes inbound messages by
+thread, sends connector replies with the right threading headers,
+and drives the reactor loop to completion. Consumed by
+`@intx/agent` for in-process agents and by `@intx/hub-agent` for
+sidecar-hosted agents.
+
+```ts
+import { createHarness, mergeToolRunners } from "@intx/harness";
+
+const harness = createHarness({
+  address: "agent@tenant.interchange.network",
+  systemPrompt,
+  source, // InferenceSource: id, provider, model, apiKey, baseURL
+  transport, // MessageTransport
+  crypto, // CryptoProvider
+  storage, // ContextStore
+  tools: mergeToolRunners([mailTools, posixTools]),
+  onEvent: (event) => {
+    // event: InferenceEvent — persist or forward
+  },
+});
+
+harness.start();
+```
+
+`HarnessConfig` in `src/config.ts` lists the optional fields:
+`director` or `defaultDirectorPolicy` (mutually exclusive),
+`beforeToolExtensions`, `auditStore`, `authorize`, and
+`onConnectorStateChanged`. `mergeToolRunners` composes multiple
+`ToolRunner` implementations into a single runner that dispatches
+by tool definition name.

--- a/packages/hub-agent/README.md
+++ b/packages/hub-agent/README.md
@@ -1,0 +1,29 @@
+# @intx/hub-agent
+
+Sidecar-side orchestrator. Builds harnesses for each agent the
+sidecar hosts, manages session lifecycle (provision, restore,
+shutdown), reconnects to the hub WebSocket on disconnect, owns
+the per-agent key store, and applies deploy and asset packs
+received from the hub.
+
+Consumed by `apps/sidecar` as the core orchestrator that turns a
+sidecar process into a fleet of agent runtimes.
+
+`createSidecarOrchestrator` takes a `SidecarOrchestratorConfig`
+specifying how to reach the hub (`hubURL`, `sidecarId`, `token`,
+`transport`), where to persist agent state (`dataDir`), how to
+build per-agent harnesses (`buildHarness`), and how to mint and
+operate the sidecar's crypto material (`createAgentCrypto`,
+`cryptoOps`). Optional fields control reconnect cadence. See
+`SidecarOrchestratorConfig` in `src/sidecar-orchestrator.ts` for
+the full surface; `createSessionManager` and `createHubLink` are
+the companion factories that produce the `buildHarness` and
+`transport` arguments.
+
+`HarnessBuilder` is a seam type the embedder supplies (the
+`buildHarness` field on both `SidecarOrchestratorConfig` and
+`SessionManagerConfig`); the session manager calls into it to wire
+`@intx/harness` together with the per-agent context store, mail
+transport, and runtime capabilities. The hub link handles the
+WebSocket transport and reconnect schedule against
+`@intx/hub-sessions` on the hub side.

--- a/packages/hub-api/README.md
+++ b/packages/hub-api/README.md
@@ -1,0 +1,29 @@
+# @intx/hub-api
+
+Hono application factory for the hub. Owns the public HTTP API
+surface: routes, middleware (session, tenant resolution, grant
+enforcement), authentication via better-auth, and the OpenAPI
+spec served from the running app.
+
+Consumed by `apps/hub` as the HTTP entry point. The factory takes
+the database client, session service, sidecar router, repo store,
+asset service, and event collector registry from `@intx/db` and
+`@intx/hub-sessions` and returns a configured Hono app.
+
+`createApp` returns a configured Hono app. Its `CreateAppOpts`
+parameter wires together the dependencies the API needs: a
+better-auth `authHandler` and matching `getSession`, the database
+client (`db`), the `SidecarRouter` and `SessionService` from
+`@intx/hub-sessions`, and an `EventCollectorRegistry`. The
+`assetService` and `repoStore` fields must be supplied but accept
+`null` for deployments that don't host the git surface; the
+`grantStore` and `sidecarWsHandler` fields are fully optional. See
+`CreateAppOpts` in `src/app.ts` for the exact field list. The
+companion `createAuth` factory builds the better-auth instance
+that supplies `authHandler` and `getSession`.
+
+`createRequireGrant` is the grant-enforcement middleware factory
+exposed for callers that mount additional routes against the same
+authorization stack; it composes with the tenant and session
+middleware so every route sees a resolved principal, tenant, and
+grant decision.

--- a/packages/hub-api/src/routes/agents.ts
+++ b/packages/hub-api/src/routes/agents.ts
@@ -42,7 +42,7 @@ function formatAgent(
   return {
     id: parsed.id,
     tenantId: parsed.tenantId,
-    creatorPrincipalId: parsed.creatorPrincipalId ?? undefined,
+    creatorPrincipalId: parsed.creatorPrincipalId,
     name: parsed.name,
     description: parsed.description ?? null,
     systemPrompt: parsed.systemPrompt ?? null,

--- a/packages/hub-api/src/routes/instances.ts
+++ b/packages/hub-api/src/routes/instances.ts
@@ -212,18 +212,6 @@ export function createInstanceRoutes({
       }
 
       const creatorPrincipalId = row.creatorPrincipalId;
-      if (!creatorPrincipalId) {
-        return c.json(
-          {
-            error: {
-              code: "not_launchable",
-              message:
-                "Definition has no creator principal for credential resolution",
-            },
-          },
-          409,
-        );
-      }
 
       // Parse modelConfig up front: the model identity is part of every
       // resolved InferenceSource (pre-catalog the same `defaultModel`
@@ -261,9 +249,9 @@ export function createInstanceRoutes({
         switch (outcome.reason) {
           case "skipped":
             // Requirement targets a principal that does not exist
-            // (creator without a creator id, or invoker without a session
-            // principal). Skip silently; the resulting empty sources[]
-            // is surfaced as a `not_launchable` 409 below.
+            // (invoker without a session principal). Skip silently;
+            // the resulting empty sources[] is surfaced as a
+            // `not_launchable` 409 below.
             continue;
           case "credential_error":
             return c.json(

--- a/packages/hub-client/README.md
+++ b/packages/hub-client/README.md
@@ -1,0 +1,31 @@
+# @intx/hub-client
+
+Browser-side client for talking to the Interchange hub. Provides a
+typed `Transport` for the hub REST API, an `InstanceSession` that
+streams agent activity over SSE and exposes a normalized
+`InstanceEvent` history, and a small library of transforms that map
+mail and turn payloads into displayable events.
+
+`apps/admin-ui` is the only consumer today. The package is
+side-effect-free at import time so it is safe to bundle into other
+browser UIs.
+
+```ts
+import {
+  createBrowserTransport,
+  createInstanceSession,
+} from "@intx/hub-client";
+
+const transport = createBrowserTransport();
+
+const session = createInstanceSession({
+  tenantId: "tnt_1",
+  instanceId: "ins_1",
+  transport,
+  onChange: () => render(session.events),
+});
+
+const stop = session.start();
+await session.sendMail("hello");
+// later: stop(); session.destroy();
+```

--- a/packages/hub-sessions/README.md
+++ b/packages/hub-sessions/README.md
@@ -1,0 +1,26 @@
+# @intx/hub-sessions
+
+Session-orchestration substrate for the hub. Owns the sidecar
+WebSocket router, the session service that provisions and tears
+down agent sessions, the agent repository store, the event
+collector registry, the asset service, and the skill kind handler.
+
+Sits between `@intx/hub-api` (HTTP surface) and `@intx/hub-agent`
+(sidecar orchestrator): HTTP routes call into the session service
+to start an agent, the session service drives the sidecar router
+to provision it on the connected sidecar, and event collectors
+feed agent events back to the HTTP layer for observability.
+
+`createSessionService` takes a `SessionServiceDeps` of
+`sidecarRouter`, `agentRepoStore`, and an optional
+`assetService` paired with a `db` handle for the asset manifest
+inserts. `createHubSessionOrchestrator` takes a
+`HubSessionOrchestratorDeps` of `events`, `router`, `db`,
+`eventCollectors`, `grantStore`, and `agentRepoStore`. See the
+exported types in `src/session-service.ts` and
+`src/hub-session-orchestrator.ts` for the authoritative shapes;
+`@intx/hub-api` is the in-tree consumer that wires these
+factories together.
+
+The package does not host HTTP routes itself; it exposes the
+factories `@intx/hub-api` composes into the application.

--- a/packages/hub-sessions/src/agent-repo.test.ts
+++ b/packages/hub-sessions/src/agent-repo.test.ts
@@ -299,12 +299,12 @@ describe("AgentRepoStore", () => {
       store.writeDeployTree("../../evil", {
         systemPrompt: "x",
       }),
-    ).toThrow("agentId contains unsafe characters");
+    ).toThrow("repo_id_invalid: ../../evil");
 
     expect(() =>
       store.writeDeployTree("agent@domain", {
         systemPrompt: "x",
       }),
-    ).toThrow("agentId contains unsafe characters");
+    ).toThrow("repo_id_invalid: agent@domain");
   });
 });

--- a/packages/hub-sessions/src/agent-repo.ts
+++ b/packages/hub-sessions/src/agent-repo.ts
@@ -1,6 +1,6 @@
 import { createSSHSignature } from "@intx/crypto-node";
 
-import { createRepoStore, SAFE_REPO_ID } from "./repo-store";
+import { createRepoStore } from "./repo-store";
 import type { AuthorizeFn, RepoId, RepoStore } from "./repo-store";
 import {
   agentStateKindHandler,
@@ -108,15 +108,7 @@ export function createAgentRepoStore(config: {
 
   const hub: AgentStateHubPrincipal = { kind: "hub" };
 
-  // The substrate enforces the same SAFE_REPO_ID rule with a different
-  // error prefix; we throw the legacy message here so existing callers
-  // and tests that match on it continue to work.
   function repoId(agentId: string): RepoId {
-    if (!SAFE_REPO_ID.test(agentId)) {
-      throw new Error(
-        `agentId contains unsafe characters: ${JSON.stringify(agentId)}`,
-      );
-    }
     return { kind: "agent-state", id: agentId };
   }
 

--- a/packages/hub-sessions/src/repo-store/index.ts
+++ b/packages/hub-sessions/src/repo-store/index.ts
@@ -11,5 +11,5 @@ export type {
   TreeContent,
   ValidatePushResult,
 } from "./types";
-export { SAFE_REPO_ID, UserPrincipal } from "./types";
+export { UserPrincipal } from "./types";
 export { createRepoStore, type CreateRepoStoreConfig } from "./store";

--- a/packages/hub-sessions/src/repo-store/types.ts
+++ b/packages/hub-sessions/src/repo-store/types.ts
@@ -44,9 +44,7 @@ export type UserPrincipal = typeof UserPrincipal.infer;
 /**
  * Regex defining the shape of a valid `RepoId.id`. The substrate
  * validates against this at every public operation and throws an Error
- * prefixed with `"repo_id_invalid: "` on mismatch. Exposed so callers
- * that want to validate ids before constructing a `RepoId` (e.g. shims
- * that throw their own legacy error messages) can use the same rule.
+ * prefixed with `"repo_id_invalid: "` on mismatch.
  */
 export const SAFE_REPO_ID = /^[a-zA-Z0-9_-]+$/;
 

--- a/packages/inference-discovery-anthropic/README.md
+++ b/packages/inference-discovery-anthropic/README.md
@@ -1,0 +1,69 @@
+# @intx/inference-discovery-anthropic
+
+Anthropic provider plug-in for the discovery rig. Captures Claude
+wire responses across streaming and non-streaming variants of each
+capability and writes them into the shared fixture corpus.
+
+See [`@intx/inference-discovery`](../inference-discovery/README.md)
+for the runtime, the plug-in contract, and the `discover` CLI.
+
+## Models
+
+- `claude-sonnet-4-5-20250929`
+- `claude-opus-4-1-20250805`
+- `claude-haiku-4-5-20251001`
+
+The full per-capability list is in `SUPPORT_MATRIX` in
+`@intx/inference-discovery/catalog`.
+
+## Usage
+
+```ts
+import { createAnthropicPlugin } from "@intx/inference-discovery-anthropic";
+
+const plugin = createAnthropicPlugin({ apiKey: process.env.ANTHROPIC_API_KEY });
+// Hand off to runCapture from @intx/inference-discovery.
+```
+
+In practice the `bin/discover.ts` CLI does this wiring for you;
+construct the plug-in directly only when writing tests or one-off
+scripts.
+
+## Environment
+
+| Variable            | Purpose                         |
+| ------------------- | ------------------------------- |
+| `ANTHROPIC_API_KEY` | Sent as the `x-api-key` header. |
+
+The key is redacted in captured fixtures.
+
+## Multi-step capabilities
+
+Three capability families drive multi-step exchanges before the
+runner writes the bundle:
+
+- **Files API** (`files-api-reference`,
+  `files-api-reference-streaming`) — the plug-in first uploads the
+  intent's media asset to the Anthropic files endpoint, then uses
+  the returned file id to construct the messages body for the
+  second step. Each step writes its own `upload/` and `generate/`
+  subdirectory under the run root.
+- **Multi-turn function calling**
+  (`function-calling-multi-turn`,
+  `function-calling-multi-turn-streaming`,
+  `function-calling-with-thinking`,
+  `function-calling-with-thinking-streaming`) — turn 1 is sent as
+  usual; the plug-in extracts the model's content blocks from the
+  parsed response and sends a turn-2 body that echoes the
+  assistant turn verbatim and appends the tool result. Each turn
+  writes its own `turn-1/` and `turn-2/` subdirectory.
+- **Redacted thinking**
+  (`redacted-thinking`, `redacted-thinking-streaming`) — turn 1
+  produces a redacted thinking block that turn 2 must echo back
+  verbatim; the plug-in extracts the redacted block from the
+  response and assembles the turn-2 body around it.
+
+The Files API and code-execution capabilities additionally set
+per-step beta-flag headers (`files-api-2025-04-14`,
+`code-execution-2025-05-22`). All other capabilities are
+single-step.

--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -1,0 +1,46 @@
+# @intx/inference
+
+Provider-agnostic inference runtime. Adapters for Anthropic,
+OpenAI-compatible relays (including OpenCode Zen), and Google
+GenAI; SSE parsing; retry and error classification; message
+transforms; and the reactor harness that drives a turn from
+prompt to settled tool calls.
+
+Consumed by `@intx/harness`, which composes the reactor with tool
+runners, directors, and runtime capabilities.
+
+```ts
+import { createReactorAssembly, createDefaultDirector } from "@intx/inference";
+
+const director = createDefaultDirector(
+  systemPrompt,
+  toolDefinitions, // ToolDefinition[] — the tool surface advertised to the model
+  policy,
+);
+
+const assembly = createReactorAssembly({
+  sessionId,
+  director,
+  source, // InferenceSource: id, provider, model, apiKey, baseURL
+  toolRunner, // ToolRunner — dispatches the tool calls the director emits
+  contextStore,
+  onEvent: (event) => {
+    // event: ReactorEmittedEvent — persist or forward
+  },
+});
+
+assembly.reactor.start();
+```
+
+Provider selection is driven by `source.provider`; the assembly
+resolves the matching adapter internally. `ReactorAssemblyConfig`
+in `src/assembly.ts` documents the optional fields (`authorize`,
+`auditStore`, transforms, compactors, correlation, gate
+timeouts).
+
+The package is the lower half of the agent stack: it knows how to
+talk to model providers, how to drive a multi-turn exchange to
+completion, and how to compose extensions (gates, audit,
+correlation, authz) into the reactor pipeline. The higher-level
+agent surface — config validation, tool runners, deploy trees,
+runtime capabilities — lives in `@intx/harness`.

--- a/packages/log/README.md
+++ b/packages/log/README.md
@@ -1,0 +1,29 @@
+# @intx/log
+
+Thin wrapper around LogTape that the rest of the monorepo uses for
+structured logging. Re-exports the core LogTape API as-is so most
+callers only need this package, and adds a `setup()` helper that
+installs the project's preferred development and production sinks.
+
+Every package gets its logger through `getLogger`; applications
+call `setup()` once at startup to choose the output format and
+override per-category log levels.
+
+```ts
+import { getLogger, setup } from "@intx/log";
+
+await setup({ dev: true, levels: { "hub.requests": "debug" } });
+
+const logger = getLogger(["hub", "ws", "sidecar"]);
+logger.info`Sidecar ${sidecarId} registered`;
+```
+
+## Surface
+
+- `@intx/log` — the LogTape re-export plus `setup()`,
+  `getLogger`, and the sink installation that runs at import time
+  so early diagnostics work before `setup()` is called.
+- `@intx/log/hono` — Hono middleware re-exported from
+  `@logtape/hono` for HTTP request logging. Hono is an optional
+  peer dependency; only import this entry point from packages that
+  already pull Hono in.

--- a/packages/log/README.md
+++ b/packages/log/README.md
@@ -1,13 +1,19 @@
 # @intx/log
 
 Thin wrapper around LogTape that the rest of the monorepo uses for
-structured logging. Re-exports the core LogTape API as-is so most
-callers only need this package, and adds a `setup()` helper that
-installs the project's preferred development and production sinks.
+structured logging. Re-exports a narrow slice of the LogTape API —
+only the symbols other `@intx/*` packages actually use today — and
+adds a `setup()` helper that installs the project's preferred
+development and production sinks.
 
 Every package gets its logger through `getLogger`; applications
 call `setup()` once at startup to choose the output format and
 override per-category log levels.
+
+Consumers that need a piece of LogTape this package does not
+re-export should import it from `@logtape/logtape` directly rather
+than widen this surface speculatively. Widen it here only when at
+least one consumer needs the symbol.
 
 ```ts
 import { getLogger, setup } from "@intx/log";
@@ -20,9 +26,12 @@ logger.info`Sidecar ${sidecarId} registered`;
 
 ## Surface
 
-- `@intx/log` — the LogTape re-export plus `setup()`,
-  `getLogger`, and the sink installation that runs at import time
-  so early diagnostics work before `setup()` is called.
+- `@intx/log` — `getLogger` for hierarchical loggers, `setup` and
+  `SetupOptions` for application configuration, plus
+  `configureSync`, `getConfig`, and `resetSync` for tests that need
+  to drive LogTape configuration directly. Importing the package
+  also installs the default console sink as a side effect so early
+  diagnostics work before `setup()` is called.
 - `@intx/log/hono` — Hono middleware re-exported from
   `@logtape/hono` for HTTP request logging. Hono is an optional
   peer dependency; only import this entry point from packages that

--- a/packages/log/src/default-sink-routing.test.ts
+++ b/packages/log/src/default-sink-routing.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { getLogger, resetSync, installDefaultConsoleSink } from "./index";
+import { getLogger, resetSync } from "./index";
+import { installDefaultConsoleSink } from "./default-sink";
 
 // Locks down two design contracts of the module-load default sink that
 // default-sink.test.ts does not currently exercise:

--- a/packages/log/src/default-sink.test.ts
+++ b/packages/log/src/default-sink.test.ts
@@ -1,11 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import {
-  getConfig,
-  getLogger,
-  resetSync,
-  installDefaultConsoleSink,
-  setup,
-} from "./index";
+import { getConfig, getLogger, resetSync, setup } from "./index";
+import { installDefaultConsoleSink } from "./default-sink";
 
 // Snapshot taken at test-file load, before any beforeEach hooks run. This is
 // the only point at which we can observe the side effect at the bottom of

--- a/packages/log/src/index.ts
+++ b/packages/log/src/index.ts
@@ -1,84 +1,16 @@
 // Install the default console sink before any caller can get a logger.
 import "./default-sink";
 
-// Re-export core LogTape functionality
+// `@intx/log` is a narrow re-export over `@logtape/logtape`. It carries
+// only the symbols other `@intx/*` packages actually use today, plus the
+// project's `setup()` helper. Consumers that need a piece of LogTape not
+// re-exported here should import it from `@logtape/logtape` directly
+// rather than widening this surface speculatively — widen it only when
+// at least one consumer needs the symbol.
 export {
-  // Logger creation and usage
   getLogger,
-  type Logger,
-  type LogMethod,
-
-  // Configuration
-  configure,
   configureSync,
-  dispose,
-  disposeSync,
-  reset,
   resetSync,
   getConfig,
-  type Config,
-  type ConfigError,
-  type LoggerConfig,
-
-  // Log levels
-  type LogLevel,
-  isLogLevel,
-  parseLogLevel,
-  compareLogLevel,
-  getLogLevels,
-
-  // Log records
-  type LogRecord,
-
-  // Sinks
-  getConsoleSink,
-  getStreamSink,
-  withFilter,
-  fingersCrossed,
-  fromAsyncSink,
-  type Sink,
-  type AsyncSink,
-  type ConsoleSinkOptions,
-  type StreamSinkOptions,
-  type FingersCrossedOptions,
-
-  // Filters
-  getLevelFilter,
-  toFilter,
-  type Filter,
-  type FilterLike,
-
-  // Formatters
-  ansiColorFormatter,
-  jsonLinesFormatter,
-  defaultTextFormatter,
-  defaultConsoleFormatter,
-  getAnsiColorFormatter,
-  getJsonLinesFormatter,
-  getTextFormatter,
-  type TextFormatter,
-  type ConsoleFormatter,
-  type TextFormatterOptions,
-  type AnsiColorFormatterOptions,
-  type JsonLinesFormatterOptions,
-  type AnsiColor,
-  type AnsiStyle,
-  type FormattedValues,
-
-  // Context
-  withContext,
-  withCategoryPrefix,
-  type ContextLocalStorage,
-
-  // Lazy evaluation
-  lazy,
-  isLazy,
-  type Lazy,
 } from "@logtape/logtape";
-
-// Re-export our setup helper
 export { setup, type SetupOptions } from "./setup";
-
-// Re-export the default sink installer for tests that need to reinstall
-// after `resetSync()`.
-export { installDefaultConsoleSink } from "./default-sink";

--- a/packages/mail-memory/README.md
+++ b/packages/mail-memory/README.md
@@ -1,0 +1,37 @@
+# @intx/mail-memory
+
+In-memory `MessageTransport` for single-process and test
+environments. A single transport instance hosts every address in
+the process; each registered address gets its own per-recipient
+transport handle that signs outbound mail with the provided
+`CryptoProvider` and delivers inbound mail straight to the
+recipient's INBOX.
+
+Consumed by examples, tests, and the in-process `@intx/agent`
+runtime. The on-the-wire format matches `@intx/mime` so a fixture
+captured here can be replayed against a real transport without
+modification.
+
+```ts
+import { createInMemoryTransport } from "@intx/mail-memory";
+import { createNodeCrypto, generateKeyPair } from "@intx/crypto-node";
+
+const transport = createInMemoryTransport();
+const alpha = createNodeCrypto(await generateKeyPair());
+const beta = createNodeCrypto(await generateKeyPair());
+
+transport.register("alpha@local.interchange", alpha);
+transport.register("beta@local.interchange", beta);
+
+const alphaMail = transport.getTransportFor("alpha@local.interchange");
+await alphaMail.send({
+  to: "beta@local.interchange",
+  type: "conversation.message",
+  content: "hello",
+});
+```
+
+Install a `RemoteSendHandler` via `transport.setRemoteSendHandler`
+to forward outbound mail for addresses the transport does not host
+locally, and add one or more `MessageSentHandler`s via
+`transport.addMessageSentHandler` for post-send observability.

--- a/packages/mime/README.md
+++ b/packages/mime/README.md
@@ -1,0 +1,32 @@
+# @intx/mime
+
+RFC 2822 message assembly and parsing. Builds multipart/signed
+messages with PGP detached signatures, parses inbound wire bytes
+back into structured parts, and owns the JMAP-shaped envelope the
+rest of the mail pipeline depends on.
+
+Consumed by `@intx/mail-memory` (in-process transport),
+`@intx/storage-isogit` (mail audit log), and `@intx/harness`
+(sidecar mail-tool plumbing).
+
+```ts
+import {
+  parseHeaderSection,
+  parseMultipart,
+  extractBoundary,
+} from "@intx/mime";
+
+const { headers, bodyOffset } = parseHeaderSection(rawMessageBytes);
+const contentType = headers.get("content-type");
+if (contentType === undefined) throw new Error("missing Content-Type");
+const boundary = extractBoundary(contentType);
+if (boundary === undefined) throw new Error("missing boundary parameter");
+const parts = parseMultipart(rawMessageBytes.subarray(bodyOffset), boundary);
+```
+
+For outbound mail the builder layer is the entry point:
+`createOutboundMessage` produces a structured envelope,
+`assembleSignedContent` canonicalises the signed body, and
+`assembleMessage` joins the signed content with a detached
+signature from `createDetachedSignatureFromProvider` into wire
+bytes.

--- a/packages/pack-transport/README.md
+++ b/packages/pack-transport/README.md
@@ -1,0 +1,33 @@
+# @intx/pack-transport
+
+Git pack chunking and reassembly for the hub-sidecar wire. Splits
+a packfile into ordered `repo.pack.push` frames on the sender, and
+reassembles the chunks on the receiver while validating sequence
+continuity and rejecting concurrent transfers for the same agent.
+
+Consumed by `@intx/hub-sessions` and `@intx/hub-agent` to ship
+agent repository state across the WebSocket link.
+
+```ts
+import { chunkPack, createPackReceiver } from "@intx/pack-transport";
+
+for (const chunk of chunkPack(packBytes)) {
+  await ws.send({
+    type: "repo.pack.push",
+    agentAddress,
+    repoId,
+    transferId,
+    seq: chunk.seq,
+    data: chunk.data,
+  });
+}
+
+const receiver = createPackReceiver();
+// On each inbound frame:
+const reject = receiver.handlePush(frame);
+if (reject) throw new Error(`pack transfer rejected: ${reject}`);
+const completed = receiver.handleDone(doneFrame);
+if (completed) {
+  // completed.pack is the reassembled packfile bytes.
+}
+```

--- a/packages/storage-isogit/README.md
+++ b/packages/storage-isogit/README.md
@@ -1,0 +1,28 @@
+# @intx/storage-isogit
+
+Isomorphic-git backed implementation of `ContextStore` and
+`AuditStore`. Each agent gets its own git repository on disk;
+inference state lives on a working branch, the tool-authorization
+audit log lives on its own branch, and mail history lives in a
+dedicated audit store that commits each inbound and outbound
+message.
+
+Consumed by `@intx/agent` for in-process persistence, and by
+`@intx/hub-sessions` and `@intx/hub-agent` for the agent
+repositories that move between the hub and the sidecar as packs.
+
+```ts
+import { createIsogitStore } from "@intx/storage-isogit";
+
+const store = await createIsogitStore("./tmp/agent-repo", signer);
+
+// store implements both ContextStore and AuditStore -- hand it to
+// the inference and tool layers as appropriate.
+```
+
+The pack-send and pack-receive helpers (`createDeployPack`,
+`createNegotiatedPack`, `applyPack`, `receivePackObjects`) produce
+and consume the wire bytes that `@intx/pack-transport` chunks
+across the WebSocket. A `CommitSigner` is optional but required
+when the consumer needs every commit to carry a verifiable
+signature.

--- a/packages/tools-lsp/README.md
+++ b/packages/tools-lsp/README.md
@@ -1,0 +1,28 @@
+# @intx/tools-lsp
+
+LSP-backed tool plugin for the agent harness. Spawns language servers
+in the agent's working directory (over JSON-RPC via
+`vscode-jsonrpc`), exposes them as a single `lsp` tool the agent can
+call, and installs middleware that ensures `write` and `edit` actions
+on `@intx/tools-posix` keep the LSP's in-memory document state in
+sync with what the agent wrote to disk.
+
+Composes with `@intx/tools-posix`. `apps/sidecar` and the
+`coding-agent` example consume both together.
+
+`createLSPPlugin` returns a `ToolPlugin`. It is installed by
+passing it to `createPosixTools` as a `plugins[]` entry; the posix
+tool runner mounts the `lsp` tool and threads the LSP middleware
+into its `write` and `edit` paths.
+
+```ts
+import { createPosixTools } from "@intx/tools-posix";
+import { createLSPPlugin } from "@intx/tools-lsp";
+
+const cwd = "/path/to/workspace";
+
+const tools = createPosixTools({
+  cwd,
+  plugins: [createLSPPlugin({ cwd, minSeverity: 2 })],
+});
+```

--- a/packages/tools-mail/README.md
+++ b/packages/tools-mail/README.md
@@ -1,0 +1,22 @@
+# @intx/tools-mail
+
+Mail tool runner for the agent harness. Exposes `mail_send`,
+`mail_reply`, `mail_search`, `mail_read`, and `mail_wait` against
+the `MessageTransport` resolved from the harness's
+`RuntimeCapabilities` registry.
+
+Consumed by `apps/sidecar` and the demo examples; pairs with
+`mergeToolRunners` from `@intx/harness` when composing the full
+tool set the reactor sees.
+
+```ts
+import { createMailTools } from "@intx/tools-mail";
+import { mergeToolRunners } from "@intx/harness";
+
+const mail = createMailTools({ capabilities });
+const tools = mergeToolRunners([mail, posixTools]);
+```
+
+The transport is resolved once at handler-init and held for the
+deploy lifetime; the handlers do not re-consult capabilities on
+each call.

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,37 @@
+# @intx/types
+
+Foundational types for the Interchange monorepo. ArkType runtime
+validators, API contract types, runtime interfaces, and sidecar
+wire frames. Nearly every other package imports from here, which
+makes this the canonical home for any shape that crosses a package
+boundary.
+
+Each entry point pairs an ArkType validator with its inferred
+TypeScript type so consumers can validate at the boundary and
+trust the resulting value internally.
+
+## Surface
+
+The package is split into several entry points so consumers only
+pull in the shapes they need:
+
+- `@intx/types` — domain validators and shared primitives: tenants,
+  principals, roles, grants, agents, sessions, approvals, wallets,
+  providers, oauth clients, credentials, offerings, models,
+  observability, sidecar status enums (distinct from the wire frames
+  under `@intx/types/sidecar` below), agent addresses, hex and
+  base64 helpers, and the `hasCode` error guard.
+- `@intx/types/authz` — grant rules, condition contexts, and
+  authorization result shapes shared between `@intx/authz` and the
+  hub.
+- `@intx/types/audit` — `AuditStore` contract for tool-authorization
+  records.
+- `@intx/types/runtime` — inference and harness contracts:
+  `ContextStore`, `ToolRunner`, `ToolDefinition`, retry policy,
+  director and reactor types.
+- `@intx/types/runtime-capabilities` — the capability-registry
+  contract harness extensions resolve against (e.g. mail transport,
+  blob reader).
+- `@intx/types/sidecar` — hub-sidecar WebSocket wire frames.
+- `@intx/types/grant-wire` — grant-update wire frames pushed from
+  the hub to the sidecar.

--- a/packages/types/src/agents.test.ts
+++ b/packages/types/src/agents.test.ts
@@ -238,6 +238,7 @@ describe("AgentResponse", () => {
   const validResponse = {
     id: "agt_1",
     tenantId: "tnt_1",
+    creatorPrincipalId: "prn_1",
     name: "Agent",
     currentVersion: "1",
     status: "deployed" as const,
@@ -246,24 +247,22 @@ describe("AgentResponse", () => {
   };
 
   test("accepts a valid response with creatorPrincipalId as a string", () => {
-    const result = AgentResponse({
-      ...validResponse,
-      creatorPrincipalId: "prn_1",
-    });
+    const result = AgentResponse(validResponse);
     expect(result instanceof type.errors).toBe(false);
   });
 
-  test("accepts a valid response with creatorPrincipalId as null", () => {
+  test("rejects a response with creatorPrincipalId as null", () => {
     const result = AgentResponse({
       ...validResponse,
       creatorPrincipalId: null,
     });
-    expect(result instanceof type.errors).toBe(false);
+    expect(result instanceof type.errors).toBe(true);
   });
 
-  test("accepts absent creatorPrincipalId (optional)", () => {
-    const result = AgentResponse(validResponse);
-    expect(result instanceof type.errors).toBe(false);
+  test("rejects a response with creatorPrincipalId absent", () => {
+    const { creatorPrincipalId: _omitted, ...withoutCreator } = validResponse;
+    const result = AgentResponse(withoutCreator);
+    expect(result instanceof type.errors).toBe(true);
   });
 
   test("accepts grantRequirements on the response", () => {

--- a/packages/types/src/agents.ts
+++ b/packages/types/src/agents.ts
@@ -76,8 +76,7 @@ export const UpdateAgent = type({
 export const AgentResponse = type({
   id: "string",
   tenantId: "string",
-  // TODO: remove null once all definitions have been backfilled
-  "creatorPrincipalId?": type("string | null").describe(
+  creatorPrincipalId: type("string").describe(
     "Identifies the definition author's principal (definitions have no principalId of their own). Used for resolving creator-sourced grant and credential requirements.",
   ),
   name: "string",


### PR DESCRIPTION
## Summary

- Per-package READMEs land for 18 previously-undocumented packages, following the existing convention.
- `creatorPrincipalId` is non-nullable on agent definitions end-to-end (DB schema, ArkType validator, REST response, admin UI type, generated API doc).
- Surface tightening: `@intx/log` re-exports only the symbols the rest of the monorepo consumes today; the `hub-sessions` legacy agent-id wrapper is gone, leaving the substrate as the single enforcement point.

## Verification

- `make build` exits 0 (TypeScript project graph passes).
- `make lint` exits 0 (Prettier, ESLint, API docs freshness all pass).
- Tests on the affected packages pass: `bun test packages/types/src/agents.test.ts` (30/30), `bun test packages/hub-sessions/src/agent-repo.test.ts` (10/10), `bun test packages/log` (10/10), `bun test packages/hub-api/src/routes/instances.test.ts` (19/19).
- The original pre-tag audit's tag-blocking and cleanup-candidate findings are addressed; the sidecar-teardown gap for agent retire is tracked separately as INTR-153.

Closes INTR-152