### PR TITLE
Carry multimedia attachments from the hub to model adapters

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -651,9 +651,10 @@ Persists the user message as a mail record and dispatches it to the running agen
 Body: SendMessage
 
 201: MailResponse -- Mail sent
-400: ErrorResponse -- Validation error
+400: AttachmentErrorResponse -- Attachment validation error. Each variant carries a structured code (oversize_attachment, disallowed_mime_type, malformed_base64, oversize_total) with the offending index and limits. A malformed request body that fails SendMessage validation returns the generic error shape instead.
 404: ErrorResponse -- Instance not found
 409: ErrorResponse -- Instance not running
+413: ErrorResponse -- Request body exceeds the maximum allowed size
 502: ErrorResponse -- Sidecar unavailable
 
 ### GET /api/tenants/:tenantId/agents/instances/:instanceId/mail
@@ -1126,6 +1127,10 @@ Source: packages/types/src/assets.ts
 ### AssetWithOriginResponse
 `{ createdAt: string, creatorPrincipalId: string | null, displayName: string | null, id: string, kind: string, name: string, origin: { direct: boolean, tenantId: string }, tenantId: string, updatedAt: string }`
 Source: packages/types/src/assets.ts
+
+### AttachmentErrorResponse
+`{ error: { attachmentIndex: number, byteLength: number, code: "oversize_attachment", limitBytes: number, message: string } | { attachmentIndex: number, code: "disallowed_mime_type", message: string, mimeType: string } | { attachmentIndex: number, code: "malformed_base64", message: string } | { code: "oversize_total", limitBytes: number, message: string, totalBytes: number } }`
+Source: packages/types/src/sessions.ts
 
 ### BranchInfo
 `{ name: string, isCurrent?: boolean, lastCommitAt?: string | null, lastCommitMessage?: string | null, lastCommitRef?: string | null }`

--- a/docs/API.md
+++ b/docs/API.md
@@ -1277,7 +1277,7 @@ Source: packages/types/src/roles.ts
 Source: packages/types/src/agents.ts
 
 ### SendMessage
-`{ content: string, attachments?: { type: string, url: string, mimeType?: string }[] }`
+`{ content: string, attachments?: { data: string, mimeType: string, name?: string, + (undeclared): reject }[] }`
 Source: packages/types/src/sessions.ts
 
 ### SessionSummary

--- a/docs/API.md
+++ b/docs/API.md
@@ -1129,7 +1129,7 @@ Source: packages/types/src/assets.ts
 Source: packages/types/src/assets.ts
 
 ### AttachmentErrorResponse
-`{ error: { attachmentIndex: number, byteLength: number, code: "oversize_attachment", limitBytes: number, message: string } | { attachmentIndex: number, code: "disallowed_mime_type", message: string, mimeType: string } | { attachmentIndex: number, code: "malformed_base64", message: string } | { code: "oversize_total", limitBytes: number, message: string, totalBytes: number } }`
+`{ error: { attachmentIndex: number, byteLength: number, code: "oversize_attachment", limitBytes: number, message: string } | { attachmentIndex: number, code: "disallowed_mime_type", message: string, mimeType: string } | { attachmentIndex: number, code: "invalid_attachment_name", message: string } | { attachmentIndex: number, code: "malformed_base64", message: string } | { code: "oversize_total", limitBytes: number, message: string, totalBytes: number } }`
 Source: packages/types/src/sessions.ts
 
 ### BranchInfo

--- a/docs/MESSAGE.md
+++ b/docs/MESSAGE.md
@@ -28,13 +28,17 @@ Every Interchange message is a PGP/MIME signed (RFC 3156) multipart message. The
 
 The outer layer is always `multipart/signed` per RFC 3156. The signed content is the first part; the detached PGP signature is the second part, computed after canonicalization (trailing whitespace removed, line endings normalized to CRLF, content constrained to 7-bit).
 
-The signed content varies by message type. Conversation messages use `text/plain` directly — they are just signed emails, readable by any mail client. Structured messages (offerings, payments, approvals, system) use `multipart/mixed` with an `application/vnd.interchange+json` part carrying machine-readable data.
+The signed content varies by message type. Conversation messages use `multipart/mixed` with a `text/plain` part plus zero or more attachment parts — they are still ordinary signed emails (a mail client renders the single `text/plain` part the same as a bare body). Structured messages (offerings, payments, approvals, system) use `multipart/mixed` with an `application/vnd.interchange+json` part carrying machine-readable data.
 
 **Conversation messages:**
 
+The shape is `multipart/mixed` unconditionally — every conversation message has the same structure regardless of attachment count.
+
 ```
 multipart/signed; protocol="application/pgp-signature"; micalg=pgp-sha512
-├── text/plain                              [the message]
+├── multipart/mixed
+│   ├── text/plain                          [the message]
+│   └── [attachment parts] (zero or more)   [images, audio, video, documents]
 └── application/pgp-signature               [Ed25519 detached signature]
 ```
 
