### PR TITLE
Make the Makefile the authoritative dev entrypoint and gate the full build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ The remaining command gets a clean, running system with seed data. It drops and 
 | Seed (requires running hub)   | `bun bin/seed.ts`              |
 | Full build verification       | `make all`                     |
 | Type check only               | `make build`                   |
+| Bundle the admin UI           | `make build-admin-ui`          |
 | Lint only                     | `make lint`                    |
 | Run tests only                | `make test`                    |
 | Auto-format                   | `make format`                  |
@@ -72,14 +73,18 @@ You must run the full build pipeline before declaring any task complete:
 make all
 ```
 
-This runs lint, type check (`tsc -b`), and tests in order, after verifying
-the environment via `bin/check-env`. Do not run `tsc`, `eslint`, or `bun
-test` directly in place of `make all` -- the Makefile is the authoritative
-entrypoint and gates on `bin/check-env` first.
+This runs lint, type check (`tsc -b`), the admin-ui production bundle
+(`vite build`), and tests in order, after verifying the environment via
+`bin/check-env`. Do not run `tsc`, `eslint`, or `bun test` directly in
+place of `make all` -- the Makefile is the authoritative entrypoint and
+gates on `bin/check-env` first.
 
 - `make build` runs `tsc -b --noEmit --force`, revalidating the entire
   TypeScript project graph on every run; an incremental build can pass
   while a cross-package type break sits latent
+- `make build-admin-ui` runs `vite build`, catching production-bundle
+  breaks that pass the type-check (the bundler resolves assets, CSS, and
+  imports that `tsc` does not exercise)
 - Individual package builds do not guarantee the full tree will build
 - Type exports and imports may not be available until the full tree is built
 - Tests may fail if dependent packages are not rebuilt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,9 @@ the environment via `bin/check-env`. Do not run `tsc`, `eslint`, or `bun
 test` directly in place of `make all` -- the Makefile is the authoritative
 entrypoint and gates on `bin/check-env` first.
 
-- `make build` validates the entire TypeScript project graph via `tsc -b`
+- `make build` runs `tsc -b --noEmit --force`, revalidating the entire
+  TypeScript project graph on every run; an incremental build can pass
+  while a cross-package type break sits latent
 - Individual package builds do not guarantee the full tree will build
 - Type exports and imports may not be available until the full tree is built
 - Tests may fail if dependent packages are not rebuilt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,9 @@ The remaining command gets a clean, running system with seed data. It drops and 
 | Regenerate API docs           | `make docs`                    |
 
 Use the `make` targets above for build, lint, test, format, and docs.
-Do not invoke the underlying `bun run` scripts directly -- the Makefile
-also runs `bin/check-env` to verify the environment before each build.
+The Makefile is the authoritative entrypoint: it runs each command
+directly and runs `bin/check-env` to verify the environment before each
+build.
 
 `bin/db-reset` only resets postgres. `--clean` additionally wipes
 `HUB_DATA_DIR` and `SIDECAR_DATA_DIR` so the sidecar does not try to
@@ -72,8 +73,9 @@ make all
 ```
 
 This runs lint, type check (`tsc -b`), and tests in order, after verifying
-the environment via `bin/check-env`. Do not substitute `bun run check`,
-`bun run lint`, or `bun run test` for `make all`.
+the environment via `bin/check-env`. Do not run `tsc`, `eslint`, or `bun
+test` directly in place of `make all` -- the Makefile is the authoritative
+entrypoint and gates on `bin/check-env` first.
 
 - `make build` validates the entire TypeScript project graph via `tsc -b`
 - Individual package builds do not guarantee the full tree will build

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -48,14 +48,14 @@ each build and runs each command directly.
 make all
 
 # Individual targets
-make build     # tsc -b --noEmit (validates entire TypeScript project graph)
+make build     # tsc -b --noEmit --force (revalidates the entire graph)
 make lint      # Prettier + ESLint + API docs freshness
 make format    # Auto-format with Prettier
 make test      # Run bun tests
 make docs      # Regenerate API documentation
 ```
 
-`make build` uses TypeScript project references (`tsc -b`). It validates the entire monorepo dependency graph, not just a single package. Changes to shared packages (types, authz, log) may break downstream consumers that `tsc -b` will catch.
+`make build` runs `tsc -b --noEmit --force`. The `--force` flag rebuilds every project from scratch, so each run revalidates the entire monorepo dependency graph rather than trusting incremental `tsconfig.tsbuildinfo` caches. Changes to shared packages (types, authz, log) may break downstream consumers; a forced build catches them, where an unforced incremental build can pass while the break sits latent.
 
 ---
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -41,7 +41,7 @@ Do not create standalone TypeScript files in the repository root.
 
 Use the `Makefile` at the repo root for build, lint, test, format, and
 docs. The Makefile verifies the environment via `bin/check-env` before
-each build and then delegates to the underlying `bun run` scripts.
+each build and runs each command directly.
 
 ```bash
 # Full build verification
