### PR TITLE
Wire the approval-flow publish step to the drafted output

### DIFF
--- a/bin/workflow-fixture.test.ts
+++ b/bin/workflow-fixture.test.ts
@@ -29,6 +29,13 @@ describe("workflow fixture", () => {
     expect(approval.name).toBe(WORKFLOW_FIXTURE_SIGNAL_NAME);
     expect(approval.after).toEqual(["draft"]);
     expect(publish?.after).toEqual(["approval"]);
+
+    // publish must consume the drafted content, not the approval node's
+    // signal payload. The default-input convention would wire it to
+    // `steps.approval.output` (the signal payload, `null` for a bare
+    // approval); the fixture overrides that to read the draft.
+    if (publish?.kind !== "step") throw new Error("unreachable");
+    expect(publish.input).toEqual({ from: "steps.draft.output" });
   });
 
   test("step-agents are authored inline with no catalog reference", () => {

--- a/bin/workflow-fixture.ts
+++ b/bin/workflow-fixture.ts
@@ -109,7 +109,17 @@ export function buildWorkflowFixture(): WorkflowDefinition {
         name: WORKFLOW_FIXTURE_SIGNAL_NAME,
         after: ["draft"],
       }),
-      publish: step({ agent: publishAgent, after: ["approval"] }),
+      // `publish` runs after `approval`, but it publishes the drafted
+      // content -- not the approval signal's payload. The default-input
+      // convention would wire a single-`after` step to its predecessor's
+      // output; the predecessor here is the `awaitSignal`, whose output
+      // is the signal payload (`null` for a bare approval). Reading the
+      // draft explicitly keeps the approved content flowing to publish.
+      publish: step({
+        agent: publishAgent,
+        after: ["approval"],
+        input: { from: "steps.draft.output" },
+      }),
     },
   });
 }


### PR DESCRIPTION
## Summary

- The seeded `approval-flow` workflow's publish step consumes the drafted release note via an explicit `steps.draft.output` input, rather than inheriting the default-input convention's wiring to the approval gate's signal payload.
- A fixture test asserts publish's input selector resolves to `{ from: "steps.draft.output" }`.

## Verification

- `make all` passes (lint, `tsc -b`, and both test passes; exits 0).
- The fixture still serializes and round-trips through `defineWorkflow` unchanged; publish reads the draft content instead of the null approval signal payload.

Closes INTR-223