@@ -49,7 +53,7 @@ multipart/signed; protocol="application/pgp-signature"; micalg=pgp-sha512
 └── application/pgp-signature               [Ed25519 detached signature]
 ```
 
-The `Interchange-Type` header determines which shape to expect. Conversation types (`conversation.message`, `conversation.join`, `conversation.leave`) use the plain text form. All other types use the structured form.
+The `Interchange-Type` header determines which shape to expect. Conversation types (`conversation.message`, `conversation.join`, `conversation.leave`) use the conversation form (text in part `1.1`). All other types use the structured form.
 
 ### Part Addressing
 
@@ -57,10 +61,12 @@ IMAP FETCH addresses MIME parts by position using dot-separated numeric paths (R
 
 **Conversation messages:**
 
-| IMAP Part | Content                         |
-| --------- | ------------------------------- |
-| `1`       | The `text/plain` message body   |
-| `2`       | The `application/pgp-signature` |
+| IMAP Part | Content                                       |
+| --------- | --------------------------------------------- |
+| `1`       | The `multipart/mixed` payload (all sub-parts) |
+| `1.1`     | The `text/plain` message body                 |
+| `1.2+`    | Attachments (if present)                      |
+| `2`       | The `application/pgp-signature`               |
 
 **Structured messages:**
 
@@ -72,7 +78,7 @@ IMAP FETCH addresses MIME parts by position using dot-separated numeric paths (R
 | `1.3+`    | Attachments (if present)                      |
 | `2`       | The `application/pgp-signature`               |
 
-For conversation messages, `BODY[1]` fetches the text. For structured messages, `BODY[1.1]` fetches just the JSON payload without downloading attachments. In both cases, `BODY[2]` fetches the signature for verification.
+For conversation messages, `BODY[1.1]` fetches the text without downloading attachments. For structured messages, `BODY[1.1]` fetches just the JSON payload. In both cases, `BODY[2]` fetches the signature for verification.
 
 ### Headers
 
@@ -119,7 +125,7 @@ Interchange headers use the `Interchange-` prefix. RFC 6648 deprecated the `X-` 
 
 ### Payload Types
 
-The `Interchange-Type` header identifies every message's type for routing without body parsing. Conversation types use `text/plain` bodies. All other types use `application/vnd.interchange+json` with a JSON object whose `type` field matches the header value.
+The `Interchange-Type` header identifies every message's type for routing without body parsing. Conversation types carry their text in the `text/plain` part of a `multipart/mixed` body. All other types use `application/vnd.interchange+json` with a JSON object whose `type` field matches the header value.
 
 **Conversation messages:**
 
@@ -168,7 +174,7 @@ Each structured payload type has a defined JSON schema. The schema version is ca
 
 ### Payload Structure
 
-Conversation messages (`conversation.message`, `conversation.join`, `conversation.leave`) have `text/plain` bodies. No JSON envelope, no schema. The message is the text.
+Conversation messages (`conversation.message`, `conversation.join`, `conversation.leave`) carry the text in the `text/plain` part of a `multipart/mixed` body, optionally followed by binary attachment parts. No JSON envelope, no schema for the text — the message is the text, and any attachments ride alongside it as standard MIME parts.
 
 Structured messages use `application/vnd.interchange+json` with a common envelope:
 
@@ -318,7 +324,7 @@ Every outbound message is signed with the sending agent's Ed25519 private key. T
 
 ### Signing Process
 
-1. The signed content is assembled — `text/plain` for conversation messages, `multipart/mixed` for structured messages
+1. The signed content is assembled — `multipart/mixed` for both conversation and structured messages
 2. Content is canonicalized: CRLF line endings, trailing whitespace removed, 7-bit encoding applied (base64 for binary parts, quoted-printable for 8-bit text)
 3. The payload is hashed (SHA-512, as required by Ed25519's internal construction)
 4. The hash is signed with the agent's Ed25519 private key
@@ -414,14 +420,14 @@ HEADER Interchange-Correlation-ID abc123 HEADER Interchange-Type offering.respon
 
 IMAP FETCH with section specifiers enables retrieving specific parts of a message without downloading the entire thing. This is critical for messages with large attachments.
 
-| Fetch specifier                                               | What it retrieves                                                                |
-| ------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `BODY[HEADER]`                                                | All message headers                                                              |
-| `BODY[HEADER.FIELDS (From To Subject Date Interchange-Type)]` | Specific headers only                                                            |
-| `BODY[1]`                                                     | Signed content (`text/plain` for conversation, `multipart/mixed` for structured) |
-| `BODY[1.1]`                                                   | The `application/vnd.interchange+json` payload (structured messages only)        |
-| `BODY[2]`                                                     | The PGP signature                                                                |
-| `BODYSTRUCTURE`                                               | MIME structure metadata (types, sizes, part hierarchy) without any content       |
+| Fetch specifier                                               | What it retrieves                                                                               |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `BODY[HEADER]`                                                | All message headers                                                                             |
+| `BODY[HEADER.FIELDS (From To Subject Date Interchange-Type)]` | Specific headers only                                                                           |
+| `BODY[1]`                                                     | Signed content (`multipart/mixed` for both conversation and structured)                         |
+| `BODY[1.1]`                                                   | The `text/plain` body (conversation) or `application/vnd.interchange+json` payload (structured) |
+| `BODY[2]`                                                     | The PGP signature                                                                               |
+| `BODYSTRUCTURE`                                               | MIME structure metadata (types, sizes, part hierarchy) without any content                      |
 
 The `BODYSTRUCTURE` fetch is particularly useful. It returns the MIME tree structure — content types, sizes, dispositions, parameters — for every part of the message without transferring any content. An agent can examine the structure to decide which parts to fetch.
 
@@ -561,7 +567,7 @@ fetchFull(ref: MessageRef): Promise<InboundMessage>
 
 `fetchStructure` retrieves the MIME tree metadata (IMAP `BODYSTRUCTURE`): content types, sizes, dispositions, parameters for every part. No content transferred.
 
-`fetchPart` retrieves a single MIME part by dot-separated path (IMAP `BODY.PEEK[path]`). Used to fetch just the JSON payload (`1.1`) or just an attachment (`1.3`) without downloading the entire message.
+`fetchPart` retrieves a single MIME part by dot-separated path (IMAP `BODY.PEEK[path]`). Used to fetch just the text or JSON payload (`1.1`) or just an attachment (`1.2+`) without downloading the entire message.
 
 `fetchFull` retrieves the complete message, parses the MIME structure, verifies the PGP signature, and returns a fully parsed `InboundMessage` with structured payload, headers, and attachments. The returned `InboundMessage` includes a `signatureStatus` field: `"valid"` (signature verified against sender's public key), `"invalid"` (signature check failed — tampering or wrong key), `"unknown"` (public key not available for verification), or `"missing"` (message was not signed). The harness decides policy based on this field — cross-tenant messages with `"invalid"` or `"missing"` status should be rejected; intra-tenant messages may be accepted with reduced trust depending on tenant policy.
 

--- a/packages/hub-api/src/attachment-validation.test.ts
+++ b/packages/hub-api/src/attachment-validation.test.ts
@@ -69,6 +69,20 @@ describe("validateAttachments", () => {
     });
   });
 
+  test("rejects a name with header-unsafe characters", () => {
+    const result = validateAttachments(
+      [
+        { mimeType: "image/png", data: b64([1]) },
+        { mimeType: "image/png", data: b64([2]), name: 'a"b.png' },
+      ],
+      policy,
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "invalid_attachment_name", attachmentIndex: 1 },
+    });
+  });
+
   test("rejects malformed base64 with the offending index", () => {
     const result = validateAttachments(
       [{ mimeType: "image/png", data: "@@not-base64@@" }],

--- a/packages/hub-api/src/attachment-validation.test.ts
+++ b/packages/hub-api/src/attachment-validation.test.ts
@@ -1,0 +1,163 @@
+import { describe, test, expect } from "bun:test";
+import {
+  validateAttachments,
+  type AttachmentInput,
+  type AttachmentPolicy,
+} from "./attachment-validation";
+
+function b64(bytes: number[]): string {
+  return Buffer.from(new Uint8Array(bytes)).toString("base64");
+}
+
+function bytesOfLength(n: number): string {
+  return Buffer.alloc(n, 0x61).toString("base64");
+}
+
+// Small limits so oversize cases need only tiny buffers.
+const policy: AttachmentPolicy = {
+  isAllowed: (m) => m === "image/png" || m === "application/pdf",
+  perAttachmentLimitBytes: 100,
+  perMessageTotalLimitBytes: 150,
+};
+
+describe("validateAttachments", () => {
+  test("accepts valid attachments and defaults names by index", () => {
+    const inputs: AttachmentInput[] = [
+      { mimeType: "image/png", data: b64([1, 2, 3]), name: "shot.png" },
+      { mimeType: "application/pdf", data: b64([4, 5]) },
+    ];
+    const result = validateAttachments(inputs, policy);
+    expect(result).toEqual({
+      ok: true,
+      attachments: [
+        {
+          name: "shot.png",
+          contentType: "image/png",
+          data: new Uint8Array([1, 2, 3]),
+        },
+        {
+          name: "attachment-1",
+          contentType: "application/pdf",
+          data: new Uint8Array([4, 5]),
+        },
+      ],
+    });
+  });
+
+  test("empty input is valid", () => {
+    expect(validateAttachments([], policy)).toEqual({
+      ok: true,
+      attachments: [],
+    });
+  });
+
+  test("rejects a disallowed mimeType with the offending index", () => {
+    const result = validateAttachments(
+      [
+        { mimeType: "image/png", data: b64([1]) },
+        { mimeType: "image/tiff", data: b64([2]) },
+      ],
+      policy,
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "disallowed_mime_type",
+        attachmentIndex: 1,
+        mimeType: "image/tiff",
+      },
+    });
+  });
+
+  test("rejects malformed base64 with the offending index", () => {
+    const result = validateAttachments(
+      [{ mimeType: "image/png", data: "@@not-base64@@" }],
+      policy,
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "malformed_base64", attachmentIndex: 0 },
+    });
+  });
+
+  test("rejects an oversize attachment with byte length and limit", () => {
+    const result = validateAttachments(
+      [{ mimeType: "image/png", data: bytesOfLength(101) }],
+      policy,
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "oversize_attachment",
+        attachmentIndex: 0,
+        byteLength: 101,
+        limitBytes: 100,
+      },
+    });
+  });
+
+  test("rejects an oversize total only after each attachment passes", () => {
+    const result = validateAttachments(
+      [
+        { mimeType: "image/png", data: bytesOfLength(80) },
+        { mimeType: "application/pdf", data: bytesOfLength(80) },
+      ],
+      policy,
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "oversize_total", totalBytes: 160, limitBytes: 150 },
+    });
+  });
+
+  test("per-attachment oversize wins over total (ordering)", () => {
+    // One oversize attachment plus a small one. Per-attachment size is the
+    // most specific error and must win over oversize_total.
+    const result = validateAttachments(
+      [
+        { mimeType: "image/png", data: bytesOfLength(200) },
+        { mimeType: "application/pdf", data: bytesOfLength(10) },
+      ],
+      policy,
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "oversize_attachment",
+        attachmentIndex: 0,
+        byteLength: 200,
+        limitBytes: 100,
+      },
+    });
+  });
+
+  test("oversize wins over disallowed mimeType and malformed base64", () => {
+    const result = validateAttachments(
+      [
+        { mimeType: "image/tiff", data: b64([1]) }, // disallowed
+        { mimeType: "image/png", data: "@@bad@@" }, // malformed
+        { mimeType: "image/png", data: bytesOfLength(200) }, // oversize
+      ],
+      policy,
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "oversize_attachment",
+        attachmentIndex: 2,
+        byteLength: 200,
+        limitBytes: 100,
+      },
+    });
+  });
+
+  test("structured errors carry a human-readable message", () => {
+    const result = validateAttachments(
+      [{ mimeType: "image/tiff", data: b64([1]) }],
+      policy,
+    );
+    if (result.ok) throw new Error("expected a validation error");
+    expect(typeof result.error.message).toBe("string");
+    expect(result.error.message.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/hub-api/src/attachment-validation.ts
+++ b/packages/hub-api/src/attachment-validation.ts
@@ -3,6 +3,7 @@ import {
   isAllowedMimeType,
   PER_ATTACHMENT_LIMIT_BYTES,
   PER_MESSAGE_TOTAL_LIMIT_BYTES,
+  type AttachmentError,
 } from "@intx/types";
 import type { MessageAttachment } from "@intx/types/runtime";
 
@@ -34,34 +35,15 @@ export const DEFAULT_ATTACHMENT_POLICY: AttachmentPolicy = {
   perMessageTotalLimitBytes: PER_MESSAGE_TOTAL_LIMIT_BYTES,
 };
 
-// Each error carries `code` plus structured fields so clients can act on the
-// code without string-parsing, and a human-readable `message` matching the
-// shape of every other error this route returns.
-export type AttachmentValidationError =
-  | {
-      code: "oversize_attachment";
-      message: string;
-      attachmentIndex: number;
-      byteLength: number;
-      limitBytes: number;
-    }
-  | {
-      code: "disallowed_mime_type";
-      message: string;
-      attachmentIndex: number;
-      mimeType: string;
-    }
-  | { code: "malformed_base64"; message: string; attachmentIndex: number }
-  | {
-      code: "oversize_total";
-      message: string;
-      totalBytes: number;
-      limitBytes: number;
-    };
+// The error shape is the wire contract `AttachmentError` from @intx/types:
+// a machine-actionable `code`, the fields needed to locate the rejection,
+// and a human-readable `message`. Defining it once in @intx/types lets the
+// route document the structured 400 in its OpenAPI surface.
+export type AttachmentValidationError = AttachmentError;
 
 export type AttachmentValidationResult =
   | { ok: true; attachments: MessageAttachment[] }
-  | { ok: false; error: AttachmentValidationError };
+  | { ok: false; error: AttachmentError };
 
 function decode(data: string): Uint8Array | null {
   try {

--- a/packages/hub-api/src/attachment-validation.ts
+++ b/packages/hub-api/src/attachment-validation.ts
@@ -1,0 +1,146 @@
+import {
+  base64Decode,
+  isAllowedMimeType,
+  PER_ATTACHMENT_LIMIT_BYTES,
+  PER_MESSAGE_TOTAL_LIMIT_BYTES,
+} from "@intx/types";
+import type { MessageAttachment } from "@intx/types/runtime";
+
+/**
+ * A single attachment as it arrives on the request body: a MIME type, the
+ * base64-encoded bytes, and an optional filename.
+ */
+export type AttachmentInput = {
+  mimeType: string;
+  data: string;
+  name?: string;
+};
+
+/**
+ * The attachment policy the route validates against. Defaults to the
+ * system-level allowlist and limits; a future per-agent or per-workflow
+ * lookup substitutes a narrowed policy here (the injection seam — no
+ * validation logic changes).
+ */
+export type AttachmentPolicy = {
+  isAllowed: (mimeType: string) => boolean;
+  perAttachmentLimitBytes: number;
+  perMessageTotalLimitBytes: number;
+};
+
+export const DEFAULT_ATTACHMENT_POLICY: AttachmentPolicy = {
+  isAllowed: isAllowedMimeType,
+  perAttachmentLimitBytes: PER_ATTACHMENT_LIMIT_BYTES,
+  perMessageTotalLimitBytes: PER_MESSAGE_TOTAL_LIMIT_BYTES,
+};
+
+// Each error carries `code` plus structured fields so clients can act on the
+// code without string-parsing, and a human-readable `message` matching the
+// shape of every other error this route returns.
+export type AttachmentValidationError =
+  | {
+      code: "oversize_attachment";
+      message: string;
+      attachmentIndex: number;
+      byteLength: number;
+      limitBytes: number;
+    }
+  | {
+      code: "disallowed_mime_type";
+      message: string;
+      attachmentIndex: number;
+      mimeType: string;
+    }
+  | { code: "malformed_base64"; message: string; attachmentIndex: number }
+  | {
+      code: "oversize_total";
+      message: string;
+      totalBytes: number;
+      limitBytes: number;
+    };
+
+export type AttachmentValidationResult =
+  | { ok: true; attachments: MessageAttachment[] }
+  | { ok: false; error: AttachmentValidationError };
+
+function decode(data: string): Uint8Array | null {
+  try {
+    return base64Decode(data.replace(/\s+/g, ""));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate and decode request-body attachments against a policy.
+ *
+ * The most specific error wins, in this priority order so the caller sees
+ * the most actionable failure: per-attachment oversize, then disallowed
+ * MIME type, then malformed base64, then per-message total oversize. On
+ * success the decoded `MessageAttachment[]` is returned with names
+ * defaulted to `attachment-{index}` by request-body position.
+ */
+export function validateAttachments(
+  inputs: readonly AttachmentInput[],
+  policy: AttachmentPolicy = DEFAULT_ATTACHMENT_POLICY,
+): AttachmentValidationResult {
+  let oversize: AttachmentValidationError | undefined;
+  let disallowed: AttachmentValidationError | undefined;
+  let malformed: AttachmentValidationError | undefined;
+  const decoded: MessageAttachment[] = [];
+
+  for (const [index, input] of inputs.entries()) {
+    const bytes = decode(input.data);
+    if (bytes === null) {
+      malformed ??= {
+        code: "malformed_base64",
+        message: `attachment ${index} is not valid base64`,
+        attachmentIndex: index,
+      };
+      continue;
+    }
+    if (bytes.length > policy.perAttachmentLimitBytes) {
+      oversize ??= {
+        code: "oversize_attachment",
+        message: `attachment ${index} is ${bytes.length} bytes, over the ${policy.perAttachmentLimitBytes}-byte limit`,
+        attachmentIndex: index,
+        byteLength: bytes.length,
+        limitBytes: policy.perAttachmentLimitBytes,
+      };
+      continue;
+    }
+    if (!policy.isAllowed(input.mimeType)) {
+      disallowed ??= {
+        code: "disallowed_mime_type",
+        message: `attachment ${index} has unsupported content type "${input.mimeType}"`,
+        attachmentIndex: index,
+        mimeType: input.mimeType,
+      };
+      continue;
+    }
+    decoded.push({
+      name: input.name ?? `attachment-${index}`,
+      contentType: input.mimeType,
+      data: bytes,
+    });
+  }
+
+  if (oversize !== undefined) return { ok: false, error: oversize };
+  if (disallowed !== undefined) return { ok: false, error: disallowed };
+  if (malformed !== undefined) return { ok: false, error: malformed };
+
+  const totalBytes = decoded.reduce((sum, a) => sum + a.data.length, 0);
+  if (totalBytes > policy.perMessageTotalLimitBytes) {
+    return {
+      ok: false,
+      error: {
+        code: "oversize_total",
+        message: `attachments total ${totalBytes} bytes, over the ${policy.perMessageTotalLimitBytes}-byte limit`,
+        totalBytes,
+        limitBytes: policy.perMessageTotalLimitBytes,
+      },
+    };
+  }
+
+  return { ok: true, attachments: decoded };
+}

--- a/packages/hub-api/src/attachment-validation.ts
+++ b/packages/hub-api/src/attachment-validation.ts
@@ -58,9 +58,9 @@ function decode(data: string): Uint8Array | null {
  *
  * The most specific error wins, in this priority order so the caller sees
  * the most actionable failure: per-attachment oversize, then disallowed
- * MIME type, then malformed base64, then per-message total oversize. On
- * success the decoded `MessageAttachment[]` is returned with names
- * defaulted to `attachment-{index}` by request-body position.
+ * MIME type, then invalid name, then malformed base64, then per-message
+ * total oversize. On success the decoded `MessageAttachment[]` is returned
+ * with names defaulted to `attachment-{index}` by request-body position.
  */
 export function validateAttachments(
   inputs: readonly AttachmentInput[],
@@ -68,6 +68,7 @@ export function validateAttachments(
 ): AttachmentValidationResult {
   let oversize: AttachmentValidationError | undefined;
   let disallowed: AttachmentValidationError | undefined;
+  let invalidName: AttachmentValidationError | undefined;
   let malformed: AttachmentValidationError | undefined;
   const decoded: MessageAttachment[] = [];
 
@@ -100,6 +101,17 @@ export function validateAttachments(
       };
       continue;
     }
+    // A user-supplied name becomes the MIME part's quoted filename, so it
+    // must not contain characters that would break out of the header
+    // (line breaks or a double quote). The default name is always safe.
+    if (input.name !== undefined && /[\r\n"]/.test(input.name)) {
+      invalidName ??= {
+        code: "invalid_attachment_name",
+        message: `attachment ${index} has a name with invalid characters (no quotes or line breaks)`,
+        attachmentIndex: index,
+      };
+      continue;
+    }
     decoded.push({
       name: input.name ?? `attachment-${index}`,
       contentType: input.mimeType,
@@ -109,6 +121,7 @@ export function validateAttachments(
 
   if (oversize !== undefined) return { ok: false, error: oversize };
   if (disallowed !== undefined) return { ok: false, error: disallowed };
+  if (invalidName !== undefined) return { ok: false, error: invalidName };
   if (malformed !== undefined) return { ok: false, error: malformed };
 
   const totalBytes = decoded.reduce((sum, a) => sum + a.data.length, 0);

--- a/packages/hub-api/src/routes/instances.test.ts
+++ b/packages/hub-api/src/routes/instances.test.ts
@@ -1,9 +1,17 @@
 import { describe, test, expect } from "bun:test";
 
 import { createInMemoryGrantStore } from "@intx/authz";
+import {
+  assembleSignedContent,
+  assembleMessage,
+  type MessageHeaders,
+} from "@intx/mime";
 import type { GrantRule } from "@intx/types/authz";
 import type { SessionStatus } from "@intx/types";
-import type { ConnectorThreadState } from "@intx/types/runtime";
+import type {
+  ConnectorThreadState,
+  MessageAttachment,
+} from "@intx/types/runtime";
 
 import { createApp } from "../app";
 import {
@@ -766,6 +774,187 @@ describe("POST /agents/instances/:instanceId/mail", () => {
     expect(captured).toHaveLength(1);
     expect(captured[0]?.inReplyTo).toBe(`<prior-1@${testTenant.domain}>`);
     expect(captured[0]?.references).toEqual([`<prior-1@${testTenant.domain}>`]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /:instanceId/mail — attachment validation
+// ---------------------------------------------------------------------------
+
+describe("POST /agents/instances/:instanceId/mail attachments", () => {
+  function makeMailGrant(): GrantRule {
+    return makeGrant({ resource: "instance:*", action: "write" });
+  }
+
+  // A session service whose sendUserMessage assembles a real conversation
+  // MIME from the params, so the route's response echoes the parsed
+  // attachment metadata exactly as production does.
+  function captureAttachmentSend(): {
+    service: SessionService;
+    captured: (MessageAttachment[] | undefined)[];
+  } {
+    const captured: (MessageAttachment[] | undefined)[] = [];
+    const service: SessionService = {
+      launchSession() {
+        throw new Error("not implemented");
+      },
+      endSession() {
+        throw new Error("not implemented");
+      },
+      sendUserMessage(params) {
+        captured.push(params.attachments);
+        const content = assembleSignedContent({
+          kind: "conversation",
+          text: params.content,
+          ...(params.attachments !== undefined
+            ? { attachments: params.attachments }
+            : {}),
+        });
+        const headers: MessageHeaders = {
+          from: params.from,
+          to: [params.agentAddress],
+          cc: undefined,
+          date: params.date,
+          messageId: params.messageId,
+          subject: undefined,
+          inReplyTo: params.inReplyTo,
+          references: params.references,
+          mimeVersion: "1.0",
+          interchangeType: "conversation.message",
+          interchangeCorrelationId: undefined,
+          interchangeTenantId: params.tenantId,
+          interchangeAgentId: undefined,
+          interchangeSessionId: params.sessionId,
+          interchangeOfferingId: undefined,
+          interchangeSchemaVersion: undefined,
+          traceparent: undefined,
+          tracestate: undefined,
+        };
+        const raw = assembleMessage(
+          headers,
+          content,
+          new TextEncoder().encode("FAKE-SIG"),
+        );
+        return Promise.resolve(raw);
+      },
+    };
+    return { service, captured };
+  }
+
+  function postMailWith(
+    app: ReturnType<typeof createTestApp>,
+    attachments: unknown[],
+  ) {
+    return app.request(`${instanceURL()}/mail`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content: "hello agent", attachments }),
+    });
+  }
+
+  test("valid attachment is decoded, forwarded, and echoed in the response", async () => {
+    const { service, captured } = captureAttachmentSend();
+    const app = createTestApp({
+      grants: [makeMailGrant()],
+      sessionService: service,
+    });
+
+    const data = Buffer.from(
+      new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]),
+    ).toString("base64");
+    const res = await postMailWith(app, [
+      { mimeType: "image/png", data, name: "shot.png" },
+    ]);
+
+    expect(res.status).toBe(201);
+    expect(captured).toEqual([
+      [
+        {
+          name: "shot.png",
+          contentType: "image/png",
+          data: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]),
+        },
+      ],
+    ]);
+
+    const json = await res.json();
+    expect(json).toMatchObject({
+      attachments: [{ name: "shot.png", type: "image/png" }],
+    });
+  });
+
+  test("disallowed mimeType yields structured disallowed_mime_type", async () => {
+    const { service } = captureAttachmentSend();
+    const app = createTestApp({
+      grants: [makeMailGrant()],
+      sessionService: service,
+    });
+
+    const data = Buffer.from(new Uint8Array([1, 2, 3])).toString("base64");
+    const res = await postMailWith(app, [{ mimeType: "image/tiff", data }]);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: {
+        code: "disallowed_mime_type",
+        attachmentIndex: 0,
+        mimeType: "image/tiff",
+      },
+    });
+  });
+
+  test("malformed base64 yields structured malformed_base64", async () => {
+    const { service } = captureAttachmentSend();
+    const app = createTestApp({
+      grants: [makeMailGrant()],
+      sessionService: service,
+    });
+
+    const res = await postMailWith(app, [
+      { mimeType: "image/png", data: "@@@not-valid-base64@@@" },
+    ]);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: { code: "malformed_base64", attachmentIndex: 0 },
+    });
+  });
+
+  test("oversize attachment wins over total, reporting the offending index", async () => {
+    const { service } = captureAttachmentSend();
+    const app = createTestApp({
+      grants: [makeMailGrant()],
+      sessionService: service,
+    });
+
+    const small = Buffer.from(new Uint8Array([1, 2, 3])).toString("base64");
+    const oversize = Buffer.alloc(11 * 1024 * 1024, 0x61).toString("base64");
+    const res = await postMailWith(app, [
+      { mimeType: "image/png", data: small },
+      { mimeType: "image/png", data: oversize },
+      { mimeType: "image/png", data: small },
+    ]);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: { code: "oversize_attachment", attachmentIndex: 1 },
+    });
+  });
+
+  test("auth runs before attachment validation", async () => {
+    const { service, captured } = captureAttachmentSend();
+    const app = createTestApp({
+      grants: [],
+      sessionService: service,
+    });
+
+    // A disallowed attachment would be a 400 if validation ran first; with
+    // no write grant the route must reject with its auth failure instead.
+    const data = Buffer.from(new Uint8Array([1, 2, 3])).toString("base64");
+    const res = await postMailWith(app, [{ mimeType: "image/tiff", data }]);
+
+    expect(res.status).toBe(403);
+    expect(captured).toHaveLength(0);
   });
 });
 

--- a/packages/hub-api/src/routes/instances.test.ts
+++ b/packages/hub-api/src/routes/instances.test.ts
@@ -920,6 +920,28 @@ describe("POST /agents/instances/:instanceId/mail attachments", () => {
     });
   });
 
+  test("an unsafe filename yields a structured 400, not a 502", async () => {
+    const { service, captured } = captureAttachmentSend();
+    const app = createTestApp({
+      grants: [makeMailGrant()],
+      sessionService: service,
+    });
+
+    const data = Buffer.from(new Uint8Array([1, 2, 3])).toString("base64");
+    const res = await postMailWith(app, [
+      { mimeType: "image/png", data, name: 'a"b.png' },
+    ]);
+
+    // Rejected at the boundary before the message is ever assembled, so the
+    // client sees a 400 with the structured code rather than a 502 from the
+    // MIME assembler's header-safety guard.
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: { code: "invalid_attachment_name", attachmentIndex: 0 },
+    });
+    expect(captured).toHaveLength(0);
+  });
+
   test("oversize attachment wins over total, reporting the offending index", async () => {
     const { service } = captureAttachmentSend();
     const app = createTestApp({

--- a/packages/hub-api/src/routes/instances.ts
+++ b/packages/hub-api/src/routes/instances.ts
@@ -34,6 +34,7 @@ import {
   GrantRequirement,
   SendMessage,
   MailResponse,
+  AttachmentErrorResponse,
   InferenceTurnResponse,
   ErrorResponse,
   formatAgentAddress,
@@ -1420,9 +1421,10 @@ export function createInstanceRoutes({
           },
         },
         400: {
-          description: "Validation error",
+          description:
+            "Attachment validation error. Each variant carries a structured code (oversize_attachment, disallowed_mime_type, malformed_base64, oversize_total) with the offending index and limits. A malformed request body that fails SendMessage validation returns the generic error shape instead.",
           content: {
-            "application/json": { schema: resolver(ErrorResponse) },
+            "application/json": { schema: resolver(AttachmentErrorResponse) },
           },
         },
         404: {
@@ -1433,6 +1435,12 @@ export function createInstanceRoutes({
         },
         409: {
           description: "Instance not running",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
+        413: {
+          description: "Request body exceeds the maximum allowed size",
           content: {
             "application/json": { schema: resolver(ErrorResponse) },
           },

--- a/packages/hub-api/src/routes/instances.ts
+++ b/packages/hub-api/src/routes/instances.ts
@@ -1,5 +1,6 @@
 import { eq, and, inArray, asc } from "drizzle-orm";
 import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
 import { describeRoute, resolver, validator } from "hono-openapi";
 import { streamSSE } from "hono/streaming";
 import { type } from "arktype";
@@ -47,6 +48,7 @@ import {
   type SidecarRouter,
 } from "@intx/hub-sessions";
 import { formatOffering } from "./offerings";
+import { validateAttachments } from "../attachment-validation";
 
 import type { TenantEnv } from "../context";
 import { idResource } from "../middleware/grant";
@@ -63,6 +65,13 @@ import {
 
 const CredentialRequirements = CredentialRequirement.array();
 const GrantRequirements = GrantRequirement.array();
+
+// DoS guard on the mail route body. Sized above the legitimate ceiling
+// (the 30 MB per-message attachment cap is ~40 MB once base64-encoded,
+// plus JSON and text overhead) so over-business-cap requests are rejected
+// by the handler with a structured error, while genuine garbage is
+// rejected here before the JSON parser allocates a giant string.
+const MAX_MAIL_BODY_BYTES = 44 * 1024 * 1024;
 
 const ModelConfig = type({
   defaultModel: "string",
@@ -1436,12 +1445,35 @@ export function createInstanceRoutes({
         },
       },
     }),
+    bodyLimit({
+      maxSize: MAX_MAIL_BODY_BYTES,
+      onError: (c) =>
+        c.json(
+          {
+            error: {
+              code: "payload_too_large",
+              message: "Request body exceeds the maximum allowed size",
+            },
+          },
+          413,
+        ),
+    }),
     validator("json", SendMessage),
     async (c) => {
       const tenant = c.get("tenant");
       const principal = c.get("principal");
       const instanceId = c.req.param("instanceId");
       const body = c.req.valid("json");
+
+      // Decode and validate attachments at the boundary, emitting ordered,
+      // per-index structured errors. The effective policy defaults to the
+      // system-level allowlist and limits; a future per-agent/per-workflow
+      // lookup substitutes a narrowed policy here.
+      const attachmentResult = validateAttachments(body.attachments ?? []);
+      if (!attachmentResult.ok) {
+        return c.json({ error: attachmentResult.error }, 400);
+      }
+      const messageAttachments = attachmentResult.attachments;
 
       const row = await db.query.agentInstance.findFirst({
         where: and(
@@ -1543,6 +1575,9 @@ export function createInstanceRoutes({
           messageId: mimeMessageId,
           date: now,
           content: body.content,
+          ...(messageAttachments.length > 0
+            ? { attachments: messageAttachments }
+            : {}),
           ...(inReplyTo !== undefined ? { inReplyTo } : {}),
           ...(references !== undefined && references.length > 0
             ? { references }

--- a/packages/hub-sessions/src/session-service.test.ts
+++ b/packages/hub-sessions/src/session-service.test.ts
@@ -4,7 +4,12 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import * as tar from "tar";
-import type { CryptoProvider, HarnessConfig } from "@intx/types/runtime";
+import type {
+  CryptoProvider,
+  HarnessConfig,
+  MessageAttachment,
+} from "@intx/types/runtime";
+import { extractAttachments } from "@intx/mime";
 import type { AgentRepoStore, DeployContent } from "./agent-repo";
 import type { AgentAssetWithAsset, AssetService } from "./asset-service";
 import type { Principal, RepoId, RepoStore } from "./repo-store";
@@ -572,6 +577,40 @@ describe("SessionService", () => {
     expect(decoded).toContain(
       "References: <root@test.local> <prev@test.local>",
     );
+  });
+
+  test("sendUserMessage threads attachments into the signed envelope", async () => {
+    const service = createSessionService({
+      sidecarRouter: router,
+      agentRepoStore: repoStore,
+    });
+
+    const attachments: MessageAttachment[] = [
+      {
+        name: "shot.png",
+        contentType: "image/png",
+        data: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      },
+    ];
+
+    await service.sendUserMessage(userMessageParams({ attachments }));
+
+    const call = router.calls.find((c) => c.method === "routeMail");
+    if (call === undefined) throw new Error("unreachable");
+    const rawArg = call.args[1];
+    if (typeof rawArg !== "string") throw new Error("expected string arg");
+    const raw = new Uint8Array(Buffer.from(rawArg, "base64"));
+
+    const extracted = extractAttachments(raw);
+    expect(extracted).toHaveLength(1);
+    const got = extracted[0];
+    const orig = attachments[0];
+    if (got === undefined || orig === undefined) {
+      throw new Error("unreachable");
+    }
+    expect(got.name).toBe("shot.png");
+    expect(got.contentType).toBe("image/png");
+    expect(Array.from(got.data)).toEqual(Array.from(orig.data));
   });
 
   test("sendUserMessage throws when agent is unreachable", async () => {

--- a/packages/hub-sessions/src/session-service.ts
+++ b/packages/hub-sessions/src/session-service.ts
@@ -23,6 +23,7 @@ import type {
   CryptoProvider,
   HarnessConfig,
   InferenceSource,
+  MessageAttachment,
 } from "@intx/types/runtime";
 import {
   type RegistryConfig,
@@ -137,6 +138,7 @@ export type UserMessageParams = {
   messageId: string;
   date: Date;
   content: string;
+  attachments?: MessageAttachment[];
   inReplyTo?: string;
   references?: string[];
   sessionId: string;
@@ -1111,6 +1113,7 @@ export function createSessionService(deps: SessionServiceDeps): SessionService {
       messageId,
       date,
       content,
+      attachments,
       inReplyTo,
       references,
       sessionId,
@@ -1142,6 +1145,7 @@ export function createSessionService(deps: SessionServiceDeps): SessionService {
     const signedContent = assembleSignedContent({
       kind: "conversation",
       text: content,
+      ...(attachments !== undefined ? { attachments } : {}),
     });
     const signature = await createDetachedSignatureFromProvider(
       signedContent,

--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -48,6 +48,7 @@ export type {
   UploadedGoogleGenAIFile,
 } from "./providers/google-genai-files";
 
+export { createInboundTurn } from "./turns";
 export { createReactor } from "./reactor";
 export type { Reactor, ReactorConfig, ReactorEmittedEvent } from "./reactor";
 export { validateActions } from "./actions";

--- a/packages/inference/src/turns.test.ts
+++ b/packages/inference/src/turns.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect } from "bun:test";
+import { base64Encode } from "@intx/types";
+import type { InboundMessage, MessageAttachment } from "@intx/types/runtime";
+import { createInboundTurn } from "./turns";
+
+function att(contentType: string, bytes: number[]): MessageAttachment {
+  return { name: "file", contentType, data: new Uint8Array(bytes) };
+}
+
+function msg(opts: {
+  content?: string;
+  attachments?: MessageAttachment[];
+  from?: string;
+  subject?: string;
+}): InboundMessage {
+  return {
+    ref: { uid: 1, mailbox: "INBOX" },
+    headers: {
+      from: opts.from ?? "",
+      to: [],
+      date: "2026-01-01T00:00:00.000Z",
+      messageId: "<m@test>",
+      ...(opts.subject !== undefined ? { subject: opts.subject } : {}),
+    },
+    flags: [],
+    signatureStatus: "valid",
+    ...(opts.content !== undefined ? { content: opts.content } : {}),
+    ...(opts.attachments !== undefined
+      ? { attachments: opts.attachments }
+      : {}),
+  };
+}
+
+describe("createInboundTurn", () => {
+  const cases: { mimeType: string; blockType: string }[] = [
+    { mimeType: "image/png", blockType: "image" },
+    { mimeType: "image/heic", blockType: "image" },
+    { mimeType: "video/mp4", blockType: "video" },
+    { mimeType: "audio/mpeg", blockType: "audio" },
+    { mimeType: "application/pdf", blockType: "document" },
+    { mimeType: "application/json", blockType: "document" },
+    { mimeType: "text/plain", blockType: "document" },
+    { mimeType: "text/csv", blockType: "document" },
+    { mimeType: "text/markdown", blockType: "document" },
+  ];
+
+  for (const { mimeType, blockType } of cases) {
+    test(`maps ${mimeType} to a ${blockType} block`, () => {
+      const turn = createInboundTurn(
+        msg({ attachments: [att(mimeType, [1, 2, 3])] }),
+      );
+      expect(turn).toMatchObject({
+        role: "user",
+        content: [
+          {
+            type: blockType,
+            source: {
+              kind: "base64",
+              mimeType,
+              data: base64Encode(new Uint8Array([1, 2, 3])),
+            },
+          },
+        ],
+      });
+    });
+  }
+
+  test("text plus attachments yields the text block then media blocks in order", () => {
+    const turn = createInboundTurn(
+      msg({
+        content: "look at these",
+        attachments: [att("image/png", [1]), att("application/pdf", [2])],
+      }),
+    );
+    expect(turn).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: "look at these" },
+        { type: "image", source: { mimeType: "image/png" } },
+        { type: "document", source: { mimeType: "application/pdf" } },
+      ],
+    });
+  });
+
+  test("image-only message (empty text) yields one image block, not null", () => {
+    const turn = createInboundTurn(
+      msg({ content: "", attachments: [att("image/png", [9, 8, 7])] }),
+    );
+    expect(turn).toMatchObject({
+      role: "user",
+      content: [{ type: "image", source: { mimeType: "image/png" } }],
+    });
+  });
+
+  test("empty content and no attachments yields null", () => {
+    expect(createInboundTurn(msg({ content: "" }))).toBeNull();
+    expect(createInboundTurn(msg({}))).toBeNull();
+  });
+
+  test("prepends the From/Subject envelope to the text block", () => {
+    const turn = createInboundTurn(
+      msg({ content: "body", from: "alice@x", subject: "Hi" }),
+    );
+    expect(turn).toMatchObject({
+      content: [
+        { type: "text", text: "[From: alice@x]\n[Subject: Hi]\n\nbody" },
+      ],
+    });
+  });
+
+  test("degrades an unmappable attachment type to a text marker, not a throw", () => {
+    // Inbound attachments come from remote senders and are not allowlist
+    // filtered; an unmappable type must surface visibly rather than throw
+    // into the reactor's delivery path.
+    const turn = createInboundTurn(
+      msg({ attachments: [att("application/zip", [1])] }),
+    );
+    expect(turn).toMatchObject({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "[Unsupported attachment: file (application/zip)]",
+        },
+      ],
+    });
+  });
+});

--- a/packages/inference/src/turns.ts
+++ b/packages/inference/src/turns.ts
@@ -3,32 +3,96 @@ import type {
   ContentBlock,
   AssistantTurn,
   InboundMessage,
+  MediaSource,
+  MessageAttachment,
   ToolCall,
   ToolResult,
 } from "@intx/types/runtime";
+import { attachmentCategory, base64Encode } from "@intx/types";
+import { getLogger } from "@intx/log";
+
+const logger = getLogger(["interchange", "inference", "turns"]);
 
 export type { ConversationTurn, ContentBlock, AssistantTurn };
 
 export type { ToolCall, ToolResult };
 
+/**
+ * Map a received attachment to a model ContentBlock.
+ *
+ * The dispatch uses two policies that look unified but are not, and must
+ * stay distinct:
+ *   - major-type dispatch for image/*, video/*, audio/* → the matching block;
+ *   - allowlist-category dispatch for the document category
+ *     (application/pdf, application/json, text/plain, text/csv,
+ *     text/markdown) → DocumentBlock.
+ * Do NOT collapse this into "always dispatch by major type": that would
+ * route text/plain to a text block instead of DocumentBlock.
+ *
+ * This function is total — it never throws. The hub route allowlist only
+ * guards the local user-upload path; inbound attachments arrive from remote
+ * senders via fetchFull and are not subtype-filtered here (provider adapters
+ * are the contract layer that rejects unsupported media at marshal time, per
+ * INTERCHANGE message design). Any major-type media is therefore passed
+ * through to the adapter. A type that maps to no block at all (e.g. an
+ * archive) degrades to a visible text marker rather than throwing: throwing
+ * here would propagate into the reactor's ungoverned delivery path and let a
+ * single malformed remote attachment tear down the session.
+ */
+function attachmentToContentBlock(att: MessageAttachment): ContentBlock {
+  const majorType = att.contentType.split("/")[0];
+  if (
+    majorType === "image" ||
+    majorType === "video" ||
+    majorType === "audio" ||
+    attachmentCategory(att.contentType) === "document"
+  ) {
+    const source: MediaSource = {
+      kind: "base64",
+      mimeType: att.contentType,
+      data: base64Encode(att.data),
+    };
+    if (majorType === "image") return { type: "image", source };
+    if (majorType === "video") return { type: "video", source };
+    if (majorType === "audio") return { type: "audio", source };
+    return { type: "document", source };
+  }
+
+  logger.warn`Unsupported attachment content type ${att.contentType}; surfacing as a text marker`;
+  return {
+    type: "text",
+    text: `[Unsupported attachment: ${att.name} (${att.contentType})]`,
+  };
+}
+
 export function createInboundTurn(
   message: InboundMessage,
 ): ConversationTurn | null {
   const content = message.content ?? "";
-  if (content.length === 0) return null;
+  const attachments = message.attachments ?? [];
+  if (content.length === 0 && attachments.length === 0) return null;
 
-  const { from, subject } = message.headers;
-  const envelope: string[] = [];
-  if (from.length > 0) envelope.push(`[From: ${from}]`);
-  if (subject !== undefined && subject.length > 0) {
-    envelope.push(`[Subject: ${subject}]`);
+  const blocks: ContentBlock[] = [];
+
+  if (content.length > 0) {
+    const { from, subject } = message.headers;
+    const envelope: string[] = [];
+    if (from.length > 0) envelope.push(`[From: ${from}]`);
+    if (subject !== undefined && subject.length > 0) {
+      envelope.push(`[Subject: ${subject}]`);
+    }
+    const text =
+      envelope.length > 0 ? `${envelope.join("\n")}\n\n${content}` : content;
+    blocks.push({ type: "text", text });
   }
 
-  const text =
-    envelope.length > 0 ? `${envelope.join("\n")}\n\n${content}` : content;
+  for (const att of attachments) {
+    blocks.push(attachmentToContentBlock(att));
+  }
+
   return {
     role: "user",
-    content: [{ type: "text", text }],
+    content: blocks,
     timestamp: Date.now(),
   };
 }

--- a/packages/mail-memory/src/fetch.ts
+++ b/packages/mail-memory/src/fetch.ts
@@ -18,6 +18,7 @@ import {
   extractBoundary,
   parseMultipart,
   extractPartByPath,
+  extractAttachments,
 } from "@intx/mime";
 import { buildMessageHeaders } from "./headers";
 import { verifyDetachedSignature } from "@intx/crypto-node";
@@ -119,12 +120,29 @@ export async function fetchFull(
 
   try {
     if (isConversation) {
-      const part1Bytes = extractPartByPath(msg.raw, "1");
-      const part1 = parseMimePart(part1Bytes);
-      result.content = new TextDecoder("utf-8", { fatal: false }).decode(
-        part1.body,
-      );
+      const part1 = parseMimePart(extractPartByPath(msg.raw, "1"));
+      const part1Mime = part1.contentType.split(";")[0]!.trim().toLowerCase();
+      if (part1Mime.startsWith("multipart/")) {
+        // Conversation shape: multipart/mixed with the text body at 1.1.
+        const textPart = parseMimePart(extractPartByPath(msg.raw, "1.1"));
+        result.content = new TextDecoder("utf-8", { fatal: false }).decode(
+          textPart.body,
+        );
+      } else {
+        // A conversation message is "literally a signed email", so a sender
+        // (e.g. a plain mail client) may sign a bare text/plain part with no
+        // multipart/mixed wrapper. This branch reads that body directly. Our
+        // own assembler always emits multipart/mixed; without this branch a
+        // bare text/plain message would fail the 1.1 lookup and silently lose
+        // its content to the catch below.
+        result.content = new TextDecoder("utf-8", { fatal: false }).decode(
+          part1.body,
+        );
+      }
     } else {
+      // Structured messages carry their JSON payload at 1.1. Attachments on
+      // structured messages are intentionally not parsed: they have no
+      // producer today, so parsing them would handle a shape nobody sends.
       const part11Bytes = extractPartByPath(msg.raw, "1.1");
       const part11 = parseMimePart(part11Bytes);
       const jsonText = new TextDecoder("utf-8", { fatal: false }).decode(
@@ -138,6 +156,15 @@ export async function fetchFull(
     }
   } catch {
     // If we can't parse the content, return what we have with the signature status.
+  }
+
+  // Attachment parsing is deliberately outside the catch above: a malformed
+  // attachment must surface as a thrown error, not be silently dropped.
+  if (isConversation) {
+    const attachments = extractAttachments(msg.raw);
+    if (attachments.length > 0) {
+      result.attachments = attachments;
+    }
   }
 
   return result;

--- a/packages/mail-memory/src/index.test.ts
+++ b/packages/mail-memory/src/index.test.ts
@@ -1,8 +1,42 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion -- test refs[0]! always follows expect(refs.length) checks */
 import { describe, test, expect } from "bun:test";
 import { generateKeyPair, createNodeCrypto } from "@intx/crypto-node";
+import {
+  assembleSignedContent,
+  assembleMessage,
+  createDetachedSignatureFromProvider,
+  generateMessageId,
+  type MessageHeaders,
+} from "@intx/mime";
 import { createInMemoryTransport } from "./index";
-import type { MailboxEvent, MessageRef } from "@intx/types/runtime";
+import type {
+  MailboxEvent,
+  MessageRef,
+  MessageAttachment,
+} from "@intx/types/runtime";
+
+function conversationHeaders(): MessageHeaders {
+  return {
+    from: "alpha@test.interchange",
+    to: ["beta@test.interchange"],
+    cc: undefined,
+    date: new Date("2026-01-15T12:00:00Z"),
+    messageId: generateMessageId("alpha@test.interchange"),
+    subject: undefined,
+    inReplyTo: undefined,
+    references: undefined,
+    mimeVersion: "1.0",
+    interchangeType: "conversation.message",
+    interchangeCorrelationId: undefined,
+    interchangeTenantId: undefined,
+    interchangeAgentId: undefined,
+    interchangeSessionId: undefined,
+    interchangeOfferingId: undefined,
+    interchangeSchemaVersion: undefined,
+    traceparent: undefined,
+    tracestate: undefined,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -282,6 +316,88 @@ describe("fetchFull", () => {
     expect(msg.payload).toBeDefined();
     expect(msg.payload!.type).toBe("offering.request");
     expect(msg.payload!.body["offeringId"]).toBe("code-review");
+  });
+
+  test("fetchFull populates attachments for a conversation message", async () => {
+    const { transport, betaTransport, cryptoA } = await createTestTransport();
+
+    const attachments: MessageAttachment[] = [
+      {
+        name: "shot.png",
+        contentType: "image/png",
+        data: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      },
+    ];
+    const content = assembleSignedContent({
+      kind: "conversation",
+      text: "with image",
+      attachments,
+    });
+    const sig = await createDetachedSignatureFromProvider(content, cryptoA);
+    const raw = assembleMessage(conversationHeaders(), content, sig);
+
+    transport.deliver("beta@test.interchange", raw);
+    const refs = await betaTransport.search("INBOX", {});
+    expect(refs).toHaveLength(1);
+
+    const msg = await betaTransport.fetchFull(refs[0]!);
+    expect(msg.signatureStatus).toBe("valid");
+    expect(msg.content).toBe("with image");
+    expect(msg.attachments).toHaveLength(1);
+    const got = msg.attachments![0]!;
+    const orig = attachments[0]!;
+    expect(got.name).toBe("shot.png");
+    expect(got.contentType).toBe("image/png");
+    expect(Array.from(got.data)).toEqual(Array.from(orig.data));
+  });
+
+  test("fetchFull surfaces a malformed attachment instead of dropping it", async () => {
+    const { transport, betaTransport, cryptoA } = await createTestTransport();
+
+    const boundary = "mixed_bad_b64";
+    const badContent = new TextEncoder().encode(
+      `Content-Type: multipart/mixed; boundary="${boundary}"\r\n\r\n` +
+        `--${boundary}\r\n` +
+        `Content-Type: text/plain; charset=utf-8\r\n` +
+        `Content-Transfer-Encoding: 7bit\r\n\r\n` +
+        `hi\r\n` +
+        `--${boundary}\r\n` +
+        `Content-Type: image/png\r\n` +
+        `Content-Transfer-Encoding: base64\r\n` +
+        `Content-Disposition: attachment; filename="bad.png"\r\n\r\n` +
+        `@@@not-valid-base64@@@\r\n` +
+        `--${boundary}--\r\n`,
+    );
+    const sig = await createDetachedSignatureFromProvider(badContent, cryptoA);
+    const raw = assembleMessage(conversationHeaders(), badContent, sig);
+
+    transport.deliver("beta@test.interchange", raw);
+    const refs = await betaTransport.search("INBOX", {});
+    expect(refs).toHaveLength(1);
+
+    await expect(betaTransport.fetchFull(refs[0]!)).rejects.toThrow();
+  });
+
+  test("fetchFull reads a bare text/plain signed conversation body", async () => {
+    // A plain signed email (no multipart/mixed wrapper) is a valid
+    // conversation message; fetchFull must read its body, not drop it.
+    const { transport, betaTransport, cryptoA } = await createTestTransport();
+
+    const bareContent = new TextEncoder().encode(
+      `Content-Type: text/plain; charset=utf-8\r\n` +
+        `Content-Transfer-Encoding: 7bit\r\n\r\n` +
+        `plain signed body`,
+    );
+    const sig = await createDetachedSignatureFromProvider(bareContent, cryptoA);
+    const raw = assembleMessage(conversationHeaders(), bareContent, sig);
+
+    transport.deliver("beta@test.interchange", raw);
+    const refs = await betaTransport.search("INBOX", {});
+    expect(refs).toHaveLength(1);
+
+    const msg = await betaTransport.fetchFull(refs[0]!);
+    expect(msg.content).toBe("plain signed body");
+    expect(msg.attachments).toBeUndefined();
   });
 
   test("fetchHeaders returns parsed headers", async () => {

--- a/packages/mime/src/index.test.ts
+++ b/packages/mime/src/index.test.ts
@@ -17,8 +17,10 @@ import {
   extractBoundary,
   extractPartByPath,
   parseMailToEmail,
+  extractAttachments,
   type MessageHeaders,
 } from "./index";
+import type { MessageAttachment } from "@intx/types/runtime";
 
 const enc = new TextEncoder();
 const dec = new TextDecoder();
@@ -159,12 +161,13 @@ describe("formatRFC2822Date", () => {
 // ---------------------------------------------------------------------------
 
 describe("assembleSignedContent", () => {
-  test("conversation produces text/plain with CRLF", () => {
+  test("conversation wraps text/plain in multipart/mixed with CRLF", () => {
     const bytes = assembleSignedContent({
       kind: "conversation",
       text: "Hello\nWorld",
     });
     const text = dec.decode(bytes);
+    expect(text).toContain("Content-Type: multipart/mixed;");
     expect(text).toContain("Content-Type: text/plain; charset=utf-8\r\n");
     expect(text).toContain("Content-Transfer-Encoding: 7bit\r\n");
     expect(text).toContain("\r\nHello\r\nWorld");
@@ -179,13 +182,17 @@ describe("assembleSignedContent", () => {
     expect(text).toContain("\r\n  leading\r\nindented");
   });
 
-  test("conversation with empty text produces headers only", () => {
+  test("conversation with empty text produces an empty text part", () => {
     const bytes = assembleSignedContent({
       kind: "conversation",
       text: "",
     });
     const text = dec.decode(bytes);
-    expect(text).toMatch(/Content-Transfer-Encoding: 7bit\r\n\r\n$/);
+    expect(text).toContain("Content-Type: multipart/mixed;");
+    // text/plain part headers, blank line, empty body CRLF, then a boundary
+    expect(text).toMatch(
+      /Content-Type: text\/plain; charset=utf-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\n\r\n--/,
+    );
   });
 
   test("conversation normalizes CRLF input without doubling", () => {
@@ -935,9 +942,16 @@ describe("assemble then parse round-trip", () => {
     );
     expect(valid).toBe(true);
 
+    // The signed content is multipart/mixed; the text lives at part 1.1.
     const parsed = parseMimePart(signedPart);
-    expect(parsed.contentType).toContain("text/plain");
-    expect(dec.decode(parsed.body)).toContain("Hello from the round-trip test");
+    expect(parsed.contentType).toContain("multipart/mixed");
+    const innerBoundary = defined(extractBoundary(parsed.contentType));
+    const innerParts = parseMultipart(parsed.body, innerBoundary);
+    const textPart = parseMimePart(defined(innerParts[0]));
+    expect(textPart.contentType).toContain("text/plain");
+    expect(dec.decode(textPart.body)).toContain(
+      "Hello from the round-trip test",
+    );
   });
 
   test("structured message survives assemble/parse cycle", async () => {
@@ -974,5 +988,160 @@ describe("assemble then parse round-trip", () => {
 
     const summaryPart = parseMimePart(defined(innerParts[1]));
     expect(dec.decode(summaryPart.body)).toContain("Deploying to prod");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversation attachments: assemble → extract round-trip
+// ---------------------------------------------------------------------------
+
+describe("conversation attachments round-trip", () => {
+  const attachments: MessageAttachment[] = [
+    {
+      name: "shot.png",
+      contentType: "image/png",
+      data: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    },
+    {
+      name: "clip.mp4",
+      contentType: "video/mp4",
+      data: new Uint8Array([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]),
+    },
+    {
+      name: "voice.mp3",
+      contentType: "audio/mpeg",
+      data: new Uint8Array([0xff, 0xfb, 0x90, 0x00, 0x11]),
+    },
+    {
+      name: "report.pdf",
+      contentType: "application/pdf",
+      data: new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]),
+    },
+  ];
+
+  function buildConversation(
+    text: string,
+    atts: MessageAttachment[] | undefined,
+  ): Uint8Array {
+    const content = assembleSignedContent({
+      kind: "conversation",
+      text,
+      ...(atts !== undefined ? { attachments: atts } : {}),
+    });
+    return assembleMessage(
+      makeHeaders({ interchangeType: "conversation.message" }),
+      content,
+      enc.encode("FAKE-SIGNATURE"),
+    );
+  }
+
+  test("assemble then extract reconstructs one attachment of each block variant", () => {
+    const msg = buildConversation("see attached", attachments);
+    const extracted = extractAttachments(msg);
+    expect(extracted).toHaveLength(attachments.length);
+    for (let i = 0; i < attachments.length; i++) {
+      const orig = defined(attachments[i]);
+      const got = defined(extracted[i]);
+      expect(got.name).toBe(orig.name);
+      expect(got.contentType).toBe(orig.contentType);
+      expect(Array.from(got.data)).toEqual(Array.from(orig.data));
+    }
+  });
+
+  test("no-attachments conversation round-trips with zero attachment parts", () => {
+    const msg = buildConversation("just text", undefined);
+    expect(extractAttachments(msg)).toHaveLength(0);
+  });
+
+  test("image-only conversation (empty text) round-trips the attachment", () => {
+    const onlyImage = defined(attachments[0]);
+    const msg = buildConversation("", [onlyImage]);
+    const extracted = extractAttachments(msg);
+    expect(extracted).toHaveLength(1);
+    expect(defined(extracted[0]).contentType).toBe("image/png");
+    expect(Array.from(defined(extracted[0]).data)).toEqual(
+      Array.from(onlyImage.data),
+    );
+  });
+
+  test("parseMailToEmail surfaces conversation attachment metadata", () => {
+    const pdf = defined(attachments[3]);
+    const msg = buildConversation("hi", [pdf]);
+    const email = parseMailToEmail(msg, "sml_conv_att");
+    expect(email.attachments).toHaveLength(1);
+    expect(defined(email.attachments[0]).name).toBe("report.pdf");
+    expect(defined(email.attachments[0]).type).toBe("application/pdf");
+  });
+
+  test("a text/plain document attachment is distinguished from the body text", () => {
+    // The trickiest case: a text/plain attachment shares its content type
+    // with the conversation body part, so the two are told apart only by
+    // Content-Disposition. The body must not be read as an attachment, and
+    // the attachment must not be lost.
+    const doc: MessageAttachment = {
+      name: "notes.txt",
+      contentType: "text/plain",
+      data: enc.encode("attached document contents"),
+    };
+    const msg = buildConversation("the conversation body", [doc]);
+
+    const extracted = extractAttachments(msg);
+    expect(extracted).toHaveLength(1);
+    expect(defined(extracted[0]).name).toBe("notes.txt");
+    expect(defined(extracted[0]).contentType).toBe("text/plain");
+    expect(dec.decode(defined(extracted[0]).data)).toBe(
+      "attached document contents",
+    );
+
+    const email = parseMailToEmail(msg, "sml_txt_doc");
+    expect(email.attachments).toHaveLength(1);
+    expect(defined(email.attachments[0]).name).toBe("notes.txt");
+    expect(defined(email.attachments[0]).type).toBe("text/plain");
+  });
+
+  test("conversation message with attachments produces a verifiable signature", async () => {
+    const kp = await generateKeyPair();
+    const provider = createNodeCrypto(kp);
+    const content = assembleSignedContent({
+      kind: "conversation",
+      text: "signed with an image",
+      attachments: [defined(attachments[0])],
+    });
+    const sig = await createDetachedSignatureFromProvider(content, provider);
+    const msg = assembleMessage(
+      makeHeaders({ interchangeType: "conversation.message" }),
+      content,
+      sig,
+    );
+
+    const { headers, bodyOffset } = parseHeaderSection(msg);
+    const boundary = defined(
+      extractBoundary(defined(headers.get("content-type"))),
+    );
+    const parts = parseMultipart(msg.slice(bodyOffset), boundary);
+    const signedPart = defined(parts[0]);
+    const sigPart = parseMimePart(defined(parts[1]));
+    const valid = await verifyDetachedSignature(
+      signedPart,
+      sigPart.body,
+      provider.getPublicKey(),
+    );
+    expect(valid).toBe(true);
+  });
+
+  test("rejects an attachment name containing CRLF (header injection)", () => {
+    expect(() =>
+      assembleSignedContent({
+        kind: "conversation",
+        text: "x",
+        attachments: [
+          {
+            name: "evil\r\nContent-Type: text/html",
+            contentType: "image/png",
+            data: new Uint8Array([1, 2, 3]),
+          },
+        ],
+      }),
+    ).toThrow();
   });
 });

--- a/packages/mime/src/index.ts
+++ b/packages/mime/src/index.ts
@@ -10,6 +10,7 @@ export {
   extractBoundary,
   extractPartByPath,
   parseMailToEmail,
+  extractAttachments,
 } from "./mime";
 
 export type {

--- a/packages/mime/src/mime.ts
+++ b/packages/mime/src/mime.ts
@@ -3,7 +3,8 @@
  * MIME byte construction and parsing for Interchange messages.
  *
  * Implements exactly two message shapes per MESSAGE.md:
- *   1. Conversation: text/plain in multipart/signed
+ *   1. Conversation: multipart/mixed (text/plain plus zero or more
+ *      attachment parts) in multipart/signed
  *   2. Structured: application/vnd.interchange+json in multipart/mixed in multipart/signed
  *
  * Produces real RFC 2822 / RFC 2046 / RFC 3156 bytes. The signed content
@@ -19,6 +20,8 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { base64Decode, base64Encode } from "@intx/types";
+import type { MessageAttachment } from "@intx/types/runtime";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -48,6 +51,7 @@ export type MessageHeaders = {
 export type ConversationContent = {
   kind: "conversation";
   text: string;
+  attachments?: MessageAttachment[];
 };
 
 export type StructuredContent = {
@@ -326,21 +330,82 @@ function serializeMessageHeaders(
 // ---------------------------------------------------------------------------
 
 /**
- * Assemble the signed content for a conversation message (text/plain).
+ * Reject values that would break out of a MIME header. CR/LF in a header
+ * value is a header-injection vector; a double quote breaks the quoted
+ * `filename="..."` / `name="..."` forms the parser relies on. The MIME
+ * layer owns header well-formedness, so it fails loudly here rather than
+ * emitting a corrupt envelope.
+ */
+function assertHeaderSafe(value: string, field: string): void {
+  if (/[\r\n]/.test(value)) {
+    throw new Error(
+      `${field} must not contain CR or LF: ${JSON.stringify(value)}`,
+    );
+  }
+  if (value.includes('"')) {
+    throw new Error(
+      `${field} must not contain a double quote: ${JSON.stringify(value)}`,
+    );
+  }
+}
+
+/**
+ * Encode bytes as base64, wrapped at 76 columns per RFC 2045. Returns the
+ * empty string for empty input.
+ */
+function base64Lines(bytes: Uint8Array): string {
+  const b64 = base64Encode(bytes);
+  const lines: string[] = [];
+  for (let i = 0; i < b64.length; i += 76) {
+    lines.push(b64.slice(i, i + 76));
+  }
+  return lines.join(CRLF);
+}
+
+/**
+ * Assemble the signed content for a conversation message.
+ *
+ * The shape is always multipart/mixed: one text/plain part (BODY[1.1])
+ * followed by zero or more binary attachment parts (BODY[1.2..N]). The
+ * shape is unconditional — there is no bare text/plain branch — so the
+ * writer, the parser, and the signed-bytes contract have one form each.
  *
  * This is the exact bytes that will be hashed for the PGP/MIME signature.
- * Content-Transfer-Encoding: 7bit (conversation messages are ASCII).
  */
-function assembleConversationSignedPart(text: string): Uint8Array {
-  // Canonicalize: CRLF line endings, strip trailing whitespace per line.
+function assembleConversationSignedPart(
+  text: string,
+  attachments: readonly MessageAttachment[] = [],
+): Uint8Array {
+  const boundary = generateBoundary();
+
+  // Canonicalize the text part: CRLF line endings, strip trailing
+  // whitespace per line.
   const lines = text.split(/\r\n|\r|\n/);
   const canonLines = lines.map((l) => l.replace(/[ \t]+$/, ""));
   const canonical = canonLines.join(CRLF);
 
-  const partHeaders =
-    `Content-Type: text/plain; charset=utf-8${CRLF}` +
-    `Content-Transfer-Encoding: 7bit${CRLF}`;
-  const body = `${partHeaders}${CRLF}${canonical}`;
+  let body = `Content-Type: multipart/mixed; boundary="${boundary}"${CRLF}${CRLF}`;
+
+  // Text part (BODY[1.1])
+  body += `--${boundary}${CRLF}`;
+  body += `Content-Type: text/plain; charset=utf-8${CRLF}`;
+  body += `Content-Transfer-Encoding: 7bit${CRLF}`;
+  body += `${CRLF}`;
+  body += `${canonical}${CRLF}`;
+
+  // Attachment parts (BODY[1.2..N])
+  for (const att of attachments) {
+    assertHeaderSafe(att.contentType, "attachment contentType");
+    assertHeaderSafe(att.name, "attachment name");
+    body += `--${boundary}${CRLF}`;
+    body += `Content-Type: ${att.contentType}${CRLF}`;
+    body += `Content-Transfer-Encoding: base64${CRLF}`;
+    body += `Content-Disposition: attachment; filename="${att.name}"${CRLF}`;
+    body += `${CRLF}`;
+    body += `${base64Lines(att.data)}${CRLF}`;
+  }
+
+  body += `--${boundary}--${CRLF}`;
   return new TextEncoder().encode(body);
 }
 
@@ -462,7 +527,7 @@ export function assembleSignedContent(
   content: ConversationContent | StructuredContent,
 ): Uint8Array {
   if (content.kind === "conversation") {
-    return assembleConversationSignedPart(content.text);
+    return assembleConversationSignedPart(content.text, content.attachments);
   }
   return assembleStructuredSignedPart(content.json, content.summary);
 }
@@ -987,4 +1052,90 @@ export function parseMailToEmail(raw: Uint8Array, mailId: string): JMAPEmail {
     attachments: ctx.attachments,
     headers: interchangeHeaders,
   };
+}
+
+/**
+ * Decode a MIME part body into raw bytes, honoring Content-Transfer-Encoding.
+ *
+ * Unlike `decodeBodyBytes` (which produces a JMAP string value), this returns
+ * the actual bytes for reconstructing a `MessageAttachment`. A malformed
+ * base64 body surfaces as a thrown error rather than a silent best-effort
+ * decode — attachment integrity is load-bearing.
+ */
+function decodeAttachmentBytes(
+  body: Uint8Array,
+  headers: Map<string, string>,
+): Uint8Array {
+  const cte = (headers.get("content-transfer-encoding") ?? "7bit")
+    .trim()
+    .toLowerCase();
+
+  if (cte === "base64") {
+    const raw = new TextDecoder("utf-8", { fatal: false }).decode(body);
+    return base64Decode(raw.replace(/\s+/g, ""));
+  }
+
+  if (cte === "quoted-printable") {
+    const raw = new TextDecoder("utf-8", { fatal: false }).decode(body);
+    const decoded = decodeQuotedPrintable(raw);
+    const out = new Uint8Array(decoded.length);
+    for (let i = 0; i < decoded.length; i++) {
+      out[i] = decoded.charCodeAt(i);
+    }
+    return out;
+  }
+
+  if (cte === "7bit" || cte === "8bit" || cte === "binary") {
+    return body;
+  }
+
+  throw new Error(
+    `decodeAttachmentBytes: unsupported content-transfer-encoding "${cte}"`,
+  );
+}
+
+/**
+ * Extract conversation attachments from raw message bytes as
+ * `MessageAttachment[]` with decoded payloads.
+ *
+ * The conversation signed content is a multipart/mixed whose first part is
+ * the text body and whose remaining attachment parts (Content-Disposition:
+ * attachment) carry the binary payloads. Returns an empty array for any
+ * shape without attachment parts — a bare text/plain signed part, a
+ * non-multipart/signed message, or a multipart/mixed with only the text
+ * part — so callers can use it unconditionally.
+ *
+ * Counterpart to `assembleConversationSignedPart`: assemble then extract
+ * round-trips a `MessageAttachment[]`.
+ */
+export function extractAttachments(raw: Uint8Array): MessageAttachment[] {
+  const { headers, bodyOffset } = parseHeaderSection(raw);
+  const body = raw.slice(bodyOffset);
+  const mime = extractContentTypeMime(headers.get("content-type") ?? "");
+
+  if (mime !== "multipart/signed") return [];
+  const outerBoundary = extractBoundary(headers.get("content-type") ?? "");
+  if (outerBoundary === undefined) return [];
+
+  const contentPart = parseMultipart(body, outerBoundary)[0];
+  if (contentPart === undefined) return [];
+
+  const signed = parseMimePart(contentPart);
+  if (!extractContentTypeMime(signed.contentType).startsWith("multipart/")) {
+    return [];
+  }
+  const innerBoundary = extractBoundary(signed.contentType);
+  if (innerBoundary === undefined) return [];
+
+  const attachments: MessageAttachment[] = [];
+  for (const subPartBytes of parseMultipart(signed.body, innerBoundary)) {
+    const subPart = parseMimePart(subPartBytes);
+    if (!isAttachmentPart(subPart.contentType, subPart.headers)) continue;
+    attachments.push({
+      name: extractFilename(subPart.headers) ?? "attachment",
+      contentType: extractContentTypeMime(subPart.contentType),
+      data: decodeAttachmentBytes(subPart.body, subPart.headers),
+    });
+  }
+  return attachments;
 }

--- a/packages/types/src/attachments.test.ts
+++ b/packages/types/src/attachments.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "bun:test";
+import {
+  ATTACHMENT_ALLOWLIST,
+  attachmentCategory,
+  isAllowedMimeType,
+  PER_ATTACHMENT_LIMIT_BYTES,
+  PER_MESSAGE_TOTAL_LIMIT_BYTES,
+} from "./attachments";
+
+describe("attachment allowlist", () => {
+  test("every allowlisted mimeType is accepted by the helper", () => {
+    for (const mimeType of Object.keys(ATTACHMENT_ALLOWLIST)) {
+      expect(isAllowedMimeType(mimeType)).toBe(true);
+    }
+  });
+
+  test("unknown mimeTypes are rejected", () => {
+    expect(isAllowedMimeType("application/x-evil")).toBe(false);
+    expect(isAllowedMimeType("image/tiff")).toBe(false);
+    expect(isAllowedMimeType("")).toBe(false);
+  });
+
+  test("category dispatch maps each major type and the document category", () => {
+    expect(attachmentCategory("image/png")).toBe("image");
+    expect(attachmentCategory("video/mp4")).toBe("video");
+    expect(attachmentCategory("audio/mpeg")).toBe("audio");
+    expect(attachmentCategory("application/pdf")).toBe("document");
+    expect(attachmentCategory("text/plain")).toBe("document");
+    expect(attachmentCategory("text/csv")).toBe("document");
+    expect(attachmentCategory("text/markdown")).toBe("document");
+    expect(attachmentCategory("application/json")).toBe("document");
+  });
+
+  test("category is undefined for unknown mimeTypes", () => {
+    expect(attachmentCategory("image/tiff")).toBeUndefined();
+  });
+
+  test("size limits are the documented defaults", () => {
+    expect(PER_ATTACHMENT_LIMIT_BYTES).toBe(10 * 1024 * 1024);
+    expect(PER_MESSAGE_TOTAL_LIMIT_BYTES).toBe(30 * 1024 * 1024);
+  });
+});

--- a/packages/types/src/attachments.ts
+++ b/packages/types/src/attachments.ts
@@ -1,0 +1,66 @@
+// Attachment allowlist — the system-level source of truth for which MIME
+// types the hub accepts as conversation attachments and which ContentBlock
+// category each maps to. Adding a MIME type is a one-line change here.
+//
+// This is the hard capability ceiling: a type is only useful if the pipeline
+// can produce the right ContentBlock and an adapter can marshal it. Per-agent
+// or per-workflow narrowing rides on top of this ceiling — it narrows the
+// accepted set, it never widens past what the adapters support.
+
+export const ATTACHMENT_CATEGORIES = [
+  "image",
+  "video",
+  "audio",
+  "document",
+] as const;
+export type AttachmentCategory = (typeof ATTACHMENT_CATEGORIES)[number];
+
+export const ATTACHMENT_ALLOWLIST = {
+  "image/png": "image",
+  "image/jpeg": "image",
+  "image/gif": "image",
+  "image/webp": "image",
+  "image/heic": "image",
+  "image/heif": "image",
+  "video/mp4": "video",
+  "video/webm": "video",
+  "video/quicktime": "video",
+  "audio/mpeg": "audio",
+  "audio/wav": "audio",
+  "audio/ogg": "audio",
+  "audio/webm": "audio",
+  "application/pdf": "document",
+  "application/json": "document",
+  "text/plain": "document",
+  "text/csv": "document",
+  "text/markdown": "document",
+} as const satisfies Record<string, AttachmentCategory>;
+
+export type AllowedMimeType = keyof typeof ATTACHMENT_ALLOWLIST;
+
+export function isAllowedMimeType(
+  mimeType: string,
+): mimeType is AllowedMimeType {
+  return mimeType in ATTACHMENT_ALLOWLIST;
+}
+
+/**
+ * The ContentBlock category for an allowlisted MIME type, or `undefined`
+ * when the type is not on the allowlist. Callers decide how to treat an
+ * unknown type (the route rejects it at the boundary; turn construction
+ * surfaces it as a text marker).
+ */
+export function attachmentCategory(
+  mimeType: string,
+): AttachmentCategory | undefined {
+  if (isAllowedMimeType(mimeType)) {
+    return ATTACHMENT_ALLOWLIST[mimeType];
+  }
+  return undefined;
+}
+
+// Default size limits, on decoded bytes. These are the system-level
+// ceiling; a future per-agent/per-workflow policy resolves an effective
+// limit that defaults to these.
+export const PER_ATTACHMENT_LIMIT_BYTES = 10 * 1024 * 1024;
+export const PER_MESSAGE_TOTAL_LIMIT_BYTES = 30 * 1024 * 1024;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,6 +5,7 @@ export * from "./principals";
 export * from "./roles";
 export * from "./grants";
 export * from "./agents";
+export * from "./attachments";
 export * from "./sessions";
 export * from "./approvals";
 export * from "./wallets";

--- a/packages/types/src/sessions.test.ts
+++ b/packages/types/src/sessions.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from "bun:test";
+import { type } from "arktype";
+import { SendMessage } from "./sessions";
+
+const okData = Buffer.from("hello world").toString("base64");
+
+describe("SendMessage attachments schema", () => {
+  test("accepts a message with no attachments", () => {
+    const result = SendMessage({ content: "hi" });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("accepts an attachment with mimeType, base64 data, and name", () => {
+    const result = SendMessage({
+      content: "see attached",
+      attachments: [{ mimeType: "image/png", data: okData, name: "shot.png" }],
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("accepts an attachment without the optional name", () => {
+    const result = SendMessage({
+      content: "",
+      attachments: [{ mimeType: "image/png", data: okData }],
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("rejects an attachment missing mimeType", () => {
+    const result = SendMessage({
+      content: "x",
+      attachments: [{ data: okData }],
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("rejects an attachment missing data", () => {
+    const result = SendMessage({
+      content: "x",
+      attachments: [{ mimeType: "image/png" }],
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("accepts any string data; base64 validity is the route's job", () => {
+    // The schema only checks that data is a string. The route boundary
+    // decodes it and emits malformed_base64 when it is not valid base64.
+    const result = SendMessage({
+      content: "x",
+      attachments: [{ mimeType: "image/png", data: "not base64!!!" }],
+    });
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  test("rejects the removed type field (closed attachment schema)", () => {
+    const result = SendMessage({
+      content: "x",
+      attachments: [{ mimeType: "image/png", data: okData, type: "image" }],
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+});

--- a/packages/types/src/sessions.test.ts
+++ b/packages/types/src/sessions.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { type } from "arktype";
-import { SendMessage } from "./sessions";
+import { SendMessage, AttachmentError } from "./sessions";
 
 const okData = Buffer.from("hello world").toString("base64");
 
@@ -56,6 +56,50 @@ describe("SendMessage attachments schema", () => {
     const result = SendMessage({
       content: "x",
       attachments: [{ mimeType: "image/png", data: okData, type: "image" }],
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+});
+
+describe("AttachmentError schema", () => {
+  test("accepts each structured error variant", () => {
+    const variants = [
+      {
+        code: "oversize_attachment",
+        message: "too big",
+        attachmentIndex: 0,
+        byteLength: 99,
+        limitBytes: 10,
+      },
+      {
+        code: "disallowed_mime_type",
+        message: "nope",
+        attachmentIndex: 1,
+        mimeType: "image/tiff",
+      },
+      { code: "malformed_base64", message: "bad", attachmentIndex: 2 },
+      {
+        code: "oversize_total",
+        message: "too much",
+        totalBytes: 99,
+        limitBytes: 30,
+      },
+    ];
+    for (const variant of variants) {
+      expect(AttachmentError(variant) instanceof type.errors).toBe(false);
+    }
+  });
+
+  test("rejects an unknown code", () => {
+    const result = AttachmentError({ code: "nope", message: "x" });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  test("rejects a variant missing its structured fields", () => {
+    const result = AttachmentError({
+      code: "oversize_attachment",
+      message: "x",
+      attachmentIndex: 0,
     });
     expect(result instanceof type.errors).toBe(true);
   });

--- a/packages/types/src/sessions.test.ts
+++ b/packages/types/src/sessions.test.ts
@@ -79,6 +79,11 @@ describe("AttachmentError schema", () => {
       },
       { code: "malformed_base64", message: "bad", attachmentIndex: 2 },
       {
+        code: "invalid_attachment_name",
+        message: "bad name",
+        attachmentIndex: 3,
+      },
+      {
         code: "oversize_total",
         message: "too much",
         totalBytes: 99,

--- a/packages/types/src/sessions.ts
+++ b/packages/types/src/sessions.ts
@@ -102,6 +102,11 @@ export const AttachmentError = type({
     mimeType: "string",
   })
   .or({
+    code: "'invalid_attachment_name'",
+    message: "string",
+    attachmentIndex: "number",
+  })
+  .or({
     code: "'malformed_base64'",
     message: "string",
     attachmentIndex: "number",

--- a/packages/types/src/sessions.ts
+++ b/packages/types/src/sessions.ts
@@ -83,6 +83,40 @@ export const MailResponse = type({
 });
 export type MailResponse = typeof MailResponse.infer;
 
+// Structured attachment-rejection errors returned by POST /:instanceId/mail.
+// Each variant carries a machine-actionable `code` plus the fields a client
+// needs to locate and explain the rejection, alongside a human-readable
+// `message`. This is the wire contract for the route's attachment 400s; the
+// route handler is the single producer.
+export const AttachmentError = type({
+  code: "'oversize_attachment'",
+  message: "string",
+  attachmentIndex: "number",
+  byteLength: "number",
+  limitBytes: "number",
+})
+  .or({
+    code: "'disallowed_mime_type'",
+    message: "string",
+    attachmentIndex: "number",
+    mimeType: "string",
+  })
+  .or({
+    code: "'malformed_base64'",
+    message: "string",
+    attachmentIndex: "number",
+  })
+  .or({
+    code: "'oversize_total'",
+    message: "string",
+    totalBytes: "number",
+    limitBytes: "number",
+  });
+export type AttachmentError = typeof AttachmentError.infer;
+
+export const AttachmentErrorResponse = type({ error: AttachmentError });
+export type AttachmentErrorResponse = typeof AttachmentErrorResponse.infer;
+
 export const InferenceTurnResponse = type({
   id: "string",
   sessionId: type("string").describe(

--- a/packages/types/src/sessions.ts
+++ b/packages/types/src/sessions.ts
@@ -28,13 +28,21 @@ export const SessionStatus = type({
 });
 export type SessionStatus = typeof SessionStatus.infer;
 
+// The schema validates structure only: a required mimeType, a required
+// string `data` carrying base64-encoded bytes, an optional name, and no
+// other keys. base64 validity, the MIME allowlist, and size limits are
+// enforced at the route boundary so it can emit ordered, per-index
+// structured errors (malformed_base64, disallowed_mime_type, oversize_*)
+// that an all-or-nothing schema validator cannot produce.
 export const SendMessage = type({
   content: "string",
   "attachments?": type({
-    type: "string",
-    url: "string",
-    "mimeType?": "string",
-  }).array(),
+    mimeType: "string",
+    data: "string",
+    "name?": "string",
+  })
+    .onUndeclaredKey("reject")
+    .array(),
 });
 
 export const MailResponse = type({

--- a/tests/inference/attachments-end-to-end.test.ts
+++ b/tests/inference/attachments-end-to-end.test.ts
@@ -1,0 +1,264 @@
+// End-to-end attachment pipe, parameterized over every shipped adapter.
+//
+// A conversation message with an image attachment is assembled exactly as
+// the session service assembles it, delivered through the real in-memory
+// transport, parsed back by the real `fetchFull` (NOT a hand-built
+// InboundMessage), turned into a ConversationTurn by the real
+// createInboundTurn, and marshaled by each real provider adapter. The test
+// asserts the original image bytes survive all the way to each adapter's
+// wire body.
+//
+// This is the only place the whole mime -> fetchFull -> turn -> adapter pipe
+// runs against real adapters at once: a future @intx/mime change that breaks
+// attachment assembly or parsing fails here for every adapter, which
+// per-adapter unit tests (mocking the upstream surface) cannot catch.
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { generateKeyPair, createNodeCrypto } from "@intx/crypto-node";
+import {
+  assembleSignedContent,
+  assembleMessage,
+  createDetachedSignatureFromProvider,
+  type MessageHeaders,
+} from "@intx/mime";
+import { createInMemoryTransport } from "@intx/mail-memory";
+import {
+  createInboundTurn,
+  createAnthropicAdapter,
+  createOpenAIAdapter,
+  createGoogleGenAIAdapter,
+} from "@intx/inference";
+import type { ProviderAdapter } from "@intx/inference";
+import { base64Encode } from "@intx/types";
+import type {
+  ConversationTurn,
+  InboundMessage,
+  LastCycleSource,
+  MessageAttachment,
+} from "@intx/types/runtime";
+
+const SENDER = "alpha@test.interchange";
+const AGENT = "beta@test.interchange";
+
+const imageBytes = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+const expectedBase64 = base64Encode(imageBytes);
+
+function conversationHeaders(): MessageHeaders {
+  return {
+    from: SENDER,
+    to: [AGENT],
+    cc: undefined,
+    date: new Date("2026-01-15T12:00:00Z"),
+    messageId: "<e2e-1@test.interchange>",
+    subject: undefined,
+    inReplyTo: undefined,
+    references: undefined,
+    mimeVersion: "1.0",
+    interchangeType: "conversation.message",
+    interchangeCorrelationId: undefined,
+    interchangeTenantId: undefined,
+    interchangeAgentId: undefined,
+    interchangeSessionId: undefined,
+    interchangeOfferingId: undefined,
+    interchangeSchemaVersion: undefined,
+    traceparent: undefined,
+    tracestate: undefined,
+  };
+}
+
+// Provider adapters and a token that proves the image was marshaled into the
+// provider's own image shape (Anthropic image block, OpenAI image_url,
+// Google inlineData).
+function source(name: string, model: string): LastCycleSource {
+  return { sourceId: `e2e-${name}`, provider: name, model };
+}
+
+const adapters: {
+  name: string;
+  adapter: ProviderAdapter;
+  model: string;
+  marker: string;
+}[] = [
+  {
+    name: "anthropic",
+    adapter: createAnthropicAdapter(
+      source("anthropic", "claude-3-5-sonnet-20241022"),
+    ),
+    model: "claude-3-5-sonnet-20241022",
+    marker: '"type":"image"',
+  },
+  {
+    name: "openai",
+    adapter: createOpenAIAdapter(source("openai", "gpt-4o")),
+    model: "gpt-4o",
+    marker: '"image_url"',
+  },
+  {
+    name: "google-genai",
+    adapter: createGoogleGenAIAdapter(
+      source("google-genai", "gemini-2.5-flash"),
+    ),
+    model: "gemini-2.5-flash",
+    marker: '"inlineData"',
+  },
+];
+
+// Assemble a conversation message carrying one attachment exactly as the
+// session service does, deliver it through the in-memory transport, and
+// reconstruct the inbound message and turn with the real fetchFull and
+// createInboundTurn.
+async function deliverAndBuild(
+  text: string,
+  attachment: MessageAttachment,
+): Promise<{ inbound: InboundMessage; turn: ConversationTurn }> {
+  const transport = createInMemoryTransport();
+  const senderCrypto = createNodeCrypto(await generateKeyPair());
+  const agentCrypto = createNodeCrypto(await generateKeyPair());
+  transport.register(SENDER, senderCrypto);
+  transport.register(AGENT, agentCrypto);
+
+  const content = assembleSignedContent({
+    kind: "conversation",
+    text,
+    attachments: [attachment],
+  });
+  const signature = await createDetachedSignatureFromProvider(
+    content,
+    senderCrypto,
+  );
+  const raw = assembleMessage(conversationHeaders(), content, signature);
+
+  transport.deliver(AGENT, raw);
+  const agentTransport = transport.getTransportFor(AGENT);
+  const refs = await agentTransport.search("INBOX", {});
+  const ref = refs[0];
+  if (refs.length !== 1 || ref === undefined) {
+    throw new Error("expected exactly one message");
+  }
+  const inbound = await agentTransport.fetchFull(ref);
+  const built = createInboundTurn(inbound);
+  if (built === null) throw new Error("expected a turn");
+  return { inbound, turn: built };
+}
+
+describe("attachment end-to-end: assemble -> fetchFull -> turn -> adapter", () => {
+  let inbound: InboundMessage;
+  let turn: ConversationTurn;
+
+  beforeAll(async () => {
+    ({ inbound, turn } = await deliverAndBuild("look at this", {
+      name: "shot.png",
+      contentType: "image/png",
+      data: imageBytes,
+    }));
+  });
+
+  test("fetchFull populates the attachment bytes (real parse)", () => {
+    expect(inbound.signatureStatus).toBe("valid");
+    expect(inbound.attachments).toEqual([
+      {
+        name: "shot.png",
+        contentType: "image/png",
+        data: imageBytes,
+      },
+    ]);
+  });
+
+  test("the turn carries a base64 ImageBlock with the original bytes", () => {
+    expect(turn).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: `[From: ${SENDER}]\n\nlook at this` },
+        {
+          type: "image",
+          source: {
+            kind: "base64",
+            mimeType: "image/png",
+            data: expectedBase64,
+          },
+        },
+      ],
+    });
+  });
+
+  for (const { name, adapter, model, marker } of adapters) {
+    test(`${name} adapter marshals the image bytes onto the wire`, () => {
+      const req = adapter.buildRequest([turn], model, {});
+      // The original bytes reach the provider wire as base64.
+      expect(req.body).toContain(expectedBase64);
+      // ...inside the provider's own image shape.
+      expect(req.body).toContain(marker);
+    });
+  }
+});
+
+// A PDF rides the same pipe as a DocumentBlock. Adapter document support is
+// uneven (Anthropic and Google marshal it; OpenAI does not yet emit document
+// blocks and rejects loudly) — so this asserts each adapter's actual behavior
+// rather than a uniform success.
+describe("attachment end-to-end: pdf document", () => {
+  const pdfBytes = new Uint8Array([
+    0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34,
+  ]); // "%PDF-1.4"
+  const pdfBase64 = base64Encode(pdfBytes);
+  let inbound: InboundMessage;
+  let turn: ConversationTurn;
+
+  beforeAll(async () => {
+    ({ inbound, turn } = await deliverAndBuild("see the report", {
+      name: "report.pdf",
+      contentType: "application/pdf",
+      data: pdfBytes,
+    }));
+  });
+
+  test("fetchFull populates the pdf bytes (real parse)", () => {
+    expect(inbound.attachments).toEqual([
+      { name: "report.pdf", contentType: "application/pdf", data: pdfBytes },
+    ]);
+  });
+
+  test("the turn carries a base64 DocumentBlock with the original pdf bytes", () => {
+    expect(turn).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: `[From: ${SENDER}]\n\nsee the report` },
+        {
+          type: "document",
+          source: {
+            kind: "base64",
+            mimeType: "application/pdf",
+            data: pdfBase64,
+          },
+        },
+      ],
+    });
+  });
+
+  test("anthropic marshals the pdf as a document block", () => {
+    const adapter = createAnthropicAdapter(
+      source("anthropic", "claude-3-5-sonnet-20241022"),
+    );
+    const req = adapter.buildRequest([turn], "claude-3-5-sonnet-20241022", {});
+    expect(req.body).toContain(pdfBase64);
+    expect(req.body).toContain('"type":"document"');
+  });
+
+  test("google marshals the pdf as inline data", () => {
+    const adapter = createGoogleGenAIAdapter(
+      source("google-genai", "gemini-2.5-flash"),
+    );
+    const req = adapter.buildRequest([turn], "gemini-2.5-flash", {});
+    expect(req.body).toContain(pdfBase64);
+    expect(req.body).toContain('"inlineData"');
+  });
+
+  test("openai rejects document blocks loudly (not yet wired)", () => {
+    const adapter = createOpenAIAdapter(source("openai", "gpt-4o"));
+    expect(() => adapter.buildRequest([turn], "gpt-4o", {})).toThrow(
+      /document/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- The mail route accepts base64-encoded attachment bytes, validates each
  against a MIME allowlist and per-attachment/per-message size limits, and
  forwards the decoded bytes to the agent. Rejections return ordered,
  per-index structured error codes.
- Conversation messages carry attachments inside the signed PGP/MIME
  envelope as a `multipart/mixed` body; received attachments are parsed
  back and mapped to the model content blocks each provider adapter
  marshals (image/video/audio by major type, documents by allowlist).
- An unmappable inbound attachment type degrades to a visible text marker
  rather than failing turn construction.

## Verification

- `make all` passes: lint, `tsc -b`, and tests (3386 + 313 tests, 0
  failures).
- An end-to-end test posts an image attachment, delivers it through the
  real transport `fetchFull`, builds the turn, and marshals it with each
  shipped adapter (Anthropic, OpenAI, Google), asserting the original
  bytes reach every provider's wire format.

Closes INTR-195