### PR TITLE
Decouple hub routing and availability from sidecar session restore

### DIFF
--- a/packages/hub-agent/src/session-manager.test.ts
+++ b/packages/hub-agent/src/session-manager.test.ts
@@ -469,3 +469,168 @@ describe("SessionManager.onAgentEvent per-agent fan-out", () => {
     expect(bobEvents).toEqual([bobTick, bobTick]);
   });
 });
+
+async function seedAgentsOnDisk(
+  dataDir: string,
+  addresses: string[],
+): Promise<void> {
+  const seed = makeManagerHarness(dataDir);
+  for (const address of addresses) {
+    await seed.manager.provisionAgent(makeConfig(address));
+    await seed.manager.startSession(address);
+  }
+}
+
+function makeRestoredBundle(): HarnessBundle {
+  return {
+    harness: makeHarnessStub(),
+    mailStore: makeMailStoreStub(),
+    updateGrants() {
+      /* no-op: restore tests do not assert on grants */
+    },
+    disposers: [],
+  };
+}
+
+function makeRestoreStores(dataDir: string): {
+  repoStore: ReturnType<typeof createAgentRepoStore>;
+  keyStore: ReturnType<typeof createAgentKeyStore>;
+} {
+  return {
+    repoStore: createAgentRepoStore({ dataDir }),
+    keyStore: createAgentKeyStore({
+      dataDir,
+      generateKeyPair: async () => makeKeyPair(11),
+      signEd25519: () => new Uint8Array(64),
+      verifySSHSig: () => true,
+    }),
+  };
+}
+
+describe("SessionManager.restoreSessions bounded parallelism", () => {
+  test("rejects a non-positive restoreConcurrency", async () => {
+    const dataDir = await tempDir();
+    const { repoStore, keyStore } = makeRestoreStores(dataDir);
+    expect(() =>
+      createSessionManager({
+        transport: createInMemoryTransport(),
+        repoStore,
+        keyStore,
+        buildHarness: makeRecordingBuilder({}),
+        createAgentCrypto: (kp) => makeCrypto(kp),
+        onEvent: () => {
+          /* no-op */
+        },
+        onConnectorStateChanged: () => {
+          /* no-op */
+        },
+        restoreConcurrency: 0,
+      }),
+    ).toThrow(/restoreConcurrency must be a positive integer/);
+  });
+
+  test("restores up to restoreConcurrency agents at once, no more", async () => {
+    const dataDir = await tempDir();
+    const addresses = ["a@local", "b@local", "c@local"];
+    await seedAgentsOnDisk(dataDir, addresses);
+
+    // Fresh stores + transport stand in for a restarted process that
+    // restores the seeded agents from disk.
+    const { repoStore, keyStore } = makeRestoreStores(dataDir);
+
+    const buildStarts: string[] = [];
+    let startedCount = 0;
+    let signalBoundReached!: () => void;
+    const boundReached = new Promise<void>((resolve) => {
+      signalBoundReached = resolve;
+    });
+    let releaseBuilds!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseBuilds = resolve;
+    });
+    const builder: HarnessBuilder = {
+      canBuildSource() {
+        /* accept every source */
+      },
+      async build(args) {
+        buildStarts.push(args.agentAddress);
+        startedCount += 1;
+        if (startedCount === 2) signalBoundReached();
+        await gate;
+        return makeRestoredBundle();
+      },
+    };
+
+    const manager = createSessionManager({
+      transport: createInMemoryTransport(),
+      repoStore,
+      keyStore,
+      buildHarness: builder,
+      createAgentCrypto: (kp) => makeCrypto(kp),
+      onEvent: () => {
+        /* no-op */
+      },
+      onConnectorStateChanged: () => {
+        /* no-op */
+      },
+      restoreConcurrency: 2,
+    });
+
+    const restorePromise = manager.restoreSessions();
+    // Two builds run at once; the third cannot start until a worker
+    // slot frees, which needs the gate to release. A serial restore
+    // would hold at one started build and this await would never settle.
+    await boundReached;
+    expect(buildStarts.length).toBe(2);
+
+    releaseBuilds();
+    const result = await restorePromise;
+    // All three eventually build once slots free up.
+    expect(buildStarts.length).toBe(3);
+    expect(result.failed).toEqual([]);
+    expect(result.restored.map((r) => r.address).sort()).toEqual(
+      [...addresses].sort(),
+    );
+  });
+
+  test("reports a failing agent as failed without blocking the rest", async () => {
+    const dataDir = await tempDir();
+    const addresses = ["healthy1@local", "wedged@local", "healthy2@local"];
+    await seedAgentsOnDisk(dataDir, addresses);
+
+    const { repoStore, keyStore } = makeRestoreStores(dataDir);
+
+    const builder: HarnessBuilder = {
+      canBuildSource() {
+        /* accept every source */
+      },
+      async build(args) {
+        if (args.agentAddress === "wedged@local") {
+          throw new Error("registry fetch exceeded the timeout");
+        }
+        return makeRestoredBundle();
+      },
+    };
+
+    const manager = createSessionManager({
+      transport: createInMemoryTransport(),
+      repoStore,
+      keyStore,
+      buildHarness: builder,
+      createAgentCrypto: (kp) => makeCrypto(kp),
+      onEvent: () => {
+        /* no-op */
+      },
+      onConnectorStateChanged: () => {
+        /* no-op */
+      },
+    });
+
+    const result = await manager.restoreSessions();
+    expect(result.failed).toEqual(["wedged@local"]);
+    expect(result.restored.map((r) => r.address).sort()).toEqual([
+      "healthy1@local",
+      "healthy2@local",
+    ]);
+  });
+});