@@ -709,9 +709,9 @@ Two locations are used for tests:
 
 - **Integration-shaped tests**: `tests/<package-name>/`. Tests that target a package's behavior but need the `@intx/inference-testing` harness, span multiple packages, or spawn real servers and subprocesses live here. Co-locating harness-driven tests in `packages/<name>/src/` would force the package to depend on `@intx/inference-testing`, creating a workspace dependency cycle (because the harness depends on the package). The `tests/` tree breaks that cycle. Tests spanning multiple packages live under `tests/<primary-target-package>/`; the "primary target" is whatever package's behavior the test is asserting, with the other packages as setup dependencies.
 
-Tests that are not parallel-safe (spawn servers, perform real `isomorphic-git` operations against `os.tmpdir()`, or otherwise need extended timeouts) run in a second pass after the fast unit suite. The split is enforced via the `test` script in the root `package.json`, which invokes `bun test` twice with explicit positional arguments: the first pass enumerates fast unit dirs at the default 5s timeout; the second pass enumerates the slow integration files with `--timeout 60000`. Bun's `[test].pathIgnorePatterns` field is documented but non-functional in bun 1.2.22; positive enumeration via positional args is the only mechanism that works.
+Tests that are not parallel-safe (spawn servers, perform real `isomorphic-git` operations against `os.tmpdir()`, or otherwise need extended timeouts) run in a second pass after the fast unit suite. The split is enforced via the `test` target in the `Makefile`, which invokes `bun test` twice with explicit positional arguments: the first pass enumerates fast unit dirs at the default 5s timeout; the second pass enumerates the slow integration files with `--timeout 60000`. Bun's `[test].pathIgnorePatterns` field is documented but non-functional in bun 1.2.22; positive enumeration via positional args is the only mechanism that works.
 
-Especially slow tests (e.g. the FIFO mail load case) live in their own files and run via a dedicated `test:load` script with an even longer timeout, so `make test` stays fast for routine iteration. The load script runs separately in CI.
+Especially slow tests (e.g. the FIFO mail load case) live in their own files and run via a dedicated `make test-load` target with an even longer timeout, so `make test` stays fast for routine iteration. The load target runs separately in CI.
 
 ---
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -48,11 +48,12 @@ each build and runs each command directly.
 make all
 
 # Individual targets
-make build     # tsc -b --noEmit --force (revalidates the entire graph)
-make lint      # Prettier + ESLint + API docs freshness
-make format    # Auto-format with Prettier
-make test      # Run bun tests
-make docs      # Regenerate API documentation
+make build           # tsc -b --noEmit --force (revalidates the entire graph)
+make build-admin-ui  # admin-ui production bundle (vite build)
+make lint            # Prettier + ESLint + API docs freshness
+make format          # Auto-format with Prettier
+make test            # Run bun tests
+make docs            # Regenerate API documentation
 ```
 
 `make build` runs `tsc -b --noEmit --force`. The `--force` flag rebuilds every project from scratch, so each run revalidates the entire monorepo dependency graph rather than trusting incremental `tsconfig.tsbuildinfo` caches. Changes to shared packages (types, authz, log) may break downstream consumers; a forced build catches them, where an unforced incremental build can pass while the break sits latent.

--- a/DEV.md
+++ b/DEV.md
@@ -141,9 +141,9 @@ bin/db-migrate
 
 ## Build Pipeline
 
-The Makefile is the canonical entry point for the build verbs. It also
-runs `bin/check-env` (via `.env-checked`) to verify the environment
-before each build, which the raw `bun run` scripts do not.
+The Makefile is the canonical entry point for the build verbs. It runs
+each command directly and runs `bin/check-env` (via `.env-checked`) to
+verify the environment before each build.
 
 ```bash
 make all       # lint + build + test (full verification)

