### PR TITLE
Tenancy-inheritable assets and the package-registry asset kind

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -103,7 +103,9 @@
 | GET | /api/tenants/:tenantId/agents/:agentId/history/:ref | Show changes in a commit |
 | GET | /api/tenants/:tenantId/agents/:agentId/branches | List branches |
 | POST | /api/tenants/:tenantId/agents/:agentId/history/:ref/restore | Restore agent data to a previous state |
+| GET | /api/tenants/:tenantId/assets | List assets |
 | POST | /api/tenants/:tenantId/assets | Create an asset |
+| GET | /api/tenants/:tenantId/assets/:assetId | Get asset metadata |
 | POST | /api/sidecars | Register or update a sidecar |
 | GET | /api/sidecars | List all sidecars |
 | GET | /api/sidecars/:id | Get a sidecar by ID |
@@ -991,6 +993,15 @@ Restores the agent's working directory to the state at the specified commit.
 
 ## Assets
 
+### GET /api/tenants/:tenantId/assets
+List assets
+
+Lists assets for the tenant. With inherited=true (the default), assets defined on ancestor tenants are included; descendant tenants shadow ancestors when they declare the same (kind, name) pair. Each row carries an `origin` tag identifying the tenant that supplied it.
+
+Query: kind?, inherited?: true|false
+
+200: AssetWithOriginResponse[] -- List of assets
+
 ### POST /api/tenants/:tenantId/assets
 Create an asset
 
@@ -1001,6 +1012,14 @@ Body: unknown
 201: unknown -- Asset created
 400: ErrorResponse -- Validation error
 409: ErrorResponse -- Asset already exists
+
+### GET /api/tenants/:tenantId/assets/:assetId
+Get asset metadata
+
+Returns asset metadata. Resolves through the tenant hierarchy: assets declared on the tenant or any ancestor are visible. Sibling-tenant assets return 404 so callers cannot probe for cross-tenant existence.
+
+200: AssetResponse -- Asset metadata
+404: ErrorResponse -- Asset not found
 
 ## Sidecars
 
@@ -1069,6 +1088,14 @@ Source: packages/types/src/me.ts
 ### ApproveAction
 `{ scope: "always" | "once" }`
 Source: packages/types/src/approvals.ts
+
+### AssetResponse
+`{ createdAt: string, creatorPrincipalId: string | null, displayName: string | null, id: string, kind: string, name: string, tenantId: string, updatedAt: string }`
+Source: packages/types/src/assets.ts
+
+### AssetWithOriginResponse
+`{ createdAt: string, creatorPrincipalId: string | null, displayName: string | null, id: string, kind: string, name: string, origin: { direct: boolean, tenantId: string }, tenantId: string, updatedAt: string }`
+Source: packages/types/src/assets.ts
 
 ### BranchInfo
 `{ name: string, isCurrent?: boolean, lastCommitAt?: string | null, lastCommitMessage?: string | null, lastCommitRef?: string | null }`