--- a/packages/hub-agent/src/session-manager.ts
+++ b/packages/hub-agent/src/session-manager.ts
@@ -95,7 +95,21 @@ export type SessionManagerConfig = {
    * distribution can omit this.
    */
   onDeployApplyError?: DeployApplyErrorSink;
+  /**
+   * Maximum number of agents whose sessions `restoreSessions` restores
+   * concurrently. Restore work is per-agent isolated (per-agent git dir,
+   * per-address repo lock), so agents restore in parallel up to this
+   * bound and a single slow or wedged agent no longer gates the rest.
+   * Defaults to `DEFAULT_RESTORE_CONCURRENCY`.
+   */
+  restoreConcurrency?: number;
 };
+
+/**
+ * Default `restoreConcurrency`: how many agents `restoreSessions`
+ * restores in parallel when the caller does not override it.
+ */
+const DEFAULT_RESTORE_CONCURRENCY = 4;
 
 export type ProvisionResult = {
   publicKey: string;
@@ -203,7 +217,13 @@ export function createSessionManager(
     onEvent,
     onConnectorStateChanged,
     onDeployApplyError,
+    restoreConcurrency = DEFAULT_RESTORE_CONCURRENCY,
   } = config;
+  if (!Number.isInteger(restoreConcurrency) || restoreConcurrency < 1) {
+    throw new Error(
+      `createSessionManager: restoreConcurrency must be a positive integer; got ${String(restoreConcurrency)}`,
+    );
+  }
 
   const sessions = new Map<string, LiveSession>();
   const provisioned = new Map<string, ProvisionedAgent>();
@@ -547,17 +567,27 @@ export function createSessionManager(
       repoStore.scanConfigs(),
     ]);
 
-    const restored: RestoredAgent[] = [];
-    const failed: string[] = [];
+    // Restore agents with bounded parallelism. Each agent's provision +
+    // startSession is per-agent isolated (per-agent git dir, per-address
+    // repo lock), so running several at once cannot corrupt shared
+    // state, and one slow or wedged agent no longer gates the rest.
+    // Outcomes are written into per-index slots so the returned order is
+    // independent of completion order.
+    type Outcome =
+      | { kind: "restored"; agent: RestoredAgent }
+      | { kind: "failed"; address: string };
+    const outcomes = new Array<Outcome | undefined>(configEntries.length);
 
