### PR TITLE
Wire compactors through createAgent and expose them to directors

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -57,6 +57,56 @@ const { reply } = await agent.send("hello");
 await agent.close();
 ```
 
+## Compactors
+
+A compactor rewrites the conversation history when the director asks for
+it. The deployer registers compactors on `env.compactors` keyed by name;
+the director picks a name at construction and emits
+`caps.compact(name, reason)` when it wants the history rewritten.
+
+```ts
+const agent = await createAgent(def, {
+  source,
+  storage,
+  workdir,
+  audit: noopAuditStore(),
+  authorize: permissiveAuthorize(),
+  directors: createDefaultDirectorRegistry(),
+  compactors: { "tail-only": tailOnlyCompactor() },
+});
+```
+
+The director author sees the registered names through
+`agentContext.compactorNames`, the same way `agentContext.toolDefinitions`
+surfaces the resolved tools:
+
+```ts
+import { defineDirector } from "@intx/agent";
+import { type } from "arktype";
+
+defineDirector({
+  id: "my-pkg/planner",
+  configSchema: type({}),
+  factory: (_config, _env, agent) => {
+    const compactor = agent.compactorNames[0];
+    if (compactor === undefined) {
+      throw new Error("planner needs a compactor; none registered on env");
+    }
+    return makePlanner({ compactor });
+  },
+});
+```
+
+The reactor resolves the name against `env.compactors` and runs the
+compactor's `apply()` on the conversation turns. A `caps.compact(name, …)`
+call against a name the deployer did not register produces a fatal
+"no compactor registered" reactor error -- the director-author contract
+is "pick from `compactorNames`," not "trust the deployer by convention."
+
+`env.compactors` is optional. A deployer that omits the field hands an
+agent whose director never calls `caps.compact(...)` an environment that
+matches an empty registry.
+
 ## Where to start
 
 Read [`examples/agent-quickstart`](../../examples/agent-quickstart/README.md).

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -304,6 +304,7 @@ function resolveDirector<EnvReq extends BaseEnv>(
   def: AgentDefinition<EnvReq>,
   env: EnvReq,
   toolDefinitions: readonly ToolDefinition[],
+  compactorNames: readonly string[],
 ): ReactorDirector {
   const ref: DirectorRef = def.director ?? env.directors.buildDefaultRef();
   const factory = env.directors.resolve(ref);
@@ -316,6 +317,7 @@ function resolveDirector<EnvReq extends BaseEnv>(
   return factory(ref.config, env, {
     systemPrompt: def.systemPrompt,
     toolDefinitions,
+    compactorNames,
   });
 }
 
@@ -348,7 +350,22 @@ export async function createAgent<EnvReq extends BaseEnv>(
       sources: [env.source],
       defaultSource: env.source.id,
     });
-    const director = resolveDirector(def, env, resolvedTools.definitions);
+    // Capture the registered names as a frozen snapshot at construction
+    // so the director receives a stable list it can iterate. The
+    // reactor assembly retains the live `env.compactors` reference for
+    // `caps.compact` lookups, so a deployer that mutates the registry
+    // after `createAgent` returns would diverge this snapshot from the
+    // reactor's resolution. Treat `env.compactors` as immutable
+    // post-construction.
+    const compactorNames: readonly string[] = Object.freeze(
+      Object.keys(env.compactors ?? {}),
+    );
+    const director = resolveDirector(
+      def,
+      env,
+      resolvedTools.definitions,
+      compactorNames,
+    );
 
     const contextStore: ContextStore = env.storage;
     const auditStore = env.audit;
@@ -613,6 +630,7 @@ export async function createAgent<EnvReq extends BaseEnv>(
         ? { sizeCapMaxChars: env.sizeCapMaxChars }
         : {}),
       ...(deps !== undefined ? { deps } : {}),
+      ...(env.compactors !== undefined ? { compactors: env.compactors } : {}),
     });
 
     sendQueue = createSendQueue<InboundMessage, SendResult>({

--- a/packages/agent/src/compactor-wiring.test.ts
+++ b/packages/agent/src/compactor-wiring.test.ts
@@ -1,0 +1,351 @@
+// Integration coverage for compactor wiring through `createAgent`.
+//
+// The agent's job here is mechanical: thread `env.compactors` into the
+// reactor assembly, surface the registered names to the director factory
+// at construction as `agentContext.compactorNames`, and trust the
+// reactor's existing `executeCompact` to resolve the name and run the
+// compactor's `apply()`. These tests pin both halves:
+//
+//  - A registered compactor runs end-to-end when the director emits
+//    `caps.compact(name, reason)` for it, and the director sees the
+//    registered name on `agentContext.compactorNames` at construction.
+//  - An unregistered name produces the reactor's existing fatal
+//    "no compactor registered" error rather than silently dropping the
+//    action.
+//
+// The directors here are hand-written test doubles: a real LLM is not
+// needed to drive a compact action.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type } from "arktype";
+
+import type { ReactorEmittedEvent } from "@intx/inference";
+import { createInboundMessage } from "@intx/mime";
+import { createIsogitStore } from "@intx/storage-isogit";
+import type {
+  Compactor,
+  ConversationTurn,
+  InferenceSource,
+  ReactorCapabilities,
+  ReactorDirector,
+  ReactorInboundEvent,
+  ReactorState,
+  StrategyContext,
+} from "@intx/types/runtime";
+
+import { createAgent } from "./agent";
+import { defineAgent } from "./definition";
+import { defineDirector } from "./director";
+import { createDirectorRegistry } from "./director-registry";
+import type { BaseEnv } from "./env";
+import { noopAuditStore } from "./testing/audit-noop";
+import { permissiveAuthorize } from "./testing/authorize-allow";
+
+// The compactor tests never call infer(); the URL is unreachable so any
+// accidental infer() would fail fast rather than hang.
+const SOURCE: InferenceSource = {
+  id: "anthropic:compactor-test",
+  provider: "anthropic",
+  baseURL: "http://localhost:1",
+  apiKey: "test-key",
+  model: "claude-test",
+};
+
+interface RecordingCompactor extends Compactor {
+  readonly calls: {
+    turns: readonly ConversationTurn[];
+    trigger: string;
+  }[];
+  /**
+   * Resolves the first time `apply()` runs. The test awaits this
+   * before delivering the follow-up message that lets the director
+   * return `done()`, so the handshake is gated on the compact path
+   * actually executing rather than on a wall-clock timer the reactor
+   * must beat.
+   */
+  readonly firstApplyStarted: Promise<void>;
+}
+
+// A compactor that captures every (turns, ctx) pair its `apply()` saw
+// and replaces the conversation with a single synthetic assistant turn.
+// The single-turn output is enough for the reactor's commit cycle to
+// distinguish "compaction ran" from "compaction skipped" via the
+// resulting history length.
+function makeRecordingCompactor(name: string): RecordingCompactor {
+  const calls: {
+    turns: readonly ConversationTurn[];
+    trigger: string;
+  }[] = [];
+  const {
+    promise: firstApplyStarted,
+    resolve: signalFirstApply,
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- Promise.withResolvers<void>() is the conventional shape for a fire-and-forget settled-signal
+  } = Promise.withResolvers<void>();
+  return {
+    name,
+    version: "1",
+    calls,
+    firstApplyStarted,
+    async apply(turns: ConversationTurn[], ctx: StrategyContext) {
+      calls.push({ turns: [...turns], trigger: ctx.trigger });
+      signalFirstApply();
+      const compacted: ConversationTurn = {
+        role: "assistant",
+        content: [{ type: "text", text: `compacted:${name}` }],
+        model: SOURCE.model,
+        timestamp: Date.now(),
+      };
+      return {
+        output: [compacted],
+        record: {
+          strategy: name,
+          version: "1",
+          parameters: {},
+          reason: ctx.trigger,
+          decisions: { kept: 1, dropped: turns.length },
+        },
+      };
+    },
+  };
+}
+
+// A test director that emits `caps.compact(name, reason)` on the first
+// inbound message and `caps.done()` on any later event. The compact
+// cycle finishes without a follow-up action from the reactor, so the
+// caller drives the director's terminal `done()` by delivering a
+// second message -- the same shape the reactor-level compact test in
+// `packages/inference/src/reactor.test.ts` uses.
+//
+// The director factory captures the `compactorNames` it received at
+// construction so the test can assert the deployer's registry
+// surfaced through to the director author the same way
+// `toolDefinitions` does.
+function defineCompactDirector(opts: {
+  compactorName: string;
+  reason: string;
+  capturedNames: { value: readonly string[] | null };
+}) {
+  let messages = 0;
+  const director: ReactorDirector = {
+    async decide(
+      event: ReactorInboundEvent,
+      _state: ReactorState,
+      caps: ReactorCapabilities,
+    ) {
+      if (event.type === "message.received") {
+        messages++;
+        if (messages === 1) {
+          return caps.compact(opts.compactorName, opts.reason);
+        }
+        return caps.done();
+      }
+      return caps.done();
+    },
+  };
+  const defined = defineDirector({
+    id: "@intx-test/compactor/probe",
+    configSchema: type({}),
+    factory: (_config, _env, agent) => {
+      opts.capturedNames.value = agent.compactorNames;
+      return director;
+    },
+  });
+  return createDirectorRegistry({
+    factories: [defined.factory],
+    defaultId: defined.factory.id,
+  });
+}
+
+async function buildEnv(opts: {
+  workdir: string;
+  directors: BaseEnv["directors"];
+  compactors?: Record<string, Compactor>;
+}): Promise<BaseEnv> {
+  const storage = await createIsogitStore(opts.workdir);
+  return {
+    source: SOURCE,
+    storage,
+    workdir: opts.workdir,
+    audit: noopAuditStore(),
+    authorize: permissiveAuthorize(),
+    directors: opts.directors,
+    ...(opts.compactors !== undefined ? { compactors: opts.compactors } : {}),
+  };
+}
+
+function inboundConversation(content: string) {
+  return createInboundMessage({
+    from: "user@local",
+    to: "agent@local",
+    content,
+    interchangeType: "conversation.message",
+  });
+}
+
+async function waitForReactorDone(
+  stream: AsyncIterable<ReactorEmittedEvent>,
+): Promise<void> {
+  for await (const event of stream) {
+    if (event.type === "reactor.done") return;
+  }
+}
+
+async function collectUntilDone(
+  stream: AsyncIterable<ReactorEmittedEvent>,
+): Promise<ReactorEmittedEvent[]> {
+  const events: ReactorEmittedEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+    if (event.type === "reactor.done") return events;
+  }
+  return events;
+}
+
+describe("createAgent compactor wiring", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "agent-compactor-"));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("a registered compactor runs and its name surfaces on agentContext", async () => {
+    const compactor = makeRecordingCompactor("test-compactor");
+    const capturedNames: { value: readonly string[] | null } = { value: null };
+    const directors = defineCompactDirector({
+      compactorName: "test-compactor",
+      reason: "test-trigger",
+      capturedNames,
+    });
+
+    const def = defineAgent({
+      id: "compactor-wired",
+      systemPrompt: "test",
+      tools: [],
+      capabilities: [],
+      inference: {
+        sources: [{ provider: SOURCE.provider, model: SOURCE.model }],
+      },
+    });
+
+    const env = await buildEnv({
+      workdir: workDir,
+      directors,
+      compactors: { "test-compactor": compactor },
+    });
+    const agent = await createAgent(def, env);
+    const stream = agent.stream();
+    try {
+      agent.deliver(inboundConversation("trigger"));
+      // Gate the follow-up delivery on the compact path actually
+      // running rather than a wall-clock timer. The compact cycle
+      // commits and waits for the next inbound event; once the
+      // recording compactor's `apply()` has started, delivering the
+      // second message lets the director return `done()` and the
+      // reactor shut down cleanly.
+      await compactor.firstApplyStarted;
+      agent.deliver(inboundConversation("done"));
+      await waitForReactorDone(stream);
+    } finally {
+      await agent.close();
+    }
+
+    // The director factory saw the registered name at construction.
+    expect(capturedNames.value).toEqual(["test-compactor"]);
+
+    // The reactor resolved the name against the env registry and called
+    // the compactor exactly once with the inbound user turn and the
+    // director's stated trigger.
+    expect(compactor.calls.length).toBe(1);
+    const call = compactor.calls[0];
+    if (call === undefined) throw new Error("expected one compactor call");
+    // The reactor namespaces the director-supplied reason with a
+    // `director:` prefix before passing it to the compactor; the
+    // contract under test here is that the director's reason reaches
+    // the strategy unchanged, not the framing.
+    expect(call.trigger).toContain("test-trigger");
+    expect(call.turns.length).toBeGreaterThanOrEqual(1);
+    const userTurn = call.turns[call.turns.length - 1];
+    if (userTurn === undefined) throw new Error("expected user turn");
+    expect(userTurn.role).toBe("user");
+    // The inbound message's payload reached the compactor through the
+    // reactor's commit-then-decide ordering; pin the content as well as
+    // the role so a regression that fed the strategy an empty or
+    // wrong-content turn collection cannot pass.
+    const userBlocks = userTurn.content;
+    const userText = userBlocks
+      .map((block) => (block.type === "text" ? block.text : ""))
+      .join("");
+    expect(userText).toContain("trigger");
+
+    // The compactor's output replaced the conversation: history reflects
+    // the single synthetic assistant turn the compactor returned.
+    const turns = await agent.history();
+    expect(turns.length).toBe(1);
+    const only = turns[0];
+    if (only === undefined) throw new Error("expected one turn");
+    expect(only.role).toBe("assistant");
+    const block = only.content[0];
+    if (block === undefined || block.type !== "text") {
+      throw new Error("expected text block");
+    }
+    expect(block.text).toBe("compacted:test-compactor");
+  });
+
+  test("an unregistered compactor name produces the reactor's fatal error", async () => {
+    const capturedNames: { value: readonly string[] | null } = { value: null };
+    const directors = defineCompactDirector({
+      compactorName: "missing",
+      reason: "test",
+      capturedNames,
+    });
+
+    const def = defineAgent({
+      id: "compactor-missing",
+      systemPrompt: "test",
+      tools: [],
+      capabilities: [],
+      inference: {
+        sources: [{ provider: SOURCE.provider, model: SOURCE.model }],
+      },
+    });
+
+    // Build env without a `compactors` field at all: the agent threads
+    // an undefined registry through and the reactor sees an empty
+    // lookup, matching the deployer who simply never registered any.
+    const env = await buildEnv({
+      workdir: workDir,
+      directors,
+    });
+    const agent = await createAgent(def, env);
+    const stream = agent.stream();
+    let events: ReactorEmittedEvent[] = [];
+    try {
+      agent.deliver(inboundConversation("trigger"));
+      events = await collectUntilDone(stream);
+    } finally {
+      await agent.close();
+    }
+
+    // The director factory saw an empty list of registered names.
+    expect(capturedNames.value).toEqual([]);
+
+    // The reactor surfaced its existing "no compactor registered" fatal
+    // error and shut down. The shape matches the reactor-level test
+    // `"compact for an unknown name emits a fatal error and shuts down"`
+    // in packages/inference/src/reactor.test.ts.
+    const reactorError = events.find((e) => e.type === "reactor.error");
+    if (reactorError === undefined || reactorError.type !== "reactor.error") {
+      throw new Error("expected a reactor.error event");
+    }
+    expect(reactorError.data.fatal).toBe(true);
+    expect(reactorError.data.error).toContain("missing");
+    expect(reactorError.data.error).toContain("no compactor registered");
+  });
+});

--- a/packages/agent/src/default-director-decide.test.ts
+++ b/packages/agent/src/default-director-decide.test.ts
@@ -145,6 +145,7 @@ function buildDirector(opts?: { mode?: "conversational" | "reactive" }) {
   return defaultDirectorFactory(opts ?? {}, env, {
     systemPrompt: "You are helpful.",
     toolDefinitions: NO_TOOLS,
+    compactorNames: [],
   });
 }
 

--- a/packages/agent/src/default-director.test.ts
+++ b/packages/agent/src/default-director.test.ts
@@ -25,6 +25,7 @@ describe("defaultDirectorFactory", () => {
     const director = defaultDirectorFactory({}, env, {
       systemPrompt: "you are a planner",
       toolDefinitions: NO_TOOLS,
+      compactorNames: [],
     });
     expect(typeof director.decide).toBe("function");
   });
@@ -35,6 +36,7 @@ describe("defaultDirectorFactory", () => {
     const director = defaultDirectorFactory({ mode: "reactive" }, env, {
       systemPrompt: "ack only",
       toolDefinitions: NO_TOOLS,
+      compactorNames: [],
     });
     expect(typeof director.decide).toBe("function");
   });

--- a/packages/agent/src/director-types.ts
+++ b/packages/agent/src/director-types.ts
@@ -21,10 +21,20 @@ import type { BaseEnv } from "./env";
  * the system prompt and the resolved tool definitions the model will
  * see. Held separately from `BaseEnv` because these values are derived
  * from the agent definition, not supplied by the caller as runtime env.
+ *
+ * `compactorNames` is the exception to the "derived from definition"
+ * shape: it lists the names the deployer registered on `env.compactors`
+ * and is surfaced here so the director picks a known name to pass to
+ * `caps.compact(name, reason)`. The list is empty when the deployer
+ * omits the env field. The shape mirrors `toolDefinitions` for the
+ * same reason: a director that emits an action keyed by name benefits
+ * from learning the registered names at construction rather than
+ * trusting the deployer by convention.
  */
 export interface DirectorAgentContext {
   readonly systemPrompt: string;
   readonly toolDefinitions: readonly ToolDefinition[];
+  readonly compactorNames: readonly string[];
 }
 
 /**
@@ -44,7 +54,8 @@ export interface DirectorRef<Config = unknown> {
 /**
  * Factory function shape that produces a `ReactorDirector` from a
  * validated config, the agent's runtime env, and the agent-instance
- * context (system prompt + tool definitions). The implementation lives
+ * context (`DirectorAgentContext`: system prompt, resolved tool
+ * definitions, registered compactor names). The implementation lives
  * in the same bundle as the agent definition; the registry resolves it
  * from `DirectorRef.id`.
  */

--- a/packages/agent/src/director.test.ts
+++ b/packages/agent/src/director.test.ts
@@ -89,7 +89,11 @@ describe("defineDirector", () => {
     }
     let seenConfig: Config | undefined;
     let seenAgent:
-      | { systemPrompt: string; toolDefinitions: readonly unknown[] }
+      | {
+          systemPrompt: string;
+          toolDefinitions: readonly unknown[];
+          compactorNames: readonly string[];
+        }
       | undefined;
 
     const defined = defineDirector<Config>({
@@ -100,6 +104,7 @@ describe("defineDirector", () => {
         seenAgent = {
           systemPrompt: agent.systemPrompt,
           toolDefinitions: agent.toolDefinitions,
+          compactorNames: agent.compactorNames,
         };
         return stubDirector();
       },
@@ -110,12 +115,14 @@ describe("defineDirector", () => {
     const agentContext = {
       systemPrompt: "you are a probe",
       toolDefinitions: [] as const,
+      compactorNames: [] as const,
     };
 
     defined.factory({ label: "x" }, env, agentContext);
     expect(seenConfig).toEqual({ label: "x" });
     expect(seenAgent?.systemPrompt).toBe("you are a probe");
     expect(seenAgent?.toolDefinitions).toEqual([]);
+    expect(seenAgent?.compactorNames).toEqual([]);
   });
 
   test("rejects a non-callable configSchema at build time", () => {

--- a/packages/agent/src/env-validation.test.ts
+++ b/packages/agent/src/env-validation.test.ts
@@ -49,6 +49,19 @@ describe("validateEnv", () => {
     expect(() => validateEnv(emptyDef(), baseEnv())).not.toThrow();
   });
 
+  test("does not require env.compactors", () => {
+    // The field is optional; an env that simply omits it is valid and a
+    // director that never emits `caps.compact(...)` runs unaffected.
+    const env = baseEnv();
+    expect(env.compactors).toBeUndefined();
+    expect(() => validateEnv(emptyDef(), env)).not.toThrow();
+  });
+
+  test("accepts env.compactors when supplied", () => {
+    const env: BaseEnv = { ...baseEnv(), compactors: {} };
+    expect(() => validateEnv(emptyDef(), env)).not.toThrow();
+  });
+
   test("collects missing core BaseEnv keys and blames BaseEnv", () => {
     const env = baseEnv();
     const bad = {

--- a/packages/agent/src/env.ts
+++ b/packages/agent/src/env.ts
@@ -15,6 +15,7 @@
 import type { AuthzCallResult, Dependencies } from "@intx/inference";
 import type {
   AuditStore,
+  Compactor,
   ContextStore,
   InferenceSource,
 } from "@intx/types/runtime";
@@ -82,6 +83,25 @@ export interface BaseEnv {
 
   /** Director registry. Required; no read-site fallback. */
   directors: DirectorRegistry;
+
+  /**
+   * Compactors registered for this deployment, keyed by name. The
+   * director picks a registered name and emits
+   * `caps.compact(name, reason)`; the reactor resolves the name against
+   * this map and runs the compactor's `apply()` on the conversation
+   * turns. Registered names are surfaced to the director factory at
+   * construction via `agentContext.compactorNames` so the director
+   * picks against a known set rather than guessing by convention.
+   *
+   * Optional: omitting the field is the same shape as registering an
+   * empty map. A `caps.compact(name, …)` call against an absent or
+   * empty registry produces the reactor's existing
+   * "no compactor registered" fatal error.
+   *
+   * Field placement mirrors `directors`: "what's registered at this
+   * deployment" is an env question, not an agent-definition question.
+   */
+  compactors?: Record<string, Compactor>;
 
   /**
    * Inference dependencies (notably `fetch`) for the reactor's


### PR DESCRIPTION
## Summary

- `BaseEnv` carries an optional `compactors?: Record<string, Compactor>` field that `createAgent` threads into the reactor assembly.
- The director factory's `agentContext` carries a `compactorNames: readonly string[]`, listing the names the deployer registered, so a director picks a known name to pass to `caps.compact(name, reason)`.
- A new integration test drives `caps.compact("name", reason)` against a registered recording compactor and asserts the strategy's `apply()` runs with the inbound user turn and the director's trigger; a regression test pins the reactor's existing fatal-error behavior for unregistered names.

## Verification

- `make all` exits 0 against the full project graph: lint (prettier + eslint + docs-gen check) passes, `tsc -b --noEmit` passes, the main test pass runs 2768 tests with 0 failures, and the secondary-pass tests run 14 more with 0 failures.
- The new tests live in `packages/agent/src/compactor-wiring.test.ts` (end-to-end + regression) and `packages/agent/src/env-validation.test.ts` (the `compactors`-is-optional contract); they run as part of `make all`.

Closes INTR-171