### PR TITLE
Compact a terminated run's event files into one combined file

### DIFF
--- a/packages/hub-sessions/src/index.ts
+++ b/packages/hub-sessions/src/index.ts
@@ -132,6 +132,10 @@ export {
   type WorkflowRunReader,
   type WorkflowRunEvent,
 } from "./workflow-run-reader";
+export {
+  WORKFLOW_RUN_EVENTS_FILE,
+  splitCombinedEventLog,
+} from "./workflow-run-event-log";
 export type {
   AuthorizeFn,
   CreateRepoStoreConfig,

--- a/packages/hub-sessions/src/index.ts
+++ b/packages/hub-sessions/src/index.ts
@@ -137,6 +137,7 @@ export type {
   CreateRepoStoreConfig,
   InitRepoOpts,
   KindHandler,
+  NewlyTerminalRun,
   Principal,
   RefEntry,
   RepoAction,
@@ -145,5 +146,6 @@ export type {
   SubscribeKindEntry,
   SubscribeKindOpts,
   ValidatePushResult,
+  WriteResult,
 } from "./repo-store";
 export { createRepoStore, subscribeKind, UserPrincipal } from "./repo-store";

--- a/packages/hub-sessions/src/index.ts
+++ b/packages/hub-sessions/src/index.ts
@@ -135,6 +135,7 @@ export {
 export {
   WORKFLOW_RUN_EVENTS_FILE,
   splitCombinedEventLog,
+  encodeCombinedEventLog,
 } from "./workflow-run-event-log";
 export type {
   AuthorizeFn,

--- a/packages/hub-sessions/src/repo-store/index.ts
+++ b/packages/hub-sessions/src/repo-store/index.ts
@@ -2,6 +2,7 @@ export type {
   AuthorizeFn,
   InitRepoOpts,
   KindHandler,
+  NewlyTerminalRun,
   Principal,
   RefEntry,
   RepoAction,
@@ -11,6 +12,7 @@ export type {
   RepoStoreSubscribeEvent,
   TreeContent,
   ValidatePushResult,
+  WriteResult,
   WriteTreePreservingPrefixArgs,
 } from "./types";
 export { UserPrincipal } from "./types";

--- a/packages/hub-sessions/src/repo-store/sealed-run-subscribe-replay.test.ts
+++ b/packages/hub-sessions/src/repo-store/sealed-run-subscribe-replay.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect, afterAll, beforeAll } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type } from "arktype";
+import { generateKeyPair } from "@intx/crypto-node";
+import type { KeyPair } from "@intx/types/runtime";
+import { createRepoStore } from "./store";
+import { subscribeKind } from "./subscribe-kind";
+import { encodeCombinedEventLog } from "../workflow-run-event-log";
+import type {
+  AuthorizeFn,
+  KindHandler,
+  Principal,
+  RepoId,
+  ValidatePushResult,
+} from "./types";
+
+const tempDirs: string[] = [];
+async function makeTempDir(prefix: string): Promise<string> {
+  const d = await fs.promises.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(d);
+  return d;
+}
+
+let signingKey: KeyPair;
+beforeAll(async () => {
+  signingKey = await generateKeyPair();
+});
+afterAll(async () => {
+  for (const d of tempDirs.splice(0)) {
+    await fs.promises.rm(d, { recursive: true, force: true }).catch(() => {
+      /* best effort */
+    });
+  }
+});
+
+function permissive(): KindHandler {
+  return {
+    kind: "agent-state",
+    directoryPrefix: "repos-sealed-replay",
+    validatePush(): ValidatePushResult {
+      return { ok: true };
+    },
+    onRefUpdated() {
+      /* this test drives subscribe replay, not ref-update side effects */
+    },
+  };
+}
+
+const allowAll: AuthorizeFn = () => ({ allowed: true });
+const principal: Principal = { kind: "test" };
+const repoId: RepoId = { kind: "agent-state", id: "subject" };
+const REF = "refs/heads/test";
+
+const TimerFired = type({
+  type: "'TimerFired'",
+  seq: "number",
+  data: { timerId: "string" },
+});
+const RunCompleted = type({ type: "'RunCompleted'", seq: "number" });
+const Ev = TimerFired.or(RunCompleted);
+
+describe("subscribeKind replay over a sealed run", () => {
+  test("from seq 0 still emits every event after compaction drops events/", async () => {
+    const dataDir = await makeTempDir("sealed-replay-");
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": permissive() },
+      authorize: allowAll,
+    });
+
+    const blob0 = JSON.stringify({
+      type: "TimerFired",
+      seq: 0,
+      data: { timerId: "t0" },
+    });
+    const blob1 = JSON.stringify({
+      type: "TimerFired",
+      seq: 1,
+      data: { timerId: "t1" },
+    });
+    const blob2 = JSON.stringify({ type: "RunCompleted", seq: 2 });
+
+    await store.writeTree(principal, repoId, REF, {
+      files: { "runs/r1/events/0.json": blob0 },
+      message: "e0",
+    });
+    await store.writeTree(principal, repoId, REF, {
+      files: { "runs/r1/events/1.json": blob1 },
+      message: "e1",
+    });
+    await store.writeTree(principal, repoId, REF, {
+      files: { "runs/r1/events/2.json": blob2 },
+      message: "e2 terminal",
+    });
+
+    // Simulate compaction: clear events/ and write the combined file.
+    const combined = encodeCombinedEventLog([
+      new TextEncoder().encode(blob0),
+      new TextEncoder().encode(blob1),
+      new TextEncoder().encode(blob2),
+    ]);
+    await store.writeTree(principal, repoId, REF, {
+      files: { "runs/r1/events.jsonl": combined },
+      clearPrefix: "runs/r1/events/",
+      message: "compact r1",
+    });
+
+    // Confirm the tip really is sealed (events/ gone, events.jsonl present).
+    const dir = store.getRepoDir(repoId);
+    expect(fs.existsSync(path.join(dir, "runs/r1/events"))).toBe(false);
+    expect(fs.existsSync(path.join(dir, "runs/r1/events.jsonl"))).toBe(true);
+
+    const ac = new AbortController();
+    const iter = subscribeKind(store, principal, repoId, REF, Ev, {
+      signal: ac.signal,
+      from: { seq: 0 },
+      kinds: ["TimerFired", "RunCompleted"],
+    });
+
+    const seen: number[] = [];
+    const abortTimer = setTimeout(() => ac.abort(), 300);
+    try {
+      for await (const e of iter) {
+        seen.push(e.seq);
+        if (seen.length === 3) {
+          ac.abort();
+          break;
+        }
+      }
+    } catch {
+      /* aborted */
+    } finally {
+      clearTimeout(abortTimer);
+    }
+    // Replay walks historical commit diffs, so all three events emit even
+    // though the tip carries only the combined file.
+    expect(seen.sort((a, b) => a - b)).toEqual([0, 1, 2]);
+  });
+});

--- a/packages/hub-sessions/src/repo-store/store.test.ts
+++ b/packages/hub-sessions/src/repo-store/store.test.ts
@@ -361,6 +361,107 @@ describe("RepoStore", () => {
     expect(xPaths).toContain("b");
   });
 
+  test("interleaved writes to two refs of one repo never contaminate either ref's tree", async () => {
+    const dataDir = await makeTempDir("repo-store-ref-switch-");
+    const handler = createTestHandler();
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: allowAll,
+    });
+    const dir = path.join(dataDir, handler.directoryPrefix, repoId.id);
+
+    const REF_A = "refs/heads/alpha";
+    const REF_B = "refs/heads/beta";
+    const ROUNDS = 3;
+
+    // Each ref owns a disjoint nested top-level prefix and replaces its
+    // whole subtree every round, so a ref switch reconciles a non-trivial
+    // subtree each time. Both the interleaved run and the serial baseline
+    // below stage identical bytes through this, so equal content must
+    // yield equal tree oids unless a ref switch contaminates the tree.
+    const roundWrite = (topPrefix: string, round: number) => ({
+      files: {
+        [`${topPrefix}/state/${round}.json`]: `${topPrefix}-${round}`,
+        [`${topPrefix}/head`]: String(round),
+      },
+      clearPrefix: `${topPrefix}/`,
+      message: `${topPrefix} ${round}`,
+    });
+
+    const treeOf = async (commitSha: string): Promise<string> =>
+      (await git.readCommit({ fs, dir, oid: commitSha })).commit.tree;
+
+    const aTrees: string[] = [];
+    const bTrees: string[] = [];
+    for (let round = 0; round < ROUNDS; round++) {
+      const a = await store.writeTree(
+        principal,
+        repoId,
+        REF_A,
+        roundWrite("alpha", round),
+      );
+      const b = await store.writeTree(
+        principal,
+        repoId,
+        REF_B,
+        roundWrite("beta", round),
+      );
+      aTrees.push(await treeOf(a.commitSha));
+      bTrees.push(await treeOf(b.commitSha));
+    }
+
+    // Direct contamination check: each ref's tip tree carries ONLY its own
+    // top-level prefix. A switch that left stale cross-ref index entries
+    // would union the other ref's subtree into this commit's tree.
+    const aTip = await git.resolveRef({ fs, dir, ref: REF_A });
+    const bTip = await git.resolveRef({ fs, dir, ref: REF_B });
+    expect(await readTreePaths(dir, await treeOf(aTip))).toEqual(["alpha"]);
+    expect(await readTreePaths(dir, await treeOf(bTip))).toEqual(["beta"]);
+
+    // Equivalence to a serial single-ref baseline: writing only one ref's
+    // sequence into a fresh repo never switches refs, so its tree is
+    // contamination-free by construction. Equal tree oids prove the
+    // interleave reconstructed each ref's tree exactly. Tree oids are
+    // asserted rather than commit oids because the signer injects
+    // wall-clock and timezone into the commit, so commit oids are not
+    // reproducible across writes.
+    const serialTrees = async (topPrefix: string): Promise<string[]> => {
+      const baseDataDir = await makeTempDir("repo-store-ref-switch-base-");
+      const baseHandler = createTestHandler();
+      const baseStore = createRepoStore({
+        dataDir: baseDataDir,
+        signingKey,
+        handlers: { "agent-state": baseHandler },
+        authorize: allowAll,
+      });
+      const baseDir = path.join(
+        baseDataDir,
+        baseHandler.directoryPrefix,
+        repoId.id,
+      );
+      const ref = `refs/heads/${topPrefix}`;
+      const trees: string[] = [];
+      for (let round = 0; round < ROUNDS; round++) {
+        const r = await baseStore.writeTree(
+          principal,
+          repoId,
+          ref,
+          roundWrite(topPrefix, round),
+        );
+        trees.push(
+          (await git.readCommit({ fs, dir: baseDir, oid: r.commitSha })).commit
+            .tree,
+        );
+      }
+      return trees;
+    };
+
+    expect(aTrees).toEqual(await serialTrees("alpha"));
+    expect(bTrees).toEqual(await serialTrees("beta"));
+  });
+
   test("receivePack accepts a valid pack and rejects one failing validatePush", async () => {
     const sourceDataDir = await makeTempDir("repo-store-pack-source-");
     const sourceHandler = createTestHandler();

--- a/packages/hub-sessions/src/repo-store/store.ts
+++ b/packages/hub-sessions/src/repo-store/store.ts
@@ -23,6 +23,7 @@ import type {
   RepoStore,
   RepoStoreSubscribeEvent,
   TreeContent,
+  WriteResult,
   WriteTreePreservingPrefixArgs,
 } from "./types";
 import { SAFE_REPO_ID } from "./types";
@@ -933,7 +934,7 @@ export function createRepoStore(config: CreateRepoStoreConfig): RepoStore {
     repoId: RepoId,
     ref: string,
     content: TreeContent,
-  ): Promise<{ commitSha: string }> {
+  ): Promise<WriteResult> {
     const dir = repoDir(repoId);
     await storageInitRepo(dir, storageOptsFor(repoId, undefined));
 
@@ -1140,7 +1141,7 @@ export function createRepoStore(config: CreateRepoStoreConfig): RepoStore {
     await handler.onRefUpdated({ repoId, ref, oldSha, newSha: commitSha });
     await emitRefUpdate(repoId, ref, oldSha, commitSha);
 
-    return { commitSha };
+    return { commitSha, newlyTerminalRuns: validation.newlyTerminalRuns ?? [] };
   }
 
   async function writeTree(
@@ -1148,7 +1149,7 @@ export function createRepoStore(config: CreateRepoStoreConfig): RepoStore {
     repoId: RepoId,
     ref: string,
     content: TreeContent,
-  ): Promise<{ commitSha: string }> {
+  ): Promise<WriteResult> {
     gateAccess(principal, repoId, ref, "writeTree");
 
     // The lock spans the entire substrate body of writeTree: index
@@ -1218,7 +1219,7 @@ export function createRepoStore(config: CreateRepoStoreConfig): RepoStore {
     repoId: RepoId,
     ref: string,
     args: WriteTreePreservingPrefixArgs,
-  ): Promise<{ commitSha: string }> {
+  ): Promise<WriteResult> {
     gateAccess(principal, repoId, ref, "writeTree");
     validateClearPrefix(args.preservePrefix);
     return withRepoLock(repoId, async () => {

--- a/packages/hub-sessions/src/repo-store/types.ts
+++ b/packages/hub-sessions/src/repo-store/types.ts
@@ -82,7 +82,34 @@ export type AuthorizeFn = (
   action: RepoAction,
 ) => { allowed: true } | { allowed: false; reason: string };
 
-export type ValidatePushResult = { ok: true } | { ok: false; reason: string };
+/**
+ * A run whose terminal event (e.g. `RunCompleted`) is *newly added* by the
+ * commit under validation -- present in the prospective tree and absent from
+ * the prior tree. The kind handler authoritatively detects this during its
+ * validation walk and surfaces it so callers do not re-derive terminal-ness
+ * by sniffing committed path shapes. `terminalEventJson` carries the raw bytes
+ * of the terminal event blob so a caller can reconstruct the event without a
+ * second read. A commit that carries an already-terminal run forward
+ * unchanged (e.g. a later compaction commit) is NOT newly terminal and does
+ * not appear here.
+ */
+export type NewlyTerminalRun = { runId: string; terminalEventJson: string };
+
+export type ValidatePushResult =
+  | { ok: true; newlyTerminalRuns?: NewlyTerminalRun[] }
+  | { ok: false; reason: string };
+
+/**
+ * Result of a `writeTree` / `writeTreePreservingPrefix` commit. `commitSha` is
+ * the new commit. `newlyTerminalRuns` surfaces the kind handler's terminal
+ * detection (empty for handlers and commits that produce none) so callers can
+ * react to a run reaching a terminal event without re-deriving it from the
+ * committed path shape.
+ */
+export type WriteResult = {
+  commitSha: string;
+  newlyTerminalRuns: readonly NewlyTerminalRun[];
+};
 
 /**
  * Per-call options for `initRepo`. Currently a single override —
@@ -254,7 +281,7 @@ export interface RepoStore {
     repoId: RepoId,
     ref: string,
     content: TreeContent,
-  ): Promise<{ commitSha: string }>;
+  ): Promise<WriteResult>;
   /**
    * Read-then-write variant for use cases that mutate a single
    * directory subtree against its current contents (overwrite one
@@ -276,7 +303,7 @@ export interface RepoStore {
     repoId: RepoId,
     ref: string,
     args: WriteTreePreservingPrefixArgs,
-  ): Promise<{ commitSha: string }>;
+  ): Promise<WriteResult>;
   /**
    * Receive a packfile and advance `ref` to `commitSha`.
    *

--- a/packages/hub-sessions/src/session-service.test.ts
+++ b/packages/hub-sessions/src/session-service.test.ts
@@ -1492,7 +1492,10 @@ describe("deployWorkflowDefinition", () => {
           repoId,
           files: Object.keys(content.files),
         });
-        return { commitSha: "wfcommit" + "0".repeat(32) };
+        return {
+          commitSha: "wfcommit" + "0".repeat(32),
+          newlyTerminalRuns: [],
+        };
       },
     };
 

--- a/packages/hub-sessions/src/workflow-run-event-log.test.ts
+++ b/packages/hub-sessions/src/workflow-run-event-log.test.ts
@@ -1,6 +1,9 @@
 import { describe, test, expect } from "bun:test";
 
-import { splitCombinedEventLog } from "./workflow-run-event-log";
+import {
+  splitCombinedEventLog,
+  encodeCombinedEventLog,
+} from "./workflow-run-event-log";
 
 describe("splitCombinedEventLog", () => {
   test("returns no entries for an empty file", () => {
@@ -39,5 +42,32 @@ describe("splitCombinedEventLog", () => {
     ];
     const combined = perEvent.join("\n") + "\n";
     expect(splitCombinedEventLog(combined)).toEqual(perEvent);
+  });
+});
+
+describe("encodeCombinedEventLog", () => {
+  const enc = new TextEncoder();
+  const dec = new TextDecoder();
+
+  test("concatenates each blob followed by a newline", () => {
+    const out = encodeCombinedEventLog([
+      enc.encode('{"seq":0}'),
+      enc.encode('{"seq":1}'),
+    ]);
+    expect(dec.decode(out)).toBe('{"seq":0}\n{"seq":1}\n');
+  });
+
+  test("an empty input yields an empty file", () => {
+    expect(encodeCombinedEventLog([]).byteLength).toBe(0);
+  });
+
+  test("preserves the exact blob bytes with no decode round-trip", () => {
+    // A byte sequence that decoding would normalise (a lone 0x80 maps to
+    // U+FFFD): the encoder must carry it verbatim, since events are signed
+    // over their own bytes.
+    const blob = new Uint8Array([0x7b, 0x80, 0x7d]);
+    expect(Array.from(encodeCombinedEventLog([blob]))).toEqual([
+      0x7b, 0x80, 0x7d, 0x0a,
+    ]);
   });
 });

--- a/packages/hub-sessions/src/workflow-run-event-log.test.ts
+++ b/packages/hub-sessions/src/workflow-run-event-log.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "bun:test";
+
+import { splitCombinedEventLog } from "./workflow-run-event-log";
+
+describe("splitCombinedEventLog", () => {
+  test("returns no entries for an empty file", () => {
+    expect(splitCombinedEventLog("")).toEqual([]);
+  });
+
+  test("splits one event per line and drops the trailing newline", () => {
+    const combined = ['{"seq":0}', '{"seq":1}', '{"seq":2}'].join("\n") + "\n";
+    expect(splitCombinedEventLog(combined)).toEqual([
+      '{"seq":0}',
+      '{"seq":1}',
+      '{"seq":2}',
+    ]);
+  });
+
+  test("keeps the last line when there is no trailing newline", () => {
+    expect(splitCombinedEventLog('{"seq":0}\n{"seq":1}')).toEqual([
+      '{"seq":0}',
+      '{"seq":1}',
+    ]);
+  });
+
+  test("drops blank interior lines rather than yielding empty entries", () => {
+    expect(splitCombinedEventLog('{"seq":0}\n\n{"seq":1}\n')).toEqual([
+      '{"seq":0}',
+      '{"seq":1}',
+    ]);
+  });
+
+  test("round-trips the verbatim per-event bytes the writer joins", () => {
+    // Each line is the exact text a per-event blob held; JSON.stringify
+    // never emits a literal newline, so a line split is a faithful inverse.
+    const perEvent = [
+      JSON.stringify({ seq: 0, type: "RunStarted", note: "a\nb" }),
+      JSON.stringify({ seq: 1, type: "RunCompleted" }),
+    ];
+    const combined = perEvent.join("\n") + "\n";
+    expect(splitCombinedEventLog(combined)).toEqual(perEvent);
+  });
+});

--- a/packages/hub-sessions/src/workflow-run-event-log.ts
+++ b/packages/hub-sessions/src/workflow-run-event-log.ts
@@ -1,0 +1,27 @@
+// The sealed-form event log for a terminated run. Compaction folds a run's
+// per-event `runs/<runId>/events/<seq>.json` blobs into a single combined
+// file, `runs/<runId>/events.jsonl`, once the run reaches a terminal event.
+// Each line of the combined file is the verbatim text of the per-event blob
+// it replaced, in seq order, so the fold is a byte-for-byte transition that
+// the workflow-run kind handler can validate against the prior per-event
+// tree. Readers handle both shapes: per-event files for in-flight runs, the
+// combined file for sealed (terminal) runs.
+
+/** Filename of a run's combined event log, a sibling of its `events/` dir. */
+export const WORKFLOW_RUN_EVENTS_FILE = "events.jsonl";
+
+/**
+ * Split a combined event-log file's content into the per-event JSON texts it
+ * holds, in file order. Each non-empty line is the verbatim text of what was
+ * an `events/<seq>.json` blob; the trailing newline yields no extra entry.
+ * Event JSON never contains a literal newline (JSON escapes them), so a line
+ * split is a faithful inverse of the encode side.
+ */
+export function splitCombinedEventLog(content: string): string[] {
+  const out: string[] = [];
+  for (const line of content.split("\n")) {
+    if (line.length === 0) continue;
+    out.push(line);
+  }
+  return out;
+}

--- a/packages/hub-sessions/src/workflow-run-event-log.ts
+++ b/packages/hub-sessions/src/workflow-run-event-log.ts
@@ -25,3 +25,30 @@ export function splitCombinedEventLog(content: string): string[] {
   }
   return out;
 }
+
+/**
+ * Join per-event blobs (in seq order) into a combined event-log file: each
+ * blob's exact bytes followed by a newline. Operating on bytes -- not
+ * decoded strings -- keeps the sealed file a *verbatim* concatenation of
+ * the per-event blobs, which matters because each event is signed over its
+ * own bytes; a decode/re-encode round-trip could alter them. This is the
+ * single source of the combined-file byte layout shared by the compaction
+ * writer and the validator's byte-equality bridge, so the two cannot
+ * drift. An empty input yields an empty file.
+ */
+export function encodeCombinedEventLog(
+  perEventBlobs: readonly Uint8Array[],
+): Uint8Array {
+  const NEWLINE = 0x0a;
+  let total = 0;
+  for (const blob of perEventBlobs) total += blob.byteLength + 1;
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const blob of perEventBlobs) {
+    out.set(blob, offset);
+    offset += blob.byteLength;
+    out[offset] = NEWLINE;
+    offset += 1;
+  }
+  return out;
+}

--- a/packages/hub-sessions/src/workflow-run-kind.test.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.test.ts
@@ -350,6 +350,122 @@ describe("workflowRunKindHandler.validatePush — accepts", () => {
   });
 });
 
+describe("workflowRunKindHandler.validatePush — newly-terminal signal", () => {
+  test("reports a run whose terminal event is newly added by this commit", async () => {
+    const r = await validate({
+      [WORKFLOW_RUN_GITIGNORE_PATH]: "",
+      [`${WORKFLOW_RUN_RUNS_PREFIX}/run-a/events/0.json`]: eventBody(
+        0,
+        "RunStarted",
+      ),
+      [`${WORKFLOW_RUN_RUNS_PREFIX}/run-a/events/1.json`]: eventBody(
+        1,
+        "RunCompleted",
+      ),
+    });
+    if (!r.ok) throw new Error(`expected ok, got: ${r.reason}`);
+    expect(r.newlyTerminalRuns).toEqual([
+      { runId: "run-a", terminalEventJson: eventBody(1, "RunCompleted") },
+    ]);
+  });
+
+  test("reports no terminal run for a commit that adds only non-terminal events", async () => {
+    const r = await validate({
+      [WORKFLOW_RUN_GITIGNORE_PATH]: "",
+      [`${WORKFLOW_RUN_RUNS_PREFIX}/run-a/events/0.json`]: eventBody(
+        0,
+        "RunStarted",
+      ),
+    });
+    if (!r.ok) throw new Error(`expected ok, got: ${r.reason}`);
+    expect(r.newlyTerminalRuns ?? []).toEqual([]);
+  });
+
+  test("does not re-report a terminal event already present in the prior tree", async () => {
+    const files = {
+      [WORKFLOW_RUN_GITIGNORE_PATH]: "",
+      [`${WORKFLOW_RUN_RUNS_PREFIX}/run-a/events/0.json`]: eventBody(
+        0,
+        "RunStarted",
+      ),
+      [`${WORKFLOW_RUN_RUNS_PREFIX}/run-a/events/1.json`]: eventBody(
+        1,
+        "RunCompleted",
+      ),
+    };
+    // The prior tree already carries the terminal event, so a no-op
+    // re-validation -- and a later compaction commit that folds the
+    // events forward -- must not re-fire the signal.
+    const r = await validate(files, { priorFiles: files });
+    if (!r.ok) throw new Error(`expected ok, got: ${r.reason}`);
+    expect(r.newlyTerminalRuns ?? []).toEqual([]);
+  });
+
+  test("reports every run whose terminal event is newly added in one commit", async () => {
+    const r = await validate({
+      [WORKFLOW_RUN_GITIGNORE_PATH]: "",
+      [`${WORKFLOW_RUN_RUNS_PREFIX}/run-a/events/0.json`]: eventBody(
+        0,
+        "RunStarted",
+      ),
+      [`${WORKFLOW_RUN_RUNS_PREFIX}/run-a/events/1.json`]: eventBody(
+        1,
+        "RunCompleted",
+      ),
+      [`${WORKFLOW_RUN_RUNS_PREFIX}/run-b/events/0.json`]: eventBody(
+        0,
+        "RunStarted",
+      ),
+      [`${WORKFLOW_RUN_RUNS_PREFIX}/run-b/events/1.json`]: eventBody(
+        1,
+        "RunCancelled",
+      ),
+    });
+    if (!r.ok) throw new Error(`expected ok, got: ${r.reason}`);
+    expect(r.newlyTerminalRuns).toEqual(
+      expect.arrayContaining([
+        { runId: "run-a", terminalEventJson: eventBody(1, "RunCompleted") },
+        { runId: "run-b", terminalEventJson: eventBody(1, "RunCancelled") },
+      ]),
+    );
+    expect(r.newlyTerminalRuns ?? []).toHaveLength(2);
+  });
+
+  test("reports only the run whose terminal event is new when another is carried forward", async () => {
+    const carried = {
+      [`${WORKFLOW_RUN_RUNS_PREFIX}/run-a/events/0.json`]: eventBody(
+        0,
+        "RunStarted",
+      ),
+      [`${WORKFLOW_RUN_RUNS_PREFIX}/run-a/events/1.json`]: eventBody(
+        1,
+        "RunCompleted",
+      ),
+    };
+    // run-a's terminal event is already in the prior tree (carried
+    // forward unchanged); only run-b's newly added terminal must fire.
+    const r = await validate(
+      {
+        [WORKFLOW_RUN_GITIGNORE_PATH]: "",
+        ...carried,
+        [`${WORKFLOW_RUN_RUNS_PREFIX}/run-b/events/0.json`]: eventBody(
+          0,
+          "RunStarted",
+        ),
+        [`${WORKFLOW_RUN_RUNS_PREFIX}/run-b/events/1.json`]: eventBody(
+          1,
+          "RunCompleted",
+        ),
+      },
+      { priorFiles: { [WORKFLOW_RUN_GITIGNORE_PATH]: "", ...carried } },
+    );
+    if (!r.ok) throw new Error(`expected ok, got: ${r.reason}`);
+    expect(r.newlyTerminalRuns).toEqual([
+      { runId: "run-b", terminalEventJson: eventBody(1, "RunCompleted") },
+    ]);
+  });
+});
+
 describe("workflowRunKindHandler.validatePush — rejects top-level shape", () => {
   test("rejects any path under control/ (unsupported subtree)", async () => {
     const r = await validate({

--- a/packages/hub-sessions/src/workflow-run-kind.test.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.test.ts
@@ -466,6 +466,168 @@ describe("workflowRunKindHandler.validatePush — newly-terminal signal", () => 
   });
 });
 
+describe("workflowRunKindHandler.validatePush — compaction (events.jsonl)", () => {
+  const RUN = "run-a";
+  const eventsDir = `${WORKFLOW_RUN_RUNS_PREFIX}/${RUN}/events`;
+  const combinedPath = `${WORKFLOW_RUN_RUNS_PREFIX}/${RUN}/events.jsonl`;
+  const e0 = eventBody(0, "RunStarted");
+  const e1 = eventBody(1, "RunCompleted");
+  const perEventPrior: Record<string, string> = {
+    [WORKFLOW_RUN_GITIGNORE_PATH]: "",
+    [`${eventsDir}/0.json`]: e0,
+    [`${eventsDir}/1.json`]: e1,
+  };
+  const fold = (...lines: string[]) => lines.join("\n") + "\n";
+
+  test("accepts a faithful byte-for-byte fold of the prior per-event files", async () => {
+    const r = await validate(
+      { [WORKFLOW_RUN_GITIGNORE_PATH]: "", [combinedPath]: fold(e0, e1) },
+      { priorFiles: perEventPrior },
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test("rejects a fold that mutates a historical event's bytes", async () => {
+    const tampered = fold(e0.replace("}", ',"tampered":1}'), e1);
+    const r = await validate(
+      { [WORKFLOW_RUN_GITIGNORE_PATH]: "", [combinedPath]: tampered },
+      { priorFiles: perEventPrior },
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.reason).toMatch(/does not fold its prior events verbatim/);
+  });
+
+  test("rejects a fold that drops a prior event", async () => {
+    const r = await validate(
+      { [WORKFLOW_RUN_GITIGNORE_PATH]: "", [combinedPath]: fold(e1) },
+      { priorFiles: perEventPrior },
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.reason).toMatch(/does not fold its prior events verbatim/);
+  });
+
+  test("rejects a fold that adds an event not in the prior tree", async () => {
+    const extra = fold(
+      e0,
+      eventBody(1, "StepStarted"),
+      eventBody(2, "RunCompleted"),
+    );
+    const r = await validate(
+      { [WORKFLOW_RUN_GITIGNORE_PATH]: "", [combinedPath]: extra },
+      { priorFiles: perEventPrior },
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.reason).toMatch(/does not fold its prior events verbatim/);
+  });
+
+  test("rejects a run carrying both a combined file and a per-event directory", async () => {
+    const r = await validate(
+      {
+        [WORKFLOW_RUN_GITIGNORE_PATH]: "",
+        [combinedPath]: fold(e0, e1),
+        [`${eventsDir}/0.json`]: e0,
+        [`${eventsDir}/1.json`]: e1,
+      },
+      { priorFiles: perEventPrior },
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.reason).toMatch(/carries both/);
+  });
+
+  test("a re-pushed sealed run is immutable", async () => {
+    const sealedPrior = {
+      [WORKFLOW_RUN_GITIGNORE_PATH]: "",
+      [combinedPath]: fold(e0, e1),
+    };
+    const unchanged = await validate(
+      { [WORKFLOW_RUN_GITIGNORE_PATH]: "", [combinedPath]: fold(e0, e1) },
+      { priorFiles: sealedPrior },
+    );
+    expect(unchanged.ok).toBe(true);
+    const mutated = await validate(
+      {
+        [WORKFLOW_RUN_GITIGNORE_PATH]: "",
+        [combinedPath]: fold(e0.replace("}", ',"x":1}'), e1),
+      },
+      { priorFiles: sealedPrior },
+    );
+    expect(mutated.ok).toBe(false);
+  });
+
+  test("rejects a freshly-sealed run with no terminal event", async () => {
+    const r = await validate({
+      [WORKFLOW_RUN_GITIGNORE_PATH]: "",
+      [combinedPath]: fold(
+        eventBody(0, "RunStarted"),
+        eventBody(1, "StepStarted"),
+      ),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.reason).toMatch(/no terminal event/);
+  });
+
+  test("the compaction commit reports no newly-terminal run", async () => {
+    const r = await validate(
+      { [WORKFLOW_RUN_GITIGNORE_PATH]: "", [combinedPath]: fold(e0, e1) },
+      { priorFiles: perEventPrior },
+    );
+    if (!r.ok) throw new Error(`expected ok, got: ${r.reason}`);
+    expect(r.newlyTerminalRuns ?? []).toEqual([]);
+  });
+
+  test("rejects a fold whose bytes differ from the prior blobs even if it decodes to the same content", async () => {
+    // The fold gate is BYTE equality, not decoded-string equality: each
+    // event is signed over its own bytes, so a sealed file that merely
+    // decodes to the prior content (here, a UTF-8 BOM prepended to the true
+    // fold) must be rejected. The string-based `validate` harness cannot
+    // express this, so drive the handler with raw bytes.
+    const enc = new TextEncoder();
+    const prospectiveKeys: Record<string, string> = {
+      [WORKFLOW_RUN_GITIGNORE_PATH]: "",
+      [combinedPath]: "",
+    };
+    const priorKeys: Record<string, string> = {
+      [WORKFLOW_RUN_GITIGNORE_PATH]: "",
+      [`${eventsDir}/0.json`]: "",
+      [`${eventsDir}/1.json`]: "",
+    };
+    const priorBytes: Record<string, Uint8Array> = {
+      [WORKFLOW_RUN_GITIGNORE_PATH]: enc.encode(""),
+      [`${eventsDir}/0.json`]: enc.encode(e0),
+      [`${eventsDir}/1.json`]: enc.encode(e1),
+    };
+    const trueFold = enc.encode(`${e0}\n${e1}\n`);
+    const bomFold = new Uint8Array([0xef, 0xbb, 0xbf, ...trueFold]);
+    const prospectiveBytes: Record<string, Uint8Array> = {
+      [WORKFLOW_RUN_GITIGNORE_PATH]: enc.encode(""),
+      [combinedPath]: bomFold,
+    };
+    const r = await workflowRunKindHandler.validatePush({
+      repoId: uniqueRepoId("wfr"),
+      ref: REF,
+      principal: HUB_PRINCIPAL,
+      topLevelTreePaths: topLevels(prospectiveKeys),
+      readBlob: async (p) => {
+        const b = prospectiveBytes[p];
+        if (b === undefined) throw new Error(`readBlob: ${p} not found`);
+        return b;
+      },
+      listDir: makeListDir(prospectiveKeys),
+      priorReadBlob: async (p) => priorBytes[p] ?? null,
+      priorListDir: makeListDir(priorKeys),
+      changedPathPrefixes: undefined,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.reason).toMatch(/does not fold its prior events verbatim/);
+  });
+});
+
 describe("workflowRunKindHandler.validatePush — rejects top-level shape", () => {
   test("rejects any path under control/ (unsupported subtree)", async () => {
     const r = await validate({

--- a/packages/hub-sessions/src/workflow-run-kind.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.ts
@@ -181,6 +181,11 @@ import {
   type RepoStore,
   type ValidatePushResult,
 } from "./repo-store";
+import {
+  WORKFLOW_RUN_EVENTS_FILE,
+  splitCombinedEventLog,
+  encodeCombinedEventLog,
+} from "./workflow-run-event-log";
 
 const logger = getLogger(["hub-sessions", "workflow-run-kind"]);
 
@@ -304,6 +309,9 @@ const BLOB_FILENAME_RE = /^[0-9a-f]{64}$/;
 const RUN_DIR_ALLOWED_CHILDREN = new Set<string>([
   WORKFLOW_RUN_EVENTS_DIR,
   WORKFLOW_RUN_BLOBS_DIR,
+  // A terminated run's event log, sealed from the per-event `events/`
+  // files into one combined file by a compaction commit.
+  WORKFLOW_RUN_EVENTS_FILE,
 ]);
 
 /**
@@ -549,10 +557,21 @@ async function enumerateEventBlobs(
     if (offender !== undefined) {
       return {
         ok: false,
-        reason: `run directory ${runDirPath} contains unexpected entry ${JSON.stringify(offender)}; only "${WORKFLOW_RUN_EVENTS_DIR}" and "${WORKFLOW_RUN_BLOBS_DIR}" are allowed`,
+        reason: `run directory ${runDirPath} contains unexpected entry ${JSON.stringify(offender)}; only "${WORKFLOW_RUN_EVENTS_DIR}", "${WORKFLOW_RUN_BLOBS_DIR}", and "${WORKFLOW_RUN_EVENTS_FILE}" are allowed`,
       };
     }
-    if (!runChildren.includes(WORKFLOW_RUN_EVENTS_DIR)) {
+    const hasCombined = runChildren.includes(WORKFLOW_RUN_EVENTS_FILE);
+    const hasPerEvent = runChildren.includes(WORKFLOW_RUN_EVENTS_DIR);
+    if (hasCombined && hasPerEvent) {
+      return {
+        ok: false,
+        reason: `run directory ${runDirPath} carries both a combined "${WORKFLOW_RUN_EVENTS_FILE}" and a per-event "${WORKFLOW_RUN_EVENTS_DIR}" subtree`,
+      };
+    }
+    // A sealed (combined) run carries no per-event entries; it is validated
+    // by the combined-form path, not this per-event enumeration.
+    if (hasCombined) continue;
+    if (!hasPerEvent) {
       return {
         ok: false,
         reason: `run directory ${runDirPath} is missing required "${WORKFLOW_RUN_EVENTS_DIR}" subdirectory`,
@@ -587,6 +606,194 @@ async function enumerateEventBlobs(
     runs.set(runId, entries);
   }
   return { ok: true, runs };
+}
+
+/**
+ * Validate the prospective tree's combined-form (sealed) runs and return
+ * the set of run ids that legitimately carry a combined `events.jsonl`.
+ * The deletion-direction guard uses that set to allow a run's per-event
+ * files to disappear when (and only when) they were folded into the
+ * combined file under this same validation.
+ *
+ * Three prior states are accepted:
+ *   - prior already combined  -> the sealed file is immutable; prospective
+ *     bytes must equal prior bytes.
+ *   - prior per-event         -> the compaction transition; the combined
+ *     file must be the byte-for-byte fold of the prior per-event blobs in
+ *     seq order. This is the audit-integrity boundary: a loose check here
+ *     would let compaction silently rewrite history.
+ *   - prior absent            -> a freshly-delivered sealed run (e.g. a
+ *     pack receive); its own structure is validated.
+ */
+async function validateCombinedEventRuns(
+  listDir: (path: string) => Promise<string[]>,
+  readBlob: (path: string) => Promise<Uint8Array>,
+  priorListDir: (path: string) => Promise<string[]>,
+  priorReadBlob: (path: string) => Promise<Uint8Array | null>,
+  scopeRunIds: ReadonlySet<string> | undefined,
+): Promise<
+  { ok: true; combinedRunIds: Set<string> } | { ok: false; reason: string }
+> {
+  const combinedRunIds = new Set<string>();
+  const runIds =
+    scopeRunIds === undefined
+      ? await listDir(WORKFLOW_RUN_RUNS_PREFIX)
+      : Array.from(scopeRunIds);
+  for (const runId of runIds) {
+    const runDirPath = `${WORKFLOW_RUN_RUNS_PREFIX}/${runId}`;
+    const children = await listDir(runDirPath);
+    if (!children.includes(WORKFLOW_RUN_EVENTS_FILE)) continue;
+    const combinedPath = `${runDirPath}/${WORKFLOW_RUN_EVENTS_FILE}`;
+    const combinedBytes = await readBlob(combinedPath);
+    const content = new TextDecoder().decode(combinedBytes);
+
+    const priorChildren = await priorListDir(runDirPath);
+    if (priorChildren.includes(WORKFLOW_RUN_EVENTS_FILE)) {
+      // Sealed once, immutable thereafter.
+      const immutable = await checkPriorByteEquality(
+        combinedPath,
+        readBlob,
+        priorReadBlob,
+      );
+      if (!immutable.ok) return immutable;
+    } else if (priorChildren.includes(WORKFLOW_RUN_EVENTS_DIR)) {
+      const structure = checkCombinedStructure(runId, combinedPath, content);
+      if (!structure.ok) return structure;
+      const fold = await checkCompactionFold(
+        runId,
+        runDirPath,
+        combinedBytes,
+        priorListDir,
+        priorReadBlob,
+      );
+      if (!fold.ok) return fold;
+    } else {
+      const structure = checkCombinedStructure(runId, combinedPath, content);
+      if (!structure.ok) return structure;
+    }
+    combinedRunIds.add(runId);
+  }
+  return { ok: true, combinedRunIds };
+}
+
+/**
+ * The audit-integrity bridge. A compaction commit replaces a run's prior
+ * `events/<seq>.json` files with one combined file; this asserts the
+ * combined file reproduces those prior blobs' bytes verbatim, in seq
+ * order, with nothing added, dropped, reordered, or mutated. It rebuilds
+ * the expected combined bytes from the prior tree through the same encoder
+ * the writer uses, so the two cannot drift, and compares for exact
+ * equality.
+ */
+async function checkCompactionFold(
+  runId: string,
+  runDirPath: string,
+  combinedBytes: Uint8Array,
+  priorListDir: (path: string) => Promise<string[]>,
+  priorReadBlob: (path: string) => Promise<Uint8Array | null>,
+): Promise<ValidatePushResult> {
+  const priorEventsDir = `${runDirPath}/${WORKFLOW_RUN_EVENTS_DIR}`;
+  const priorEntries: { seq: number; path: string }[] = [];
+  for (const filename of await priorListDir(priorEventsDir)) {
+    const match = EVENT_FILENAME_RE.exec(filename);
+    if (match === null || match[1] === undefined) {
+      return {
+        ok: false,
+        reason: `prior event filename ${priorEventsDir}/${filename} does not match <seq>.json; cannot validate compaction of run ${runId}`,
+      };
+    }
+    priorEntries.push({
+      seq: Number.parseInt(match[1], 10),
+      path: `${priorEventsDir}/${filename}`,
+    });
+  }
+  priorEntries.sort((a, b) => a.seq - b.seq);
+  const priorBlobs: Uint8Array[] = [];
+  for (const entry of priorEntries) {
+    const bytes = await priorReadBlob(entry.path);
+    if (bytes === null) {
+      return {
+        ok: false,
+        reason: `prior event ${entry.path} is unreadable; cannot validate compaction of run ${runId}`,
+      };
+    }
+    priorBlobs.push(bytes);
+  }
+  // Byte equality, not decoded-string equality: each event is signed over
+  // its own bytes, so the sealed file must be the verbatim concatenation
+  // of the prior blobs, not merely decode-equivalent to it.
+  const expected = encodeCombinedEventLog(priorBlobs);
+  const sameBytes =
+    combinedBytes.byteLength === expected.byteLength &&
+    combinedBytes.every((b, i) => b === expected[i]);
+  if (!sameBytes) {
+    return {
+      ok: false,
+      reason: `run ${runId} compaction does not fold its prior events verbatim: ${runDirPath}/${WORKFLOW_RUN_EVENTS_FILE} must equal the run's prior events/<seq>.json blobs joined in seq order`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Validate a combined event log's own structure: every line a valid event
+ * envelope, contiguous seqs, exactly one terminal event and it is last
+ * (so a sealed run is genuinely terminal). Used for a sealed run with no
+ * prior per-event form to bridge against.
+ */
+function checkCombinedStructure(
+  runId: string,
+  combinedPath: string,
+  content: string,
+): ValidatePushResult {
+  const lines = splitCombinedEventLog(content);
+  if (lines.length === 0) {
+    return { ok: false, reason: `combined event log ${combinedPath} is empty` };
+  }
+  let baseSeq: number | null = null;
+  let terminalSeq: number | null = null;
+  for (const [i, line] of lines.entries()) {
+    let body: unknown;
+    try {
+      body = JSON.parse(line);
+    } catch {
+      return {
+        ok: false,
+        reason: `combined event log ${combinedPath} line ${String(i)} is not valid JSON`,
+      };
+    }
+    const validated = EventEnvelope(body);
+    if (validated instanceof type.errors) {
+      return {
+        ok: false,
+        reason: `combined event log ${combinedPath} line ${String(i)} envelope invalid: ${validated.summary}`,
+      };
+    }
+    if (baseSeq === null) {
+      baseSeq = validated.seq;
+    } else if (validated.seq !== baseSeq + i) {
+      return {
+        ok: false,
+        reason: `combined event log ${combinedPath} has a sequence gap at line ${String(i)} (expected seq ${String(baseSeq + i)}, got ${String(validated.seq)})`,
+      };
+    }
+    if (terminalSeq !== null) {
+      return {
+        ok: false,
+        reason: `combined event log ${combinedPath} has an event at seq ${String(validated.seq)} after terminal at seq ${String(terminalSeq)}`,
+      };
+    }
+    if (TERMINAL_EVENT_TYPES.has(validated.type)) {
+      terminalSeq = validated.seq;
+    }
+  }
+  if (terminalSeq === null) {
+    return {
+      ok: false,
+      reason: `combined event log ${combinedPath} for run ${runId} has no terminal event; only a terminated run is sealed`,
+    };
+  }
+  return { ok: true };
 }
 
 type RunBlobEntry = {
@@ -1815,6 +2022,18 @@ export const workflowRunKindHandler: KindHandler = {
       }
     }
 
+    const combinedRuns = await validateCombinedEventRuns(
+      listDir,
+      readBlob,
+      priorListDir,
+      priorReadBlob,
+      scopeRunIds,
+    );
+    if (!combinedRuns.ok) {
+      logger.debug`workflow-run validatePush rejected ${repoId.kind}/${repoId.id} on ${ref}: ${combinedRuns.reason}`;
+      return { ok: false, reason: combinedRuns.reason };
+    }
+
     const blobsEnumerated = await enumerateRunBlobs(listDir, scopeRunIds);
     if (!blobsEnumerated.ok) {
       logger.debug`workflow-run validatePush rejected ${repoId.kind}/${repoId.id} on ${ref}: ${blobsEnumerated.reason}`;
@@ -1856,6 +2075,10 @@ export const workflowRunKindHandler: KindHandler = {
     for (const entries of priorEnumerated.runs.values()) {
       for (const e of entries) {
         if (prospectiveEventPaths.has(e.blobPath)) continue;
+        // A run sealed into its combined events.jsonl by this commit
+        // legitimately drops its per-event files; the fold was validated
+        // byte-for-byte against these same prior blobs above.
+        if (combinedRuns.combinedRunIds.has(e.runId)) continue;
         return {
           ok: false,
           reason: `event ${e.blobPath} present in the prior tree is missing from the prospective tree; event blobs are append-only`,

--- a/packages/hub-sessions/src/workflow-run-kind.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.ts
@@ -175,6 +175,7 @@ import {
   UserPrincipal,
   type AuthorizeFn,
   type KindHandler,
+  type NewlyTerminalRun,
   type Principal,
   type RepoId,
   type RepoStore,
@@ -1719,6 +1720,7 @@ export const workflowRunKindHandler: KindHandler = {
       return { ok: false, reason: enumerated.reason };
     }
 
+    const newlyTerminalRuns: NewlyTerminalRun[] = [];
     for (const [runId, entries] of enumerated.runs) {
       if (entries.length === 0) {
         return {
@@ -1794,6 +1796,21 @@ export const workflowRunKindHandler: KindHandler = {
         if (TERMINAL_EVENT_TYPES.has(parsed.parsed.body.type)) {
           terminalSeq = entry.filenameSeq;
           terminalType = parsed.parsed.body.type;
+          // Surface the run as newly terminal only when this commit is
+          // the one that ADDS the terminal event -- i.e. the terminal
+          // blob is absent from the prior tree. A commit that carries an
+          // already-terminal run forward unchanged (a later compaction
+          // commit folding the per-event files into one) finds the
+          // terminal blob already present in the prior tree and emits no
+          // signal, so a downstream consumer keyed on the signal does
+          // not double-fire.
+          if ((await priorReadBlob(entry.blobPath)) === null) {
+            const terminalBytes = await readBlob(entry.blobPath);
+            newlyTerminalRuns.push({
+              runId,
+              terminalEventJson: new TextDecoder().decode(terminalBytes),
+            });
+          }
         }
       }
     }
@@ -1866,7 +1883,7 @@ export const workflowRunKindHandler: KindHandler = {
       };
     }
 
-    return { ok: true };
+    return { ok: true, newlyTerminalRuns };
   },
   onRefUpdated() {
     // No cached index today. Consumers read events through the

--- a/packages/hub-sessions/src/workflow-run-reader.test.ts
+++ b/packages/hub-sessions/src/workflow-run-reader.test.ts
@@ -98,6 +98,42 @@ describe("WorkflowRunReader", () => {
     });
   });
 
+  test("reads a combined events.jsonl identically to per-event files", async () => {
+    const events = [
+      { seq: 0, type: "RunStarted", consumedMessageId: "m1" },
+      { seq: 1, type: "SignalAwaited", name: "approve" },
+      { seq: 2, type: "RunCompleted" },
+    ];
+    // run-a holds the per-event form; run-b holds the same events folded
+    // into one `events.jsonl` -- each line the verbatim per-event JSON, in
+    // seq order, with a trailing newline -- the shape the writer produces.
+    const perEvent: Record<string, string> = {};
+    for (const e of events) {
+      perEvent[`runs/run-a/events/${e.seq}.json`] = JSON.stringify(e);
+    }
+    const combined = events.map((e) => JSON.stringify(e)).join("\n") + "\n";
+    await commitFiles(dir, {
+      ...perEvent,
+      "runs/run-b/events.jsonl": combined,
+    });
+
+    const fromPerEvent = await reader.readRunEvents(REPO_ID, REF, "run-a");
+    const fromCombined = await reader.readRunEvents(REPO_ID, REF, "run-b");
+
+    const shape = (e: { seq: number; type: string; body: unknown }) => ({
+      seq: e.seq,
+      type: e.type,
+      body: e.body,
+    });
+    expect(fromCombined.map(shape)).toEqual(fromPerEvent.map(shape));
+    expect(fromCombined.map((e) => e.seq)).toEqual([0, 1, 2]);
+    expect(fromCombined.map((e) => e.type)).toEqual([
+      "RunStarted",
+      "SignalAwaited",
+      "RunCompleted",
+    ]);
+  });
+
   test("ignores non-event blobs in the events dir", async () => {
     await commitFiles(dir, {
       "runs/run-1/events/0.json": JSON.stringify({ type: "RunStarted" }),

--- a/packages/hub-sessions/src/workflow-run-reader.ts
+++ b/packages/hub-sessions/src/workflow-run-reader.ts
@@ -7,6 +7,10 @@ import {
   WORKFLOW_RUN_EVENTS_DIR,
   WORKFLOW_RUN_RUNS_PREFIX,
 } from "./workflow-run-kind";
+import {
+  WORKFLOW_RUN_EVENTS_FILE,
+  splitCombinedEventLog,
+} from "./workflow-run-event-log";
 
 /**
  * A workflow-run event as committed under
@@ -125,7 +129,43 @@ export function createWorkflowRunReader(
     if (dir === null) return [];
     const oid = await resolveRefOrNull(dir, ref);
     if (oid === null) return [];
-    const eventsDir = `${WORKFLOW_RUN_RUNS_PREFIX}/${runId}/${WORKFLOW_RUN_EVENTS_DIR}`;
+    const runDir = `${WORKFLOW_RUN_RUNS_PREFIX}/${runId}`;
+    let runTree: Awaited<ReturnType<typeof git.readTree>>;
+    try {
+      runTree = await git.readTree({ fs, dir, oid, filepath: runDir });
+    } catch (cause) {
+      if (cause instanceof git.Errors.NotFoundError) return [];
+      throw cause;
+    }
+    // A terminated run is sealed into a single combined `events.jsonl`;
+    // an in-flight run keeps per-event `events/<seq>.json` files. The two
+    // forms are mutually exclusive in a run directory; a run carrying both
+    // is a botched seal, and silently preferring one would mask it, so
+    // surface it instead.
+    const combined = runTree.tree.find(
+      (e) => e.type === "blob" && e.path === WORKFLOW_RUN_EVENTS_FILE,
+    );
+    const perEventDir = runTree.tree.find(
+      (e) => e.type === "tree" && e.path === WORKFLOW_RUN_EVENTS_DIR,
+    );
+    if (combined !== undefined && perEventDir !== undefined) {
+      throw new Error(
+        `workflow-run reader: run ${runId} carries both a combined ${WORKFLOW_RUN_EVENTS_FILE} and a per-event ${WORKFLOW_RUN_EVENTS_DIR}/ directory`,
+      );
+    }
+    if (combined !== undefined) {
+      const blob = await git.readBlob({ fs, dir, oid: combined.oid });
+      const source = `${runDir}/${WORKFLOW_RUN_EVENTS_FILE}`;
+      const events: WorkflowRunEvent[] = [];
+      for (const line of splitCombinedEventLog(
+        new TextDecoder().decode(blob.blob),
+      )) {
+        events.push(parseRunEventLine(line, source));
+      }
+      events.sort((a, b) => a.seq - b.seq);
+      return events;
+    }
+    const eventsDir = `${runDir}/${WORKFLOW_RUN_EVENTS_DIR}`;
     let tree: Awaited<ReturnType<typeof git.readTree>>;
     try {
       tree = await git.readTree({ fs, dir, oid, filepath: eventsDir });
@@ -140,27 +180,67 @@ export function createWorkflowRunReader(
       if (m === null || m[1] === undefined) continue;
       const seq = Number.parseInt(m[1], 10);
       const blob = await git.readBlob({ fs, dir, oid: entry.oid });
-      const parsed: unknown = JSON.parse(new TextDecoder().decode(blob.blob));
-      if (
-        typeof parsed !== "object" ||
-        parsed === null ||
-        Array.isArray(parsed)
-      ) {
-        throw new Error(
-          `workflow-run reader: event at ${entry.path} is not a JSON object`,
-        );
-      }
-      const body: Record<string, unknown> = { ...parsed };
-      const type = body["type"];
+      const path = `${eventsDir}/${entry.path}`;
+      const parsed = parseEventObject(
+        new TextDecoder().decode(blob.blob),
+        path,
+      );
+      const type = parsed["type"];
       if (typeof type !== "string") {
         throw new Error(
-          `workflow-run reader: event at ${entry.path} is missing a string \`type\` field`,
+          `workflow-run reader: event at ${path} is missing a string \`type\` field`,
         );
       }
-      events.push({ seq, type, body });
+      // The per-event form carries the seq in the filename; when the body
+      // also carries one, the two must agree (the combined form reads the
+      // seq from the body, so a disagreement would make the forms diverge).
+      const bodySeq = parsed["seq"];
+      if (typeof bodySeq === "number" && bodySeq !== seq) {
+        throw new Error(
+          `workflow-run reader: event at ${path} body seq ${String(bodySeq)} does not match filename seq ${String(seq)}`,
+        );
+      }
+      events.push({ seq, type, body: parsed });
     }
     events.sort((a, b) => a.seq - b.seq);
     return events;
+  }
+
+  // Parse one combined-log line (the verbatim text of a former
+  // `events/<seq>.json` blob): the seq is read from the body, since the
+  // combined form drops the per-event filename that carried it.
+  function parseRunEventLine(line: string, source: string): WorkflowRunEvent {
+    const parsed = parseEventObject(line, source);
+    const seq = parsed["seq"];
+    const type = parsed["type"];
+    if (typeof seq !== "number") {
+      throw new Error(
+        `workflow-run reader: event in ${source} is missing a numeric \`seq\` field`,
+      );
+    }
+    if (typeof type !== "string") {
+      throw new Error(
+        `workflow-run reader: event in ${source} is missing a string \`type\` field`,
+      );
+    }
+    return { seq, type, body: parsed };
+  }
+
+  function parseEventObject(
+    text: string,
+    source: string,
+  ): Record<string, unknown> {
+    const parsed: unknown = JSON.parse(text);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      throw new Error(
+        `workflow-run reader: event at ${source} is not a JSON object`,
+      );
+    }
+    return { ...parsed };
   }
 
   return { listRunIds, readRunEvents };

--- a/packages/workflow-host/src/adapters/repo-store.test.ts
+++ b/packages/workflow-host/src/adapters/repo-store.test.ts
@@ -119,6 +119,60 @@ describe("workflow-host RepoStore adapter — happy path", () => {
     expect(events[1]?.seq).toBe(2);
   });
 
+  test("read folds a combined events.jsonl identically to the per-event files", async () => {
+    const dataDir = await makeTempDir("repo-store-adapter-combined-");
+    const repoId: RepoId = { kind: "workflow-run", id: "deployment-combined" };
+    const substrate = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "workflow-run": workflowRunKindHandler },
+      authorize: allowAll,
+    });
+    await substrate.writeTree({ kind: "hub" }, repoId, REF, {
+      files: { [WORKFLOW_RUN_GITIGNORE_PATH]: "" },
+      message: "genesis",
+    });
+    const adapter = createWorkflowRunRepoStore({
+      substrate,
+      repoId,
+      principal: WORKFLOW_PROCESS_PRINCIPAL,
+      ref: REF,
+    });
+
+    const perEventRun = "run-perevent";
+    await adapter.append(perEventRun, freshRunStarted(perEventRun, 1));
+    await adapter.append(perEventRun, freshStepStarted(2));
+
+    // Fold the per-event run's on-disk blobs into a sibling run's combined
+    // events.jsonl -- byte-for-byte, one line per event in seq order, with
+    // a trailing newline -- the exact shape the compaction writer produces.
+    const dir = substrate.getRepoDir(repoId);
+    const fsp = await import("node:fs/promises");
+    const eventsDir = path.join(dir, "runs", perEventRun, "events");
+    const names = (await fsp.readdir(eventsDir))
+      .filter((n) => /^(0|[1-9][0-9]*)\.json$/.test(n))
+      .sort((a, b) => Number.parseInt(a, 10) - Number.parseInt(b, 10));
+    const lines: string[] = [];
+    for (const n of names) {
+      lines.push(await fsp.readFile(path.join(eventsDir, n), "utf8"));
+    }
+    const combinedRun = "run-combined";
+    await fsp.mkdir(path.join(dir, "runs", combinedRun), { recursive: true });
+    await fsp.writeFile(
+      path.join(dir, "runs", combinedRun, "events.jsonl"),
+      lines.join("\n") + "\n",
+    );
+
+    const fromPerEvent = await adapter.read(perEventRun);
+    const fromCombined = await adapter.read(combinedRun);
+    expect(fromCombined).toEqual(fromPerEvent);
+    expect(fromCombined.map((e) => e.kind)).toEqual([
+      "RunStarted",
+      "StepStarted",
+    ]);
+    expect(fromCombined.map((e) => e.seq)).toEqual([1, 2]);
+  });
+
   test("on-disk envelope carries top-level seq and type matching the workflow-run kind handler contract", async () => {
     const dataDir = await makeTempDir("repo-store-adapter-envelope-");
     const repoId: RepoId = { kind: "workflow-run", id: "deployment-envelope" };

--- a/packages/workflow-host/src/adapters/repo-store.ts
+++ b/packages/workflow-host/src/adapters/repo-store.ts
@@ -34,7 +34,11 @@ import type {
   RepoId,
   RepoStore as SubstrateRepoStore,
 } from "@intx/hub-sessions";
-import { subscribeKind } from "@intx/hub-sessions";
+import {
+  subscribeKind,
+  WORKFLOW_RUN_EVENTS_FILE,
+  splitCombinedEventLog,
+} from "@intx/hub-sessions";
 import type { RepoStore, WorkflowEvent } from "@intx/workflow";
 
 /**
@@ -157,7 +161,52 @@ async function readAllEventsForRun(
   const fs = await import("node:fs/promises");
   const path = await import("node:path");
   const dir = opts.substrate.getRepoDir(opts.repoId);
-  const eventsDir = path.join(dir, RUNS_PREFIX, runId, EVENTS_DIR);
+  const runDir = path.join(dir, RUNS_PREFIX, runId);
+  const entries: { seq: number; event: WorkflowEvent }[] = [];
+
+  // A terminated run is sealed into a single combined `events.jsonl`; an
+  // in-flight run keeps per-event `events/<seq>.json` files. The combined
+  // file's presence selects the read path; the two forms are mutually
+  // exclusive in a run directory.
+  let combinedRaw: string | null;
+  try {
+    combinedRaw = await fs.readFile(
+      path.join(runDir, WORKFLOW_RUN_EVENTS_FILE),
+      "utf8",
+    );
+  } catch (cause) {
+    if (!isErrnoNotFound(cause)) throw cause;
+    combinedRaw = null;
+  }
+  if (combinedRaw !== null) {
+    // The two forms are mutually exclusive; a run carrying both is a
+    // botched seal, and silently reading only the combined file would
+    // mask it, so surface it instead.
+    let perEventPresent = false;
+    try {
+      await fs.access(path.join(runDir, EVENTS_DIR));
+      perEventPresent = true;
+    } catch (cause) {
+      if (!isErrnoNotFound(cause)) throw cause;
+    }
+    if (perEventPresent) {
+      throw new Error(
+        `workflow-runtime: run ${runId} carries both a combined ${WORKFLOW_RUN_EVENTS_FILE} and a per-event ${EVENTS_DIR}/ directory`,
+      );
+    }
+    for (const line of splitCombinedEventLog(combinedRaw)) {
+      entries.push(
+        parseEventEnvelope(
+          line,
+          `${opts.repoId.id}/${runId}/${WORKFLOW_RUN_EVENTS_FILE}`,
+        ),
+      );
+    }
+    entries.sort((a, b) => a.seq - b.seq);
+    return entries.map((e) => e.event);
+  }
+
+  const eventsDir = path.join(runDir, EVENTS_DIR);
   let filenames: string[];
   try {
     filenames = await fs.readdir(eventsDir);
@@ -165,7 +214,6 @@ async function readAllEventsForRun(
     if (isErrnoNotFound(cause)) return [];
     throw cause;
   }
-  const entries: { seq: number; event: WorkflowEvent }[] = [];
   for (const name of filenames) {
     const match = EVENT_FILENAME_RE.exec(name);
     if (match === null) continue;
@@ -173,33 +221,42 @@ async function readAllEventsForRun(
     if (seqStr === undefined) continue;
     const seqFromName = Number.parseInt(seqStr, 10);
     const raw = await fs.readFile(path.join(eventsDir, name), "utf8");
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch (cause) {
+    const source = `${opts.repoId.id}/${runId}/${EVENTS_DIR}/${name}`;
+    const entry = parseEventEnvelope(raw, source);
+    if (entry.seq !== seqFromName) {
       throw new Error(
-        `workflow-runtime: read ${opts.repoId.id}/${runId}/${EVENTS_DIR}/${name} is not valid JSON`,
-        { cause },
+        `workflow-runtime: read ${source} body.seq ${String(entry.seq)} does not match filename seq ${String(seqFromName)}`,
       );
     }
-    const envelope = OnDiskEnvelope(parsed);
-    if (envelope instanceof type.errors) {
-      throw new Error(
-        `workflow-runtime: read ${opts.repoId.id}/${runId}/${EVENTS_DIR}/${name} envelope invalid: ${envelope.summary}`,
-      );
-    }
-    if (envelope.seq !== seqFromName) {
-      throw new Error(
-        `workflow-runtime: read ${opts.repoId.id}/${runId}/${EVENTS_DIR}/${name} body.seq ${String(envelope.seq)} does not match filename seq ${String(seqFromName)}`,
-      );
-    }
-    entries.push({
-      seq: envelope.seq,
-      event: onDiskToWorkflowEvent(envelope),
-    });
+    entries.push(entry);
   }
   entries.sort((a, b) => a.seq - b.seq);
   return entries.map((e) => e.event);
+}
+
+// Parse one on-disk event envelope -- a per-event file's bytes or one line
+// of a combined `events.jsonl` (which holds the same bytes verbatim). The
+// per-event caller additionally cross-checks the seq against the filename;
+// the combined form carries the seq only in the body.
+function parseEventEnvelope(
+  raw: string,
+  source: string,
+): { seq: number; event: WorkflowEvent } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (cause) {
+    throw new Error(`workflow-runtime: read ${source} is not valid JSON`, {
+      cause,
+    });
+  }
+  const envelope = OnDiskEnvelope(parsed);
+  if (envelope instanceof type.errors) {
+    throw new Error(
+      `workflow-runtime: read ${source} envelope invalid: ${envelope.summary}`,
+    );
+  }
+  return { seq: envelope.seq, event: onDiskToWorkflowEvent(envelope) };
 }
 
 /**

--- a/packages/workflow-host/src/child/proxy-repo-store.ts
+++ b/packages/workflow-host/src/child/proxy-repo-store.ts
@@ -32,6 +32,7 @@ import type {
   Principal,
   RepoId,
   RepoStore,
+  WriteResult,
 } from "@intx/hub-sessions";
 
 import type { ChildSubstrateWriteBridge } from "./substrate-write-bridge";
@@ -148,7 +149,7 @@ export function createProxyWorkflowRunRepoStore(
       _repoId: RepoId,
       _ref: string,
       _content: WriteTreeArgs,
-    ): Promise<{ commitSha: string }> => {
+    ): Promise<WriteResult> => {
       throw new Error(
         "workflow-child proxy substrate: writeTree is not supported (writes are proxied to the supervisor)",
       );
@@ -170,7 +171,7 @@ export function createProxyWorkflowRunRepoStore(
       repoId: RepoId,
       ref: string,
       args: WriteTreePreservingPrefixArgs,
-    ): Promise<{ commitSha: string }> {
+    ): Promise<WriteResult> {
       if (
         repoId.kind !== workflowRunRepoId.kind ||
         repoId.id !== workflowRunRepoId.id
@@ -192,7 +193,10 @@ export function createProxyWorkflowRunRepoStore(
       });
       lastSha.set(key, result.commitSha);
       notifyRefUpdate(repoId, ref, priorSha, result.commitSha);
-      return result;
+      // The terminal signal is consumed supervisor-side (where the real
+      // substrate write happens); the child-proxied result carries only
+      // the commit, so report no terminal runs to the runtime body.
+      return { commitSha: result.commitSha, newlyTerminalRuns: [] };
     },
     createPack: bareStore.createPack.bind(bareStore),
     resolveRef: bareStore.resolveRef.bind(bareStore),

--- a/packages/workflow-host/src/child/run-child.test.ts
+++ b/packages/workflow-host/src/child/run-child.test.ts
@@ -164,7 +164,7 @@ function createStubRepoStore(baseDir: string): RepoStore {
       return path.join(baseDir, repoId.kind, repoId.id);
     },
     async writeTreePreservingPrefix(_principal, _repoId, _ref, _args) {
-      return { commitSha: "deadbeefcafef00d" };
+      return { commitSha: "deadbeefcafef00d", newlyTerminalRuns: [] };
     },
   };
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub; missing methods surface as a precise failure via the proxy

--- a/packages/workflow-host/src/seams/scheduler.ts
+++ b/packages/workflow-host/src/seams/scheduler.ts
@@ -386,7 +386,10 @@ type RawEventRecord = {
 /**
  * Walk the workflow-run repo's `runs/<runId>/events/<seq>.json`
  * subtree at the current ref tip and return every event blob's
- * payload, attributed to its run.
+ * payload, attributed to its run. A terminated run whose events have
+ * been compacted into a combined `events.jsonl` (no `events/` subtree)
+ * is skipped: this walk recovers pending timers, and a terminated run
+ * has none.
  */
 async function enumerateEventBlobs(
   opts: SchedulerOpts,

--- a/packages/workflow-host/src/supervisor/drain-timeout.test.ts
+++ b/packages/workflow-host/src/supervisor/drain-timeout.test.ts
@@ -59,7 +59,7 @@ function createStubRepoStore(opts: {
       const existing = new Map<string, Uint8Array>();
       const files = await args.merge(existing);
       opts.onWrite?.({ principal, repoId, ref, files });
-      return { commitSha: "deadbeefcafef00d" };
+      return { commitSha: "deadbeefcafef00d", newlyTerminalRuns: [] };
     },
   };
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub; only the subset the accumulator invokes is implemented

--- a/packages/workflow-host/src/supervisor/lifecycle-races.test.ts
+++ b/packages/workflow-host/src/supervisor/lifecycle-races.test.ts
@@ -182,7 +182,7 @@ function createStubRepoStore(baseDir: string): RepoStore {
       return path.join(baseDir, repoId.kind, repoId.id);
     },
     async writeTreePreservingPrefix(_principal, _repoId, _ref, _args) {
-      return { commitSha: "deadbeefcafef00d" };
+      return { commitSha: "deadbeefcafef00d", newlyTerminalRuns: [] };
     },
   };
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub; missing methods surface a precise failure via the proxy

--- a/packages/workflow-host/src/supervisor/recycle.test.ts
+++ b/packages/workflow-host/src/supervisor/recycle.test.ts
@@ -212,7 +212,7 @@ function createStubRepoStore(baseDir: string): RepoStore {
       return path.join(baseDir, repoId.kind, repoId.id);
     },
     async writeTreePreservingPrefix(_principal, _repoId, _ref, _args) {
-      return { commitSha: "deadbeefcafef00d" };
+      return { commitSha: "deadbeefcafef00d", newlyTerminalRuns: [] };
     },
   };
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub; missing methods surface as a precise failure via the proxy

--- a/packages/workflow-host/src/supervisor/run-event-signing.test.ts
+++ b/packages/workflow-host/src/supervisor/run-event-signing.test.ts
@@ -1,0 +1,285 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { generateKeyPair } from "@intx/crypto-node";
+import type { KeyPair } from "@intx/types/runtime";
+import {
+  createRepoStore,
+  createWorkflowRunReader,
+  workflowRunKindHandler,
+  WORKFLOW_RUN_GITIGNORE_PATH,
+} from "@intx/hub-sessions";
+import type {
+  AuthorizeFn,
+  RepoId,
+  WorkflowRunSupervisorPrincipal,
+} from "@intx/hub-sessions";
+
+import { compactRunEvents } from "./run-event-signing";
+
+const REF = "refs/heads/main";
+const allowAll: AuthorizeFn = () => ({ allowed: true });
+
+const tempDirs: string[] = [];
+let signingKey: KeyPair;
+
+beforeAll(async () => {
+  signingKey = await generateKeyPair();
+});
+afterAll(async () => {
+  for (const d of tempDirs.splice(0)) {
+    await fs.promises.rm(d, { recursive: true, force: true }).catch(() => {
+      /* best effort */
+    });
+  }
+});
+async function makeTempDir(prefix: string): Promise<string> {
+  const d = await fs.promises.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(d);
+  return d;
+}
+
+function ev(seq: number, type: string): string {
+  return JSON.stringify({ seq, type, runId: "run-1" });
+}
+
+async function setup(deploymentId: string) {
+  const dataDir = await makeTempDir("compact-");
+  const repoId: RepoId = { kind: "workflow-run", id: deploymentId };
+  const substrate = createRepoStore({
+    dataDir,
+    signingKey,
+    handlers: { "workflow-run": workflowRunKindHandler },
+    authorize: allowAll,
+  });
+  await substrate.writeTree({ kind: "hub" }, repoId, REF, {
+    files: { [WORKFLOW_RUN_GITIGNORE_PATH]: "" },
+    message: "genesis",
+  });
+  const supervisor: WorkflowRunSupervisorPrincipal = {
+    kind: "supervisor",
+    deploymentId,
+  };
+  const eventsDir = () =>
+    path.join(substrate.getRepoDir(repoId), "runs", "run-1", "events");
+  return { repoId, substrate, supervisor, deploymentId, eventsDir };
+}
+
+describe("compactRunEvents", () => {
+  test("folds a terminated run's events into one combined file", async () => {
+    const { repoId, substrate, supervisor, deploymentId, eventsDir } =
+      await setup("dep-1");
+    await substrate.writeTreePreservingPrefix(supervisor, repoId, REF, {
+      preservePrefix: "runs/run-1/events/",
+      merge: async () => ({
+        "runs/run-1/events/0.json": ev(0, "RunStarted"),
+        "runs/run-1/events/1.json": ev(1, "RunCompleted"),
+      }),
+      message: "seed events",
+    });
+    expect((await fs.promises.readdir(eventsDir())).sort()).toEqual([
+      "0.json",
+      "1.json",
+    ]);
+
+    const result = await compactRunEvents({
+      substrate,
+      repoId,
+      ref: REF,
+      deploymentId,
+      runId: "run-1",
+    });
+    expect(result.compacted).toBe(true);
+
+    // The per-event directory is gone; the combined file holds the verbatim
+    // fold of the per-event blobs.
+    await expect(fs.promises.readdir(eventsDir())).rejects.toThrow();
+    const combined = await fs.promises.readFile(
+      path.join(substrate.getRepoDir(repoId), "runs", "run-1", "events.jsonl"),
+      "utf8",
+    );
+    expect(combined).toBe(`${ev(0, "RunStarted")}\n${ev(1, "RunCompleted")}\n`);
+
+    // The committed tree still reads back the same events through the reader.
+    const reader = createWorkflowRunReader(substrate);
+    const events = await reader.readRunEvents(repoId, REF, "run-1");
+    expect(events.map((e) => [e.seq, e.type])).toEqual([
+      [0, "RunStarted"],
+      [1, "RunCompleted"],
+    ]);
+
+    // Idempotent: a second seal is a no-op.
+    const again = await compactRunEvents({
+      substrate,
+      repoId,
+      ref: REF,
+      deploymentId,
+      runId: "run-1",
+    });
+    expect(again.compacted).toBe(false);
+  });
+
+  test("leaves an in-flight (non-terminal) run untouched", async () => {
+    const { repoId, substrate, supervisor, deploymentId, eventsDir } =
+      await setup("dep-2");
+    await substrate.writeTreePreservingPrefix(supervisor, repoId, REF, {
+      preservePrefix: "runs/run-1/events/",
+      merge: async () => ({ "runs/run-1/events/0.json": ev(0, "RunStarted") }),
+      message: "seed",
+    });
+
+    const result = await compactRunEvents({
+      substrate,
+      repoId,
+      ref: REF,
+      deploymentId,
+      runId: "run-1",
+    });
+    expect(result.compacted).toBe(false);
+    expect((await fs.promises.readdir(eventsDir())).sort()).toEqual(["0.json"]);
+  });
+
+  test("two concurrent seals do not destroy the combined file", async () => {
+    const { repoId, substrate, supervisor, deploymentId } =
+      await setup("dep-concurrent");
+    await substrate.writeTreePreservingPrefix(supervisor, repoId, REF, {
+      preservePrefix: "runs/run-1/events/",
+      merge: async () => ({
+        "runs/run-1/events/0.json": ev(0, "RunStarted"),
+        "runs/run-1/events/1.json": ev(1, "RunCompleted"),
+      }),
+      message: "seed events",
+    });
+
+    const calls = {
+      substrate,
+      repoId,
+      ref: REF,
+      deploymentId,
+      runId: "run-1",
+    };
+    const [a, b] = await Promise.all([
+      compactRunEvents(calls),
+      compactRunEvents(calls),
+    ]);
+    // Exactly one performs the fold; the loser reads an already-sealed run.
+    expect([a.compacted, b.compacted].filter(Boolean).length).toBe(1);
+
+    const combined = await fs.promises.readFile(
+      path.join(substrate.getRepoDir(repoId), "runs", "run-1", "events.jsonl"),
+      "utf8",
+    );
+    expect(combined).toBe(`${ev(0, "RunStarted")}\n${ev(1, "RunCompleted")}\n`);
+    const reader = createWorkflowRunReader(substrate);
+    expect(
+      (await reader.readRunEvents(repoId, REF, "run-1")).map((e) => e.seq),
+    ).toEqual([0, 1]);
+  });
+
+  test("a sibling blobs/ subtree survives a seal", async () => {
+    const { repoId, substrate, supervisor, deploymentId } =
+      await setup("dep-blobs");
+    await substrate.writeTreePreservingPrefix(supervisor, repoId, REF, {
+      preservePrefix: "runs/run-1/events/",
+      merge: async () => ({
+        "runs/run-1/events/0.json": ev(0, "RunStarted"),
+        "runs/run-1/events/1.json": ev(1, "RunCompleted"),
+        [`runs/run-1/blobs/${"a".repeat(64)}`]: "payload-bytes",
+      }),
+      message: "seed events and a blob",
+    });
+
+    expect(
+      (
+        await compactRunEvents({
+          substrate,
+          repoId,
+          ref: REF,
+          deploymentId,
+          runId: "run-1",
+        })
+      ).compacted,
+    ).toBe(true);
+
+    const blob = await fs.promises.readFile(
+      path.join(
+        substrate.getRepoDir(repoId),
+        "runs",
+        "run-1",
+        "blobs",
+        "a".repeat(64),
+      ),
+      "utf8",
+    );
+    expect(blob).toBe("payload-bytes");
+  });
+
+  test("folds multi-digit seqs in numeric, not lexical, order", async () => {
+    const { repoId, substrate, supervisor, deploymentId } =
+      await setup("dep-multidigit");
+    const seqs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+    const typeAt = (s: number) => (s === 11 ? "RunCompleted" : "StepStarted");
+    await substrate.writeTreePreservingPrefix(supervisor, repoId, REF, {
+      preservePrefix: "runs/run-1/events/",
+      merge: async () => {
+        const out: Record<string, string> = {};
+        for (const s of seqs)
+          out[`runs/run-1/events/${s}.json`] = ev(s, typeAt(s));
+        return out;
+      },
+      message: "seed multi-digit",
+    });
+
+    expect(
+      (
+        await compactRunEvents({
+          substrate,
+          repoId,
+          ref: REF,
+          deploymentId,
+          runId: "run-1",
+        })
+      ).compacted,
+    ).toBe(true);
+
+    const combined = await fs.promises.readFile(
+      path.join(substrate.getRepoDir(repoId), "runs", "run-1", "events.jsonl"),
+      "utf8",
+    );
+    expect(combined).toBe(`${seqs.map((s) => ev(s, typeAt(s))).join("\n")}\n`);
+  });
+
+  test("a run skipped while in-flight is sealed once it reaches a terminal event", async () => {
+    const { repoId, substrate, supervisor, deploymentId, eventsDir } =
+      await setup("dep-becomes-terminal");
+    const calls = {
+      substrate,
+      repoId,
+      ref: REF,
+      deploymentId,
+      runId: "run-1",
+    };
+    await substrate.writeTreePreservingPrefix(supervisor, repoId, REF, {
+      preservePrefix: "runs/run-1/events/",
+      merge: async () => ({ "runs/run-1/events/0.json": ev(0, "RunStarted") }),
+      message: "seed non-terminal",
+    });
+    expect((await compactRunEvents(calls)).compacted).toBe(false);
+
+    // The run reaches a terminal event; the same call now seals it.
+    await substrate.writeTreePreservingPrefix(supervisor, repoId, REF, {
+      preservePrefix: "runs/run-1/events/",
+      merge: async (existing) => {
+        const files: Record<string, string | Uint8Array> = {};
+        for (const [k, v] of existing) files[k] = v;
+        files["runs/run-1/events/1.json"] = ev(1, "RunCompleted");
+        return files;
+      },
+      message: "append terminal",
+    });
+    expect((await compactRunEvents(calls)).compacted).toBe(true);
+    await expect(fs.promises.readdir(eventsDir())).rejects.toThrow();
+  });
+});

--- a/packages/workflow-host/src/supervisor/run-event-signing.ts
+++ b/packages/workflow-host/src/supervisor/run-event-signing.ts
@@ -19,6 +19,10 @@ import type {
   RepoStore as SubstrateRepoStore,
   WorkflowRunSupervisorPrincipal,
 } from "@intx/hub-sessions";
+import {
+  WORKFLOW_RUN_EVENTS_FILE,
+  encodeCombinedEventLog,
+} from "@intx/hub-sessions";
 
 import { SUPERVISOR_PRINCIPAL_KIND } from "./cancel-signing";
 import type { PrincipalSigner, SignedPayload } from "./types";
@@ -26,6 +30,11 @@ import type { PrincipalSigner, SignedPayload } from "./types";
 const RUNS_PREFIX = "runs";
 const EVENTS_DIR = "events";
 const EVENT_FILENAME_RE = /^(0|[1-9][0-9]*)\.json$/;
+const TERMINAL_EVENT_TYPES = new Set<string>([
+  "RunCompleted",
+  "RunFailed",
+  "RunCancelled",
+]);
 
 /**
  * Shape of the run-lifecycle events the supervisor commits inline.
@@ -223,6 +232,124 @@ export async function commitRunEvent(
   }
   const final: { seq: number; signature: SignedPayload } = resolved;
   return { commitSha, seq: final.seq, signature: final.signature };
+}
+
+export type CompactRunEventsOpts = {
+  /** Substrate handle the supervisor writes through. */
+  substrate: SubstrateRepoStore;
+  /** Workflow-run repo for this deployment. */
+  repoId: RepoId;
+  /** Events ref the workflow-run repo writes to. */
+  ref: string;
+  /** Deployment id used to construct the supervisor principal. */
+  deploymentId: string;
+  /** Run to seal. */
+  runId: string;
+};
+
+/**
+ * Fold a terminated run's per-event `events/<seq>.json` blobs into one
+ * combined `events.jsonl`, dropping the per-event files. This shrinks the
+ * repo's file count -- and so every per-commit cost that scales with it --
+ * without losing any event.
+ *
+ * Idempotent and terminal-only: a run already sealed (no `events/` subtree)
+ * or one whose latest event is not terminal is left untouched, so the call
+ * is safe to repeat. The live caller fires it once per run, right after the
+ * run terminates; a bounded recovery sweep that would re-fire it to seal a
+ * run whose fold a crash interrupted is tracked separately (INTR-229).
+ *
+ * The combined file is the verbatim byte concatenation of the per-event
+ * blobs in seq order (`encodeCombinedEventLog`), the exact shape the
+ * workflow-run kind handler's compaction validation requires. It is written
+ * as a sibling of `events/`, so returning it from the merge while omitting
+ * the per-event files lets the substrate's prefix clear drop them.
+ */
+export async function compactRunEvents(
+  opts: CompactRunEventsOpts,
+): Promise<{ compacted: boolean }> {
+  const fs = await import("node:fs/promises");
+  const path = await import("node:path");
+  const dir = opts.substrate.getRepoDir(opts.repoId);
+  const eventsDir = path.join(dir, RUNS_PREFIX, opts.runId, EVENTS_DIR);
+
+  // Cheap pre-check off the working tree to skip an empty commit when there
+  // is nothing to seal (already combined, or not yet terminal). The merge
+  // re-reads the prefix under the per-repo lock, so the seal stays
+  // consistent if another writer raced in between.
+  let filenames: string[];
+  try {
+    filenames = await fs.readdir(eventsDir);
+  } catch (cause) {
+    if (isErrnoNotFound(cause)) return { compacted: false };
+    throw cause;
+  }
+  const seqs: number[] = [];
+  for (const name of filenames) {
+    const match = EVENT_FILENAME_RE.exec(name);
+    if (match === null || match[1] === undefined) continue;
+    seqs.push(Number.parseInt(match[1], 10));
+  }
+  if (seqs.length === 0) return { compacted: false };
+  const lastRaw = await fs.readFile(
+    path.join(eventsDir, `${String(Math.max(...seqs))}.json`),
+    "utf8",
+  );
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(lastRaw);
+  } catch {
+    return { compacted: false };
+  }
+  if (typeof parsed !== "object" || parsed === null || !("type" in parsed)) {
+    return { compacted: false };
+  }
+  const lastType = (parsed as { type?: unknown }).type;
+  if (typeof lastType !== "string" || !TERMINAL_EVENT_TYPES.has(lastType)) {
+    return { compacted: false };
+  }
+
+  const prefix = `${RUNS_PREFIX}/${opts.runId}/${EVENTS_DIR}/`;
+  const combinedPath = `${RUNS_PREFIX}/${opts.runId}/${WORKFLOW_RUN_EVENTS_FILE}`;
+  const principal: WorkflowRunSupervisorPrincipal = {
+    kind: SUPERVISOR_PRINCIPAL_KIND,
+    deploymentId: opts.deploymentId,
+  };
+  let sealed = false;
+  await opts.substrate.writeTreePreservingPrefix(
+    principal,
+    opts.repoId,
+    opts.ref,
+    {
+      preservePrefix: prefix,
+      merge: async (existing) => {
+        const entries: { seq: number; bytes: Uint8Array }[] = [];
+        for (const [filepath, bytes] of existing) {
+          const name = filepath.slice(prefix.length);
+          const match = EVENT_FILENAME_RE.exec(name);
+          if (match === null || match[1] === undefined) {
+            throw new Error(
+              `supervisor run-event-signing: unexpected non-event file ${filepath} under run ${opts.runId}; refusing to compact`,
+            );
+          }
+          entries.push({ seq: Number.parseInt(match[1], 10), bytes });
+        }
+        if (entries.length === 0) return {};
+        entries.sort((a, b) => a.seq - b.seq);
+        sealed = true;
+        return {
+          [combinedPath]: encodeCombinedEventLog(entries.map((e) => e.bytes)),
+        };
+      },
+      message: `compact run ${opts.runId} events`,
+    },
+  );
+  return { compacted: sealed };
+}
+
+function isErrnoNotFound(cause: unknown): boolean {
+  if (cause === null || typeof cause !== "object") return false;
+  return (cause as { code?: unknown }).code === "ENOENT";
 }
 
 function serializeSignedPayload(signed: SignedPayload): {

--- a/packages/workflow-host/src/supervisor/spawn-replay-fifo.test.ts
+++ b/packages/workflow-host/src/supervisor/spawn-replay-fifo.test.ts
@@ -196,7 +196,7 @@ function createStubRepoStore(baseDir: string): RepoStore {
       return path.join(baseDir, repoId.kind, repoId.id);
     },
     async writeTreePreservingPrefix(_principal, _repoId, _ref, _args) {
-      return { commitSha: "deadbeefcafef00d" };
+      return { commitSha: "deadbeefcafef00d", newlyTerminalRuns: [] };
     },
   };
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub; missing methods surface as a precise failure via the proxy

--- a/packages/workflow-host/src/supervisor/stale-cohort-routing.test.ts
+++ b/packages/workflow-host/src/supervisor/stale-cohort-routing.test.ts
@@ -185,7 +185,7 @@ function createStubRepoStore(baseDir: string): RepoStore {
       return path.join(baseDir, repoId.kind, repoId.id);
     },
     async writeTreePreservingPrefix() {
-      return { commitSha: "deadbeefcafef00d" };
+      return { commitSha: "deadbeefcafef00d", newlyTerminalRuns: [] };
     },
   };
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub; missing methods surface as a precise failure via the proxy

--- a/packages/workflow-host/src/supervisor/substrate-write.test.ts
+++ b/packages/workflow-host/src/supervisor/substrate-write.test.ts
@@ -190,6 +190,46 @@ type WriteCapture = {
   message: string;
 };
 
+// Mirror the workflow-run kind handler's terminal detection for the stub
+// substrate: a run is newly terminal when the merge produced a terminal
+// event blob under its `events/` prefix. The real handler scopes this to
+// events newly added against the prior tree; the stub's merge always runs
+// against an empty prior, so every terminal event it emits is new.
+const STUB_TERMINAL_EVENT_TYPES = new Set([
+  "RunCompleted",
+  "RunFailed",
+  "RunCancelled",
+]);
+const STUB_RUN_EVENT_PATH_RE = /^runs\/([^/]+)\/events\/[0-9]+\.json$/;
+function deriveNewlyTerminalRuns(
+  merged: Record<string, string | Uint8Array>,
+): { runId: string; terminalEventJson: string }[] {
+  const out: { runId: string; terminalEventJson: string }[] = [];
+  for (const [blobPath, content] of Object.entries(merged)) {
+    const match = STUB_RUN_EVENT_PATH_RE.exec(blobPath);
+    if (match === null || match[1] === undefined) continue;
+    const json =
+      typeof content === "string" ? content : new TextDecoder().decode(content);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(json);
+    } catch {
+      continue;
+    }
+    if (typeof parsed !== "object" || parsed === null || !("type" in parsed)) {
+      continue;
+    }
+    const eventType = (parsed as { type?: unknown }).type;
+    if (
+      typeof eventType === "string" &&
+      STUB_TERMINAL_EVENT_TYPES.has(eventType)
+    ) {
+      out.push({ runId: match[1], terminalEventJson: json });
+    }
+  }
+  return out;
+}
+
 function createStubRepoStore(opts: {
   baseDir: string;
   /**
@@ -219,14 +259,16 @@ function createStubRepoStore(opts: {
         preservePrefix: args.preservePrefix,
         message: args.message,
       });
+      let newlyTerminalRuns: { runId: string; terminalEventJson: string }[] =
+        [];
       if (opts.invokeMerge !== false) {
         const merged = await args.merge(new Map());
-        // Touch the merged value so the linter knows the round-trip
-        // ran; the substrate would commit these bytes against the
-        // workflow-run repo's ref.
-        void Object.keys(merged).length;
+        // Stand in for the real workflow-run kind handler's terminal
+        // detection: surface any run whose terminal event the merge
+        // produced, the way the handler's validation walk would.
+        newlyTerminalRuns = deriveNewlyTerminalRuns(merged);
       }
-      return { commitSha: "deadbeefcafef00d" };
+      return { commitSha: "deadbeefcafef00d", newlyTerminalRuns };
     },
   };
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub; missing methods surface as a precise failure via the proxy

--- a/packages/workflow-host/src/supervisor/supervisor.test.ts
+++ b/packages/workflow-host/src/supervisor/supervisor.test.ts
@@ -302,7 +302,7 @@ function createStubRepoStore(opts: {
         }
         committed.set(key, next);
       }
-      return { commitSha: "deadbeefcafef00d" };
+      return { commitSha: "deadbeefcafef00d", newlyTerminalRuns: [] };
     },
   };
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub; only the subset the supervisor invokes is implemented and a missing method throws via the proxy below

--- a/packages/workflow-host/src/supervisor/supervisor.ts
+++ b/packages/workflow-host/src/supervisor/supervisor.ts
@@ -57,6 +57,7 @@ import {
   markConsumed as defaultMarkConsumed,
   replayProcessingToInbox as defaultReplayProcessingToInbox,
   DEFAULT_CONSUMED_RETENTION_MS,
+  type NewlyTerminalRun,
   type Principal,
   type WorkflowRunSupervisorPrincipal,
   type WorkflowRunWorkflowProcessPrincipal,
@@ -956,18 +957,17 @@ export function createWorkflowSupervisor(
       kind: "workflow-process",
       deploymentId: bindings.deploymentId,
     };
-    // Capture the prospective files from each merge round-trip so
-    // the post-commit inspection below can detect terminal-event
-    // writes and synchronously trigger the dispatch loop's
-    // markConsumed before the substrate.write.response unblocks the
-    // child. Holding the response gates the child's
-    // runtime-body progress on the inbox transition landing,
+    // The commit's terminal detection comes from the kind handler's
+    // typed `newlyTerminalRuns` signal (returned below), not a sniff of
+    // the merged files: the handler authoritatively determines, during
+    // validation, which runs reached a terminal event in this commit.
+    // Holding the substrate.write.response on that signal gates the
+    // child's runtime-body progress on the inbox transition landing,
     // closing the window where a downstream consumer observes
     // RunCompleted ahead of the matching consumed/ entry on this
-    // supervisor (the cross-process hub-pack ordering is still
-    // racy, but the local supervisor's state is self-consistent
-    // at the response boundary).
-    let lastMergedFiles: Record<string, string | Uint8Array> | null = null;
+    // supervisor (the cross-process hub-pack ordering is still racy, but
+    // the local supervisor's state is self-consistent at the response
+    // boundary).
     // D2 leg classification (measurement-only). The child proxies two
     // distinct substrate commits through this one handler, discriminated
     // by the write's `preservePrefix`:
@@ -986,63 +986,63 @@ export function createWorkflowSupervisor(
       legMarkStart(legClassification.runId, legClassification.leg);
     }
     try {
-      const { commitSha } = await bindings.repoStore.writeTreePreservingPrefix(
-        writePrincipal,
-        validatedRepoId,
-        data.ref,
-        {
-          preservePrefix: data.preservePrefix,
-          message: data.message,
-          merge: async (existing) => {
-            const sender = activeControlSender();
-            if (sender === null) {
-              throw new Error(
-                "supervisor substrate.write.request: control channel unavailable for merge round-trip",
-              );
-            }
-            const result = await new Promise<
-              | { ok: true; files: Record<string, string | Uint8Array> }
-              | { ok: false; reason: string }
-            >((resolve) => {
-              pendingMerges.set(data.requestId, { resolve });
-              const wireExisting: {
-                path: string;
-                contentBase64: string;
-              }[] = [];
-              for (const [path, bytes] of existing) {
-                wireExisting.push({
-                  path,
-                  contentBase64: bytesToBase64(bytes),
-                });
+      const { commitSha, newlyTerminalRuns } =
+        await bindings.repoStore.writeTreePreservingPrefix(
+          writePrincipal,
+          validatedRepoId,
+          data.ref,
+          {
+            preservePrefix: data.preservePrefix,
+            message: data.message,
+            merge: async (existing) => {
+              const sender = activeControlSender();
+              if (sender === null) {
+                throw new Error(
+                  "supervisor substrate.write.request: control channel unavailable for merge round-trip",
+                );
               }
-              void sender
-                .send({
-                  type: "substrate.merge.request",
-                  data: {
-                    requestId: data.requestId,
-                    existing: wireExisting,
-                  },
-                })
-                .catch((cause) => {
-                  pendingMerges.delete(data.requestId);
-                  const reason =
-                    cause instanceof Error ? cause.message : String(cause);
-                  resolve({
-                    ok: false,
-                    reason: `supervisor substrate.merge.request send failed: ${reason}`,
+              const result = await new Promise<
+                | { ok: true; files: Record<string, string | Uint8Array> }
+                | { ok: false; reason: string }
+              >((resolve) => {
+                pendingMerges.set(data.requestId, { resolve });
+                const wireExisting: {
+                  path: string;
+                  contentBase64: string;
+                }[] = [];
+                for (const [path, bytes] of existing) {
+                  wireExisting.push({
+                    path,
+                    contentBase64: bytesToBase64(bytes),
                   });
-                });
-            });
-            if (!result.ok) {
-              throw new Error(
-                `supervisor substrate.write.request: child merge failed: ${result.reason}`,
-              );
-            }
-            lastMergedFiles = result.files;
-            return result.files;
+                }
+                void sender
+                  .send({
+                    type: "substrate.merge.request",
+                    data: {
+                      requestId: data.requestId,
+                      existing: wireExisting,
+                    },
+                  })
+                  .catch((cause) => {
+                    pendingMerges.delete(data.requestId);
+                    const reason =
+                      cause instanceof Error ? cause.message : String(cause);
+                    resolve({
+                      ok: false,
+                      reason: `supervisor substrate.merge.request send failed: ${reason}`,
+                    });
+                  });
+              });
+              if (!result.ok) {
+                throw new Error(
+                  `supervisor substrate.write.request: child merge failed: ${result.reason}`,
+                );
+              }
+              return result.files;
+            },
           },
-        },
-      );
+        );
       // D2 leg end: the substrate commit (hash objects, write tree,
       // advance ref under the per-repo lock) just resolved. Stamped here,
       // before the terminal-write markConsumed-coupling wait below, so the
@@ -1051,21 +1051,17 @@ export function createWorkflowSupervisor(
       if (legClassification !== null) {
         legMarkEnd(legClassification.runId, legClassification.leg);
       }
-      if (lastMergedFiles !== null) {
-        const watchdog = await synchronouslyDispatchTerminalWrite(
-          data.preservePrefix,
-          lastMergedFiles,
-        );
-        if (!watchdog.ok) {
-          await controlSender.send({
-            type: "substrate.write.response",
-            data: {
-              requestId: data.requestId,
-              result: { ok: false, reason: watchdog.reason },
-            },
-          });
-          return;
-        }
+      const watchdog =
+        await synchronouslyDispatchTerminalWrite(newlyTerminalRuns);
+      if (!watchdog.ok) {
+        await controlSender.send({
+          type: "substrate.write.response",
+          data: {
+            requestId: data.requestId,
+            result: { ok: false, reason: watchdog.reason },
+          },
+        });
+        return;
       }
       await controlSender.send({
         type: "substrate.write.response",
@@ -1110,96 +1106,50 @@ export function createWorkflowSupervisor(
     waiter.resolve();
   }
 
-  // Path-shape sniff. The terminal-write detection couples to the
-  // workflow-run substrate's on-disk run-event path shape
-  // (`runs/<runId>/events/<seq>.json`); the cleaner design is a
-  // typed terminal signal the workflow-run kind handler emits at
-  // commit time, but the handler does not surface that signal
-  // today and the regex matches exactly one well-formed shape the
-  // substrate is already responsible for emitting. If the substrate
-  // ever rearranges that layout, the sniff silently stops firing
-  // and the dispatch-loop sync degrades to "send response
-  // immediately" -- the cross-package contract holds today but is
-  // load-bearing.
-  const RUN_EVENT_PATH_RE = /^runs\/([^/]+)\/events\/[0-9]+\.json$/;
-  const TERMINAL_EVENT_TYPES = new Set([
-    "RunCompleted",
-    "RunFailed",
-    "RunCancelled",
-  ]);
-
   /**
-   * If the supplied merged-files set contains a terminal event blob
-   * for any runId in the active processing/ set, wait for the
-   * dispatch loop's markConsumed to settle before sending the
-   * substrate.write.response. The notification path is the
-   * `notifyMarkConsumed` hook the dispatch loop fires at the end of
-   * dispatchOne; the wait here is per-runId so multiple runs can
-   * proceed concurrently if a future dispatch loop ever processes
-   * more than one mail in parallel.
+   * Hold the substrate.write.response until the dispatch loop's
+   * markConsumed settles for each run the kind handler reports as newly
+   * terminal in this commit. Terminal-ness comes from the handler's typed
+   * `newlyTerminalRuns` signal -- determined authoritatively during
+   * validation -- not re-derived from the committed path shape, so it
+   * survives the run-event layout changing (e.g. compaction folding a
+   * run's per-event files into one combined file). The wait is per-runId
+   * so multiple runs can proceed concurrently if a future dispatch loop
+   * ever processes more than one mail in parallel.
    *
-   * A watchdog timeout (`terminalWriteWatchdogMs`) caps the wait so a
+   * A watchdog timeout (`terminalWriteWatchdogMs`) caps each wait so a
    * never-arming markConsumed (a bug in the dispatch loop, a torn-down
    * cohort, a stalled inbox primitive) does not deadlock the child's
    * write -- and therefore the runtime body, and therefore the dispatch
-   * loop. On expiry the waiter is force-released and a structured
-   * failure propagates back to the child as
+   * loop. On expiry the waiter is force-released and a structured failure
+   * propagates back to the child as
    * `{ ok: false, reason: "terminal-write watchdog timeout: ..." }`.
    */
   async function synchronouslyDispatchTerminalWrite(
-    preservePrefix: string,
-    mergedFiles: Record<string, string | Uint8Array>,
+    newlyTerminalRuns: readonly NewlyTerminalRun[],
   ): Promise<{ ok: true } | { ok: false; reason: string }> {
-    // The preservePrefix shape for run-event writes is
-    // `runs/<runId>/events/`; the substrate accepts any prefix that
-    // ends with `/`, so a write whose prefix does not match the
-    // runs/-events shape is not a terminal-event write and we
-    // short-circuit.
-    if (!preservePrefix.startsWith("runs/")) return { ok: true };
-    let runId: string | null = null;
-    let isTerminal = false;
-    for (const [path, content] of Object.entries(mergedFiles)) {
-      const match = RUN_EVENT_PATH_RE.exec(path);
-      if (match === null) continue;
-      const fromPath = match[1];
-      if (fromPath === undefined) continue;
-      const bytes =
-        typeof content === "string"
-          ? new TextEncoder().encode(content)
-          : content;
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(new TextDecoder().decode(bytes));
-      } catch {
-        continue;
-      }
-      if (
-        typeof parsed !== "object" ||
-        parsed === null ||
-        !("type" in parsed)
-      ) {
-        continue;
-      }
-      const t = (parsed as { type?: unknown }).type;
-      if (typeof t !== "string") continue;
-      if (TERMINAL_EVENT_TYPES.has(t)) {
-        runId = fromPath;
-        isTerminal = true;
-      }
+    const holds: Promise<{ ok: true } | { ok: false; reason: string }>[] = [];
+    for (const { runId, terminalEventJson } of newlyTerminalRuns) {
+      if (!inFlightRuns.has(runId)) continue;
+      holds.push(holdResponseForMarkConsumed(runId, terminalEventJson));
     }
-    if (!isTerminal || runId === null) return { ok: true };
-    if (!inFlightRuns.has(runId)) {
-      return { ok: true };
-    }
-    const waiterRunId = runId;
+    if (holds.length === 0) return { ok: true };
+    const results = await Promise.all(holds);
+    return results.find((r) => !r.ok) ?? { ok: true };
+  }
+
+  async function holdResponseForMarkConsumed(
+    runId: string,
+    terminalEventJson: string,
+  ): Promise<{ ok: true } | { ok: false; reason: string }> {
     const completed = new Promise<void>((resolve, reject) => {
-      markConsumedCompletionWaiters.set(waiterRunId, { resolve, reject });
+      markConsumedCompletionWaiters.set(runId, { resolve, reject });
     });
     const broadcaster = activeTerminalBroadcaster();
     if (broadcaster !== null) {
-      const synthetic = synthesizeTerminalEvent(mergedFiles, waiterRunId);
+      const synthetic = synthesizeTerminalEvent(terminalEventJson);
       if (synthetic !== null) {
-        broadcaster.notify(waiterRunId, synthetic);
+        broadcaster.notify(runId, synthetic);
       }
     }
     let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
@@ -1212,11 +1162,11 @@ export function createWorkflowSupervisor(
         // logged through the package logger so the watchdog is not
         // silent on the host side.
         const stillPending =
-          markConsumedCompletionWaiters.get(waiterRunId) !== undefined;
+          markConsumedCompletionWaiters.get(runId) !== undefined;
         if (stillPending) {
-          markConsumedCompletionWaiters.delete(waiterRunId);
+          markConsumedCompletionWaiters.delete(runId);
         }
-        const reason = `terminal-write watchdog timeout: markConsumed for runId=${waiterRunId} did not settle within ${String(terminalWriteWatchdogMs)}ms`;
+        const reason = `terminal-write watchdog timeout: markConsumed for runId=${runId} did not settle within ${String(terminalWriteWatchdogMs)}ms`;
         logger.error`${reason}`;
         resolve({ ok: false, reason });
       }, terminalWriteWatchdogMs);
@@ -1232,63 +1182,52 @@ export function createWorkflowSupervisor(
   }
 
   function synthesizeTerminalEvent(
-    files: Record<string, string | Uint8Array>,
-    runId: string,
+    terminalEventJson: string,
   ): TerminalRunEvent | null {
-    for (const [path, content] of Object.entries(files)) {
-      const match = RUN_EVENT_PATH_RE.exec(path);
-      if (match === null) continue;
-      if (match[1] !== runId) continue;
-      const bytes =
-        typeof content === "string"
-          ? new TextEncoder().encode(content)
-          : content;
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(new TextDecoder().decode(bytes));
-      } catch {
-        continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(terminalEventJson);
+    } catch {
+      return null;
+    }
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      !("type" in parsed) ||
+      !("seq" in parsed)
+    ) {
+      return null;
+    }
+    const body = parsed as {
+      type?: unknown;
+      seq?: unknown;
+      at?: unknown;
+      error?: { message?: unknown };
+    };
+    if (typeof body.seq !== "number") return null;
+    const at = typeof body.at === "string" ? body.at : new Date().toISOString();
+    if (body.type === "RunCompleted") {
+      return { kind: "RunCompleted", seq: body.seq, at };
+    }
+    if (body.type === "RunCancelled") {
+      return { kind: "RunCancelled", seq: body.seq, at };
+    }
+    if (body.type === "RunFailed") {
+      // The wire schema makes `error.message` required when the event
+      // type is `RunFailed`. An event that doesn't carry one is a
+      // contract violation upstream of the supervisor; coercing it to an
+      // empty string would silently hide the producer bug.
+      if (typeof body.error?.message !== "string") {
+        throw new Error(
+          `synthesizeTerminalEvent: RunFailed event missing required error.message`,
+        );
       }
-      if (
-        typeof parsed !== "object" ||
-        parsed === null ||
-        !("type" in parsed) ||
-        !("seq" in parsed)
-      ) {
-        continue;
-      }
-      const body = parsed as {
-        type?: unknown;
-        seq?: unknown;
-        at?: unknown;
-        error?: { message?: unknown };
+      return {
+        kind: "RunFailed",
+        seq: body.seq,
+        at,
+        error: { message: body.error.message },
       };
-      if (typeof body.seq !== "number") continue;
-      const at =
-        typeof body.at === "string" ? body.at : new Date().toISOString();
-      if (body.type === "RunCompleted") {
-        return { kind: "RunCompleted", seq: body.seq, at };
-      }
-      if (body.type === "RunCancelled") {
-        return { kind: "RunCancelled", seq: body.seq, at };
-      }
-      if (body.type === "RunFailed") {
-        // The wire schema makes `error.message` required when the event
-        // type is `RunFailed`. A blob that doesn't carry one is a
-        // contract violation upstream of the supervisor; coercing it
-        // to an empty string would silently hide the producer bug.
-        if (typeof body.error?.message !== "string") {
-          throw new Error(
-            `synthesizeTerminalEvent: RunFailed blob at ${path} missing required error.message`,
-          );
-        }
-        return {
-          kind: "RunFailed",
-          seq: body.seq,
-          at,
-          error: { message: body.error.message },
-        };
-      }
     }
     return null;
   }

--- a/packages/workflow-host/src/supervisor/supervisor.ts
+++ b/packages/workflow-host/src/supervisor/supervisor.ts
@@ -83,7 +83,7 @@ import {
   type CredentialsSnapshot,
 } from "./credentials";
 import { commitCancelRequested } from "./cancel-signing";
-import { commitRunEvent } from "./run-event-signing";
+import { commitRunEvent, compactRunEvents } from "./run-event-signing";
 import {
   createDrainTimeoutAccumulator,
   DEFAULT_DRAIN_TIMEOUT_MS,
@@ -1070,6 +1070,27 @@ export function createWorkflowSupervisor(
           result: { ok: true, commitSha },
         },
       });
+      // Seal each run that reached a terminal event in this commit: fold
+      // its per-event files into one combined events.jsonl. Off the hot
+      // path -- the child's write has already been acknowledged above -- so
+      // a failure is logged and does not block dispatch; the run is left in
+      // per-event form, which readers handle. There is no later trigger for
+      // a run whose fold is interrupted here (e.g. by a crash before the
+      // fold commits): the terminal signal fires once. A bounded recovery
+      // sweep is tracked as INTR-229; until then such a run stays
+      // per-event. The fold commit carries no newly-added terminal event,
+      // so it does not re-fire this terminal-write coupling.
+      for (const { runId } of newlyTerminalRuns) {
+        void compactRunEvents({
+          substrate: bindings.repoStore,
+          repoId: validatedRepoId,
+          ref: data.ref,
+          deploymentId: bindings.deploymentId,
+          runId,
+        }).catch((cause) => {
+          logger.warn`compaction of run ${runId} failed: ${cause instanceof Error ? cause.message : String(cause)}`;
+        });
+      }
     } catch (cause) {
       // Clean up any merge awaiter that the substrate may not have
       // reached (e.g. the write threw before invoking the merge


### PR DESCRIPTION
## Summary

- A workflow-run repo no longer grows one file per event without bound: when a run terminates, its per-event `runs/<runId>/events/<seq>.json` blobs fold into one combined `runs/<runId>/events.jsonl`, bounding the file count every per-commit git cost scales with. No event is lost — both readers handle either form and the fold is validated byte-for-byte.
- The supervisor learns a run reached a terminal event from a typed handler signal instead of sniffing the committed event path shape, so terminal detection no longer depends on where events live.

## Verification

- `make all` is green (build, lint, 3690 + 364 tests exit 0).
- The fold is gated byte-for-byte: adversarial tests assert a fold that mutates, drops, adds, or reorders an event is rejected, as is a run carrying both forms.
- Form-equivalence tests assert both readers return identical events for a run in either form; a subscribe-replay test confirms a sealed run still replays every event from seq 0.

Closes INTR-214