-    for (const entry of configEntries) {
+    async function restoreOne(index: number): Promise<void> {
+      const entry = configEntries[index];
+      if (entry === undefined) return;
       const keyEntry: AgentKeyEntry | undefined = keysByAddress.get(
         entry.address,
       );
       if (keyEntry === undefined) {
         logger.error`Cannot restore "${entry.address}": agent.json exists but key pair is missing`;
-        failed.push(entry.address);
-        continue;
+        outcomes[index] = { kind: "failed", address: entry.address };
+        return;
       }
 
       const agent: RestoredAgent = {
@@ -569,8 +599,8 @@ export function createSessionManager(
       }
 
       if (sessions.has(entry.address)) {
-        restored.push(agent);
-        continue;
+        outcomes[index] = { kind: "restored", agent };
+        return;
       }
       try {
         await provisionAgent(entry.config);
@@ -578,13 +608,36 @@ export function createSessionManager(
           await repoStore.persistPairing(entry.address, entry.hubPublicKey);
         }
         await startSession(entry.address);
-        restored.push(agent);
+        outcomes[index] = { kind: "restored", agent };
         logger.info`Restored session for ${entry.address}`;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        failed.push(entry.address);
+        outcomes[index] = { kind: "failed", address: entry.address };
         logger.error`Failed to restore session for ${entry.address}: ${msg}`;
       }
+    }
+
+    // Worker pool: each worker pulls the next index until the list
+    // drains. Reading and advancing `cursor` is synchronous (no await
+    // between), so each index is handed to exactly one worker.
+    let cursor = 0;
+    async function worker(): Promise<void> {
+      for (;;) {
+        const index = cursor;
+        cursor += 1;
+        if (index >= configEntries.length) return;
+        await restoreOne(index);
+      }
+    }
+    const workerCount = Math.min(restoreConcurrency, configEntries.length);
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+    const restored: RestoredAgent[] = [];
+    const failed: string[] = [];
+    for (const outcome of outcomes) {
+      if (outcome === undefined) continue;
+      if (outcome.kind === "restored") restored.push(outcome.agent);
+      else failed.push(outcome.address);
     }
 
     return { restored, failed };

--- a/packages/hub-agent/src/ws/hub-link.test.ts
+++ b/packages/hub-agent/src/ws/hub-link.test.ts
@@ -1623,3 +1623,98 @@ describe("sidecar↔hub integration", () => {
     }
   });
 });
+
+describe("routability decoupled from restore", () => {
+  test("empty register ships before restore resolves; reconnect-with-addresses only after", async () => {
+    const frames: string[] = [];
+    const app = new Hono();
+    app.get(
+      "/ws",
+      upgradeWebSocket((_c) => ({
+        onMessage(evt, _ws) {
+          if (typeof evt.data === "string") {
+            frames.push(evt.data);
+          }
+        },
+      })),
+    );
+    const server = Bun.serve({ fetch: app.fetch, websocket, port: 0 });
+
+    const transport = createInMemoryTransport();
+    const sessions = createMockSessionManager();
+
+    type RestoreResult = Awaited<ReturnType<SessionManager["restoreSessions"]>>;
+    let releaseRestore!: (result: RestoreResult) => void;
+    const pendingRestore = new Promise<RestoreResult>((resolve) => {
+      releaseRestore = resolve;
+    });
+    sessions.restoreSessions = () => pendingRestore;
+    sessions.getDeployRef = async () => "a".repeat(40);
+
+    const client = createHubLink({
+      hubURL: `ws://localhost:${server.port}/ws`,
+      sidecarId: "sc-early-register",
+      token: "test-token",
+      transport,
+      sessions,
+      ...withTestDeployBindings(sessions),
+    });
+
+    client.connect();
+    try {
+      // The empty-address register reaches the hub while restoreSessions is
+      // still pending: routability no longer waits on restore.
+      await waitFor(() =>
+        frames
+          .map((s) => JSON.parse(s))
+          .some((f: { type: string }) => f.type === "register"),
+      );
+      const beforeResolve = frames.map((s) => JSON.parse(s));
+      const registerFrames = beforeResolve.filter(
+        (f: { type: string }) => f.type === "register",
+      );
+      expect(registerFrames).toHaveLength(1);
+      expect(registerFrames[0].agentAddresses).toEqual([]);
+      // No reconnect yet: addresses enter addressIndex only after restore.
+      expect(
+        beforeResolve.some((f: { type: string }) => f.type === "reconnect"),
+      ).toBe(false);
+
+      releaseRestore({
+        restored: [
+          {
+            address: "agent-1@test.interchange",
+            keyPair: {
+              publicKey: new Uint8Array(32),
+              privateKey: new Uint8Array(32),
+            },
+          },
+        ],
+        failed: [],
+      });
+
+      // The challenged reconnect frame, carrying the restored address, ships
+      // only after restore resolves.
+      await waitFor(() =>
+        frames
+          .map((s) => JSON.parse(s))
+          .some((f: { type: string }) => f.type === "reconnect"),
+      );
+      const parsed = frames.map((s) => JSON.parse(s));
+      const reconnectFrame = parsed.find(
+        (f: { type: string }) => f.type === "reconnect",
+      );
+      expect(reconnectFrame.agentAddresses).toEqual([
+        "agent-1@test.interchange",
+      ]);
+      expect(
+        parsed.findIndex((f: { type: string }) => f.type === "register"),
+      ).toBeLessThan(
+        parsed.findIndex((f: { type: string }) => f.type === "reconnect"),
+      );
+    } finally {
+      client.close();
+      server.stop(true);
+    }
+  });
+});