--- a/packages/db/src/asset-resolution.test.ts
+++ b/packages/db/src/asset-resolution.test.ts
@@ -1,0 +1,511 @@
+import { describe, test, expect } from "bun:test";
+
+import type { DB } from "./client";
+import {
+  resolveAssetByName,
+  resolveAssetById,
+  listAssetsForTenant,
+  type AssetRow,
+} from "./asset-resolution";
+
+type TenantRow = {
+  id: string;
+  parentId: string | null;
+};
+
+type DBState = {
+  tenants: TenantRow[];
+  assets: AssetRow[];
+};
+
+const SQL_TO_JS: Record<string, string> = {
+  id: "id",
+  tenant_id: "tenantId",
+  parent_id: "parentId",
+  kind: "kind",
+  name: "name",
+};
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function getString(v: unknown, key: string): string | undefined {
+  if (!isObject(v)) return undefined;
+  const candidate = v[key];
+  return typeof candidate === "string" ? candidate : undefined;
+}
+
+function getArray(v: unknown, key: string): unknown[] | undefined {
+  if (!isObject(v)) return undefined;
+  const candidate = v[key];
+  return Array.isArray(candidate) ? candidate : undefined;
+}
+
+/**
+ * Walks a drizzle `where` expression and extracts the `(column = value)`
+ * bindings it imposes. Recognises `eq()` (which appears as a column
+ * followed by ` = ` and a value chunk) and `and()` (which wraps nested
+ * predicates in additional `queryChunks`). Sufficient for the queries
+ * the asset walker actually issues; not a general-purpose drizzle
+ * interpreter.
+ */
+function extractEqualities(
+  predicate: unknown,
+  into: Record<string, unknown>,
+): void {
+  const chunks = getArray(predicate, "queryChunks");
+  if (chunks === undefined) return;
+  for (let i = 0; i < chunks.length; i++) {
+    const c = chunks[i];
+    const colName = getString(c, "name");
+    if (colName !== undefined) {
+      const sepValue = getArray(chunks[i + 1], "value");
+      if (sepValue !== undefined && sepValue[0] === " = ") {
+        const valChunk = chunks[i + 2];
+        if (isObject(valChunk) && "value" in valChunk) {
+          const jsName = SQL_TO_JS[colName];
+          if (jsName === undefined) {
+            throw new Error(`unmapped SQL column in test mock: ${colName}`);
+          }
+          into[jsName] = valChunk["value"];
+        }
+      }
+    } else if (getArray(c, "queryChunks") !== undefined) {
+      extractEqualities(c, into);
+    }
+  }
+}
+
+function matches(row: object, filter: Record<string, unknown>): boolean {
+  const entries = Object.entries(row);
+  const rowMap = new Map<string, unknown>(entries);
+  for (const [k, v] of Object.entries(filter)) {
+    if (rowMap.get(k) !== v) return false;
+  }
+  return true;
+}
+
+function makeMockDB(state: DBState): DB["db"] {
+  function tenantFindFirst(opts: {
+    where?: unknown;
+  }): Promise<TenantRow | undefined> {
+    const filter: Record<string, unknown> = {};
+    extractEqualities(opts.where, filter);
+    return Promise.resolve(state.tenants.find((t) => matches(t, filter)));
+  }
+  function assetFindFirst(opts: {
+    where?: unknown;
+  }): Promise<AssetRow | undefined> {
+    const filter: Record<string, unknown> = {};
+    extractEqualities(opts.where, filter);
+    return Promise.resolve(state.assets.find((a) => matches(a, filter)));
+  }
+  function assetFindMany(opts: { where?: unknown }): Promise<AssetRow[]> {
+    const filter: Record<string, unknown> = {};
+    extractEqualities(opts.where, filter);
+    return Promise.resolve(state.assets.filter((a) => matches(a, filter)));
+  }
+  const mock = {
+    query: {
+      tenant: { findFirst: tenantFindFirst },
+      asset: { findFirst: assetFindFirst, findMany: assetFindMany },
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- drizzle PgDatabase type cannot be structurally satisfied in tests
+  return mock as unknown as DB["db"];
+}
+
+function makeAsset(
+  overrides: Partial<AssetRow> & {
+    id: string;
+    tenantId: string;
+    kind: string;
+    name: string;
+  },
+): AssetRow {
+  return {
+    displayName: null,
+    creatorPrincipalId: null,
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-01-01"),
+    ...overrides,
+  };
+}
+
+describe("resolveAssetByName", () => {
+  test("returns null when the chain has no matching asset", async () => {
+    const db = makeMockDB({
+      tenants: [{ id: "tnt_leaf", parentId: null }],
+      assets: [],
+    });
+    const got = await resolveAssetByName(db, "tnt_leaf", "skill", "greet");
+    expect(got).toBeNull();
+  });
+
+  test("returns the asset declared on the input tenant", async () => {
+    const db = makeMockDB({
+      tenants: [{ id: "tnt_leaf", parentId: null }],
+      assets: [
+        makeAsset({
+          id: "ast_1",
+          tenantId: "tnt_leaf",
+          kind: "skill",
+          name: "greet",
+        }),
+      ],
+    });
+    const got = await resolveAssetByName(db, "tnt_leaf", "skill", "greet");
+    expect(got?.id).toBe("ast_1");
+  });
+
+  test("returns the ancestor asset when the input tenant has none", async () => {
+    const db = makeMockDB({
+      tenants: [
+        { id: "tnt_leaf", parentId: "tnt_root" },
+        { id: "tnt_root", parentId: null },
+      ],
+      assets: [
+        makeAsset({
+          id: "ast_root",
+          tenantId: "tnt_root",
+          kind: "skill",
+          name: "greet",
+        }),
+      ],
+    });
+    const got = await resolveAssetByName(db, "tnt_leaf", "skill", "greet");
+    expect(got?.id).toBe("ast_root");
+  });
+
+  test("child shadows ancestor when both declare the same (kind, name)", async () => {
+    const db = makeMockDB({
+      tenants: [
+        { id: "tnt_leaf", parentId: "tnt_root" },
+        { id: "tnt_root", parentId: null },
+      ],
+      assets: [
+        makeAsset({
+          id: "ast_root",
+          tenantId: "tnt_root",
+          kind: "skill",
+          name: "greet",
+        }),
+        makeAsset({
+          id: "ast_leaf",
+          tenantId: "tnt_leaf",
+          kind: "skill",
+          name: "greet",
+        }),
+      ],
+    });
+    const got = await resolveAssetByName(db, "tnt_leaf", "skill", "greet");
+    expect(got?.id).toBe("ast_leaf");
+  });
+
+  test("filters by kind so distinct kinds with the same name do not collide", async () => {
+    const db = makeMockDB({
+      tenants: [{ id: "tnt_leaf", parentId: null }],
+      assets: [
+        makeAsset({
+          id: "ast_skill",
+          tenantId: "tnt_leaf",
+          kind: "skill",
+          name: "shared",
+        }),
+        makeAsset({
+          id: "ast_pkg",
+          tenantId: "tnt_leaf",
+          kind: "package-registry",
+          name: "shared",
+        }),
+      ],
+    });
+    const skill = await resolveAssetByName(db, "tnt_leaf", "skill", "shared");
+    const pkg = await resolveAssetByName(
+      db,
+      "tnt_leaf",
+      "package-registry",
+      "shared",
+    );
+    expect(skill?.id).toBe("ast_skill");
+    expect(pkg?.id).toBe("ast_pkg");
+  });
+});
+
+describe("resolveAssetById", () => {
+  test("returns the asset when it belongs to the input tenant", async () => {
+    const db = makeMockDB({
+      tenants: [{ id: "tnt_leaf", parentId: null }],
+      assets: [
+        makeAsset({
+          id: "ast_1",
+          tenantId: "tnt_leaf",
+          kind: "skill",
+          name: "greet",
+        }),
+      ],
+    });
+    const got = await resolveAssetById(db, "tnt_leaf", "ast_1");
+    expect(got?.id).toBe("ast_1");
+  });
+
+  test("returns the asset when it belongs to an ancestor tenant", async () => {
+    const db = makeMockDB({
+      tenants: [
+        { id: "tnt_leaf", parentId: "tnt_root" },
+        { id: "tnt_root", parentId: null },
+      ],
+      assets: [
+        makeAsset({
+          id: "ast_root",
+          tenantId: "tnt_root",
+          kind: "skill",
+          name: "greet",
+        }),
+      ],
+    });
+    const got = await resolveAssetById(db, "tnt_leaf", "ast_root");
+    expect(got?.id).toBe("ast_root");
+  });
+
+  test("returns null when the asset belongs to a sibling tenant", async () => {
+    const db = makeMockDB({
+      tenants: [
+        { id: "tnt_a", parentId: "tnt_root" },
+        { id: "tnt_b", parentId: "tnt_root" },
+        { id: "tnt_root", parentId: null },
+      ],
+      assets: [
+        makeAsset({
+          id: "ast_b",
+          tenantId: "tnt_b",
+          kind: "skill",
+          name: "greet",
+        }),
+      ],
+    });
+    const got = await resolveAssetById(db, "tnt_a", "ast_b");
+    expect(got).toBeNull();
+  });
+
+  test("returns null when the asset does not exist", async () => {
+    const db = makeMockDB({
+      tenants: [{ id: "tnt_leaf", parentId: null }],
+      assets: [],
+    });
+    const got = await resolveAssetById(db, "tnt_leaf", "ast_missing");
+    expect(got).toBeNull();
+  });
+});
+
+describe("listAssetsForTenant", () => {
+  test("returns an empty list when the chain has no assets", async () => {
+    const db = makeMockDB({
+      tenants: [{ id: "tnt_leaf", parentId: null }],
+      assets: [],
+    });
+    const got = await listAssetsForTenant(db, "tnt_leaf");
+    expect(got).toEqual([]);
+  });
+
+  test("tags direct assets with origin.direct = true", async () => {
+    const db = makeMockDB({
+      tenants: [{ id: "tnt_leaf", parentId: null }],
+      assets: [
+        makeAsset({
+          id: "ast_1",
+          tenantId: "tnt_leaf",
+          kind: "skill",
+          name: "greet",
+        }),
+      ],
+    });
+    const [only] = await listAssetsForTenant(db, "tnt_leaf");
+    expect(only?.id).toBe("ast_1");
+    expect(only?.origin).toEqual({ tenantId: "tnt_leaf", direct: true });
+  });
+
+  test("tags inherited assets with the ancestor tenant id and direct = false", async () => {
+    const db = makeMockDB({
+      tenants: [
+        { id: "tnt_leaf", parentId: "tnt_root" },
+        { id: "tnt_root", parentId: null },
+      ],
+      assets: [
+        makeAsset({
+          id: "ast_root",
+          tenantId: "tnt_root",
+          kind: "skill",
+          name: "greet",
+        }),
+      ],
+    });
+    const [only] = await listAssetsForTenant(db, "tnt_leaf");
+    expect(only?.id).toBe("ast_root");
+    expect(only?.origin).toEqual({ tenantId: "tnt_root", direct: false });
+  });
+
+  test("child overrides parent which overrides grandparent for matching (kind, name)", async () => {
+    const db = makeMockDB({
+      tenants: [
+        { id: "tnt_leaf", parentId: "tnt_mid" },
+        { id: "tnt_mid", parentId: "tnt_root" },
+        { id: "tnt_root", parentId: null },
+      ],
+      assets: [
+        makeAsset({
+          id: "ast_root",
+          tenantId: "tnt_root",
+          kind: "skill",
+          name: "greet",
+        }),
+        makeAsset({
+          id: "ast_mid",
+          tenantId: "tnt_mid",
+          kind: "skill",
+          name: "greet",
+        }),
+        makeAsset({
+          id: "ast_leaf",
+          tenantId: "tnt_leaf",
+          kind: "skill",
+          name: "greet",
+        }),
+      ],
+    });
+    const list = await listAssetsForTenant(db, "tnt_leaf");
+    expect(list).toHaveLength(1);
+    expect(list[0]?.id).toBe("ast_leaf");
+    expect(list[0]?.origin).toEqual({ tenantId: "tnt_leaf", direct: true });
+
+    const fromMid = await listAssetsForTenant(db, "tnt_mid");
+    expect(fromMid).toHaveLength(1);
+    expect(fromMid[0]?.id).toBe("ast_mid");
+    expect(fromMid[0]?.origin).toEqual({ tenantId: "tnt_mid", direct: true });
+  });
+
+  test("inner package-registry shadows outer when both share the same name", async () => {
+    // Two `package-registry` assets at different tenancy levels with
+    // the same name resolve to the inner one. The session service's
+    // resolver walks `listAssetsForTenant(..., "package-registry")`
+    // and trusts the dedup, so a regression here would let an outer
+    // registry leak into the inner tenant's resolver map.
+    const db = makeMockDB({
+      tenants: [
+        { id: "tnt_leaf", parentId: "tnt_root" },
+        { id: "tnt_root", parentId: null },
+      ],
+      assets: [
+        makeAsset({
+          id: "ast_pkg_outer",
+          tenantId: "tnt_root",
+          kind: "package-registry",
+          name: "workspace-builtins",
+        }),
+        makeAsset({
+          id: "ast_pkg_inner",
+          tenantId: "tnt_leaf",
+          kind: "package-registry",
+          name: "workspace-builtins",
+        }),
+      ],
+    });
+    const list = await listAssetsForTenant(db, "tnt_leaf", "package-registry");
+    expect(list).toHaveLength(1);
+    expect(list[0]?.id).toBe("ast_pkg_inner");
+    expect(list[0]?.origin).toEqual({ tenantId: "tnt_leaf", direct: true });
+  });
+
+  test("filters by kind when supplied", async () => {
+    const db = makeMockDB({
+      tenants: [{ id: "tnt_leaf", parentId: null }],
+      assets: [
+        makeAsset({
+          id: "ast_skill",
+          tenantId: "tnt_leaf",
+          kind: "skill",
+          name: "greet",
+        }),
+        makeAsset({
+          id: "ast_pkg",
+          tenantId: "tnt_leaf",
+          kind: "package-registry",
+          name: "registry",
+        }),
+      ],
+    });
+    const onlyPkg = await listAssetsForTenant(
+      db,
+      "tnt_leaf",
+      "package-registry",
+    );
+    expect(onlyPkg).toHaveLength(1);
+    expect(onlyPkg[0]?.id).toBe("ast_pkg");
+  });
+
+  test("merges distinct (kind, name) pairs across the chain", async () => {
+    const db = makeMockDB({
+      tenants: [
+        { id: "tnt_leaf", parentId: "tnt_root" },
+        { id: "tnt_root", parentId: null },
+      ],
+      assets: [
+        makeAsset({
+          id: "ast_root",
+          tenantId: "tnt_root",
+          kind: "skill",
+          name: "greet",
+        }),
+        makeAsset({
+          id: "ast_leaf",
+          tenantId: "tnt_leaf",
+          kind: "skill",
+          name: "search",
+        }),
+      ],
+    });
+    const list = await listAssetsForTenant(db, "tnt_leaf");
+    expect(list).toHaveLength(2);
+    const byId = new Map(list.map((row) => [row.id, row]));
+    expect(byId.get("ast_leaf")?.origin).toEqual({
+      tenantId: "tnt_leaf",
+      direct: true,
+    });
+    expect(byId.get("ast_root")?.origin).toEqual({
+      tenantId: "tnt_root",
+      direct: false,
+    });
+  });
+});
+
+describe("ancestor-chain depth guard", () => {
+  test("walker terminates when the chain exceeds the MAX_DEPTH guard", async () => {
+    // Build a 30-link chain: tnt_0 -> tnt_1 -> ... -> tnt_29. The
+    // getAncestorChain helper caps traversal at MAX_DEPTH=20, so the
+    // walker must terminate without examining the deepest ancestors;
+    // we exercise this by parking an asset at tnt_25 (out of reach)
+    // and verifying resolveAssetByName returns null rather than
+    // looping or throwing.
+    const tenants: TenantRow[] = [];
+    for (let i = 0; i < 30; i++) {
+      tenants.push({
+        id: `tnt_${i}`,
+        parentId: i === 29 ? null : `tnt_${i + 1}`,
+      });
+    }
+    const db = makeMockDB({
+      tenants,
+      assets: [
+        makeAsset({
+          id: "ast_far",
+          tenantId: "tnt_25",
+          kind: "skill",
+          name: "greet",
+        }),
+      ],
+    });
+    const got = await resolveAssetByName(db, "tnt_0", "skill", "greet");
+    expect(got).toBeNull();
+  });
+});

--- a/packages/db/src/asset-resolution.ts
+++ b/packages/db/src/asset-resolution.ts
@@ -1,0 +1,104 @@
+import { eq, and } from "drizzle-orm";
+
+import type { DB } from "./client";
+import { asset } from "./schema/assets";
+import { getAncestorChain } from "./tenant-hierarchy";
+
+export type AssetRow = typeof asset.$inferSelect;
+
+/**
+ * An asset row paired with the tenant that supplied it. `direct` is
+ * true when the asset was declared on the input tenant itself, false
+ * when it was inherited from an ancestor.
+ */
+export type AssetWithOrigin = AssetRow & {
+  origin: { tenantId: string; direct: boolean };
+};
+
+/**
+ * Resolves an asset by (kind, name), walking up the tenant hierarchy.
+ * Returns the first match (child shadows parent).
+ */
+export async function resolveAssetByName(
+  db: DB["db"],
+  tenantId: string,
+  kind: string,
+  name: string,
+) {
+  const chain = await getAncestorChain(db, tenantId);
+
+  for (const tid of chain) {
+    const row = await db.query.asset.findFirst({
+      where: and(
+        eq(asset.tenantId, tid),
+        eq(asset.kind, kind),
+        eq(asset.name, name),
+      ),
+    });
+    if (row) return row;
+  }
+
+  return null;
+}
+
+/**
+ * Resolves an asset by ID, validating that it belongs to the given
+ * tenant or one of its ancestors. Sibling-tenant assets resolve to
+ * null so callers cannot probe for cross-tenant existence.
+ */
+export async function resolveAssetById(
+  db: DB["db"],
+  tenantId: string,
+  assetId: string,
+) {
+  const row = await db.query.asset.findFirst({
+    where: eq(asset.id, assetId),
+  });
+
+  if (!row) return null;
+
+  const chain = await getAncestorChain(db, tenantId);
+  if (!chain.includes(row.tenantId)) return null;
+
+  return row;
+}
+
+const KIND_NAME_SEPARATOR = "\u0000";
+
+/**
+ * Lists assets visible to the tenant, including those inherited from
+ * ancestors. When two ancestors expose the same `(kind, name)` pair,
+ * the descendant shadows the ancestor: the chain is walked leaf-to-root
+ * and the first row to claim a `(kind, name)` key wins.
+ *
+ * When `kind` is supplied the result is filtered to that kind.
+ */
+export async function listAssetsForTenant(
+  db: DB["db"],
+  tenantId: string,
+  kind?: string,
+): Promise<AssetWithOrigin[]> {
+  const chain = await getAncestorChain(db, tenantId);
+  const byKey = new Map<string, AssetWithOrigin>();
+
+  for (const tid of chain) {
+    const conditions = [eq(asset.tenantId, tid)];
+    if (kind !== undefined) {
+      conditions.push(eq(asset.kind, kind));
+    }
+    const rows = await db.query.asset.findMany({
+      where: and(...conditions),
+    });
+
+    for (const row of rows) {
+      const key = `${row.kind}${KIND_NAME_SEPARATOR}${row.name}`;
+      if (byKey.has(key)) continue;
+      byKey.set(key, {
+        ...row,
+        origin: { tenantId: tid, direct: tid === tenantId },
+      });
+    }
+  }
+
+  return Array.from(byKey.values());
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -15,6 +15,13 @@ export {
   ProviderMetadata,
 } from "./credential-resolution";
 export {
+  resolveAssetByName,
+  resolveAssetById,
+  listAssetsForTenant,
+  type AssetRow,
+  type AssetWithOrigin,
+} from "./asset-resolution";
+export {
   parseAgentRow,
   parseAgentVersionRow,
   parseGrantRow,

--- a/packages/hub-api/src/routes/assets.test.ts
+++ b/packages/hub-api/src/routes/assets.test.ts
@@ -13,7 +13,7 @@ import {
 } from "@intx/crypto-node";
 import type { KeyPair } from "@intx/types/runtime";
 import type { GrantRule } from "@intx/types/authz";
-import type { DB } from "@intx/db";
+import type { AssetRow as DBAssetRow, DB } from "@intx/db";
 import {
   asset as assetTable,
   agentAsset as agentAssetTable,
@@ -563,5 +563,492 @@ describe("smart-HTTP asset routes", () => {
     const url = `/api/tenants/${TENANT_ID}/assets/skill/missing.git/git-receive-pack`;
     const res = await h.app.request(url, { method: "POST" });
     expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-tenant fixtures for the inherited GET endpoints
+// ---------------------------------------------------------------------------
+
+const ROOT_TENANT_ID = "tnt_root";
+const CHILD_TENANT_ID = "tnt_child";
+const SIBLING_TENANT_ID = "tnt_sibling";
+const ROOT_PRINCIPAL_ID = "prn_root";
+const CHILD_PRINCIPAL_ID = "prn_child";
+const ROOT_USER_ID = "usr_root";
+const CHILD_USER_ID = "usr_child";
+
+type TenantStub = {
+  id: string;
+  name: string;
+  slug: string;
+  domain: string;
+  parentId: string | null;
+  config: null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type PrincipalStub = {
+  id: string;
+  tenantId: string;
+  kind: "user";
+  refId: string;
+  status: "active";
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const SQL_TO_JS_COLUMN: Record<string, string> = {
+  id: "id",
+  tenant_id: "tenantId",
+  parent_id: "parentId",
+  kind: "kind",
+  name: "name",
+  ref_id: "refId",
+};
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function getString(v: unknown, key: string): string | undefined {
+  if (!isObject(v)) return undefined;
+  const candidate = v[key];
+  return typeof candidate === "string" ? candidate : undefined;
+}
+
+function getArray(v: unknown, key: string): unknown[] | undefined {
+  if (!isObject(v)) return undefined;
+  const candidate = v[key];
+  return Array.isArray(candidate) ? candidate : undefined;
+}
+
+/**
+ * Walks a drizzle `where` expression and extracts the `(column = value)`
+ * bindings it imposes. Mirrors the helper in
+ * `packages/db/src/asset-resolution.test.ts`; covers the queries the
+ * tenant/principal middleware and asset walker issue.
+ */
+function extractEqualities(
+  predicate: unknown,
+  into: Record<string, unknown>,
+): void {
+  const chunks = getArray(predicate, "queryChunks");
+  if (chunks === undefined) return;
+  for (let i = 0; i < chunks.length; i++) {
+    const c = chunks[i];
+    const colName = getString(c, "name");
+    if (colName !== undefined) {
+      const sepValue = getArray(chunks[i + 1], "value");
+      if (sepValue !== undefined && sepValue[0] === " = ") {
+        const valChunk = chunks[i + 2];
+        if (isObject(valChunk) && "value" in valChunk) {
+          const jsName = SQL_TO_JS_COLUMN[colName];
+          if (jsName === undefined) {
+            throw new Error(`unmapped SQL column in test mock: ${colName}`);
+          }
+          into[jsName] = valChunk["value"];
+        }
+      }
+    } else if (getArray(c, "queryChunks") !== undefined) {
+      extractEqualities(c, into);
+    }
+  }
+}
+
+function rowMatches(row: object, filter: Record<string, unknown>): boolean {
+  const map = new Map<string, unknown>(Object.entries(row));
+  for (const [k, v] of Object.entries(filter)) {
+    if (map.get(k) !== v) return false;
+  }
+  return true;
+}
+
+type MultiTenantState = {
+  tenants: TenantStub[];
+  principals: PrincipalStub[];
+  assets: DBAssetRow[];
+};
+
+function makeMultiTenantMockDB(state: MultiTenantState): DB["db"] {
+  function findByPredicate<T extends object>(
+    rows: T[],
+    where: unknown,
+  ): T | undefined {
+    const filter: Record<string, unknown> = {};
+    extractEqualities(where, filter);
+    return rows.find((r) => rowMatches(r, filter));
+  }
+  function filterByPredicate<T extends object>(rows: T[], where: unknown): T[] {
+    const filter: Record<string, unknown> = {};
+    extractEqualities(where, filter);
+    return rows.filter((r) => rowMatches(r, filter));
+  }
+  const mock = {
+    query: {
+      tenant: {
+        findFirst: (opts: { where?: unknown }) =>
+          Promise.resolve(findByPredicate(state.tenants, opts.where)),
+        findMany: (opts: { where?: unknown }) =>
+          Promise.resolve(filterByPredicate(state.tenants, opts.where)),
+      },
+      principal: {
+        findFirst: (opts: { where?: unknown }) =>
+          Promise.resolve(findByPredicate(state.principals, opts.where)),
+        findMany: (opts: { where?: unknown }) =>
+          Promise.resolve(filterByPredicate(state.principals, opts.where)),
+      },
+      asset: {
+        findFirst: (opts: { where?: unknown }) =>
+          Promise.resolve(findByPredicate(state.assets, opts.where)),
+        findMany: (opts: { where?: unknown }) =>
+          Promise.resolve(filterByPredicate(state.assets, opts.where)),
+      },
+      gitToken: {
+        findFirst: async () => undefined,
+        findMany: async () => [],
+      },
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- drizzle PgDatabase type cannot be structurally satisfied in tests
+  return mock as unknown as DB["db"];
+}
+
+function makeTenantStub(
+  overrides: { id: string; slug: string; parentId: string | null } & Partial<
+    Omit<TenantStub, "id" | "slug" | "parentId">
+  >,
+): TenantStub {
+  return {
+    name: overrides.slug,
+    domain: `${overrides.slug}.example.com`,
+    config: null,
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-01-01"),
+    ...overrides,
+  };
+}
+
+function makePrincipalStub(opts: {
+  id: string;
+  tenantId: string;
+  refId: string;
+}): PrincipalStub {
+  return {
+    kind: "user",
+    status: "active",
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-01-01"),
+    ...opts,
+  };
+}
+
+function makeAssetRow(opts: {
+  id: string;
+  tenantId: string;
+  kind: string;
+  name: string;
+  displayName?: string;
+}): DBAssetRow {
+  return {
+    id: opts.id,
+    tenantId: opts.tenantId,
+    kind: opts.kind,
+    name: opts.name,
+    displayName: opts.displayName ?? null,
+    creatorPrincipalId: null,
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-01-01"),
+  };
+}
+
+type MultiTenantHarness = {
+  app: ReturnType<typeof createApp>;
+  state: MultiTenantState;
+};
+
+async function setupMultiTenant(opts: {
+  userId: string;
+  grants?: GrantRule[];
+  extraAssets?: DBAssetRow[];
+}): Promise<MultiTenantHarness> {
+  const state: MultiTenantState = {
+    tenants: [
+      makeTenantStub({ id: ROOT_TENANT_ID, slug: "root", parentId: null }),
+      makeTenantStub({
+        id: CHILD_TENANT_ID,
+        slug: "child",
+        parentId: ROOT_TENANT_ID,
+      }),
+      makeTenantStub({
+        id: SIBLING_TENANT_ID,
+        slug: "sibling",
+        parentId: ROOT_TENANT_ID,
+      }),
+    ],
+    principals: [
+      makePrincipalStub({
+        id: ROOT_PRINCIPAL_ID,
+        tenantId: ROOT_TENANT_ID,
+        refId: ROOT_USER_ID,
+      }),
+      makePrincipalStub({
+        id: CHILD_PRINCIPAL_ID,
+        tenantId: CHILD_TENANT_ID,
+        refId: CHILD_USER_ID,
+      }),
+    ],
+    assets: opts.extraAssets ?? [],
+  };
+  const db = makeMultiTenantMockDB(state);
+  const { dataDir: _dataDir, repoStore } = await createWiredSubstrate();
+  const assetService = createAssetService({ db, repoStore });
+  const defaultGrants: GrantRule[] = [
+    {
+      id: "grant-root-read",
+      resource: "asset:*",
+      action: "read",
+      effect: "allow",
+      origin: "system",
+      conditions: null,
+      expiresAt: null,
+      roleId: null,
+      principalId: ROOT_PRINCIPAL_ID,
+    },
+    {
+      id: "grant-child-read",
+      resource: "asset:*",
+      action: "read",
+      effect: "allow",
+      origin: "system",
+      conditions: null,
+      expiresAt: null,
+      roleId: null,
+      principalId: CHILD_PRINCIPAL_ID,
+    },
+  ];
+  const app = createApp({
+    getSession: createMockGetSession(opts.userId),
+    authHandler: () => new Response("", { status: 404 }),
+    db,
+    grantStore: createInMemoryGrantStore(opts.grants ?? defaultGrants),
+    sidecarRouter: createMockSidecarRouter(),
+    sessionService: createMockSessionService(),
+    eventCollectors: createMockEventCollectors(),
+    assetService,
+    repoStore,
+  });
+  return { app, state };
+}
+
+const AssetWithOriginShape = type({
+  id: "string",
+  tenantId: "string",
+  kind: "string",
+  name: "string",
+  displayName: "string | null",
+  creatorPrincipalId: "string | null",
+  createdAt: "string",
+  updatedAt: "string",
+  origin: {
+    tenantId: "string",
+    direct: "boolean",
+  },
+});
+const AssetListShape = AssetWithOriginShape.array();
+
+async function parseAssetList(res: Response) {
+  const raw: unknown = await res.json();
+  const parsed = AssetListShape(raw);
+  if (parsed instanceof type.errors) {
+    throw new Error(`asset list did not validate: ${parsed.summary}`);
+  }
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// GET /assets (inherited list)
+// ---------------------------------------------------------------------------
+
+describe("GET /api/tenants/:tenantId/assets", () => {
+  test("returns a root asset with origin.direct = false when listed from a child tenant", async () => {
+    const h = await setupMultiTenant({
+      userId: CHILD_USER_ID,
+      extraAssets: [
+        makeAssetRow({
+          id: "ast_root_greet",
+          tenantId: ROOT_TENANT_ID,
+          kind: "skill",
+          name: "greet",
+        }),
+      ],
+    });
+    const res = await h.app.request(`/api/tenants/${CHILD_TENANT_ID}/assets`, {
+      method: "GET",
+    });
+    expect(res.status).toBe(200);
+    const list = await parseAssetList(res);
+    expect(list).toHaveLength(1);
+    expect(list[0]?.id).toBe("ast_root_greet");
+    expect(list[0]?.origin).toEqual({
+      tenantId: ROOT_TENANT_ID,
+      direct: false,
+    });
+  });
+
+  test("child asset shadows the inherited root asset of the same (kind, name)", async () => {
+    const h = await setupMultiTenant({
+      userId: CHILD_USER_ID,
+      extraAssets: [
+        makeAssetRow({
+          id: "ast_root_greet",
+          tenantId: ROOT_TENANT_ID,
+          kind: "skill",
+          name: "greet",
+        }),
+        makeAssetRow({
+          id: "ast_child_greet",
+          tenantId: CHILD_TENANT_ID,
+          kind: "skill",
+          name: "greet",
+        }),
+      ],
+    });
+    const res = await h.app.request(`/api/tenants/${CHILD_TENANT_ID}/assets`, {
+      method: "GET",
+    });
+    expect(res.status).toBe(200);
+    const list = await parseAssetList(res);
+    expect(list).toHaveLength(1);
+    expect(list[0]?.id).toBe("ast_child_greet");
+    expect(list[0]?.origin).toEqual({
+      tenantId: CHILD_TENANT_ID,
+      direct: true,
+    });
+  });
+
+  test("filters by kind when ?kind= is supplied", async () => {
+    const h = await setupMultiTenant({
+      userId: ROOT_USER_ID,
+      extraAssets: [
+        makeAssetRow({
+          id: "ast_skill",
+          tenantId: ROOT_TENANT_ID,
+          kind: "skill",
+          name: "greet",
+        }),
+        makeAssetRow({
+          id: "ast_pkg",
+          tenantId: ROOT_TENANT_ID,
+          kind: "package-registry",
+          name: "main",
+        }),
+      ],
+    });
+    const res = await h.app.request(
+      `/api/tenants/${ROOT_TENANT_ID}/assets?kind=package-registry`,
+      { method: "GET" },
+    );
+    expect(res.status).toBe(200);
+    const list = await parseAssetList(res);
+    expect(list).toHaveLength(1);
+    expect(list[0]?.id).toBe("ast_pkg");
+  });
+
+  test("inherited=false suppresses ancestor rows", async () => {
+    const h = await setupMultiTenant({
+      userId: CHILD_USER_ID,
+      extraAssets: [
+        makeAssetRow({
+          id: "ast_root_greet",
+          tenantId: ROOT_TENANT_ID,
+          kind: "skill",
+          name: "greet",
+        }),
+        makeAssetRow({
+          id: "ast_child_search",
+          tenantId: CHILD_TENANT_ID,
+          kind: "skill",
+          name: "search",
+        }),
+      ],
+    });
+    const res = await h.app.request(
+      `/api/tenants/${CHILD_TENANT_ID}/assets?inherited=false`,
+      { method: "GET" },
+    );
+    expect(res.status).toBe(200);
+    const list = await parseAssetList(res);
+    expect(list).toHaveLength(1);
+    expect(list[0]?.id).toBe("ast_child_search");
+  });
+
+  test("rejects inherited values other than true or false with 400", async () => {
+    const h = await setupMultiTenant({ userId: CHILD_USER_ID });
+    const res = await h.app.request(
+      `/api/tenants/${CHILD_TENANT_ID}/assets?inherited=please`,
+      { method: "GET" },
+    );
+    expect(res.status).toBe(400);
+    const body = await parseErrorResponse(res);
+    expect(body.error.code).toBe("bad_request");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /assets/:assetId (chain-validated)
+// ---------------------------------------------------------------------------
+
+describe("GET /api/tenants/:tenantId/assets/:assetId", () => {
+  test("returns the asset when it belongs to an ancestor tenant", async () => {
+    const h = await setupMultiTenant({
+      userId: CHILD_USER_ID,
+      extraAssets: [
+        makeAssetRow({
+          id: "ast_root_greet",
+          tenantId: ROOT_TENANT_ID,
+          kind: "skill",
+          name: "greet",
+        }),
+      ],
+    });
+    const res = await h.app.request(
+      `/api/tenants/${CHILD_TENANT_ID}/assets/ast_root_greet`,
+      { method: "GET" },
+    );
+    expect(res.status).toBe(200);
+    const body: unknown = await res.json();
+    if (!isObject(body)) throw new Error("expected object body");
+    expect(body["id"]).toBe("ast_root_greet");
+    expect(body["tenantId"]).toBe(ROOT_TENANT_ID);
+  });
+
+  test("returns 404 when the asset belongs to a sibling tenant", async () => {
+    const h = await setupMultiTenant({
+      userId: CHILD_USER_ID,
+      extraAssets: [
+        makeAssetRow({
+          id: "ast_sibling_secret",
+          tenantId: SIBLING_TENANT_ID,
+          kind: "package-registry",
+          name: "private",
+        }),
+      ],
+    });
+    const res = await h.app.request(
+      `/api/tenants/${CHILD_TENANT_ID}/assets/ast_sibling_secret`,
+      { method: "GET" },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  test("returns 404 when the asset does not exist", async () => {
+    const h = await setupMultiTenant({ userId: ROOT_USER_ID });
+    const res = await h.app.request(
+      `/api/tenants/${ROOT_TENANT_ID}/assets/ast_missing`,
+      { method: "GET" },
+    );
+    expect(res.status).toBe(404);
   });
 });

--- a/packages/hub-api/src/routes/assets.ts
+++ b/packages/hub-api/src/routes/assets.ts
@@ -31,7 +31,12 @@ import { type } from "arktype";
 
 import { authorize } from "@intx/authz";
 import { asset as assetTable } from "@intx/db/schema";
-import type { DB } from "@intx/db";
+import {
+  listAssetsForTenant,
+  resolveAssetById,
+  type AssetWithOrigin,
+  type DB,
+} from "@intx/db";
 import { repoActionToGrantVerb } from "@intx/hub-common";
 import { getLogger } from "@intx/log";
 import {
@@ -44,7 +49,11 @@ import {
 } from "@intx/hub-sessions";
 import type { RepoAction, RepoKind } from "@intx/types/sidecar";
 import type { ConditionRegistry, GrantStore } from "@intx/types/authz";
-import { ErrorResponse } from "@intx/types";
+import {
+  AssetResponse,
+  AssetWithOriginResponse,
+  ErrorResponse,
+} from "@intx/types";
 
 import type { TenantEnv } from "../context";
 import { ts } from "../format";
@@ -52,7 +61,7 @@ import type {
   GitTokenClaims,
   TenantGitTokenEnv,
 } from "../middleware/git-token-auth";
-import type { RequireGrant } from "../middleware/grant";
+import { idResource, type RequireGrant } from "../middleware/grant";
 import {
   advertiseReceivePack,
   advertiseUploadPack,
@@ -229,6 +238,29 @@ export type CreateAssetRoutesDeps = {
   requireGrant: RequireGrant;
 };
 
+function formatAsset(row: typeof assetTable.$inferSelect) {
+  return {
+    id: row.id,
+    tenantId: row.tenantId,
+    kind: row.kind,
+    name: row.name,
+    displayName: row.displayName,
+    creatorPrincipalId: row.creatorPrincipalId,
+    createdAt: ts(row.createdAt),
+    updatedAt: ts(row.updatedAt),
+  };
+}
+
+function formatAssetWithOrigin(
+  row: typeof assetTable.$inferSelect,
+  origin: AssetWithOrigin["origin"],
+) {
+  return {
+    ...formatAsset(row),
+    origin,
+  };
+}
+
 export function createAssetRoutes({
   db,
   assetService,
@@ -238,6 +270,122 @@ export function createAssetRoutes({
   requireGrant,
 }: CreateAssetRoutesDeps): Hono<TenantEnv> {
   const app = new Hono<TenantEnv>();
+
+  app.get(
+    "/",
+    requireGrant("asset:*", "read"),
+    describeRoute({
+      tags: ["Assets"],
+      summary: "List assets",
+      description:
+        "Lists assets for the tenant. With inherited=true (the default), assets defined on ancestor tenants are included; descendant tenants shadow ancestors when they declare the same (kind, name) pair. Each row carries an `origin` tag identifying the tenant that supplied it.",
+      parameters: [
+        {
+          name: "kind",
+          in: "query",
+          schema: { type: "string" },
+        },
+        {
+          name: "inherited",
+          in: "query",
+          schema: { type: "string", enum: ["true", "false"] },
+        },
+      ],
+      responses: {
+        200: {
+          description: "List of assets",
+          content: {
+            "application/json": {
+              schema: resolver(AssetWithOriginResponse.array()),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const kindRaw = c.req.query("kind");
+      const inheritedRaw = c.req.query("inherited");
+      let inherited: boolean;
+      if (inheritedRaw === undefined || inheritedRaw === "true") {
+        inherited = true;
+      } else if (inheritedRaw === "false") {
+        inherited = false;
+      } else {
+        return c.json(
+          {
+            error: {
+              code: "bad_request",
+              message: `inherited must be "true" or "false", got ${JSON.stringify(inheritedRaw)}`,
+            },
+          },
+          400,
+        );
+      }
+
+      if (inherited) {
+        const rows = await listAssetsForTenant(db, tenantCtx.id, kindRaw);
+        return c.json(
+          rows.map((row) => formatAssetWithOrigin(row, row.origin)),
+        );
+      }
+
+      const conditions = [eq(assetTable.tenantId, tenantCtx.id)];
+      if (kindRaw !== undefined) {
+        conditions.push(eq(assetTable.kind, kindRaw));
+      }
+      const rows = await db.query.asset.findMany({
+        where: and(...conditions),
+      });
+      return c.json(
+        rows.map((row) =>
+          formatAssetWithOrigin(row, {
+            tenantId: row.tenantId,
+            direct: true,
+          }),
+        ),
+      );
+    },
+  );
+
+  app.get(
+    "/:assetId",
+    requireGrant(idResource("asset", "assetId"), "read"),
+    describeRoute({
+      tags: ["Assets"],
+      summary: "Get asset metadata",
+      description:
+        "Returns asset metadata. Resolves through the tenant hierarchy: assets declared on the tenant or any ancestor are visible. Sibling-tenant assets return 404 so callers cannot probe for cross-tenant existence.",
+      responses: {
+        200: {
+          description: "Asset metadata",
+          content: {
+            "application/json": { schema: resolver(AssetResponse) },
+          },
+        },
+        404: {
+          description: "Asset not found",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const tenantCtx = c.get("tenant");
+      const assetId = c.req.param("assetId");
+
+      const row = await resolveAssetById(db, tenantCtx.id, assetId);
+      if (row === null) {
+        return c.json(
+          { error: { code: "not_found", message: "Asset not found" } },
+          404,
+        );
+      }
+
+      return c.json(formatAsset(row));
+    },
+  );
 
   app.post(
     "/",
@@ -294,19 +442,7 @@ export function createAssetRoutes({
             id: asset.id,
           },
         );
-        return c.json(
-          {
-            id: asset.id,
-            tenantId: asset.tenantId,
-            kind: asset.kind,
-            name: asset.name,
-            displayName: asset.displayName,
-            creatorPrincipalId: asset.creatorPrincipalId,
-            createdAt: ts(asset.createdAt),
-            updatedAt: ts(asset.updatedAt),
-          },
-          201,
-        );
+        return c.json(formatAsset(asset), 201);
       } catch (err) {
         if (err instanceof AssetServiceError) {
           let status: 400 | 409;

--- a/packages/types/src/assets.ts
+++ b/packages/types/src/assets.ts
@@ -1,0 +1,33 @@
+import { type } from "arktype";
+
+export const AssetResponse = type({
+  id: "string",
+  tenantId: "string",
+  kind: "string",
+  name: "string",
+  displayName: "string | null",
+  creatorPrincipalId: "string | null",
+  createdAt: "string",
+  updatedAt: "string",
+});
+
+/**
+ * `AssetResponse` extended with the tenant that supplied the row. The
+ * inherited-list endpoint stamps every row with this tag so callers can
+ * distinguish locally-defined assets from inherited ones without
+ * issuing a second round-trip per row.
+ */
+export const AssetWithOriginResponse = type({
+  id: "string",
+  tenantId: "string",
+  kind: "string",
+  name: "string",
+  displayName: "string | null",
+  creatorPrincipalId: "string | null",
+  createdAt: "string",
+  updatedAt: "string",
+  origin: {
+    tenantId: "string",
+    direct: "boolean",
+  },
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -11,6 +11,7 @@ export * from "./wallets";
 export * from "./providers";
 export * from "./oauth-clients";
 export * from "./credentials";
+export * from "./assets";
 export * from "./offerings";
 export * from "./models";
 export * from "./observability";


### PR DESCRIPTION
Implements [INTR-178](https://linear.app/abklabs/issue/INTR-178/tenancy-inheritable-assets-and-the-package-registry-asset-kind).

## Summary

- Introduces `packages/db/src/asset-resolution.ts` with `resolveAssetByName`, `resolveAssetById`, and `listAssetsForTenant` — the tenant ancestor walker for the `asset` table. Mirrors the existing credential and provider walkers (child shadows parent, MAX_DEPTH=20 cycle guard, dedup by `(kind, name)` with inner overriding outer and origin tags on every row).
- Adds `GET /tenants/:id/assets?kind=...&inherited=...` and `GET /assets/:id` to the hub API. The list endpoint walks the ancestor chain when `inherited=true` (default) and tags each row with the tenant that supplied it; the lookup endpoint validates chain membership before returning. Mirrors the `providers?inherited=true` shape.
- Schema unchanged. The `asset` table already encoded the pattern; this PR adds the walker, the routes, and tests.

Two commits:

1. `Add the tenant-aware asset resolver` — the walker plus 511 lines of tests covering walk order, MAX_DEPTH, override semantics across both `skill` and `package-registry` kinds, and origin tagging.
2. `Expose tenant-aware asset listing and lookup over the hub API` — the routes, their tests, the OpenAPI regeneration, and the `AssetResponse` / `AssetWithOriginResponse` arktype shapes.

## Test plan

- [x] `make all` green on the rewritten branch (2820 tests pass, 0 fail)
- [x] Walker tests cover walk order, MAX_DEPTH cycle guard, `(kind, name)` collision override, no-orphan
- [x] Hub-API tests cover attach-at-root-tenant + list-from-child-agent + observe inheritance and override
- [x] Existing credential and provider tests still pass
- [x] `bin/gen-api-docs.ts --check` passes (OpenAPI in sync)

## Out of scope

- Sidecar materialization. Triggered by deploy-pack contents, which are written by INTR-108's resolver. INTR-108 rebases on top of this PR.
- A `kind`-narrowing type. The schema column stays `text`; consumers pass `kind: string` for now. A future ticket can narrow the column type, the walker signatures, and the route handler params in one coherent change once a consumer load-bears against it.