### PR TITLE
Fix from-scratch bring-up on main: make build and asset seed 409

### DIFF
--- a/examples/posix-demo/src/cli.ts
+++ b/examples/posix-demo/src/cli.ts
@@ -335,7 +335,8 @@ const betaDef = defineAgent({
 });
 
 const alphaEnv: MailEnv = {
-  source: alphaSource,
+  sources: [alphaSource],
+  defaultSource: alphaSource.id,
   storage: storageAlpha,
   workdir: alphaDir,
   audit: noopAuditStore(),
@@ -346,7 +347,8 @@ const alphaEnv: MailEnv = {
 };
 
 const betaEnv: MailEnv = {
-  source: betaSource,
+  sources: [betaSource],
+  defaultSource: betaSource.id,
   storage: storageBeta,
   workdir: betaDir,
   audit: noopAuditStore(),

--- a/examples/ring-demo/src/cli.ts
+++ b/examples/ring-demo/src/cli.ts
@@ -394,7 +394,8 @@ for (const [i, name] of AGENT_NAMES.entries()) {
   });
 
   const env: MailEnv = {
-    source,
+    sources: [source],
+    defaultSource: source.id,
     storage,
     workdir: join(TMP_ROOT, name),
     audit: noopAuditStore(),

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,9 @@
 export { createDB, type DB } from "./client";
+export {
+  pgErrorCode,
+  PG_UNIQUE_VIOLATION,
+  PG_FOREIGN_KEY_VIOLATION,
+} from "./pg-error";
 export type { DBConfig } from "./config";
 export { runMigrations, dropSchema } from "./migrate";
 export { createGrantStore } from "./grant-store";

--- a/packages/db/src/pg-error.ts
+++ b/packages/db/src/pg-error.ts
@@ -1,0 +1,21 @@
+import { hasCode } from "@intx/types";
+
+// Postgres SQLSTATE codes. https://www.postgresql.org/docs/current/errcodes-appendix.html
+export const PG_UNIQUE_VIOLATION = "23505";
+export const PG_FOREIGN_KEY_VIOLATION = "23503";
+
+// Extract a Postgres SQLSTATE from an error that a driver or ORM may have
+// wrapped. postgres-js sets the code on the error it throws; Drizzle
+// re-wraps that as the `cause` of a DrizzleQueryError, so the code can sit
+// one or more levels down the cause chain. Walk the chain (depth-bounded so
+// a self-referential cause cannot loop) and return the first code found.
+export function pgErrorCode(err: unknown): string | undefined {
+  let cur: unknown = err;
+  for (let depth = 0; cur != null && depth < 8; depth++) {
+    if (hasCode(cur)) {
+      return cur.code;
+    }
+    cur = (cur as { cause?: unknown }).cause;
+  }
+  return undefined;
+}

--- a/packages/hub-api/src/routes/assets.test.ts
+++ b/packages/hub-api/src/routes/assets.test.ts
@@ -145,10 +145,12 @@ function makeMockDB(state: DBState): DB["db"] {
                   existing.name === r.name,
               )
             ) {
-              const err = new Error(
+              const driverErr = new Error(
                 `duplicate key value violates unique constraint`,
               ) as Error & { code?: string };
-              err.code = "23505";
+              driverErr.code = "23505";
+              // Mirror Drizzle: the driver error is wrapped as `cause`.
+              const err = new Error("Failed query", { cause: driverErr });
               return {
                 returning: () => Promise.reject(err),
                 then: (_resolve: (v: undefined) => unknown) =>
@@ -711,10 +713,12 @@ function makeMultiTenantMockDB(state: MultiTenantState): DB["db"] {
         existing.name === row.name,
     );
     if (duplicate) {
-      const err = new Error(
+      const driverErr = new Error(
         `duplicate key value violates unique constraint`,
       ) as Error & { code?: string };
-      err.code = "23505";
+      driverErr.code = "23505";
+      // Mirror Drizzle: the driver error is wrapped as `cause`.
+      const err = new Error("Failed query", { cause: driverErr });
       return Promise.reject(err);
     }
     state.assets.push(row);

--- a/packages/hub-sessions/src/asset-service.test.ts
+++ b/packages/hub-sessions/src/asset-service.test.ts
@@ -26,9 +26,15 @@ import { skillKindHandler, skillAuthorize } from "./skill-kind";
 // Mirrors the mocking style used by hub-session-orchestrator.test.ts: a
 // minimal in-memory store routed by drizzle table identity. Captures the
 // rows passed to insert/values so the test can assert column-level shape,
-// and raises a typed Postgres unique-violation error (code "23505") to
+// and raises a typed Postgres unique-violation error (SQLSTATE "23505") to
 // exercise the AssetService's translation of duplicates into typed domain
 // errors.
+//
+// Drizzle does not surface the driver error directly: it wraps the
+// postgres-js error (which carries `code`) as the `cause` of a
+// DrizzleQueryError, so the SQLSTATE sits on `.cause`, not on the
+// top-level error. The violation fixtures mirror that wrapping so the
+// stub reproduces the shape the service must walk to find the code.
 //
 // The where-clauses passed by drizzle's `eq` are opaque values; rather
 // than inspect them, the stub exposes `nextFindFirstAssetId` and
@@ -56,17 +62,35 @@ type AgentAssetRow = {
   createdAt: Date;
 };
 
+// A postgres-js-style driver error: carries the SQLSTATE on `code`.
+class PostgresError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+// A DrizzleQueryError-style wrapper: the SQLSTATE lives on `.cause`, not on
+// the top-level error. This is the shape Drizzle actually throws, so the
+// service must walk the cause chain to recover the code.
 class UniqueViolation extends Error {
-  readonly code = "23505";
   constructor(constraint: string) {
-    super(`duplicate key value violates unique constraint "${constraint}"`);
+    const driver = new PostgresError(
+      "23505",
+      `duplicate key value violates unique constraint "${constraint}"`,
+    );
+    super(`Failed query: insert`, { cause: driver });
   }
 }
 
 class ForeignKeyViolation extends Error {
-  readonly code = "23503";
   constructor(constraint: string) {
-    super(`insert violates foreign key constraint "${constraint}"`);
+    const driver = new PostgresError(
+      "23503",
+      `insert violates foreign key constraint "${constraint}"`,
+    );
+    super(`Failed query: insert`, { cause: driver });
   }
 }
 
@@ -423,6 +447,51 @@ describe("AssetService", () => {
       if (!(err instanceof AssetServiceError)) throw new Error("unreachable");
       expect(err.reason).toBe("duplicate_asset");
       expect(dbFixture.assets).toHaveLength(1);
+    });
+
+    test("detects a unique violation whose SQLSTATE is nested under .cause", async () => {
+      // Regression guard for the DrizzleQueryError wrapping: Drizzle
+      // re-wraps the postgres-js driver error as its `.cause`, so the
+      // SQLSTATE never appears on the top-level error. A check that only
+      // inspected the top-level `code` would miss it and let the raw
+      // error escape as a 500. Build a db whose insert rejects with a
+      // multi-level wrapped error and assert the duplicate path still
+      // fires.
+      const wrapped = new Error("Failed query: insert into asset", {
+        cause: new Error("driver layer", {
+          cause: new PostgresError(
+            "23505",
+            'duplicate key value violates unique constraint "asset_tenant_kind_name"',
+          ),
+        }),
+      });
+      /* eslint-disable @typescript-eslint/no-unsafe-type-assertion --
+       * drizzle PgDatabase type cannot be structurally satisfied in tests */
+      const db = {
+        insert(_t: unknown) {
+          return {
+            values(_row: unknown) {
+              return {
+                returning: () => Promise.reject(wrapped),
+              };
+            },
+          };
+        },
+      } as unknown as DB["db"];
+      /* eslint-enable @typescript-eslint/no-unsafe-type-assertion */
+
+      const wrappedService = createAssetService({ db, repoStore });
+      const err = await wrappedService
+        .createAsset({
+          tenantId: "tnt_1",
+          kind: "skill",
+          name: "greet",
+        })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(AssetServiceError);
+      if (!(err instanceof AssetServiceError)) throw new Error("unreachable");
+      expect(err.reason).toBe("duplicate_asset");
     });
   });
 

--- a/packages/hub-sessions/src/asset-service.ts
+++ b/packages/hub-sessions/src/asset-service.ts
@@ -20,14 +20,18 @@
 import fs from "node:fs";
 import { asc, eq } from "drizzle-orm";
 import git from "isomorphic-git";
-import { type DB } from "@intx/db";
+import {
+  type DB,
+  pgErrorCode,
+  PG_UNIQUE_VIOLATION,
+  PG_FOREIGN_KEY_VIOLATION,
+} from "@intx/db";
 import {
   agentAsset as agentAssetTable,
   asset as assetTable,
 } from "@intx/db/schema";
 import { generateId } from "@intx/hub-common";
 import { getLogger } from "@intx/log";
-import { hasCode } from "@intx/types";
 import type { RepoKind } from "@intx/types/sidecar";
 
 import type {
@@ -38,11 +42,6 @@ import type {
 } from "./repo-store";
 
 const logger = getLogger(["hub-sessions", "asset-service"]);
-
-// Postgres SQLSTATE codes. drizzle / postgres-js surfaces the original
-// error with `code` set; `hasCode` narrows safely.
-const PG_UNIQUE_VIOLATION = "23505";
-const PG_FOREIGN_KEY_VIOLATION = "23503";
 
 export type Asset = {
   id: string;
@@ -377,7 +376,7 @@ export function createAssetService(deps: {
       }
       inserted = row;
     } catch (err) {
-      if (hasCode(err) && err.code === PG_UNIQUE_VIOLATION) {
+      if (pgErrorCode(err) === PG_UNIQUE_VIOLATION) {
         throw new AssetServiceError(
           "duplicate_asset",
           `asset (tenantId=${params.tenantId}, kind=${params.kind}, name=${params.name}) already exists`,
@@ -449,14 +448,14 @@ export function createAssetService(deps: {
       }
       inserted = row;
     } catch (err) {
-      if (hasCode(err) && err.code === PG_UNIQUE_VIOLATION) {
+      if (pgErrorCode(err) === PG_UNIQUE_VIOLATION) {
         throw new AssetServiceError(
           "duplicate_attachment",
           `agent_asset (agentId=${params.agentId}, assetId=${params.assetId}) already attached`,
           err,
         );
       }
-      if (hasCode(err) && err.code === PG_FOREIGN_KEY_VIOLATION) {
+      if (pgErrorCode(err) === PG_FOREIGN_KEY_VIOLATION) {
         throw new AssetServiceError(
           "invalid_reference",
           `agent_asset (agentId=${params.agentId}, assetId=${params.assetId}) references a missing agent or asset`,

--- a/packages/workflow-host/src/adapters/step-invoker.test.ts
+++ b/packages/workflow-host/src/adapters/step-invoker.test.ts
@@ -47,7 +47,8 @@ function stubBlobReader(): BlobReader {
 
 function stubBuildEnv(): StepEnvBase {
   return {
-    source: STUB_SOURCE,
+    sources: [STUB_SOURCE],
+    defaultSource: STUB_SOURCE.id,
     storage: stubContextStore(),
     workdir: "/tmp/workflow-step-invoker-stub",
     audit: noopAuditStore(),
@@ -128,6 +129,9 @@ function buildStubAgent(): StubAgentControl {
     },
     setSource(_source: InferenceSource) {
       throw new Error("stub setSource() not used");
+    },
+    setSources(_sources: InferenceSource[], _defaultSource: string) {
+      throw new Error("stub setSources() not used");
     },
     async history() {
       return [];


### PR DESCRIPTION
## Summary

- Restores a clean `make build` on `main`. An inference rename from a single `source` to an ordered `sources` list plus `defaultSource`, and a new `setSources` agent method, had left three consumers behind, so `tsc -b` failed.
- Fixes the documented quick-start `bin/db-reset && bun bin/dev.ts --seed`, which aborted with HTTP 500 during seeding. Duplicate asset inserts now map to 409 because the Postgres SQLSTATE is read from the Drizzle-wrapped error's `cause` chain instead of only the top-level error.

## Changes

- `examples/posix-demo/src/cli.ts`, `examples/ring-demo/src/cli.ts`, `packages/workflow-host/src/adapters/step-invoker.test.ts`: migrate each call site to `sources: [source]` + `defaultSource: source.id`, and add a `setSources` stub alongside the existing `setSource`. Test and example code only.
- `packages/db/src/pg-error.ts` (new): `pgErrorCode` walks the error `cause` chain (depth-bounded, reuses `hasCode`) and returns the first SQLSTATE found, plus the `PG_UNIQUE_VIOLATION` / `PG_FOREIGN_KEY_VIOLATION` constants. Lives in `@intx/db`, the package that owns Drizzle and the postgres driver.
- `packages/hub-sessions/src/asset-service.ts`: the three constraint-violation guards use `pgErrorCode`, keeping each `throw err` fall-through so unrecognized errors still surface.
- `packages/hub-sessions/src/asset-service.test.ts`, `packages/hub-api/src/routes/assets.test.ts`: fixtures nest the SQLSTATE under `cause` to mirror how Drizzle throws, with a regression test for the wrapped shape.

The seed itself is unchanged: its conflict-tolerant single POST is correct once the hub returns 409.

## Testing

- `make all` green: 3521 unit tests and 344 integration tests pass, 0 fail.
- Mutation check: reverting the guard to the old top-level-only check fails 4 tests, confirming the regression coverage is real.
- Live end-to-end: `bin/db-reset && bun bin/dev.ts --seed` completes a full seed; the `workspace-builtins` re-create returns 409 instead of 500.

Closes INTR-213