--- a/DEV.md
+++ b/DEV.md
@@ -146,13 +146,14 @@ each command directly and runs `bin/check-env` (via `.env-checked`) to
 verify the environment before each build.
 
 ```bash
-make all       # lint + build + test (full verification)
-make build     # TypeScript type checking (tsc -b --noEmit --force)
-make lint      # Prettier + ESLint + API docs freshness
-make format    # Prettier auto-fix
-make test      # All tests
-make docs      # Regenerate API documentation
-make clean     # Remove tsbuildinfo, dist directories, env stamp
+make all            # lint + build + admin-ui bundle + test
+make build          # TypeScript type checking (tsc -b --noEmit --force)
+make build-admin-ui # admin-ui production bundle (vite build)
+make lint           # Prettier + ESLint + API docs freshness
+make format         # Prettier auto-fix
+make test           # All tests
+make docs           # Regenerate API documentation
+make clean          # Remove tsbuildinfo, dist directories, env stamp
 ```
 
 The pre-commit hook checks out the staged tree into a temporary

--- a/DEV.md
+++ b/DEV.md
@@ -147,7 +147,7 @@ verify the environment before each build.
 
 ```bash
 make all       # lint + build + test (full verification)
-make build     # TypeScript type checking (tsc -b --noEmit)
+make build     # TypeScript type checking (tsc -b --noEmit --force)
 make lint      # Prettier + ESLint + API docs freshness
 make format    # Prettier auto-fix
 make test      # All tests

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export PATH := $(PWD)/node_modules/.bin:$(PWD)/bin:$(PATH)
 all: lint build test
 
 build: FORCE
-	tsc -b --noEmit
+	tsc -b --noEmit --force
 
 lint: FORCE
 	prettier -c .

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 export PATH := $(PWD)/node_modules/.bin:$(PWD)/bin:$(PATH)
 
-all: lint build test
+all: lint build build-admin-ui test
 
 build: FORCE
 	tsc -b --noEmit --force
+
+build-admin-ui: FORCE
+	cd apps/admin-ui && vite build
 
 lint: FORCE
 	prettier -c .
@@ -41,5 +44,5 @@ clean:
 
 include .env-checked
 
-.PHONY: all build lint test test-load format docs clean builtins publish-builtins
+.PHONY: all build build-admin-ui lint test test-load format docs clean builtins publish-builtins
 FORCE:

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,28 @@
-export PATH := $(PWD)/bin:$(PATH)
+export PATH := $(PWD)/node_modules/.bin:$(PWD)/bin:$(PATH)
 
 all: lint build test
 
 build: FORCE
-	bun run check
+	tsc -b --noEmit
 
 lint: FORCE
-	bun run lint
+	prettier -c .
+	eslint --cache .
+	bun bin/gen-api-docs.ts --check
+	bun bin/check-deps.ts
 
 test: FORCE
-	bun run test
+	bun test packages/ apps/ bin/ tests/agent/ tests/agent-audit-log/ tests/agent-blob-spill/ tests/agent-common/ tests/agent-multi-provider/ tests/agent-quickstart/ tests/agent-resume/ tests/agent-rewind/ tests/agent-rich-tool/ tests/agent-structured-payload/ tests/coding-agent/ tests/hub-agent/lib/ tests/inference-testing/ tests/tool-packaging/ tests/workflow/
+	bun test --timeout 120000 tests/hub-agent/deploy-flow.test.ts tests/workflow-deploy/trivial-roundtrip.test.ts tests/workflow-deploy/multistep-signal.test.ts tests/workflow-deploy/single-step-real-agent.test.ts tests/workflow-deploy/single-step-message-input.test.ts tests/workflow-deploy/single-step-posix-tool.test.ts tests/workflow-deploy/single-step-grants-bridge.test.ts tests/workflow-deploy/single-step-event-threading.test.ts tests/workflow-deploy/single-step-conversation-durability.test.ts tests/workflow-deploy/single-step-full-lifecycle.test.ts tests/workflow-deploy/conversation-state-wal.test.ts tests/workflow-deploy/drain-roundtrip.test.ts tests/workflow-deploy/child-workflow-roundtrip.test.ts tests/workflow-deploy/unresolvable-director.test.ts tests/workflow-deploy/fifo-mail.test.ts tests/workflow-deploy/mail-edge-cases.test.ts tests/inference/ tests/skill-attachment-flow.test.ts tests/hub-api/
 
 test-load: FORCE
-	bun run test:load
+	bun test --timeout 300000 tests/workflow-deploy/fifo-mail-load.test.ts
 
 format: FORCE
-	bun run format
+	prettier -w .
 
 docs: FORCE
-	bun run docs
+	bun bin/gen-api-docs.ts
 
 builtins: FORCE
 	bun run bin/build-builtins.ts

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ reset recipes.
 
 Build, lint, test, and format go through the `Makefile` at the repo
 root, which verifies the environment via
-[`bin/check-env`](./bin/check-env) before delegating to the
-underlying `bun run` scripts.
+[`bin/check-env`](./bin/check-env) before running each command
+directly.
 
 | Target        | Description                                  |
 | ------------- | -------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ directly.
 | Target        | Description                                  |
 | ------------- | -------------------------------------------- |
 | `make all`    | lint + build + test (full verification)      |
-| `make build`  | type check (`tsc -b --noEmit`)               |
+| `make build`  | type check (`tsc -b --noEmit --force`)       |
 | `make lint`   | prettier + eslint + API docs freshness       |
 | `make format` | auto-format                                  |
 | `make test`   | run tests                                    |

--- a/README.md
+++ b/README.md
@@ -133,15 +133,16 @@ root, which verifies the environment via
 [`bin/check-env`](./bin/check-env) before running each command
 directly.
 
-| Target        | Description                                  |
-| ------------- | -------------------------------------------- |
-| `make all`    | lint + build + test (full verification)      |
-| `make build`  | type check (`tsc -b --noEmit --force`)       |
-| `make lint`   | prettier + eslint + API docs freshness       |
-| `make format` | auto-format                                  |
-| `make test`   | run tests                                    |
-| `make docs`   | regenerate [`docs/API.md`](./docs/API.md)    |
-| `make clean`  | remove `tsbuildinfo`, `dist/`, and env stamp |
+| Target                | Description                                  |
+| --------------------- | -------------------------------------------- |
+| `make all`            | lint + build + admin-ui bundle + test        |
+| `make build`          | type check (`tsc -b --noEmit --force`)       |
+| `make build-admin-ui` | bundle the admin UI (`vite build`)           |
+| `make lint`           | prettier + eslint + API docs freshness       |
+| `make format`         | auto-format                                  |
+| `make test`           | run tests                                    |
+| `make docs`           | regenerate [`docs/API.md`](./docs/API.md)    |
+| `make clean`          | remove `tsbuildinfo`, `dist/`, and env stamp |
 
 Run `make all` before declaring a change correct; individual
 package builds do not guarantee the full project graph compiles.

--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -27,7 +27,7 @@ fi
 
 step::10::type_check() {
 	log::info "running type check..."
-	bun run check || log::fatal "type check failed, fix errors before migrating"
+	(cd "$REPODIR" && make build) || log::fatal "type check failed, fix errors before migrating"
 }
 
 step::20::generate() {

--- a/bin/gen-api-docs.ts
+++ b/bin/gen-api-docs.ts
@@ -402,12 +402,12 @@ const generated = lines.join("\n") + "\n";
 
 if (check) {
   if (!existsSync(outPath)) {
-    log.error("docs/API.md does not exist. Run: bun run docs");
+    log.error("docs/API.md does not exist. Run: make docs");
     process.exit(1);
   }
   const current = readFileSync(outPath, "utf-8");
   if (generated !== current) {
-    log.error("docs/API.md is stale. Run: bun run docs");
+    log.error("docs/API.md is stale. Run: make docs");
     process.exit(1);
   }
   log.info("docs/API.md is up to date");

--- a/package.json
+++ b/package.json
@@ -19,16 +19,6 @@
     "ssri": "^12.0.0",
     "tar": "^7.5.1"
   },
-  "scripts": {
-    "check": "tsc -b --noEmit",
-    "lint": "prettier -c . && eslint --cache . && bun run check:docs && bun run check:deps",
-    "format": "prettier -w .",
-    "test": "bun test packages/ apps/ bin/ tests/agent/ tests/agent-audit-log/ tests/agent-blob-spill/ tests/agent-common/ tests/agent-multi-provider/ tests/agent-quickstart/ tests/agent-resume/ tests/agent-rewind/ tests/agent-rich-tool/ tests/agent-structured-payload/ tests/coding-agent/ tests/hub-agent/lib/ tests/inference-testing/ tests/tool-packaging/ tests/workflow/ && bun test --timeout 120000 tests/hub-agent/deploy-flow.test.ts tests/workflow-deploy/trivial-roundtrip.test.ts tests/workflow-deploy/multistep-signal.test.ts tests/workflow-deploy/single-step-real-agent.test.ts tests/workflow-deploy/single-step-message-input.test.ts tests/workflow-deploy/single-step-posix-tool.test.ts tests/workflow-deploy/single-step-grants-bridge.test.ts tests/workflow-deploy/single-step-event-threading.test.ts tests/workflow-deploy/single-step-conversation-durability.test.ts tests/workflow-deploy/single-step-full-lifecycle.test.ts tests/workflow-deploy/conversation-state-wal.test.ts tests/workflow-deploy/drain-roundtrip.test.ts tests/workflow-deploy/child-workflow-roundtrip.test.ts tests/workflow-deploy/unresolvable-director.test.ts tests/workflow-deploy/fifo-mail.test.ts tests/workflow-deploy/mail-edge-cases.test.ts tests/inference/ tests/skill-attachment-flow.test.ts tests/hub-api/",
-    "test:load": "bun test --timeout 300000 tests/workflow-deploy/fifo-mail-load.test.ts",
-    "docs": "bun bin/gen-api-docs.ts",
-    "check:docs": "bun bin/gen-api-docs.ts --check",
-    "check:deps": "bun bin/check-deps.ts"
-  },
   "devDependencies": {
     "@eslint/js": "9.34.0",
     "@types/bun": "1.3.9",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,10 +13,6 @@
       "default": "./src/schema/index.ts"
     }
   },
-  "scripts": {
-    "db:generate": "drizzle-kit generate --config=drizzle.config.ts",
-    "db:migrate": "drizzle-kit migrate --config=drizzle.config.ts"
-  },
   "dependencies": {
     "@intx/log": "workspace:*",
     "@intx/types": "workspace:*",

--- a/tests/workflow-deploy/fifo-mail-load.test.ts
+++ b/tests/workflow-deploy/fifo-mail-load.test.ts
@@ -12,7 +12,7 @@
 // sustained-pressure test: it fires a large batch of mails in quick
 // succession to exercise the dispatch loop under load, which is a
 // heavier workload than the routine integration suite carries. The
-// test runs through the dedicated `bun run test:load` script
+// test runs through the dedicated `make test-load` target
 // instead; CI invokes that separately.
 //
 // The runtime-coverage rationale matches the 3-mail case: the
@@ -102,7 +102,7 @@ const WORKFLOW_RUN_REF = "refs/heads/main";
 //      The quadratic receive-side floor is gone.
 //
 // With the receive-side enumeration bounded to the touched run, 50
-// mails complete well within the `test:load` budget.
+// mails complete well within the `make test-load` budget.
 const LOAD_MAIL_COUNT = 50;
 const LOAD_MESSAGE_IDS: readonly string[] = Array.from(
   { length: LOAD_MAIL_COUNT },

--- a/tests/workflow-deploy/fifo-mail.test.ts
+++ b/tests/workflow-deploy/fifo-mail.test.ts
@@ -103,7 +103,7 @@ const MESSAGE_IDS: readonly string[] = [
 // survives a sustained batch of concurrent enqueues). The load case
 // is held out of `make test`'s default run because it is a
 // sustained-pressure test rather than a routine integration check;
-// it runs via `bun run test:load` instead.
+// it runs via `make test-load` instead.
 
 let env: DeployFlowEnv;
 


### PR DESCRIPTION
## Summary

- The `Makefile` is the single authoritative entrypoint for the
  dev-workflow verbs (`build`, `lint`, `test`, `test-load`, `format`,
  `docs`): each runs its command directly, with tool binaries resolved
  from `node_modules/.bin`. The root `package.json` scripts and the dead
  `packages/db` `db:*` scripts are gone.
- `make build` runs `tsc -b --noEmit --force`, so the gate revalidates the
  entire TypeScript project graph every run instead of trusting incremental
  `tsconfig.tsbuildinfo` state.
- `make all` also runs the admin-ui production bundle via a new
  `build-admin-ui` target (`vite build`), closing the gap where a broken
  Vite bundle merged green — admin-ui's types were already gated, the
  bundler step was not.
- Consumers and docs that named the removed scripts now point at the
  Makefile targets.

## Verification

- `make all` passes (exit 0): lint, forced build, admin-ui bundle, and the
  full suite (336 pass, 28 skip, 0 fail).
- The forced gate catches cross-package breaks: dropping `newlyTerminalRuns`
  from a sidecar `RepoStore` fake makes `make build` exit non-zero, which an
  incremental build passed.
- The admin-ui gate catches bundler-only breaks: a bad import in
  `apps/admin-ui/vite.config.ts` passes `make build` but fails
  `make build-admin-ui` (`Could not resolve ...`, `failed to load config`).
- The pre-commit hook's `make lint` runs clean in its staging checkout.

Closes INTR-230
Closes INTR-231