--- a/packages/hub-agent/src/ws/hub-link.ts
+++ b/packages/hub-agent/src/ws/hub-link.ts
@@ -1017,6 +1017,23 @@ export function createHubLink(config: HubLinkConfig): HubLink {
       packReceiver.reset();
       packSender.cancelAll("Connection lost");
 
+      // Register the connection for routing before the restore loop runs. The
+      // hub learns of a sidecar only from a register/reconnect frame, and
+      // connections is the map sendAgentDeploy consults to route a new
+      // provision. An empty-address register here populates that map
+      // immediately, so a provision arriving during restore routes instead of
+      // hitting an empty map and failing with "No sidecar available". The
+      // address list must stay empty: carrying addresses through register
+      // writes addressIndex with no challenge and discards disconnect queues,
+      // so restored sessions enter addressIndex through the challenged
+      // reconnect frame below instead.
+      send({
+        type: "register",
+        sidecarId,
+        token,
+        agentAddresses: [],
+      });
+
       void (async () => {
         try {
           const { restored, failed } = await sessions.restoreSessions();
@@ -1049,12 +1066,24 @@ export function createHubLink(config: HubLinkConfig): HubLink {
               logger.info`Sent reconnect with ${String(restored.length)} agent(s)`;
             }
           } else {
-            send({
-              type: "register",
-              sidecarId,
-              token,
-              agentAddresses: sessions.getAddresses(),
-            });
+            // Reached only when nothing was restored from disk. The
+            // empty register on open already established routability, so
+            // skip a second empty frame. Any address present here belongs
+            // to an agent provisioned during the restore window —
+            // provisions route on that open register — which the hub
+            // already placed in addressIndex when it routed the deploy.
+            // Re-announcing those is consistent with that entry, not an
+            // unchallenged write of a disk-restored address; those take
+            // the reconnect branch above.
+            const addresses = sessions.getAddresses();
+            if (addresses.length > 0) {
+              send({
+                type: "register",
+                sidecarId,
+                token,
+                agentAddresses: addresses,
+              });
+            }
           }
 
           flush();

--- a/packages/hub-sessions/src/ws/sidecar-handler.test.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.test.ts
@@ -1328,6 +1328,189 @@ describe("SidecarRouter", () => {
   });
 
   describe("challenge/response reconnect", () => {
+    test("a provision routed during the restore window survives a reconnect", async () => {
+      // An agent provisioned while the sidecar is restoring must stay
+      // routable after the reconnect frame for the disk-restored agents
+      // lands. lookupPublicKey returns null so the challenge
+      // short-circuits; the eviction under test happens in
+      // handleReconnect's internal register before any challenge work.
+      const router = createSidecarRouter({
+        requestTimeoutMs: 500,
+        hubPublicKey: TEST_HUB_KEY,
+        lookups: {
+          lookupPublicKey: async () => null,
+        },
+      });
+
+      const config = {
+        sessionId: "ses_test",
+        agentId: "a1",
+        tenantId: "t1",
+        principalId: "prin_test",
+        agentAddress: "window-agent@local",
+        systemPrompt: "test",
+        tools: [],
+        grants: [],
+        sources: [
+          {
+            id: "anthropic:claude-sonnet-4-20250514",
+            provider: "anthropic",
+            baseURL: "https://api.anthropic.com",
+            apiKey: "sk-test",
+            model: "claude-sonnet-4-20250514",
+          },
+        ],
+        defaultSource: "anthropic:claude-sonnet-4-20250514",
+      };
+
+      const ws = createMockWs();
+      router.handleOpen(ws);
+
+      // Empty register on socket open establishes routability before restore.
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "register",
+          sidecarId: "sc-1",
+          token: "tok",
+          agentAddresses: [],
+        }),
+      );
+
+      // A fresh provision routes to this sidecar during the restore window.
+      const deployPromise = router.sendAgentDeploy(
+        "window-agent@local",
+        config,
+      );
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "agent.deploy.ack",
+          agentAddress: "window-agent@local",
+          publicKey: "deadbeef",
+        }),
+      );
+      await deployPromise;
+      expect(router.getRoutableAddresses()).toContain("window-agent@local");
+
+      // Restore finishes; the sidecar reconnects with only its
+      // disk-restored addresses.
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "reconnect",
+          sidecarId: "sc-1",
+          token: "tok",
+          agentAddresses: ["restored@local"],
+          deployRefs: {},
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 50));
+
+      // The window-provisioned agent stays routable.
+      expect(router.getRoutableAddresses()).toContain("window-agent@local");
+    });
+
+    test("a window-provisioned agent's connector state survives a reconnect", async () => {
+      // The same eviction that drops routing also drops the cached
+      // connector thread state. A window agent that established a thread
+      // during the restore window must keep it across the reconnect, or a
+      // following no-history user message forks a new thread instead of
+      // continuing the agent's active one.
+      const router = createSidecarRouter({
+        requestTimeoutMs: 500,
+        hubPublicKey: TEST_HUB_KEY,
+        lookups: {
+          lookupPublicKey: async () => null,
+        },
+      });
+
+      const config = {
+        sessionId: "ses_test",
+        agentId: "a1",
+        tenantId: "t1",
+        principalId: "prin_test",
+        agentAddress: "window-agent@local",
+        systemPrompt: "test",
+        tools: [],
+        grants: [],
+        sources: [
+          {
+            id: "anthropic:claude-sonnet-4-20250514",
+            provider: "anthropic",
+            baseURL: "https://api.anthropic.com",
+            apiKey: "sk-test",
+            model: "claude-sonnet-4-20250514",
+          },
+        ],
+        defaultSource: "anthropic:claude-sonnet-4-20250514",
+      };
+
+      const ws = createMockWs();
+      router.handleOpen(ws);
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "register",
+          sidecarId: "sc-1",
+          token: "tok",
+          agentAddresses: [],
+        }),
+      );
+
+      const deployPromise = router.sendAgentDeploy(
+        "window-agent@local",
+        config,
+      );
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "agent.deploy.ack",
+          agentAddress: "window-agent@local",
+          publicKey: "deadbeef",
+        }),
+      );
+      await deployPromise;
+
+      // The window agent establishes a connector thread during the window.
+      const connectorState = {
+        threadRoot: "<root@example.com>",
+        lastMessageId: "<last@example.com>",
+        replyTo: "user@example.com",
+        cc: [],
+      };
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "connector.state.changed",
+          agentAddress: "window-agent@local",
+          connectorState,
+        }),
+      );
+      expect(router.getConnectorState("window-agent@local")).toEqual(
+        connectorState,
+      );
+
+      // Restore finishes; the sidecar reconnects with only its
+      // disk-restored addresses.
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "reconnect",
+          sidecarId: "sc-1",
+          token: "tok",
+          agentAddresses: ["restored@local"],
+          deployRefs: {},
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 50));
+
+      // The window agent's connector thread state survives.
+      expect(router.getConnectorState("window-agent@local")).toEqual(
+        connectorState,
+      );
+    });
+
     test("reconnect issues challenge and verifies signature", async () => {
       const kp = await generateKeyPair();
       const publicKeyHex = hexEncode(kp.publicKey);

--- a/packages/hub-sessions/src/ws/sidecar-handler.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.ts
@@ -507,15 +507,18 @@ export function createSidecarRouter(
       return;
     }
 
-    // If this sidecar was already connected, clean up old state.
+    // If this same ws is re-registering, drop its addressIndex entries so
+    // the new register/reconnect rebuilds the owned set (handleReconnect
+    // and the loop below re-add the addresses that remain owned). Do not
+    // drop connectorStates here: this branch is reached only on a same-ws
+    // re-register, where the harness is live and its connector state is
+    // current. A genuinely restarting harness opens a new ws (so existing
+    // is undefined) and its stale state is cleared by the cross-ws ghost
+    // loop below and by handleClose.
     const existing = connections.get(ws);
     if (existing !== undefined) {
       for (const addr of existing.agentAddresses) {
         addressIndex.delete(addr);
-        // The harness on this ws is restarting; the cached connector
-        // state from its previous incarnation is now stale. The new
-        // harness will bootstrap via restore-fires-callback.
-        connectorStates.delete(addr);
       }
     }
 
@@ -603,12 +606,31 @@ export function createSidecarRouter(
       pendingChallenges.delete(ws);
     }
 
+    // Capture the addresses this live connection already owns. The
+    // internal register below clears them, but ones the reconnect is not
+    // re-challenging are still valid — an agent provisioned during the
+    // sidecar's restore window is routed into addressIndex by its deploy
+    // and is not part of the disk-restored set this reconnect carries.
+    // Without preserving them, the reconnect silently drops a
+    // freshly-deployed agent from routing.
+    const previouslyOwned = new Set(connections.get(ws)?.agentAddresses);
+
     // Register the sidecar connection immediately (with no addresses)
     // so it can receive frames while the challenge is pending.
     handleRegister(ws, sidecarId, token, []);
 
     const conn = connections.get(ws);
     if (conn === undefined) return;
+
+    // Re-add the still-owned addresses the register cleared but this
+    // reconnect is not re-challenging. The challenged addresses below
+    // re-enter addressIndex through the verified path instead.
+    const claimedAddresses = new Set(agentAddresses);
+    for (const addr of previouslyOwned) {
+      if (claimedAddresses.has(addr)) continue;
+      conn.agentAddresses.add(addr);
+      addressIndex.set(addr, ws);
+    }
 
     // Look up stored public keys for all claimed addresses.
     const keyLookups = await Promise.all(

--- a/packages/tool-packaging/src/loader.test.ts
+++ b/packages/tool-packaging/src/loader.test.ts
@@ -229,6 +229,21 @@ describe("createToolLoader", () => {
     expect(loaded[0]?.factories[0]?.id).toBe("@vendor/leaf/main");
   });
 
+  test("rejects a non-positive registryFetchTimeoutMs", () => {
+    const cache = createTarballCache({
+      rootDir: cacheDir,
+      maxBytes: 10_000_000,
+    });
+    expect(() =>
+      createToolLoader({
+        cache,
+        registries: new Map([["npmjs", { url: "https://r.test" }]]),
+        host: { os: "linux", cpu: "x64" },
+        registryFetchTimeoutMs: 0,
+      }),
+    ).toThrow(/registryFetchTimeoutMs must be a positive finite number/);
+  });
+
   test("skips entries whose os does not match the host", async () => {
     const cache = createTarballCache({
       rootDir: cacheDir,
@@ -2580,6 +2595,33 @@ describe("readResponseWithLimit", () => {
     const buf = await readResponseWithLimit(res, cap, stubCtx);
     expect(buf.byteLength).toBe(payload.byteLength);
     expect(buf[0]).toBe(0x7f);
+  });
+
+  test("aborts a stalled body when the fetch deadline signal fires", async () => {
+    // A body that never produces a chunk and never closes: reader.read()
+    // stays pending until the deadline cancels it. Without the signal
+    // guard this would block forever under the byte cap.
+    const stream = new ReadableStream<Uint8Array>({
+      start() {
+        // never enqueue, never close
+      },
+    });
+    const res = new Response(stream);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 20);
+    let caught: unknown;
+    try {
+      await readResponseWithLimit(res, 1024, stubCtx, controller.signal);
+    } catch (err) {
+      caught = err;
+    } finally {
+      clearTimeout(timer);
+    }
+    expect(caught).toBeInstanceOf(ToolLoaderError);
+    if (caught instanceof ToolLoaderError) {
+      expect(caught.category).toBe("registry.fetch.failed");
+      expect(caught.message).toMatch(/exceeded the registry fetch timeout/);
+    }
   });
 });
 

--- a/packages/tool-packaging/src/loader.ts
+++ b/packages/tool-packaging/src/loader.ts
@@ -138,6 +138,15 @@ export interface LoaderConfig {
    */
   readonly maxRegistryTarballBytes?: number;
   /**
+   * Deadline in milliseconds for a single HTTP-registry tarball fetch,
+   * spanning the request and the streamed body read. A stalled registry
+   * cannot block the fetch -- and the restoring `startSession` awaiting
+   * it -- past this bound. Defaults to
+   * `DEFAULT_REGISTRY_FETCH_TIMEOUT_MS`. Asset-sourced tarballs read from
+   * the local filesystem and are not subject to it.
+   */
+  readonly registryFetchTimeoutMs?: number;
+  /**
    * Test seam for tarball fetching. Production omits this and the
    * loader uses npm-registry-fetch + filesystem reads.
    */
@@ -160,6 +169,19 @@ export interface LoaderConfig {
  * mirror replays it.
  */
 export const DEFAULT_MAX_REGISTRY_TARBALL_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Default deadline for a single HTTP-registry tarball fetch, covering
+ * both the request and the streamed body read. `readResponseWithLimit`
+ * consumes the body through a manual reader loop, so the byte cap bounds
+ * size but nothing bounds time: a registry that accepts the connection
+ * and then stalls mid-stream would block the fetch -- and the
+ * `startSession` awaiting it during a sidecar restore -- indefinitely.
+ * The deadline is generous so a legitimately large tarball on a slow
+ * link still completes within it. Callers that need a different bound
+ * pass `registryFetchTimeoutMs` to `createToolLoader`.
+ */
+export const DEFAULT_REGISTRY_FETCH_TIMEOUT_MS = 120 * 1000;
 
 export type TarballFetcher = (
   entry: ToolPackageManifestEntry,
@@ -222,6 +244,13 @@ export function createToolLoader(config: LoaderConfig): ToolLoader {
   ) {
     throw new Error(
       `createToolLoader: maxRegistryTarballBytes must be a positive finite number; got ${String(maxRegistryTarballBytes)}`,
+    );
+  }
+  const registryFetchTimeoutMs =
+    config.registryFetchTimeoutMs ?? DEFAULT_REGISTRY_FETCH_TIMEOUT_MS;
+  if (!Number.isFinite(registryFetchTimeoutMs) || registryFetchTimeoutMs <= 0) {
+    throw new Error(
+      `createToolLoader: registryFetchTimeoutMs must be a positive finite number; got ${String(registryFetchTimeoutMs)}`,
     );
   }
   const fetchTarball = config.fetchTarball ?? makeDefaultTarballFetcher();
@@ -696,9 +725,19 @@ export function createToolLoader(config: LoaderConfig): ToolLoader {
       const tarballUrl =
         entry.tarballUrl ??
         defaultTarballUrl(registry.url, entry.name, entry.version);
+      // Bound the whole fetch -- request and streamed body read -- so a
+      // stalled registry cannot block the awaiting startSession forever.
+      // npm-registry-fetch honors the signal for the request phase;
+      // readResponseWithLimit honors it for the manual body read. The
+      // timer spans both phases and is cleared only once the read settles.
+      const controller = new AbortController();
+      const timer = setTimeout(() => {
+        controller.abort();
+      }, registryFetchTimeoutMs);
       try {
         const res = await npmRegistryFetch(tarballUrl, {
           ...buildRegistryFetchOpts(registry),
+          signal: controller.signal,
         });
         if (res.status === 401 || res.status === 403) {
           throw new ToolLoaderError({
@@ -714,18 +753,32 @@ export function createToolLoader(config: LoaderConfig): ToolLoader {
             package: { name: entry.name, version: entry.version },
           });
         }
-        return await readResponseWithLimit(res, maxRegistryTarballBytes, {
-          registry: entry.source.registry,
-          name: entry.name,
-          version: entry.version,
-        });
+        return await readResponseWithLimit(
+          res,
+          maxRegistryTarballBytes,
+          {
+            registry: entry.source.registry,
+            name: entry.name,
+            version: entry.version,
+          },
+          controller.signal,
+        );
       } catch (err) {
         if (err instanceof ToolLoaderError) throw err;
+        if (controller.signal.aborted) {
+          throw new ToolLoaderError({
+            category: "registry.fetch.failed",
+            message: `registry "${entry.source.registry}" fetch for ${entry.name}@${entry.version} exceeded the ${String(registryFetchTimeoutMs)}ms timeout`,
+            package: { name: entry.name, version: entry.version },
+          });
+        }
         throw new ToolLoaderError({
           category: "registry.fetch.failed",
           message: `registry "${entry.source.registry}" fetch failed for ${entry.name}@${entry.version}: ${describeError(err)}`,
           package: { name: entry.name, version: entry.version },
         });
+      } finally {
+        clearTimeout(timer);
       }
     };
   }
@@ -776,7 +829,12 @@ function defaultTarballUrl(
  *      the read when the running total crosses the cap. This catches
  *      the missing-or-lying header case.
  *
- * Both rejections surface as `registry.fetch.failed` so the apply layer
+ * An optional `signal` adds a time guard: when it aborts (the caller's
+ * fetch deadline), the in-flight read is cancelled and the call rejects,
+ * so a registry that streams the body slowly or stalls mid-stream cannot
+ * outlast the deadline while staying under the byte cap.
+ *
+ * All rejections surface as `registry.fetch.failed` so the apply layer
  * routes them the same as any other registry-side fetch defect.
  *
  * Exported for direct unit testing.
@@ -789,6 +847,7 @@ export async function readResponseWithLimit(
     readonly name: string;
     readonly version: string;
   },
+  signal?: AbortSignal,
 ): Promise<Buffer> {
   const declaredLengthRaw = res.headers.get("content-length");
   if (declaredLengthRaw !== null) {
@@ -820,9 +879,26 @@ export async function readResponseWithLimit(
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
+  // Cancelling the reader settles any pending read() as done, so the
+  // post-read check below surfaces the timeout even when the underlying
+  // body stream does not itself observe the abort signal.
+  let timedOut = false;
+  const onAbort = () => {
+    timedOut = true;
+    void reader.cancel();
+  };
+  signal?.addEventListener("abort", onAbort, { once: true });
+  if (signal?.aborted === true) onAbort();
   try {
     for (;;) {
       const { value, done } = await reader.read();
+      if (timedOut) {
+        throw new ToolLoaderError({
+          category: "registry.fetch.failed",
+          message: `tarball read for ${ctx.name}@${ctx.version} exceeded the registry fetch timeout`,
+          package: { name: ctx.name, version: ctx.version },
+        });
+      }
       if (done) break;
       if (value === undefined) continue;
       total += value.byteLength;
@@ -841,6 +917,7 @@ export async function readResponseWithLimit(
       chunks.push(value);
     }
   } finally {
+    signal?.removeEventListener("abort", onAbort);
     reader.releaseLock();
   }
   const out = Buffer.allocUnsafe(total);


### PR DESCRIPTION
## Summary

- On socket-open the sidecar registers for routing with an empty address
  list, so a provision arriving while it restores sessions routes
  immediately instead of failing with "No sidecar available"; the hub
  keeps that provision's routing and connector state across the
  restore-completing reconnect.
- The registry tarball fetch carries a deadline spanning the request and
  the streamed body read, so a stalled registry fails the fetch instead
  of hanging session restore.
- Session restore runs agents with bounded parallelism, so one slow or
  failing agent no longer blocks restoration of the others.

## Verification

- `make all` passes: lint, type-check, the admin-ui production bundle,
  and both test suites exit 0 (3732 + 339 tests, 0 failures).
- Tests cover the new behavior: a provision routed during restore stays
  routable and keeps its connector state across the reconnect; a stalled
  registry fetch aborts at its deadline; bounded-parallel restore
  isolates a wedged agent while healthy agents restore.

Closes INTR-235