### PR TITLE
fix: add missing providerId on missing credentials

### DIFF
--- a/apps/admin-ui/src/lib/queries/tenants.ts
+++ b/apps/admin-ui/src/lib/queries/tenants.ts
@@ -664,7 +664,8 @@ export function deleteGrantMutation(
 
 // Credentials
 
-type CreateCredentialBody = {
+export type CreateCredentialBody = {
+  providerId: string;
   name: string;
   type: "api_key" | "oauth_token" | "certificate" | "other";
   secret: string;

--- a/apps/admin-ui/src/pages/tenant-credentials.tsx
+++ b/apps/admin-ui/src/pages/tenant-credentials.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
@@ -8,6 +8,8 @@ import { TenantNav } from "@/components/tenant-nav";
 import { MutationError } from "@/components/mutation-error";
 import {
   createCredentialMutation,
+  type CreateCredentialBody,
+  tenantProvidersQuery,
   tenantCredentialsQuery,
 } from "@/lib/queries/tenants";
 import { Badge } from "@/components/ui/badge";
@@ -67,19 +69,31 @@ export function TenantCredentialsPage() {
   const { data: credentials, isLoading } = useQuery(
     tenantCredentialsQuery(tenantId),
   );
+  const { data: providers, isLoading: providersLoading } = useQuery(
+    tenantProvidersQuery(tenantId),
+  );
 
   const [createOpen, setCreateOpen] = useState(false);
   const [createName, setCreateName] = useState("");
   const [createType, setCreateType] = useState<CredentialType>("api_key");
+  const [createProviderId, setCreateProviderId] = useState("");
   const [createSecret, setCreateSecret] = useState("");
   const [createDescription, setCreateDescription] = useState("");
+  const selectedProviderId = createProviderId || providers?.[0]?.id || "";
 
   function resetCreateForm() {
     setCreateName("");
     setCreateType("api_key");
+    setCreateProviderId("");
     setCreateSecret("");
     setCreateDescription("");
   }
+
+  useEffect(() => {
+    const providerId = providers?.[0]?.id;
+    if (!createOpen || createProviderId || !providerId) return;
+    setCreateProviderId(providerId);
+  }, [createOpen, createProviderId, providers]);
 
   const createMut = useMutation({
     ...createCredentialMutation(tenantId, queryClient),
@@ -163,12 +177,8 @@ export function TenantCredentialsPage() {
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              const body: {
-                name: string;
-                type: CredentialType;
-                secret: string;
-                description?: string;
-              } = {
+              const body: CreateCredentialBody = {
+                providerId: selectedProviderId,
                 name: createName.trim(),
                 type: createType,
                 secret: createSecret,
@@ -188,6 +198,25 @@ export function TenantCredentialsPage() {
                 required
                 autoFocus
               />
+            </div>
+            <div className="grid gap-2">
+              <Label>Provider</Label>
+              <Select
+                value={selectedProviderId}
+                onValueChange={setCreateProviderId}
+                disabled={providersLoading || !providers?.length}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select a provider" />
+                </SelectTrigger>
+                <SelectContent>
+                  {providers?.map((provider) => (
+                    <SelectItem key={provider.id} value={provider.id}>
+                      {provider.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
             <div className="grid gap-2">
               <Label>Type</Label>
@@ -233,7 +262,10 @@ export function TenantCredentialsPage() {
               <Button
                 type="submit"
                 disabled={
-                  createMut.isPending || !createName.trim() || !createSecret
+                  createMut.isPending ||
+                  !selectedProviderId ||
+                  !createName.trim() ||
+                  !createSecret
                 }
               >
                 {createMut.isPending ? "Creating..." : "Create"}

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "interchange",


### PR DESCRIPTION
## Summary

Fix admin-ui credential creation so it sends the `providerId` required by the hub API.

## What changed

- Added tenant provider loading to the credential create dialog.
- Added a provider selector and wired its value into the create payload.
- Exported the credential create payload type from the shared query module instead of duplicating it locally.

## Self-review

The fix is correct at the contract level: `POST /api/tenants/:tenantId/credentials` now receives the shape the hub already validates. The change is deliberately scoped to the admin UI and does not alter the hub route or shared credential schema.

The main tradeoff is UX: the dialog auto-selects the first available provider if one exists. That keeps the form usable without adding extra branching, but it assumes the first provider is an acceptable default. If the tenant has multiple providers and the wrong one is selected, the user can still change it before submitting. If that becomes a real workflow issue, the next step is to surface provider names more explicitly or group them by plugin.

I do not see a backend compatibility risk in this patch. The only behavior change is that credential creation now succeeds where it previously failed with a 400 because `providerId` was missing.

## Verification

- `make all`
