### PR TITLE
fix(hub-sessions): adopt open running turn on reconnect

### DIFF
--- a/apps/admin-ui/vite.config.ts
+++ b/apps/admin-ui/vite.config.ts
@@ -11,15 +11,19 @@ export default defineConfig({
     },
   },
   server: {
-    port: 5173,
+    // TEMPORARY UPSTREAM FIX (CL-1534): env-driven port + hub target so the
+    // GTM Workbench dev script can run admin-ui alongside web (5174) and proxy
+    // to our hub (:4000) instead of the hardcoded Interchange dev port (:3000).
+    // Upstream this as first-class VITE_HUB_URL / port env support.
+    port: Number(process.env.ADMIN_UI_PORT ?? 5175),
     proxy: {
       "/api": {
-        target: "http://localhost:3000",
+        target: process.env.VITE_HUB_URL ?? "http://localhost:4000",
         changeOrigin: true,
-        headers: { origin: "http://localhost:3000" },
+        headers: { origin: process.env.VITE_HUB_URL ?? "http://localhost:4000" },
       },
       "/ws": {
-        target: "http://localhost:3000",
+        target: process.env.VITE_HUB_URL ?? "http://localhost:4000",
         ws: true,
       },
     },

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@intx/inference": "workspace:*",
+    "@intx/log": "workspace:*",
     "@intx/mime": "workspace:*",
     "@intx/types": "workspace:*",
     "arktype": "catalog:"

--- a/packages/db/src/credential-resolution.ts
+++ b/packages/db/src/credential-resolution.ts
@@ -17,7 +17,7 @@ const log = getLogger(["db", "credentials"]);
 
 const CredentialRequirements = CredentialRequirementType.array();
 
-export const ProviderMetadata = type({ baseURL: "string" });
+export const ProviderMetadata = type({ baseURL: "string", "maxTokens?": "number" });
 
 const AgentModelConfig = type({ defaultModel: "string" });
 
@@ -294,6 +294,9 @@ export async function resolveOneCredential(
       baseURL: metadata.baseURL,
       apiKey: resolved.secret,
       model: defaultModel,
+      ...(metadata.maxTokens !== undefined
+        ? { defaults: { maxTokens: metadata.maxTokens } }
+        : {}),
     },
   };
 }

--- a/packages/hub-sessions/src/event-collector-registry.ts
+++ b/packages/hub-sessions/src/event-collector-registry.ts
@@ -24,6 +24,7 @@ export type EventCollectorRegistry = {
     tenantId: string,
     sessionId: string,
     instanceId: string,
+    resumeTurn?: { id: string; nextOrdinal: number },
   ): void;
   dispatch(agentAddress: string, event: InferenceEvent): void;
   abandon(agentAddress: string): void;
