### PR TITLE
Prevent overlapping inference during pending tool cycles

### DIFF
--- a/packages/inference/src/reactor.test.ts
+++ b/packages/inference/src/reactor.test.ts
@@ -1796,9 +1796,10 @@ describe("createReactor — abort handling", () => {
 describe("createReactor — dequeue priority", () => {
   test("tool.done is prioritized over message.received when tool calls are pending", async () => {
     // Pre-seed history with an assistant message containing a tool_call
-    // block. Using addToHistory=false on executeTools keeps this as the
-    // last message, so historyHasPendingToolCalls() stays true when the
-    // loop calls dequeueNext() after tools complete.
+    // block, then run tools with addToHistory=false so no tool-result turn is
+    // appended. pendingContinuations keeps the cycle pending regardless of
+    // history shape: the enqueued tool.done is drained before the message
+    // delivered mid-run.
     const seededTurns: ConversationTurn[] = [
       {
         role: "assistant",
@@ -1817,9 +1818,8 @@ describe("createReactor — dequeue priority", () => {
 
     const order: string[] = [];
 
-    // Empty content prevents the reactor from appending a user text
-    // message to history, preserving the assistant tool_call as the
-    // last entry so historyHasPendingToolCalls() stays true.
+    // A minimal inbound message; its content is irrelevant to the cycle-event
+    // drain ordering this test exercises.
     const emptyMessage: InboundMessage = {
       ref: { uid: 1, mailbox: "INBOX" },
       headers: {
@@ -1868,14 +1868,232 @@ describe("createReactor — dequeue priority", () => {
     reactor.deliver(emptyMessage);
     await waitFor("reactor.done");
 
-    // tool.done should appear before the second message.received in the
-    // order array, because dequeueNext prioritizes cycle events when
-    // the last history message has pending tool_calls.
+    // tool.done should appear before the second message.received in the order
+    // array, because dequeueNext drains cycle events while
+    // pendingContinuations is positive.
     const toolDoneIdx = order.indexOf("tool.done");
     const secondMessageIdx = order.lastIndexOf("message.received");
     expect(toolDoneIdx).toBeGreaterThan(-1);
     expect(secondMessageIdx).toBeGreaterThan(-1);
     expect(toolDoneIdx).toBeLessThan(secondMessageIdx);
+  });
+
+  function assistantToolCallTurn(ids: string[]): ConversationTurn {
+    return {
+      role: "assistant",
+      content: ids.map((id) => ({
+        type: "tool_call" as const,
+        id,
+        name: "some_tool",
+        arguments: {},
+      })),
+      model: "test-model",
+      timestamp: 1000,
+    };
+  }
+
+  test("tool.done is prioritized over message.received with addToHistory=true", async () => {
+    // The production path uses addToHistory=true, so executeTools appends the
+    // tool-result turn to history before its tool.done events are consumed.
+    // The pendingContinuations counter, not history shape, must keep the
+    // cycle pending so mail delivered mid-batch cannot start an overlapping
+    // inference. Against the old history-shape gate the appended tool-result
+    // turn flips the gate false, the queued message.received jumps ahead, the
+    // director shuts down on it, and tool.done is never processed.
+    const order: string[] = [];
+
+    const { reactor, waitFor } = createTestReactor({
+      contextStore: makeContextStore([assistantToolCallTurn(["tc-pending"])]),
+      director: {
+        async decide(event, _state, caps) {
+          order.push(event.type);
+          if (event.type === "message.received") {
+            if (order.filter((t) => t === "message.received").length >= 2) {
+              return caps.done();
+            }
+            return caps.executeTools(
+              [{ id: "tc-pending", name: "some_tool", arguments: {} }],
+              true,
+              true,
+            );
+          }
+          if (event.type === "tool.done") {
+            return caps.wait();
+          }
+          return caps.done();
+        },
+      },
+      toolRunner: makeToolRunner(async (call) => {
+        // Deliver a second message while the tool runs, then yield to a real
+        // timer so deliver()'s async enqueue lands before executeTools
+        // enqueues tool.done. This pins the queue order to
+        // [message.received, tool.done] — the interleave that triggers the bug.
+        reactor.deliver(makeInboundMessage());
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return { callId: call.id, content: "ok" };
+      }),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    const toolDoneIdx = order.indexOf("tool.done");
+    const secondMessageIdx = order.lastIndexOf("message.received");
+    expect(toolDoneIdx).toBeGreaterThan(-1);
+    expect(secondMessageIdx).toBeGreaterThan(-1);
+    expect(toolDoneIdx).toBeLessThan(secondMessageIdx);
+  });
+
+  // Both tool.done events of a two-call batch must be drained before mail
+  // delivered mid-batch. pendingContinuations must track the full batch count,
+  // not a single in-cycle flag. Run for both parallel and sequential
+  // execution since those take different enqueue paths in executeTools.
+  async function collectBatchDrainOrder(parallel: boolean): Promise<string[]> {
+    const order: string[] = [];
+    let toolDoneCount = 0;
+
+    const { reactor, waitFor } = createTestReactor({
+      contextStore: makeContextStore([assistantToolCallTurn(["tc-a", "tc-b"])]),
+      director: {
+        async decide(event, _state, caps) {
+          order.push(event.type);
+          if (event.type === "message.received") {
+            if (order.filter((t) => t === "message.received").length >= 2) {
+              return caps.done();
+            }
+            return caps.executeTools(
+              [
+                { id: "tc-a", name: "some_tool", arguments: {} },
+                { id: "tc-b", name: "some_tool", arguments: {} },
+              ],
+              parallel,
+              true,
+            );
+          }
+          if (event.type === "tool.done") {
+            toolDoneCount += 1;
+            return toolDoneCount >= 2 ? caps.wait() : [];
+          }
+          return caps.done();
+        },
+      },
+      toolRunner: makeToolRunner(async (call) => {
+        reactor.deliver(makeInboundMessage());
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return { callId: call.id, content: "ok" };
+      }),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+    return order;
+  }
+
+  test("drains an entire parallel tool batch before inbound mail", async () => {
+    const order = await collectBatchDrainOrder(true);
+    expect(order.filter((t) => t === "tool.done").length).toBe(2);
+    expect(order.lastIndexOf("tool.done")).toBeLessThan(
+      order.lastIndexOf("message.received"),
+    );
+  });
+
+  test("drains an entire sequential tool batch before inbound mail", async () => {
+    const order = await collectBatchDrainOrder(false);
+    expect(order.filter((t) => t === "tool.done").length).toBe(2);
+    expect(order.lastIndexOf("tool.done")).toBeLessThan(
+      order.lastIndexOf("message.received"),
+    );
+  });
+
+  test("abort during a tool batch shuts down cleanly", async () => {
+    // An abort preempts a cycle, leaving pendingContinuations positive. The
+    // reactor must still terminate: abort takes priority over cycle draining
+    // and the leftover count is never read after shutdown.
+    const { reactor, waitFor } = createTestReactor({
+      contextStore: makeContextStore([assistantToolCallTurn(["tc-pending"])]),
+      director: {
+        async decide(event, _state, caps) {
+          if (event.type === "message.received") {
+            return caps.executeTools(
+              [{ id: "tc-pending", name: "some_tool", arguments: {} }],
+              true,
+              true,
+            );
+          }
+          return caps.done();
+        },
+      },
+      toolRunner: makeToolRunner(async (call) => {
+        reactor.abort("admin_kill");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return { callId: call.id, content: "ok" };
+      }),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    // Reaching reactor.done is the assertion: abort preempted the queued
+    // tool.done and the reactor terminated despite a positive count.
+    await waitFor("reactor.done");
+  });
+
+  test("inference.done is processed before mail delivered mid-inference", async () => {
+    // The overlapping-inference window for a plain (no-tool) response: mail
+    // arriving while an inference runs must not start a second inference ahead
+    // of the first inference's own completion event. The counter defers it;
+    // the old history-shape gate would have let the mail jump ahead, since a
+    // plain-text assistant turn is not a pending tool_call turn.
+    const order: string[] = [];
+    let inferenceCount = 0;
+
+    const { reactor, waitFor } = createTestReactor({
+      director: {
+        async decide(event, _state, caps) {
+          order.push(event.type);
+          if (event.type === "message.received") {
+            if (order.filter((t) => t === "message.received").length >= 2) {
+              return caps.done();
+            }
+            return caps.infer();
+          }
+          if (event.type === "inference.done") {
+            return caps.wait();
+          }
+          return caps.done();
+        },
+      },
+      inferenceRunner: async function* (opts) {
+        inferenceCount += 1;
+        // Deliver mail mid-inference, then yield to a real timer so the
+        // message is enqueued before inference.done.
+        reactor.deliver(makeInboundMessage());
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        yield {
+          type: "inference.done",
+          seq: opts.nextSeq(),
+          data: {
+            turn: makeAssistantTurn("plain reply"),
+            usage: emptyUsage(),
+            source: TEST_SOURCE,
+          },
+        };
+      },
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    const inferenceDoneIdx = order.indexOf("inference.done");
+    const secondMessageIdx = order.lastIndexOf("message.received");
+    expect(inferenceDoneIdx).toBeGreaterThan(-1);
+    expect(secondMessageIdx).toBeGreaterThan(-1);
+    expect(inferenceDoneIdx).toBeLessThan(secondMessageIdx);
+    // Sanity check: exactly one inference ran for the single inferring
+    // message. The ordering assertions above are what guard the regression.
+    expect(inferenceCount).toBe(1);
   });
 });
 

--- a/packages/inference/src/reactor.test.ts
+++ b/packages/inference/src/reactor.test.ts
@@ -4303,3 +4303,71 @@ describe("createReactor — source failover", () => {
     );
   });
 });
+
+describe("createReactor — prompt well-formedness tripwire", () => {
+  test("rejects a malformed assembled prompt before inferring", async () => {
+    // History with two tool_result blocks for one callId is the shape
+    // OpenAI-compatible providers reject with HTTP 400. executeInfer must
+    // catch it before sending and surface it as a fatal reactor error rather
+    // than letting it reach a provider. This also guards the assertion's
+    // call site: without it, no test would notice the prompt going out.
+    const malformed: ConversationTurn[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_call", id: "tc-1", name: "some_tool", arguments: {} },
+        ],
+        model: "test-model",
+        timestamp: 0,
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            callId: "tc-1",
+            content: [{ type: "text", text: "first" }],
+          },
+          {
+            type: "tool_result",
+            callId: "tc-1",
+            content: [{ type: "text", text: "duplicate" }],
+          },
+        ],
+        timestamp: 0,
+      },
+    ];
+
+    let inferenceRan = false;
+
+    const { reactor, events, waitFor } = createTestReactor({
+      contextStore: makeContextStore(malformed),
+      director: directorFromTable({
+        "message.received": (_e, _s, caps) => caps.infer(),
+      }),
+      inferenceRunner: async function* () {
+        inferenceRan = true;
+        yield {
+          type: "inference.done",
+          seq: 1,
+          data: {
+            turn: makeAssistantTurn("unreachable"),
+            usage: emptyUsage(),
+            source: TEST_SOURCE,
+          },
+        };
+      },
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    const error = getEvent(events, "reactor.error");
+    expect(error.data.fatal).toBe(true);
+    expect(error.data.error).toMatch(/Malformed tool sequence/);
+    expect(error.data.error).toMatch(/duplicate tool_result for "tc-1"/);
+    // The prompt never reached the inference runner.
+    expect(inferenceRan).toBe(false);
+  });
+});

--- a/packages/inference/src/reactor.ts
+++ b/packages/inference/src/reactor.ts
@@ -45,7 +45,11 @@ import { createGateManager } from "./gates";
 import { createCorrelationRegistry } from "./correlation";
 import { createStateManager } from "./state";
 import { validateActions } from "./actions";
-import { createToolResultTurn, createInboundTurn } from "./turns";
+import {
+  createToolResultTurn,
+  createInboundTurn,
+  assertWellFormedToolSequence,
+} from "./turns";
 import type { CorrelationValidator } from "./correlation";
 
 const logger = getLogger(["interchange", "reactor"]);
@@ -441,6 +445,13 @@ export function createReactor(config: ReactorConfig): Reactor {
       manifestBuffer.push(result.record);
       await persistBlobs(result.blobs);
     }
+
+    // Tripwire: a malformed tool sequence is invalid in a coherent tool
+    // conversation and would otherwise surface as an opaque provider rejection.
+    // Catch it here, before the prompt is persisted or sent, so the corruption
+    // fails loud as an internal error at the assembly boundary. Throwing routes
+    // through the reactor's fatal-error path.
+    assertWellFormedToolSequence(prompt);
 
     try {
       await contextStore.writePrompt(prompt);

--- a/packages/inference/src/reactor.ts
+++ b/packages/inference/src/reactor.ts
@@ -167,7 +167,40 @@ export function createReactor(config: ReactorConfig): Reactor {
   const queue: ReactorInboundEvent[] = [];
   let queueResolve: (() => void) | null = null;
 
+  // A tool cycle spans from the moment the reactor dispatches an inference or
+  // a tool batch until the director has consumed every completion event that
+  // operation produces. While a cycle is in flight, admitting a new inbound
+  // message — and the inference it triggers — ahead of the outstanding
+  // completion events corrupts the prompt: an assistant tool_call turn must be
+  // immediately followed by its tool results, and a new inference would
+  // instead interleave fresh turns and re-infer against a half-finished batch,
+  // which providers reject.
+  //
+  // pendingContinuations is the authoritative count of dispatched operations
+  // whose completion events have not yet been consumed. Every cycle event is
+  // counted as it is enqueued and uncounted as it is dequeued, so the count
+  // always equals the number of cycle events waiting in the queue. While it is
+  // positive, dequeueNext drains cycle events ahead of inbound mail; at zero
+  // the cycle is quiescent and processing reverts to FIFO.
+  //
+  // An earlier design inferred "mid-cycle" from history shape — whether the
+  // last turn was an assistant tool_call turn. That underreports in-flight
+  // work: a finished tool batch appends its tool-result turn to history before
+  // its tool.done events are consumed, flipping the last turn away from the
+  // assistant tool_call turn while completion events are still queued, which
+  // let inbound mail start an overlapping inference.
+  const CYCLE_EVENT_TYPES = new Set<ReactorInboundEvent["type"]>([
+    "inference.done",
+    "inference.error",
+    "tool.done",
+  ]);
+
+  let pendingContinuations = 0;
+
   function enqueue(event: ReactorInboundEvent): void {
+    if (CYCLE_EVENT_TYPES.has(event.type)) {
+      pendingContinuations += 1;
+    }
     queue.push(event);
     if (queueResolve !== null) {
       const resolve = queueResolve;
@@ -183,34 +216,6 @@ export function createReactor(config: ReactorConfig): Reactor {
     });
   }
 
-  // When the last message in history is an assistant message with tool_calls
-  // whose results haven't been appended yet, the conversation is in a
-  // transient state. Inserting a user text message (from message.received)
-  // at this point violates the provider's protocol: an assistant tool_call
-  // must be immediately followed by the corresponding tool result messages.
-  //
-  // To prevent this, we check whether the history has pending tool_calls
-  // and, if so, prioritize inference-cycle events (inference.done,
-  // inference.error, tool.done) so the cycle completes before inbound
-  // messages are interleaved. Once the tool results are in history, we
-  // revert to FIFO so inbound messages are processed promptly.
-  const CYCLE_EVENT_TYPES = new Set<ReactorInboundEvent["type"]>([
-    "inference.done",
-    "inference.error",
-    "tool.done",
-  ]);
-
-  function historyHasPendingToolCalls(): boolean {
-    if (stateManager === null) return false;
-    const turns = stateManager.getTurns();
-    if (turns.length === 0) return false;
-
-    const last = turns.at(-1);
-    if (last === undefined || last.role !== "assistant") return false;
-
-    return last.content.some((b) => b.type === "tool_call");
-  }
-
   function dequeueNext(): ReactorInboundEvent | undefined {
     if (queue.length === 0) return undefined;
 
@@ -220,9 +225,10 @@ export function createReactor(config: ReactorConfig): Reactor {
       return queue.splice(abortIdx, 1)[0];
     }
 
-    // When mid-cycle (assistant tool_calls without tool results), drain
-    // inference-cycle events before anything else.
-    if (historyHasPendingToolCalls()) {
+    // Mid-cycle: drain inference-cycle events before anything else so the
+    // outstanding inference or tool batch completes before new mail can start
+    // an overlapping inference.
+    if (pendingContinuations > 0) {
       const idx = queue.findIndex((e) => CYCLE_EVENT_TYPES.has(e.type));
       if (idx !== -1) {
         return queue.splice(idx, 1)[0];
@@ -827,6 +833,13 @@ export function createReactor(config: ReactorConfig): Reactor {
 
       const event = dequeueNext();
       if (event === undefined) continue;
+
+      // A dequeued cycle event is one fewer in-flight continuation. Pairs with
+      // the increment in enqueue(); both key off CYCLE_EVENT_TYPES so they
+      // cannot drift.
+      if (CYCLE_EVENT_TYPES.has(event.type)) {
+        pendingContinuations -= 1;
+      }
 
       // Handle abort events: initiate shutdown regardless of director.
       if (event.type === "abort") {

--- a/packages/inference/src/turns.test.ts
+++ b/packages/inference/src/turns.test.ts
@@ -1,7 +1,11 @@
 import { describe, test, expect } from "bun:test";
 import { base64Encode } from "@intx/types";
-import type { InboundMessage, MessageAttachment } from "@intx/types/runtime";
-import { createInboundTurn } from "./turns";
+import type {
+  ConversationTurn,
+  InboundMessage,
+  MessageAttachment,
+} from "@intx/types/runtime";
+import { assertWellFormedToolSequence, createInboundTurn } from "./turns";
 
 function att(contentType: string, bytes: number[]): MessageAttachment {
   return { name: "file", contentType, data: new Uint8Array(bytes) };
@@ -124,5 +128,104 @@ describe("createInboundTurn", () => {
         },
       ],
     });
+  });
+});
+
+function toolCallTurn(ids: string[]): ConversationTurn {
+  return {
+    role: "assistant",
+    content: ids.map((id) => ({
+      type: "tool_call" as const,
+      id,
+      name: "some_tool",
+      arguments: {},
+    })),
+    model: "test-model",
+    timestamp: 0,
+  };
+}
+
+function toolResultTurn(callIds: string[]): ConversationTurn {
+  return {
+    role: "user",
+    content: callIds.map((callId) => ({
+      type: "tool_result" as const,
+      callId,
+      content: [{ type: "text" as const, text: "ok" }],
+    })),
+    timestamp: 0,
+  };
+}
+
+describe("assertWellFormedToolSequence", () => {
+  test("accepts a well-formed multi-cycle conversation", () => {
+    const turns: ConversationTurn[] = [
+      { role: "user", content: [{ type: "text", text: "hi" }], timestamp: 0 },
+      toolCallTurn(["c1", "c2"]),
+      toolResultTurn(["c1", "c2"]),
+      toolCallTurn(["c3"]),
+      toolResultTurn(["c3"]),
+    ];
+    expect(() => assertWellFormedToolSequence(turns)).not.toThrow();
+  });
+
+  test("accepts an unanswered tool_call (halt/abort leaves no result)", () => {
+    const turns: ConversationTurn[] = [toolCallTurn(["c1"])];
+    expect(() => assertWellFormedToolSequence(turns)).not.toThrow();
+  });
+
+  test("accepts empty input", () => {
+    expect(() => assertWellFormedToolSequence([])).not.toThrow();
+  });
+
+  test("throws when a call id is re-emitted after it was answered", () => {
+    // The literal INTR-225 overlap shape: a stale batch re-issues a call id
+    // that already has a result.
+    const turns: ConversationTurn[] = [
+      toolCallTurn(["c1"]),
+      toolResultTurn(["c1"]),
+      toolCallTurn(["c1"]),
+    ];
+    expect(() => assertWellFormedToolSequence(turns)).toThrow(
+      /duplicate tool_call id "c1"/,
+    );
+  });
+
+  test("throws on two results for one call in the same turn", () => {
+    const turns: ConversationTurn[] = [
+      toolCallTurn(["c1"]),
+      toolResultTurn(["c1", "c1"]),
+    ];
+    expect(() => assertWellFormedToolSequence(turns)).toThrow(
+      /duplicate tool_result for "c1"/,
+    );
+  });
+
+  test("throws on a duplicate tool_result for one callId", () => {
+    const turns: ConversationTurn[] = [
+      toolCallTurn(["c1"]),
+      toolResultTurn(["c1"]),
+      toolResultTurn(["c1"]),
+    ];
+    expect(() => assertWellFormedToolSequence(turns)).toThrow(
+      /duplicate tool_result for "c1"/,
+    );
+  });
+
+  test("throws on a tool_result with no preceding tool_call", () => {
+    const turns: ConversationTurn[] = [toolResultTurn(["c1"])];
+    expect(() => assertWellFormedToolSequence(turns)).toThrow(
+      /no preceding tool_call/,
+    );
+  });
+
+  test("throws on a duplicate tool_call id", () => {
+    const turns: ConversationTurn[] = [
+      toolCallTurn(["c1"]),
+      toolCallTurn(["c1"]),
+    ];
+    expect(() => assertWellFormedToolSequence(turns)).toThrow(
+      /duplicate tool_call id "c1"/,
+    );
   });
 });

--- a/packages/inference/src/turns.ts
+++ b/packages/inference/src/turns.ts
@@ -97,6 +97,54 @@ export function createInboundTurn(
   };
 }
 
+/**
+ * Assert that a prompt's tool_call / tool_result blocks are structurally
+ * well-formed before it is sent to a provider.
+ *
+ * Throws if a tool_call id is emitted twice, if a tool_result references a
+ * callId with no preceding tool_call, or if two tool_result blocks answer the
+ * same callId. None of these are valid in a coherent tool conversation — a
+ * tool call has exactly one result. Catching it here surfaces the corruption
+ * as an internal error at the assembly boundary, with the offending id and
+ * turn index, instead of an opaque downstream provider rejection.
+ *
+ * This deliberately does NOT require every tool_call to have a result: an
+ * unanswered tool_call is left legitimately by an after-inference halt/abort
+ * and is repaired downstream for cross-provider replay.
+ */
+export function assertWellFormedToolSequence(turns: ConversationTurn[]): void {
+  const calledIds = new Set<string>();
+  const answeredIds = new Set<string>();
+
+  for (let turnIndex = 0; turnIndex < turns.length; turnIndex++) {
+    const turn = turns[turnIndex];
+    if (turn === undefined) continue;
+
+    for (const block of turn.content) {
+      if (block.type === "tool_call") {
+        if (calledIds.has(block.id)) {
+          throw new Error(
+            `Malformed tool sequence: duplicate tool_call id ${JSON.stringify(block.id)} at turn ${String(turnIndex)}`,
+          );
+        }
+        calledIds.add(block.id);
+      } else if (block.type === "tool_result") {
+        if (!calledIds.has(block.callId)) {
+          throw new Error(
+            `Malformed tool sequence: tool_result for ${JSON.stringify(block.callId)} at turn ${String(turnIndex)} has no preceding tool_call`,
+          );
+        }
+        if (answeredIds.has(block.callId)) {
+          throw new Error(
+            `Malformed tool sequence: duplicate tool_result for ${JSON.stringify(block.callId)} at turn ${String(turnIndex)}`,
+          );
+        }
+        answeredIds.add(block.callId);
+      }
+    }
+  }
+}
+
 export function createToolResultTurn(results: ToolResult[]): ConversationTurn {
   const blocks: ContentBlock[] = results.map((r) => {
     const raw =


### PR DESCRIPTION
## Summary

- Defer inbound mail behind a tool cycle's in-flight completion events
  so a new inference cannot start mid-batch. A reactor-owned counter of
  outstanding continuation events replaces the history-shape gate, which
  went stale the moment a finished batch's tool results were appended to
  history but before its completion events were consumed.
- Reject a malformed tool sequence (a repeated or orphaned tool result)
  at the inference boundary, failing loud as an internal error that names
  the offending call id instead of an opaque provider HTTP 400.

## Verification

- `make all` passes: lint, type-check, and both test passes are green.
- New tests reproduce the mail-interleave race and assert a single,
  correctly ordered cycle; cover multi-tool batch drain (parallel and
  sequential) and abort-mid-cycle; and exercise the prompt tripwire both
  directly and through the reactor.

Closes INTR-225