@@ -73,6 +74,7 @@ export function createEventCollectorRegistry(
     tenantId: string,
     sessionId: string,
     instanceId: string,
+    resumeTurn?: { id: string; nextOrdinal: number },
   ): void {
     if (collectors.has(agentAddress)) {
       log.warn`Collector already exists for ${agentAddress}, replacing`;
@@ -84,6 +86,7 @@ export function createEventCollectorRegistry(
       sessionId,
       instanceId,
       tenantId,
+      ...(resumeTurn ? { resumeTurn } : {}),
       ...(onTurnFinalized
         ? {
             onTurnFinalized: (turn: TurnFinalized) =>

--- a/packages/hub-sessions/src/event-collector.test.ts
+++ b/packages/hub-sessions/src/event-collector.test.ts
@@ -1385,3 +1385,77 @@ describe("EventCollector.getLastTurnId", () => {
     expect(collector.getLastTurnId()).not.toBe(firstTurnId);
   });
 });
+
+describe("EventCollector resumeTurn (reconnect adoption)", () => {
+  function doneTextEvent(): InferenceEvent {
+    return event("inference.done", 5, {
+      turn: {
+        role: "assistant",
+        content: [{ type: "text", text: "resumed reply" }],
+        model: "gpt-4",
+      },
+      usage: { input: 10, output: 20 },
+    });
+  }
+
+  test("drops trailing parts when no turn was adopted", async () => {
+    const fakeDB = createFakeDB();
+    const collector = createEventCollector({
+      db: fakeDB.db,
+      sessionId: "ses_test",
+      instanceId: "ins_test",
+      tenantId: "tnt_test",
+    });
+
+    // No inference.start: this simulates a fresh collector receiving the tail
+    // of a turn that began before a reconnect.
+    await collector.onEvent(doneTextEvent());
+
+    expect(fakeDB.inserts.filter((i) => i.table === "turn_part")).toHaveLength(0);
+    expect(collector.getCurrentTurnId()).toBeNull();
+  });
+
+  test("writes trailing parts into the adopted turn with continuing ordinals", async () => {
+    const fakeDB = createFakeDB();
+    const collector = createEventCollector({
+      db: fakeDB.db,
+      sessionId: "ses_test",
+      instanceId: "ins_test",
+      tenantId: "tnt_test",
+      resumeTurn: { id: "turn_resumed", nextOrdinal: 7 },
+    });
+
+    expect(collector.getCurrentTurnId()).toBe("turn_resumed");
+
+    await collector.onEvent(doneTextEvent());
+
+    const parts = fakeDB.inserts.filter((i) => i.table === "turn_part");
+    const textPart = parts.find((p) => p.values.type === "text");
+    expect(textPart).not.toBeUndefined();
+    expect(at(parts, 0).values.turnId).toBe("turn_resumed");
+    expect(textPart?.values.content).toBe("resumed reply");
+    expect(textPart?.values.ordinal).toBe(7);
+    // No new inference_turn row is minted — the existing one is reused.
+    expect(fakeDB.inserts.filter((i) => i.table === "inference_turn")).toHaveLength(0);
+  });
+
+  test("finalizes the adopted turn on connector.reply / reactor.done", async () => {
+    const fakeDB = createFakeDB();
+    const collector = createEventCollector({
+      db: fakeDB.db,
+      sessionId: "ses_test",
+      instanceId: "ins_test",
+      tenantId: "tnt_test",
+      resumeTurn: { id: "turn_resumed", nextOrdinal: 3 },
+    });
+
+    await collector.onEvent(doneTextEvent());
+    await collector.onEvent(event("reactor.done", 6, {}));
+
+    const turnUpdates = fakeDB.updates.filter((u) => u.table === "inference_turn");
+    expect(turnUpdates).toHaveLength(1);
+    expect(at(turnUpdates, 0).set.status).toBe("completed");
+    expect(at(turnUpdates, 0).set.endedAt).toBeInstanceOf(Date);
+    expect(collector.getCurrentTurnId()).toBeNull();
+  });
+});

--- a/packages/hub-sessions/src/event-collector.ts
+++ b/packages/hub-sessions/src/event-collector.ts
@@ -48,10 +48,12 @@ export type EventCollectorConfig = {
   tenantId: string;
   onTurnFinalized?: (turn: TurnFinalized) => void;
   // When a collector is rebuilt for a session whose agent was mid-turn at
-  // disconnect (e.g. a hub redeploy), adopt that still-running turn so the
-  // resumed inference.done / step-finish parts land in it rather than being
-  // dropped for having no active turn. `nextOrdinal` continues the existing
-  // part sequence so ordinals stay monotonic and collision-free.
+  // disconnect (e.g. a hub redeploy), adopt that still-running turn so any
+  // resumed inference.done / step-finish parts the sidecar redelivers land in
+  // it rather than being dropped for having no active turn. Best-effort: parts
+  // already emitted to the dead socket, or dropped under the sidecar send-queue
+  // cap, are not recovered. `nextOrdinal` continues the existing part sequence
+  // so ordinals stay monotonic.
   resumeTurn?: { id: string; nextOrdinal: number };
 };
 

--- a/packages/hub-sessions/src/event-collector.ts
+++ b/packages/hub-sessions/src/event-collector.ts
@@ -47,22 +47,30 @@ export type EventCollectorConfig = {
   instanceId: string;
   tenantId: string;
   onTurnFinalized?: (turn: TurnFinalized) => void;
+  // When a collector is rebuilt for a session whose agent was mid-turn at
+  // disconnect (e.g. a hub redeploy), adopt that still-running turn so the
+  // resumed inference.done / step-finish parts land in it rather than being
+  // dropped for having no active turn. `nextOrdinal` continues the existing
+  // part sequence so ordinals stay monotonic and collision-free.
+  resumeTurn?: { id: string; nextOrdinal: number };
 };
 
 export function createEventCollector(
   config: EventCollectorConfig,
 ): EventCollector {
-  const { db, sessionId, instanceId, tenantId, onTurnFinalized } = config;
+  const { db, sessionId, instanceId, tenantId, onTurnFinalized, resumeTurn } =
+    config;
 
   // Current inference turn being accumulated. A new turn is created on each
   // inference.start. Finalized on connector.reply, reactor.done,
-  // reactor.error (fatal), or abandon. Null when no turn is active.
-  let currentTurnId: string | null = null;
+  // reactor.error (fatal), or abandon. Null when no turn is active — except
+  // when resuming a running turn adopted on reconnect.
+  let currentTurnId: string | null = resumeTurn?.id ?? null;
   // Most recent turn ID, set in beginTurn. Unlike currentTurnId this is NOT
   // cleared on finalization — the SSE replay endpoint needs the turn ID
   // after the turn commits but before the collector is removed.
-  let lastTurnId: string | null = null;
-  let ordinal = 0;
+  let lastTurnId: string | null = resumeTurn?.id ?? null;
+  let ordinal = resumeTurn?.nextOrdinal ?? 0;
   // Prevents double-finalization when reactor.done and abandon() race.
   let finalized = false;
   // Set when inference.error fires so connector.reply knows to persist its

--- a/packages/hub-sessions/src/hub-session-orchestrator.test.ts
+++ b/packages/hub-sessions/src/hub-session-orchestrator.test.ts
@@ -69,7 +69,7 @@ type MockDBOpts = {
   emptyProviderTables?: boolean;
   /** When set, the inference_turn select returns this still-running turn so
    * findOpenTurn (reconnect adoption) resolves it. */
-  openTurn?: { id: string } | undefined;
+  openTurn?: { id: string; startedAt: Date } | undefined;
   /** Highest existing turn_part ordinal for the open turn (null = none). */
   maxOrdinal?: number | null;
 };
@@ -443,7 +443,7 @@ describe("createHubSessionOrchestrator", () => {
     test("adopts the session's open running turn so trailing parts are not dropped", async () => {
       harness = setup({
         instance: makeInstance(),
-        openTurn: { id: "turn_open" },
+        openTurn: { id: "turn_open", startedAt: new Date() },
         maxOrdinal: 4,
       });
 
@@ -461,7 +461,7 @@ describe("createHubSessionOrchestrator", () => {
     test("starts the next part at ordinal 0 when the open turn has no parts", async () => {
       harness = setup({
         instance: makeInstance(),
-        openTurn: { id: "turn_open" },
+        openTurn: { id: "turn_open", startedAt: new Date() },
         maxOrdinal: null,
       });
 
@@ -477,6 +477,27 @@ describe("createHubSessionOrchestrator", () => {
 
     test("passes no resumeTurn when the session has no open turn", async () => {
       harness = setup({ instance: makeInstance(), openTurn: undefined });
+
+      await harness.events.emitAndAwait("agent.reconnected", {
+        agentAddress: AGENT_ADDRESS,
+      });
+
+      const created = harness.collectors.calls.find((c) => c.kind === "create");
+      expect(created).toBeDefined();
+      if (created?.kind === "create") {
+        expect(created.resumeTurn).toBeUndefined();
+      }
+    });
+
+    test("does not adopt a turn older than the resumable window (orphaned zombie)", async () => {
+      harness = setup({
+        instance: makeInstance(),
+        openTurn: {
+          id: "turn_zombie",
+          startedAt: new Date(Date.now() - 60 * 60 * 1000),
+        },
+        maxOrdinal: 2,
+      });
 
       await harness.events.emitAndAwait("agent.reconnected", {
         agentAddress: AGENT_ADDRESS,

--- a/packages/hub-sessions/src/hub-session-orchestrator.test.ts
+++ b/packages/hub-sessions/src/hub-session-orchestrator.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach } from "bun:test";
 
 import type { DB } from "@intx/db";
+import { inferenceTurn, turnPart } from "@intx/db/schema";
 import type { GrantRule, GrantStore } from "@intx/types/authz";
 import type { InferenceEvent, InferenceSource } from "@intx/types/runtime";
 
@@ -66,6 +67,11 @@ type MockDBOpts = {
    * tables; the helper returns empty arrays so the orchestrator's
    * credential push is a no-op. */
   emptyProviderTables?: boolean;
+  /** When set, the inference_turn select returns this still-running turn so
+   * findOpenTurn (reconnect adoption) resolves it. */
+  openTurn?: { id: string } | undefined;
+  /** Highest existing turn_part ordinal for the open turn (null = none). */
+  maxOrdinal?: number | null;
 };
 
 function createMockDB(opts: MockDBOpts) {
@@ -107,15 +113,31 @@ function createMockDB(opts: MockDBOpts) {
     },
     select() {
       return {
-        from: () => ({
-          where: () => ({
-            limit: () => Promise.resolve([]),
-            orderBy: () => ({ limit: () => Promise.resolve([]) }),
-          }),
-          innerJoin: () => ({
-            where: () => ({ limit: () => Promise.resolve([]) }),
-          }),
-        }),
+        from: (t: unknown) => {
+          if (t === inferenceTurn) {
+            const rows = opts.openTurn ? [opts.openTurn] : [];
+            return {
+              where: () => ({
+                orderBy: () => ({ limit: () => Promise.resolve(rows) }),
+                limit: () => Promise.resolve(rows),
+              }),
+            };
+          }
+          if (t === turnPart) {
+            return {
+              where: () => Promise.resolve([{ max: opts.maxOrdinal ?? null }]),
+            };
+          }
+          return {
+            where: () => ({
+              limit: () => Promise.resolve([]),
+              orderBy: () => ({ limit: () => Promise.resolve([]) }),
+            }),
+            innerJoin: () => ({
+              where: () => ({ limit: () => Promise.resolve([]) }),
+            }),
+          };
+        },
       };
     },
   } as unknown as DB["db"];
@@ -164,7 +186,12 @@ function createRouterFacade(): {
 }
 
 type CollectorCall =
-  | { kind: "create"; addr: string; sessionId: string }
+  | {
+      kind: "create";
+      addr: string;
+      sessionId: string;
+      resumeTurn: { id: string; nextOrdinal: number } | undefined;
+    }
   | { kind: "dispatch"; addr: string; event: InferenceEvent }
   | { kind: "abandon"; addr: string };
 
@@ -181,9 +208,9 @@ function createCollectorRegistry(
     calls,
     has,
     registry: {
-      create(addr, _tenantId, sessionId, _instanceId) {
+      create(addr, _tenantId, sessionId, _instanceId, resumeTurn) {
         has.add(addr);
-        calls.push({ kind: "create", addr, sessionId });
+        calls.push({ kind: "create", addr, sessionId, resumeTurn });
       },
       dispatch(addr, event) {
         calls.push({ kind: "dispatch", addr, event });
@@ -410,6 +437,55 @@ describe("createHubSessionOrchestrator", () => {
       if (created?.kind === "create") {
         expect(created.addr).toBe(AGENT_ADDRESS);
         expect(created.sessionId).toBe(SESSION_ID);
+      }
+    });
+
+    test("adopts the session's open running turn so trailing parts are not dropped", async () => {
+      harness = setup({
+        instance: makeInstance(),
+        openTurn: { id: "turn_open" },
+        maxOrdinal: 4,
+      });
+
+      await harness.events.emitAndAwait("agent.reconnected", {
+        agentAddress: AGENT_ADDRESS,
+      });
+
+      const created = harness.collectors.calls.find((c) => c.kind === "create");
+      expect(created).toBeDefined();
+      if (created?.kind === "create") {
+        expect(created.resumeTurn).toEqual({ id: "turn_open", nextOrdinal: 5 });
+      }
+    });
+
+    test("starts the next part at ordinal 0 when the open turn has no parts", async () => {
+      harness = setup({
+        instance: makeInstance(),
+        openTurn: { id: "turn_open" },
+        maxOrdinal: null,
+      });
+
+      await harness.events.emitAndAwait("agent.reconnected", {
+        agentAddress: AGENT_ADDRESS,
+      });
+
+      const created = harness.collectors.calls.find((c) => c.kind === "create");
+      if (created?.kind === "create") {
+        expect(created.resumeTurn).toEqual({ id: "turn_open", nextOrdinal: 0 });
+      }
+    });
+
+    test("passes no resumeTurn when the session has no open turn", async () => {
+      harness = setup({ instance: makeInstance(), openTurn: undefined });
+
+      await harness.events.emitAndAwait("agent.reconnected", {
+        agentAddress: AGENT_ADDRESS,
+      });
+
+      const created = harness.collectors.calls.find((c) => c.kind === "create");
+      expect(created).toBeDefined();
+      if (created?.kind === "create") {
+        expect(created.resumeTurn).toBeUndefined();
       }
     });
 

--- a/packages/hub-sessions/src/hub-session-orchestrator.ts
+++ b/packages/hub-sessions/src/hub-session-orchestrator.ts
@@ -10,10 +10,10 @@
 // than the full SidecarRouter, so tests can drive subscriber behavior
 // with a small stub and an isolated emitter.
 
-import { eq } from "drizzle-orm";
+import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import { type } from "arktype";
 import type { DB } from "@intx/db";
-import { agentInstance } from "@intx/db/schema";
+import { agentInstance, inferenceTurn, turnPart } from "@intx/db/schema";
 import { resolveInstanceSources } from "@intx/db";
 import { parseMailToEmail } from "@intx/mime";
 import { parseInferenceEvent } from "@intx/types/runtime";
@@ -166,11 +166,17 @@ export function createHubSessionOrchestrator(
           .where(eq(agentInstance.id, instance.id));
       }
       if (!eventCollectors.has(agentAddress)) {
+        // If the agent was mid-turn when the link dropped, the turn row is
+        // still 'running'. Adopt it so the resumed inference.done / step-finish
+        // parts land in that turn instead of being dropped for having no active
+        // turn — the live reply survives the reconnect (CL-1654).
+        const resumeTurn = await findOpenTurn(db, sessionId);
         eventCollectors.create(
           agentAddress,
           instance.tenantId,
           sessionId,
           instance.id,
+          resumeTurn,
         );
         log.info(
           "Restored event collector for reconnected agent {agentAddress}",
@@ -210,4 +216,38 @@ export function createHubSessionOrchestrator(
       for (const off of unsubscribers) off();
     },
   };
+}
+
+/**
+ * Find the session's still-open inference turn, if any, so a collector rebuilt
+ * on reconnect can resume it rather than dropping the trailing parts of a turn
+ * that was in flight when the link dropped. Returns the turn id and the next
+ * ordinal (one past the highest part already written) so the part sequence
+ * stays monotonic. Returns undefined when no running turn exists.
+ */
+async function findOpenTurn(
+  db: DB["db"],
+  sessionId: string,
+): Promise<{ id: string; nextOrdinal: number } | undefined> {
+  const [openTurn] = await db
+    .select({ id: inferenceTurn.id })
+    .from(inferenceTurn)
+    .where(
+      and(
+        eq(inferenceTurn.sessionId, sessionId),
+        eq(inferenceTurn.status, "running"),
+        isNull(inferenceTurn.endedAt),
+      ),
+    )
+    .orderBy(desc(inferenceTurn.startedAt))
+    .limit(1);
+
+  if (openTurn === undefined) return undefined;
+
+  const [maxRow] = await db
+    .select({ max: sql<number | null>`max(${turnPart.ordinal})` })
+    .from(turnPart)
+    .where(eq(turnPart.turnId, openTurn.id));
+
+  return { id: openTurn.id, nextOrdinal: (maxRow?.max ?? -1) + 1 };
 }

--- a/packages/hub-sessions/src/hub-session-orchestrator.ts
+++ b/packages/hub-sessions/src/hub-session-orchestrator.ts
@@ -218,19 +218,35 @@ export function createHubSessionOrchestrator(
   };
 }
 
+// A turn this old at reconnect is almost certainly orphaned — a harness that
+// crashed mid-turn leaves the row 'running' forever (nothing finalizes it on
+// the crash path), and `agent.reconnected` proves only that the sidecar owns
+// the key, not that the inference is still alive. Adopting such a turn would
+// re-adopt the same zombie on every future reconnect, so bound adoption to a
+// turn that could plausibly still be streaming. Real in-flight turns at a hub
+// redeploy are seconds old; this leaves generous headroom for long inferences.
+const MAX_RESUMABLE_TURN_AGE_MS = 15 * 60 * 1000;
+
 /**
  * Find the session's still-open inference turn, if any, so a collector rebuilt
  * on reconnect can resume it rather than dropping the trailing parts of a turn
- * that was in flight when the link dropped. Returns the turn id and the next
- * ordinal (one past the highest part already written) so the part sequence
- * stays monotonic. Returns undefined when no running turn exists.
+ * that was in flight when the link dropped.
+ *
+ * Best-effort, not a guarantee: it preserves the tail only when the sidecar
+ * actually redelivers it on reconnect (frames emitted to the dead socket, or
+ * dropped under the hub-link send-queue cap, are gone regardless). It also
+ * skips turns older than MAX_RESUMABLE_TURN_AGE_MS so a crashed-harness zombie
+ * is not adopted indefinitely. Returns the turn id and the next ordinal (one
+ * past the highest part already written) so the part sequence stays monotonic;
+ * the caller is the sole writer to that turn, so the read-then-write is safe.
+ * Returns undefined when no adoptable running turn exists.
  */
 async function findOpenTurn(
   db: DB["db"],
   sessionId: string,
 ): Promise<{ id: string; nextOrdinal: number } | undefined> {
   const [openTurn] = await db
-    .select({ id: inferenceTurn.id })
+    .select({ id: inferenceTurn.id, startedAt: inferenceTurn.startedAt })
     .from(inferenceTurn)
     .where(
       and(
@@ -239,10 +255,13 @@ async function findOpenTurn(
         isNull(inferenceTurn.endedAt),
       ),
     )
-    .orderBy(desc(inferenceTurn.startedAt))
+    .orderBy(desc(inferenceTurn.startedAt), desc(inferenceTurn.id))
     .limit(1);
 
   if (openTurn === undefined) return undefined;
+  if (Date.now() - openTurn.startedAt.getTime() > MAX_RESUMABLE_TURN_AGE_MS) {
+    return undefined;
+  }
 
   const [maxRow] = await db
     .select({ max: sql<number | null>`max(${turnPart.ordinal})` })


### PR DESCRIPTION
On `agent.reconnected` the orchestrator builds a fresh event collector with no active turn. If the agent was mid-turn when the link dropped (e.g. the consuming hub redeployed), the resumed `inference.done` / `step-finish` parts hit the null-turn guard in `insertPart` and are dropped — the live reply is lost (only reappears on reload if persisted).

This resolves the session's still-running `inferenceTurn` on collector restore and resumes it, continuing the part ordinal sequence so ordinals stay monotonic. Threads an optional `resumeTurn` through the event-collector registry and collector.

Surfaced downstream via gtm-workbench CL-1654 (corbitsdev/gtm-workbench#157), where a hub redeploy on every merge made this a recurring "chat dropped / out of order" symptom.

Tests: collector drops trailing parts without adoption vs. writes them into the adopted turn with continuing ordinals and finalizes on reactor.done; orchestrator passes the open turn (nextOrdinal = max+1, 0 when empty, undefined when none).