### PR TITLE
Materialize tool packages at a stable per-deploy-id path

### DIFF
--- a/apps/sidecar/src/tool-materialization.test.ts
+++ b/apps/sidecar/src/tool-materialization.test.ts
@@ -292,7 +292,7 @@ describe("materializeToolPackages — manifest.invalid gate", () => {
 
   test("boot reconciliation reads the dirty marker as previousDeployId", async () => {
     // Seed an instance where the prior apply could not durably record
-    // the post-swap deploy id and a dirty marker carries the truth.
+    // the committed deploy id and a dirty marker carries the truth.
     // The next apply (any apply — here, a manifest-invalid one) must
     // surface the marker's id as `previousDeployId` in the failure
     // frame, not the stale recorded id and not "none".

--- a/apps/sidecar/src/tool-materialization.ts
+++ b/apps/sidecar/src/tool-materialization.ts
@@ -229,20 +229,20 @@ export async function materializeToolPackages(args: {
   const activeIdFile = path.join(instanceDir, "active-deploy-id");
   const activeIdDirtyFile = `${activeIdFile}.dirty`;
   // The dirty marker is written by `persistActiveDeployId`'s catch
-  // path when the post-swap persist (the normal write + fsync + dir
+  // path when the commit persist (the normal write + fsync + dir
   // fsync) failed on the prior apply and even the no-fsync fallback
-  // failed. Its presence means the on-disk apply state (the active
-  // tree) is newer than `active-deploy-id` and the marker carries the
-  // id that belongs there. Read it first so a degraded prior boot
-  // doesn't surface as `previousDeployId="none"` and silently demote
-  // the in-place active tree to "fresh instance".
+  // failed. Its presence means the staged deploy was committed but the
+  // recorded `active-deploy-id` is stale, and the marker carries the id
+  // that belongs there. Read it first so a degraded prior boot doesn't
+  // surface as `previousDeployId="none"` and silently demote the
+  // committed deploy to "fresh instance".
   let previousDeployId = NO_PRIOR_DEPLOY_ID;
   try {
     const dirtyRaw = (
       await fs.promises.readFile(activeIdDirtyFile, "utf-8")
     ).trim();
     const dirtyId = parseActiveDeployId(dirtyRaw, activeIdDirtyFile);
-    logger.warn`active-deploy-id dirty marker present at ${activeIdDirtyFile}; the prior apply could not durably record the post-swap deploy id and the boot is reconciling from ${dirtyId}`;
+    logger.warn`active-deploy-id dirty marker present at ${activeIdDirtyFile}; the prior apply could not durably record the committed deploy id and the boot is reconciling from ${dirtyId}`;
     previousDeployId = dirtyId;
   } catch (err) {
     if (!(hasCode(err) && err.code === "ENOENT")) {
@@ -339,26 +339,13 @@ export async function materializeToolPackages(args: {
   });
   if (result.status === "failed") {
     logger.warn`tool-package apply rejected for ${args.agentAddress}: ${result.category} — ${result.message}`;
-    // For `apply.previous-rotation.failed`, the swap committed: the new
-    // deploy is live on disk and `result.previousDeployId` carries the
-    // newDeployId (see ApplyAtomicFailure docs for that category).
-    // Durably record the new active id before emitting the failure so
-    // a crash or a hub-side abort after this point sees the on-disk
-    // state and the recorded id agree. The next apply will then read
-    // the new id as `previousDeployId` rather than the pre-apply one.
-    if (result.category === "apply.previous-rotation.failed") {
-      // The atomic-apply layer already finished the swap before the
-      // rotation failure; the new deploy is live and the failure frame
-      // carries the new id in `previousDeployId`. Use the same
-      // degradation ladder as the post-swap persist site below so a
-      // disk-full or EIO at this layer still writes either a no-fsync
-      // record or a dirty marker the next boot can reconcile.
-      await persistActiveDeployIdWithFallback(
-        instanceDir,
-        activeIdFile,
-        result.previousDeployId,
-      );
-    }
+    // A failed apply never wrote `active-deploy-id`: `applyAtomic`
+    // stages into a per-deploy-id directory and the commit is the
+    // persist below, which only runs on success. So the prior deploy is
+    // trivially still live and `result.previousDeployId` carries the
+    // unchanged prior id. There is no committed-but-failed swap to
+    // reconcile here — that case existed only under the old rename
+    // protocol.
     await writeRejectedApplyAudit({
       storeDir: args.storeDir,
       attemptId: result.attemptId,
@@ -385,20 +372,21 @@ export async function materializeToolPackages(args: {
     );
   }
 
-  // Apply committed: the new active tree is live on disk. Persisting
-  // the new active id is the last step that makes the on-disk state
-  // and the recorded id agree. If the write or its fsync fails (disk
-  // full, EIO, EROFS), the on-disk apply state has already diverged
-  // from the recorded id: the active tree is the new deploy, but the
-  // active-deploy-id file still points at the prior id (or is
-  // missing). Route this through the same `apply.previous-rotation.failed`
-  // shape used when the post-swap rotation cannot complete — the wire
-  // contract for that category already says `previousDeployId` carries
-  // the **new** deploy id (i.e. the one now live on disk) so the hub
-  // records the on-disk truth. Emit the failure frame and the audit
-  // entry, then throw so the harness tears down: the disk-vs-recorded
-  // divergence means the next apply cannot trust `previousDeployId`
-  // until the next boot reconciles by reading the active tree.
+  // Apply staged: the loader built the new deploy at
+  // `packages/<newDeployId>/`. Persisting the new active id is the
+  // commit — the single write that advances the live deploy from the
+  // prior id to this one. If the write or its fsync fails (disk full,
+  // EIO, EROFS), the on-disk state has diverged from the recorded id:
+  // `persistActiveDeployIdWithFallback` has already written the new id
+  // through its no-fsync / dirty-marker degradation ladder, so the new
+  // deploy is logically committed, but the id was not durably flushed.
+  // Route this through `apply.previous-rotation.failed` — the wire
+  // contract for that category says `previousDeployId` carries the
+  // **new** deploy id (the one now live) so the hub records the on-disk
+  // truth. Emit the failure frame and the audit entry, then throw so
+  // the harness tears down: the durability gap means the next apply
+  // cannot trust `previousDeployId` until the next boot reconciles via
+  // the dirty marker.
   const persistOutcome = await persistActiveDeployIdWithFallback(
     instanceDir,
     activeIdFile,
@@ -407,7 +395,7 @@ export async function materializeToolPackages(args: {
   if (persistOutcome.degraded) {
     const err = persistOutcome.error;
     const occurredAt = new Date().toISOString();
-    const message = `active-deploy-id persist failed after pending→active swap: ${err instanceof Error ? err.message : String(err)}`;
+    const message = `active-deploy-id persist failed after staging deploy: ${err instanceof Error ? err.message : String(err)}`;
     logger.error`tool-package apply: ${message}; active deploy ${result.activeDeployId} is live on disk but the recorded id was not durably written`;
     await writeRejectedApplyAudit({
       storeDir: args.storeDir,
@@ -446,17 +434,17 @@ export async function materializeToolPackages(args: {
  * file's own data/metadata and the parent directory entry. POSIX does
  * not guarantee a parent-directory entry is durably linked from a
  * file's own fsync alone, so the dir handle is opened and synced
- * separately. Without that, a crash between the first apply's swap and
- * the next boot could leave the active tree present while
+ * separately. Without that, a crash between a deploy's commit and the
+ * next boot could leave the staged deploy directory present while
  * active-deploy-id is not yet visible — the next apply would then read
- * previousDeployId="none" and treat the in-place active tree as
- * belonging to a fresh, deploy-less instance.
+ * previousDeployId="none" and treat the committed deploy as belonging
+ * to a fresh, deploy-less instance.
  *
  * Dir-fsync is best-effort durability hardening, not part of the
  * apply's structural success contract. Some filesystems (notably
  * FAT/exFAT, certain network mounts) do not support fsync on a
- * directory handle and will surface EINVAL / ENOTSUP. The apply has
- * already swapped on disk and the deploy-id file's own fsync has
+ * directory handle and will surface EINVAL / ENOTSUP. The deploy is
+ * already staged on disk and the deploy-id file's own fsync has
  * landed; tearing the harness down at this point would force a
  * restart for a degraded-durability condition the operator has no
  * way to act on. Log it and continue.
@@ -533,7 +521,7 @@ async function persistActiveDeployId(
       await dirHandle.close();
     }
   } catch (err) {
-    logger.warn`parent-dir fsync failed for ${instanceDir} after deploy-id persist; deploy-id durability is degraded but the active tree is in place — ${err instanceof Error ? err.message : String(err)}`;
+    logger.warn`parent-dir fsync failed for ${instanceDir} after deploy-id persist; deploy-id durability is degraded but the committed deploy is staged on disk — ${err instanceof Error ? err.message : String(err)}`;
   }
   await clearDirtyMarker(activeIdFile, "successful persist");
 }

--- a/packages/tool-packaging/ASSET-LAYOUT.md
+++ b/packages/tool-packaging/ASSET-LAYOUT.md
@@ -81,6 +81,49 @@ the map to resolve every `kind: "asset"` entry — looking up the mount
 path by `source.assetId`, then joining it with `source.path` against
 the workspace's asset root.
 
+## Per-instance apply state on the sidecar
+
+Each apply materializes its resolved closure into a stable, per-deploy-id
+directory under the agent's tool-package instance directory
+(`<storeDir>/tool-packages/`). The directory is never renamed:
+
+```
+<storeDir>/tool-packages/
+├── active-deploy-id           # commit switch; content "v1:<deploy-id>"
+├── active-deploy-id.dirty     # present only after a degraded persist
+└── packages/
+    ├── <deploy-id-current>/   # store/<name>/<version>/... for the live deploy
+    └── <deploy-id-previous>/  # the immediately-prior deploy, retained
+```
+
+The loader builds `packages/<deploy-id>/store/<name>/<version>/` and
+dynamic-imports each pinned package's `interchange.tools` entry from that
+path. Because the path is never renamed, a package that resolves files
+relative to its own on-disk location at run time — `import.meta.url`,
+`require.resolve()`, a call-time `await import("./sibling.js")` — keeps
+resolving for the life of the deploy.
+
+**Commit.** Staging a deploy directory does not make it live. The commit
+is a single write of the `active-deploy-id` file naming the new deploy
+id. Until that write lands, the instance is still running the previous
+deploy, whose directory is untouched. There is no filesystem rename in
+the apply path; the `active-deploy-id` write is the only atomic switch.
+
+**Retention.** A prelude sweep at the start of every apply removes every
+`packages/<id>/` except the current deploy and the immediately-prior
+one, bounding disk to ~2 closures. The prior deploy is retained as a
+liveness window: a session still draining against it may perform a
+call-time import into its tree. The next apply reaps it once the prior
+session's harness has been torn down.
+
+**Crash safety.** Boot never reads a deploy directory — the harness
+rebuilds from the current manifest into a fresh deploy id — so a
+half-written deploy directory left by a crash is self-healing: the next
+boot re-materializes and the prelude sweep reclaims the orphan. Only
+`active-deploy-id` needs durability; it carries an fsync + dirty-marker
+ladder owned by the sidecar's materialization layer. See
+`packages/tool-packaging/src/atomic-apply.ts` for the full protocol.
+
 ## Tarballs
 
 - Bytes are exactly what an npm registry would serve: the package tree

--- a/packages/tool-packaging/README.md
+++ b/packages/tool-packaging/README.md
@@ -95,27 +95,20 @@ A follow-up that snapshots the asset's commit SHA at resolution time
 and replays against it at apply time is in scope if this shows up in
 operator practice; it is not implemented today.
 
-## Author constraint: `import.meta.url` after the swap
+## Call-time imports and `import.meta.url`
 
-Tool packages MUST NOT perform call-time dynamic imports relative to
-`import.meta.url`. The loader imports each top-level package's
-`interchange.tools` entry from a path under `<instanceDir>/pending/`
-which the atomic-apply swap step renames to `<instanceDir>/active/`
-once the load succeeds. Modules loaded that way therefore carry the
-pending path on `import.meta.url`; an `await import(new URL(...,
-import.meta.url))` evaluated after the swap completes will fail
-because the original path is gone.
+Tool packages may resolve files relative to their own on-disk location
+at run time — `import.meta.url`, `require.resolve()`, or an
+`await import(new URL("./sibling.js", import.meta.url))` evaluated long
+after the module first loaded. The loader imports each top-level
+package's `interchange.tools` entry from a path under
+`<instanceDir>/packages/<deploy-id>/` that is never renamed, so a
+module's `import.meta.url` stays valid for the life of the deploy.
 
-Top-level `import` declarations are unaffected — they resolve at
-module-init time, before the swap fires — and bare-specifier dynamic
-imports that flow through Node's `node_modules` resolver are
-unaffected as well. The constraint is specific to URLs derived from
-`import.meta.url` at call time.
-
-A future loader change can lift this constraint by realpath-resolving
-the entry path or by re-loading the entry from the post-swap
-`active/` path; until then, package authors should keep dynamic
-imports module-relative through bundlers or package exports.
+The prior deploy's directory is retained across the next apply, so a
+session still draining against an older deploy keeps resolving its own
+files until a further apply supersedes it. See `ASSET-LAYOUT.md` for
+the on-disk layout and retention rules.
 
 ## Follow-up reference
 

--- a/packages/tool-packaging/src/atomic-apply.test.ts
+++ b/packages/tool-packaging/src/atomic-apply.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { promises as fs, type PathLike } from "node:fs";
+import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { type AnnotatedPluginFactory, definePlugin } from "@intx/agent";
 import type { DeployApplyErrorCategory } from "@intx/types/sidecar";
 import type { ToolPackageManifest } from "@intx/types/tool-packages";
 
@@ -30,12 +31,28 @@ afterEach(async () => {
   await fs.rm(scratch, { recursive: true, force: true });
 });
 
+function deployDir(id: string): string {
+  return path.join(instanceDir, "packages", id);
+}
+
+async function seedDeploy(id: string, marker: string): Promise<string> {
+  const dir = deployDir(id);
+  await fs.mkdir(dir, { recursive: true });
+  const markerPath = path.join(dir, "marker");
+  await fs.writeFile(markerPath, marker);
+  return markerPath;
+}
+
 function fakeFactory(id: string): LoadedToolFactory {
   const fn = () => ({
     definitions: [],
     run: async () => ({ callId: "stub", content: "ok" }),
   });
   return Object.assign(fn, { id, requires: [] as readonly string[] });
+}
+
+function fakePlugin(id: string): AnnotatedPluginFactory {
+  return definePlugin({ id, factory: () => ({}) });
 }
 
 function makeStubLoader(
@@ -70,7 +87,7 @@ async function dirExists(p: string): Promise<boolean> {
 }
 
 describe("applyAtomic success", () => {
-  test("swaps pending to active and returns the new deploy id", async () => {
+  test("stages a per-deploy-id directory and returns its path and the new id", async () => {
     const loader = makeStubLoader(async () => [
       {
         name: "foo",
@@ -93,14 +110,19 @@ describe("applyAtomic success", () => {
     expect(result.status).toBe("ok");
     if (result.status !== "ok") return;
     expect(result.activeDeployId).toBe("dpl_1");
+    expect(result.deployDir).toBe(deployDir("dpl_1"));
     expect(result.loaded).toHaveLength(1);
-    expect(await dirExists(path.join(instanceDir, "active"))).toBe(true);
+    expect(await dirExists(deployDir("dpl_1"))).toBe(true);
+    // The loader staged into the deploy dir, not a swappable path.
+    expect(
+      await dirExists(path.join(deployDir("dpl_1"), "loader-sentinel")),
+    ).toBe(true);
+    // The protocol no longer renames; there is no active/pending tree.
+    expect(await dirExists(path.join(instanceDir, "active"))).toBe(false);
     expect(await dirExists(path.join(instanceDir, "pending"))).toBe(false);
-    // First apply has no previous active to back up.
-    expect(await dirExists(path.join(instanceDir, "previous"))).toBe(false);
   });
 
-  test("on second apply, prior active becomes previous", async () => {
+  test("retains the previous deploy directory across the next apply", async () => {
     const loader = makeStubLoader(async () => []);
     await applyAtomic({
       manifest: minimalManifest,
@@ -112,8 +134,8 @@ describe("applyAtomic success", () => {
       previousDeployId: "dpl_0",
       newDeployId: "dpl_1",
     });
-    // Marker so we can confirm the original active tree was preserved.
-    await fs.writeFile(path.join(instanceDir, "active", "marker"), "first");
+    // Marker so we can confirm the dpl_1 tree survives the next apply.
+    await fs.writeFile(path.join(deployDir("dpl_1"), "marker"), "first");
 
     await applyAtomic({
       manifest: minimalManifest,
@@ -125,12 +147,37 @@ describe("applyAtomic success", () => {
       previousDeployId: "dpl_1",
       newDeployId: "dpl_2",
     });
-    expect(await dirExists(path.join(instanceDir, "active"))).toBe(true);
-    expect(await dirExists(path.join(instanceDir, "previous"))).toBe(true);
-    // The marker should now live under previous/.
+    expect(await dirExists(deployDir("dpl_2"))).toBe(true);
+    // dpl_1 is the previous deploy and is retained untouched.
     expect(
-      await fs.readFile(path.join(instanceDir, "previous", "marker"), "utf8"),
+      await fs.readFile(path.join(deployDir("dpl_1"), "marker"), "utf8"),
     ).toBe("first");
+  });
+
+  test("prelude sweep reaps every deploy except current and previous", async () => {
+    // Seed a stale deploy (two generations back) and the immediately
+    // prior deploy. The apply must reap the stale one and keep the
+    // prior one.
+    const stalePath = await seedDeploy("dpl_stale", "two-back");
+    const prevPath = await seedDeploy("dpl_prev", "one-back");
+
+    const loader = makeStubLoader(async () => []);
+    const result = await applyAtomic({
+      manifest: minimalManifest,
+      loader,
+      instanceDir,
+      assetRoot,
+      assetMounts: new Map(),
+      attemptId: "atp_S",
+      previousDeployId: "dpl_prev",
+      newDeployId: "dpl_new",
+    });
+    expect(result.status).toBe("ok");
+    expect(await dirExists(deployDir("dpl_stale"))).toBe(false);
+    expect(await dirExists(stalePath)).toBe(false);
+    // previous and current survive.
+    expect(await fs.readFile(prevPath, "utf8")).toBe("one-back");
+    expect(await dirExists(deployDir("dpl_new"))).toBe(true);
   });
 });
 
@@ -149,11 +196,9 @@ describe("applyAtomic failure: every loader error category", () => {
   ];
 
   for (const category of categories) {
-    test(`category ${category}: pending discarded, active untouched, error carries previousDeployId`, async () => {
-      // Seed an "active" tree to confirm it is preserved.
-      const activeMarker = path.join(instanceDir, "active", "marker");
-      await fs.mkdir(path.dirname(activeMarker), { recursive: true });
-      await fs.writeFile(activeMarker, "untouched");
+    test(`category ${category}: deploy dir discarded, previous untouched, error carries previousDeployId`, async () => {
+      // Seed a prior deploy to confirm it is preserved.
+      const priorMarker = await seedDeploy("dpl_prior", "untouched");
 
       const loader: ToolLoader = {
         loadManifest: async () => {
@@ -181,16 +226,17 @@ describe("applyAtomic failure: every loader error category", () => {
       expect(result.attemptId).toBe("atp_X");
       expect(result.package).toEqual({ name: "p", version: "1.0.0" });
 
-      // Atomicity invariant: active is unchanged.
-      expect(await fs.readFile(activeMarker, "utf8")).toBe("untouched");
-      // Pending has been removed.
-      expect(await dirExists(path.join(instanceDir, "pending"))).toBe(false);
+      // Atomicity invariant: the prior deploy is unchanged.
+      expect(await fs.readFile(priorMarker, "utf8")).toBe("untouched");
+      // The attempted deploy dir has been removed.
+      expect(await dirExists(deployDir("dpl_attempted"))).toBe(false);
     });
   }
 });
 
 describe("applyAtomic failure: tool.name.duplicate", () => {
   test("two factories with the same id across packages → tool.name.duplicate", async () => {
+    const priorMarker = await seedDeploy("dpl_prior", "untouched");
     const loader = makeStubLoader(async () => [
       {
         name: "a",
@@ -221,8 +267,48 @@ describe("applyAtomic failure: tool.name.duplicate", () => {
     if (result.status !== "failed") return;
     expect(result.category).toBe("tool.name.duplicate");
     expect(result.previousDeployId).toBe("dpl_prior");
-    expect(await dirExists(path.join(instanceDir, "active"))).toBe(false);
-    expect(await dirExists(path.join(instanceDir, "pending"))).toBe(false);
+    expect(await dirExists(deployDir("dpl_attempted"))).toBe(false);
+    expect(await fs.readFile(priorMarker, "utf8")).toBe("untouched");
+  });
+
+  test("two plugins with the same id across packages → tool.name.duplicate", async () => {
+    const priorMarker = await seedDeploy("dpl_prior", "untouched");
+    const loader = makeStubLoader(async () => [
+      {
+        name: "a",
+        version: "1.0.0",
+        plugins: [fakePlugin("dup/plug")],
+        factories: [],
+        directors: [],
+      },
+      {
+        name: "b",
+        version: "2.0.0",
+        plugins: [fakePlugin("dup/plug")],
+        factories: [],
+        directors: [],
+      },
+    ]);
+    const result = await applyAtomic({
+      manifest: minimalManifest,
+      loader,
+      instanceDir,
+      assetRoot,
+      assetMounts: new Map(),
+      attemptId: "atp_DP",
+      previousDeployId: "dpl_prior",
+      newDeployId: "dpl_attempted",
+    });
+    expect(result.status).toBe("failed");
+    if (result.status !== "failed") return;
+    expect(result.category).toBe("tool.name.duplicate");
+    expect(result.message).toContain("plugin factory id dup/plug");
+    // The collision is attributed to the second package that carried
+    // the already-seen plugin id.
+    expect(result.package).toEqual({ name: "b", version: "2.0.0" });
+    expect(result.previousDeployId).toBe("dpl_prior");
+    expect(await dirExists(deployDir("dpl_attempted"))).toBe(false);
+    expect(await fs.readFile(priorMarker, "utf8")).toBe("untouched");
   });
 });
 
@@ -247,516 +333,17 @@ describe("applyAtomic failure: unexpected error shape", () => {
     if (result.status !== "failed") return;
     expect(result.category).toBe("factory.construct.failed");
     expect(result.message).toContain("something exploded");
+    expect(await dirExists(deployDir("dpl_attempted"))).toBe(false);
   });
 });
 
-describe("applyAtomic failure: pending→active swap", () => {
-  // Fault-injection helper: wrap fs.promises.rename to fail on calls
-  // whose destination matches a predicate. Returns a restore fn. Used
-  // to exercise the swap-failure branches that the success path
-  // (everything above) cannot reach without an actual fs failure.
-  function patchRename(failIf: (dst: string) => string | null): () => void {
-    const real = fs.rename.bind(fs);
-    const wrapped = async (src: PathLike, dst: PathLike): Promise<void> => {
-      const reason = failIf(String(dst));
-      if (reason !== null) {
-        const e = new Error(reason);
-        Object.assign(e, { code: "EIO" });
-        throw e;
-      }
-      await real(src, dst);
-    };
-    fs.rename = wrapped;
-    return () => {
-      fs.rename = real;
-    };
-  }
-
-  test("single rename failure (rollback ok) → apply.swap.failed structured failure", async () => {
-    // Seed a prior active so step-2 has something to roll back.
-    const activeMarker = path.join(instanceDir, "active", "marker");
-    await fs.mkdir(path.dirname(activeMarker), { recursive: true });
-    await fs.writeFile(activeMarker, "prior-active");
-
-    const loader = makeStubLoader(async () => []);
-    const activeDir = path.join(instanceDir, "active");
-    // Fail only the FIRST rename targeting activeDir (the
-    // pending→active swap). The rollback's previous→active rename is
-    // the second such call and is allowed through, exercising the
-    // rollback-succeeded branch.
-    let activeRenameSeen = 0;
-    const restore = patchRename((dst) => {
-      if (dst !== activeDir) return null;
-      activeRenameSeen += 1;
-      return activeRenameSeen === 1 ? "induced step-3 rename failure" : null;
-    });
-    try {
-      const result = await applyAtomic({
-        manifest: minimalManifest,
-        loader,
-        instanceDir,
-        assetRoot,
-        assetMounts: new Map(),
-        attemptId: "atp_S1",
-        previousDeployId: "dpl_prior",
-        newDeployId: "dpl_attempted",
-      });
-      expect(result.status).toBe("failed");
-      if (result.status !== "failed") return;
-      expect(result.category).toBe("apply.swap.failed");
-      expect(result.message).toContain("pending→active swap failed");
-      expect(result.message).toContain("induced step-3 rename failure");
-      expect(result.previousDeployId).toBe("dpl_prior");
-      expect(result.attemptId).toBe("atp_S1");
-      // Rollback restored the prior active tree byte-for-byte.
-      expect(await fs.readFile(activeMarker, "utf8")).toBe("prior-active");
-      // Aborted apply does not leave a staged pending tree behind —
-      // matches the sibling failure branches' cleanup behavior.
-      expect(await dirExists(path.join(instanceDir, "pending"))).toBe(false);
-    } finally {
-      restore();
-    }
-  });
-
-  test("active→staged rename failure sweeps the pending dir before returning apply.swap.failed", async () => {
-    // Seed a prior active so the swap prelude attempts the
-    // active→staged rename. Fail that rename, then assert the
-    // structured failure category fires and no `pending/` tree
-    // survives.
-    const activeMarker = path.join(instanceDir, "active", "marker");
-    await fs.mkdir(path.dirname(activeMarker), { recursive: true });
-    await fs.writeFile(activeMarker, "prior-active");
-
-    const stagedDir = path.join(instanceDir, "previous.staged");
-    const loader = makeStubLoader(async () => []);
-    const restore = patchRename((dst) =>
-      dst === stagedDir ? "induced active→staged rename failure" : null,
-    );
-    try {
-      const result = await applyAtomic({
-        manifest: minimalManifest,
-        loader,
-        instanceDir,
-        assetRoot,
-        assetMounts: new Map(),
-        attemptId: "atp_AS",
-        previousDeployId: "dpl_prior",
-        newDeployId: "dpl_attempted",
-      });
-      expect(result.status).toBe("failed");
-      if (result.status !== "failed") return;
-      expect(result.category).toBe("apply.swap.failed");
-      expect(result.message).toContain("active→staged swap failed");
-      expect(await dirExists(path.join(instanceDir, "pending"))).toBe(false);
-    } finally {
-      restore();
-    }
-  });
-
-  test("swap failure preserves the prior-previous safety net", async () => {
-    // Seed the on-disk shape that exists on a second apply: an
-    // existing `active/` (prior deploy) AND an existing `previous/`
-    // (the prior-previous safety net the docstring at the top of
-    // `atomic-apply.ts` promises to retain). Then induce a swap
-    // failure; `previous/` must still be present and untouched
-    // afterwards.
-    const activeMarker = path.join(instanceDir, "active", "marker");
-    await fs.mkdir(path.dirname(activeMarker), { recursive: true });
-    await fs.writeFile(activeMarker, "prior-active");
-    const previousMarker = path.join(instanceDir, "previous", "marker");
-    await fs.mkdir(path.dirname(previousMarker), { recursive: true });
-    await fs.writeFile(previousMarker, "prior-previous");
-
-    const loader = makeStubLoader(async () => []);
-    const activeDir = path.join(instanceDir, "active");
-    let activeRenameSeen = 0;
-    const restore = patchRename((dst) => {
-      if (dst !== activeDir) return null;
-      activeRenameSeen += 1;
-      return activeRenameSeen === 1 ? "induced step-3 rename failure" : null;
-    });
-    try {
-      const result = await applyAtomic({
-        manifest: minimalManifest,
-        loader,
-        instanceDir,
-        assetRoot,
-        assetMounts: new Map(),
-        attemptId: "atp_SP",
-        previousDeployId: "dpl_prior",
-        newDeployId: "dpl_attempted",
-      });
-      expect(result.status).toBe("failed");
-      // Both safety nets must survive: rollback restored prior-active,
-      // and prior-previous was never touched.
-      expect(await fs.readFile(activeMarker, "utf8")).toBe("prior-active");
-      expect(await fs.readFile(previousMarker, "utf8")).toBe("prior-previous");
-    } finally {
-      restore();
-    }
-  });
-
-  test("double rename failure (rollback also fails) throws with diverged-disk message", async () => {
-    const activeMarker = path.join(instanceDir, "active", "marker");
-    await fs.mkdir(path.dirname(activeMarker), { recursive: true });
-    await fs.writeFile(activeMarker, "prior-active");
-
-    const loader = makeStubLoader(async () => []);
-    const activeDir = path.join(instanceDir, "active");
-    // Fail every rename whose destination is activeDir — that is
-    // both step-3 (pending → active) and the rollback (previous →
-    // active). The active → previous step (step 2) renames TO
-    // previous and is allowed through.
-    const restore = patchRename((dst) =>
-      dst === activeDir ? "induced rename failure" : null,
-    );
-    try {
-      let caught: unknown;
-      try {
-        await applyAtomic({
-          manifest: minimalManifest,
-          loader,
-          instanceDir,
-          assetRoot,
-          assetMounts: new Map(),
-          attemptId: "atp_S2",
-          previousDeployId: "dpl_prior",
-          newDeployId: "dpl_attempted",
-        });
-      } catch (err) {
-        caught = err;
-      }
-      expect(caught).toBeInstanceOf(Error);
-      const msg = String(caught);
-      expect(msg).toContain("atomic apply diverged on disk");
-      expect(msg).toContain("atp_S2");
-      expect(msg).toContain("pending→active rename failed");
-      expect(msg).toContain("staged→active rollback also failed");
-      expect(msg).toContain("harness must abort");
-      // cause chain points at the original step-3 rename error.
-      if (caught instanceof Error) {
-        expect(caught.cause).toBeInstanceOf(Error);
-      }
-    } finally {
-      restore();
-    }
-  });
-});
-
-describe("applyAtomic failure: post-swap previous-dir rotation", () => {
-  // Fault-injection helper. Returns a restore function. The predicate
-  // sees both the source and destination so a test can fail one
-  // rename in a sequence without also failing a sibling rename whose
-  // destination matches but whose source does not (e.g. failing
-  // `stagedDir → previousDir` while permitting the `reapDir →
-  // previousDir` rollback that follows).
-  function patchRename(
-    failIf: (src: string, dst: string) => string | null,
-  ): () => void {
-    const real = fs.rename.bind(fs);
-    fs.rename = (async (src: PathLike, dst: PathLike): Promise<void> => {
-      const reason = failIf(String(src), String(dst));
-      if (reason !== null) {
-        const e = new Error(reason);
-        Object.assign(e, { code: "EBUSY" });
-        throw e;
-      }
-      await real(src, dst);
-    }) as typeof fs.rename;
-    return () => {
-      fs.rename = real;
-    };
-  }
-
-  test("fs.rename failure moving prior-previous aside surfaces as apply.previous-rotation.failed and preserves the safety net", async () => {
-    // Seed two prior applies so the third one exercises the
-    // post-swap rotation branch (active exists and previous exists).
-    const loader = makeStubLoader(async () => []);
-    await applyAtomic({
-      manifest: minimalManifest,
-      loader,
-      instanceDir,
-      assetRoot,
-      assetMounts: new Map(),
-      attemptId: "atp_1",
-      previousDeployId: "dpl_0",
-      newDeployId: "dpl_1",
-    });
-    await applyAtomic({
-      manifest: minimalManifest,
-      loader,
-      instanceDir,
-      assetRoot,
-      assetMounts: new Map(),
-      attemptId: "atp_2",
-      previousDeployId: "dpl_1",
-      newDeployId: "dpl_2",
-    });
-
-    // Drop a marker into the prior-previous tree so we can confirm
-    // the rotation never destroyed it — the docstring at the top of
-    // atomic-apply.ts promises the previous-deploy safety net survives
-    // a failed rotation.
-    const previousDir = path.join(instanceDir, "previous");
-    const reapDir = path.join(instanceDir, "previous.reap");
-    const previousMarker = path.join(previousDir, "safety-net-marker");
-    await fs.writeFile(previousMarker, "prior-previous");
-
-    // Fail the previous→reap rename specifically (the move-aside that
-    // displaces the prior-previous before the staged→previous rename
-    // promotes the prior-active).
-    const restore = patchRename((_src, dst) =>
-      dst === reapDir ? "induced EBUSY on previous→reap rename" : null,
-    );
-    try {
-      const result = await applyAtomic({
-        manifest: minimalManifest,
-        loader,
-        instanceDir,
-        assetRoot,
-        assetMounts: new Map(),
-        attemptId: "atp_3",
-        previousDeployId: "dpl_2",
-        newDeployId: "dpl_3",
-      });
-      expect(result.status).toBe("failed");
-      if (result.status !== "failed") return;
-      expect(result.category).toBe("apply.previous-rotation.failed");
-      expect(result.message).toContain(
-        "post-swap previous-dir rotation failed",
-      );
-      // The new deploy is live on disk; previousDeployId carries the
-      // new id rather than the pre-apply one.
-      expect(result.previousDeployId).toBe("dpl_3");
-      expect(result.attemptId).toBe("atp_3");
-      // Active is the new deploy.
-      expect(await dirExists(path.join(instanceDir, "active"))).toBe(true);
-      // Safety net retained: the marker file written into the
-      // prior-previous tree is still readable at previousDir.
-      expect(await fs.readFile(previousMarker, "utf8")).toBe("prior-previous");
-      // The pending dir was renamed to active before the rotation
-      // failed; no leftover pending tree survives this category
-      // either, matching the swap-failure sibling branches.
-      expect(await dirExists(path.join(instanceDir, "pending"))).toBe(false);
-    } finally {
-      restore();
-    }
-  });
-
-  test("fs.rename failure on the staged→previous step surfaces as apply.previous-rotation.failed and rolls back the safety net", async () => {
-    const loader = makeStubLoader(async () => []);
-    // Seed two prior applies so the third one hits the rotation path
-    // with a prior-previous tree to roll back from after the staged→
-    // previous rename fails.
-    await applyAtomic({
-      manifest: minimalManifest,
-      loader,
-      instanceDir,
-      assetRoot,
-      assetMounts: new Map(),
-      attemptId: "atp_1",
-      previousDeployId: "dpl_0",
-      newDeployId: "dpl_1",
-    });
-    await applyAtomic({
-      manifest: minimalManifest,
-      loader,
-      instanceDir,
-      assetRoot,
-      assetMounts: new Map(),
-      attemptId: "atp_2",
-      previousDeployId: "dpl_1",
-      newDeployId: "dpl_2",
-    });
-
-    // Seed a marker into the prior-previous tree so the rollback
-    // assertion can confirm the safety net is restored bit-for-bit.
-    const previousDir = path.join(instanceDir, "previous");
-    const previousMarker = path.join(previousDir, "safety-net-marker");
-    await fs.writeFile(previousMarker, "prior-previous");
-
-    // Allow the previous→reap and pending→active renames through;
-    // fail the staged→previous rename in the post-swap rotation.
-    // Discriminate on src as well as dst so the reapDir→previousDir
-    // rollback that runs after the staged→previous failure is
-    // permitted to succeed (the safety-net-restored assertion below
-    // depends on the rollback landing).
-    const stagedDir = path.join(instanceDir, "previous.staged");
-    const restore = patchRename((src, dst) =>
-      src === stagedDir && dst === previousDir
-        ? "induced EBUSY on staged→previous rename"
-        : null,
-    );
-    try {
-      const result = await applyAtomic({
-        manifest: minimalManifest,
-        loader,
-        instanceDir,
-        assetRoot,
-        assetMounts: new Map(),
-        attemptId: "atp_3",
-        previousDeployId: "dpl_2",
-        newDeployId: "dpl_3",
-      });
-      expect(result.status).toBe("failed");
-      if (result.status !== "failed") return;
-      expect(result.category).toBe("apply.previous-rotation.failed");
-      expect(result.message).toContain(
-        "post-swap previous-dir rotation failed",
-      );
-      expect(result.previousDeployId).toBe("dpl_3");
-      expect(result.attemptId).toBe("atp_3");
-      expect(await dirExists(path.join(instanceDir, "active"))).toBe(true);
-      // Safety net restored: the rollback put the prior-previous tree
-      // back at previousDir after the staged→previous rename failed.
-      expect(await fs.readFile(previousMarker, "utf8")).toBe("prior-previous");
-      // Same as the move-aside-failure sibling: pending is gone by
-      // the time the rotation step runs.
-      expect(await dirExists(path.join(instanceDir, "pending"))).toBe(false);
-    } finally {
-      restore();
-    }
-  });
-
-  test("staged→previous rename failure surfaces apply.previous-rotation.failed even when no prior-previous existed", async () => {
-    // The rotation runs whenever the prior apply produced an active
-    // tree, regardless of whether a prior-previous slot was occupied.
-    // First apply: no rotation (active was absent). Second apply:
-    // rotation fires with `activeExists === true` but `previousDir`
-    // does not exist yet — `fs.access(previousDir)` ENOENTs and
-    // `priorPreviousMovedAside` stays false. If the staged→previous
-    // rename then fails, the rollback branch must NOT fire (there's
-    // nothing in `reapDir` to restore from) but the structured
-    // failure must still surface so the caller routes it through
-    // the apply-error pipeline rather than letting the exception
-    // bubble past.
-    const loader = makeStubLoader(async () => []);
-    await applyAtomic({
-      manifest: minimalManifest,
-      loader,
-      instanceDir,
-      assetRoot,
-      assetMounts: new Map(),
-      attemptId: "atp_1",
-      previousDeployId: "dpl_0",
-      newDeployId: "dpl_1",
-    });
-
-    // Confirm the setup: active exists, previous does not.
-    expect(await dirExists(path.join(instanceDir, "active"))).toBe(true);
-    expect(await dirExists(path.join(instanceDir, "previous"))).toBe(false);
-
-    // Allow previous→reap to no-op (no previous to move aside) and
-    // pending→active rename to succeed; fail the staged→previous
-    // rename in the post-swap rotation.
-    const previousDir = path.join(instanceDir, "previous");
-    const stagedDir = path.join(instanceDir, "previous.staged");
-    const restore = patchRename((src, dst) =>
-      src === stagedDir && dst === previousDir
-        ? "induced EBUSY on staged→previous rename"
-        : null,
-    );
-    try {
-      const result = await applyAtomic({
-        manifest: minimalManifest,
-        loader,
-        instanceDir,
-        assetRoot,
-        assetMounts: new Map(),
-        attemptId: "atp_2",
-        previousDeployId: "dpl_1",
-        newDeployId: "dpl_2",
-      });
-      expect(result.status).toBe("failed");
-      if (result.status !== "failed") return;
-      expect(result.category).toBe("apply.previous-rotation.failed");
-      expect(result.message).toContain(
-        "post-swap previous-dir rotation failed",
-      );
-      // The swap committed before the rotation step failed, so the
-      // new deploy is live and previousDeployId carries it.
-      expect(result.previousDeployId).toBe("dpl_2");
-      expect(result.attemptId).toBe("atp_2");
-      expect(await dirExists(path.join(instanceDir, "active"))).toBe(true);
-      expect(await dirExists(path.join(instanceDir, "pending"))).toBe(false);
-    } finally {
-      restore();
-    }
-  });
-
-  test("staged→previous and reap→previous both failing still surfaces apply.previous-rotation.failed (cascade)", async () => {
-    // The rollback path can itself fail: staged→previous fails first,
-    // then the reapDir→previousDir rollback fails too. The safety-net
-    // tree is genuinely lost on disk in that branch, but the apply
-    // pipeline still owes the caller a structured failure — the swap
-    // already committed, so an exception bubble-up would leave
-    // active-deploy-id un-bumped while the on-disk tree advanced.
-    // Verify the structured failure still surfaces and carries the
-    // newDeployId (the swap is live on disk in this branch).
-    const loader = makeStubLoader(async () => []);
-    await applyAtomic({
-      manifest: minimalManifest,
-      loader,
-      instanceDir,
-      assetRoot,
-      assetMounts: new Map(),
-      attemptId: "atp_1",
-      previousDeployId: "dpl_0",
-      newDeployId: "dpl_1",
-    });
-    await applyAtomic({
-      manifest: minimalManifest,
-      loader,
-      instanceDir,
-      assetRoot,
-      assetMounts: new Map(),
-      attemptId: "atp_2",
-      previousDeployId: "dpl_1",
-      newDeployId: "dpl_2",
-    });
-
-    // Fail every rename whose destination is `previousDir` — that
-    // matches both staged→previous (the primary rotation step) and
-    // reap→previous (the rollback). The previous→reap move-aside is
-    // permitted because its destination is reapDir.
-    const previousDir = path.join(instanceDir, "previous");
-    const restore = patchRename((_src, dst) =>
-      dst === previousDir
-        ? "induced EBUSY on every previous-dir destination"
-        : null,
-    );
-    try {
-      const result = await applyAtomic({
-        manifest: minimalManifest,
-        loader,
-        instanceDir,
-        assetRoot,
-        assetMounts: new Map(),
-        attemptId: "atp_3",
-        previousDeployId: "dpl_2",
-        newDeployId: "dpl_3",
-      });
-      expect(result.status).toBe("failed");
-      if (result.status !== "failed") return;
-      expect(result.category).toBe("apply.previous-rotation.failed");
-      expect(result.message).toContain(
-        "post-swap previous-dir rotation failed",
-      );
-      // newDeployId because the swap committed before the rotation
-      // step failed — the on-disk active tree is now the new deploy.
-      expect(result.previousDeployId).toBe("dpl_3");
-      expect(result.attemptId).toBe("atp_3");
-      expect(await dirExists(path.join(instanceDir, "active"))).toBe(true);
-    } finally {
-      restore();
-    }
-  });
-});
-
-describe("applyAtomic clears a stale pending dir before staging", () => {
-  test("a leftover pending directory does not block the next apply", async () => {
-    await fs.mkdir(path.join(instanceDir, "pending"), { recursive: true });
-    await fs.writeFile(path.join(instanceDir, "pending", "stale"), "old");
+describe("applyAtomic clears a stale deploy dir before staging", () => {
+  test("a leftover directory under the new deploy id does not leak into the staged tree", async () => {
+    // A crash mid-build (or uuid reuse) can leave a partial tree under
+    // the exact id this apply is about to build. The prelude must clear
+    // it so the loader stages into a clean directory.
+    await fs.mkdir(deployDir("dpl_new"), { recursive: true });
+    await fs.writeFile(path.join(deployDir("dpl_new"), "stale"), "old");
     const loader = makeStubLoader(async () => []);
     const result = await applyAtomic({
       manifest: minimalManifest,
@@ -764,37 +351,16 @@ describe("applyAtomic clears a stale pending dir before staging", () => {
       instanceDir,
       assetRoot,
       assetMounts: new Map(),
-      attemptId: "atp_S",
+      attemptId: "atp_L",
       previousDeployId: "dpl_prior",
       newDeployId: "dpl_new",
     });
     expect(result.status).toBe("ok");
-    // The stale file should not be present in the resulting active dir.
-    expect(await dirExists(path.join(instanceDir, "active", "stale"))).toBe(
+    expect(await dirExists(path.join(deployDir("dpl_new"), "stale"))).toBe(
       false,
     );
-  });
-
-  test("a leftover previous.staged directory is swept on the next apply", async () => {
-    // apply.previous-rotation.failed leaves `previous.staged` in
-    // place (the comment chain in atomic-apply.ts says the next
-    // apply sweeps it). Seed a fake stale staged dir and verify the
-    // next apply removes it as part of its swap prelude.
-    const stagedDir = path.join(instanceDir, "previous.staged");
-    await fs.mkdir(stagedDir, { recursive: true });
-    await fs.writeFile(path.join(stagedDir, "leftover"), "stale");
-    const loader = makeStubLoader(async () => []);
-    const result = await applyAtomic({
-      manifest: minimalManifest,
-      loader,
-      instanceDir,
-      assetRoot,
-      assetMounts: new Map(),
-      attemptId: "atp_PS",
-      previousDeployId: "dpl_prior",
-      newDeployId: "dpl_new",
-    });
-    expect(result.status).toBe("ok");
-    expect(await dirExists(stagedDir)).toBe(false);
+    expect(
+      await dirExists(path.join(deployDir("dpl_new"), "loader-sentinel")),
+    ).toBe(true);
   });
 });

--- a/packages/tool-packaging/src/atomic-apply.ts
+++ b/packages/tool-packaging/src/atomic-apply.ts
@@ -1,54 +1,68 @@
-// Atomic apply protocol for a ToolPackageManifest.
+// Apply protocol for a ToolPackageManifest.
 //
-// Wraps the loader in a stage-and-swap transaction:
+// Each apply materializes its closure into a stable, per-deploy-id
+// directory that is never moved:
 //
-//   1. Stage everything under `<instanceDir>/pending/`.
-//   2. Run the loader against the pending tree end-to-end (materialize
-//      every entry, dynamic-import every top-level entry, validate
-//      AnnotatedToolFactory exports).
-//   3. On success, atomically swap: remove `<instanceDir>/previous/`,
-//      rename `<instanceDir>/active/` → `<instanceDir>/previous/`,
-//      rename `<instanceDir>/pending/` → `<instanceDir>/active/`. The
-//      previous-deploy tree is retained as a safety net the caller may
-//      keep or prune on its own schedule.
-//   4. On any loader failure, delete `<instanceDir>/pending/`, leave
-//      `<instanceDir>/active/` untouched, return a DeployApplyError
-//      with the loader's category.
+//   <instanceDir>/packages/<deploy-id>/store/<name>/<version>/...
+//
+// The loader dynamic-imports each pinned package's `interchange.tools`
+// module from an absolute path inside that deploy-id directory. Because
+// the directory is never renamed, the URL Node keys its ESM module
+// cache under stays valid for the life of the deploy: a tool package
+// that uses `import.meta.url`, `require.resolve()`, or a call-time
+// `await import("./sibling.js")` resolves against a path that still
+// exists. (The earlier protocol staged under `pending/` and renamed
+// `pending/` → `active/` after import; the renamed-away URL ENOENTed
+// any late path resolution. This module exists to remove that swap.)
+//
+// This module does NOT commit. It stages, loads, validates, and
+// returns the loaded packages plus the deploy-id directory. The commit
+// point lives one layer up: the caller writes the instance's
+// `active-deploy-id` file to name `newDeployId`. Until that write
+// lands, the instance is still running `previousDeployId`, whose
+// directory is left untouched here. The "atomic swap" is therefore the
+// single `active-deploy-id` file write the caller performs, not a
+// directory rename.
+//
+// Retention. A prelude sweep removes every `packages/<id>/` except
+// `{newDeployId, previousDeployId}`. The keep set is invariant across
+// the caller's commit: before the commit the live deploy is
+// `previousDeployId`; after it the live deploy is `newDeployId` and
+// `previousDeployId` is the retained prior tree. So a single sweep at
+// the start of the apply both bounds disk to ~2 closures and preserves
+// exactly the prior deploy as a liveness window for any session still
+// draining against it.
+//
+// Retention invariant: the previous deploy's directory must survive
+// until the next apply, because a session built against it may still
+// perform a call-time `await import()` into its tree. The next apply's
+// prelude reaps it. This is safe only because per-agent applies are
+// serialized (the hub runs one apply per `agentAddress` at a time) and
+// each successful apply replaces the running harness, so by the time
+// apply N+2 reaps deploy N, generation-N's harness teardown has
+// completed and no live code references deploy N's tree.
 //
 // Caller responsibilities (not handled here):
 //
+//   - Writing `active-deploy-id` to commit the staged deploy.
 //   - Constructing the WebSocket frame from the returned error.
 //   - Writing the rejected manifest + error to the sidecar's git audit
 //     trail under `audit/rejected-applies/<attemptId>/`.
-//   - Pruning `<instanceDir>/previous/` on whatever lifecycle suits the
-//     deploy machinery (next-successful-apply, garbage collector, etc).
 //
-// The previousDeployId is opaque to this module; it is carried through
-// on the returned DeployApplyError so the caller can confirm the
-// atomicity invariant ("the instance's active deploy id is unchanged
-// after a failed apply") without re-deriving it.
+// Crash safety. Boot never reads a deploy-id directory: the harness
+// rebuilds by re-running the apply against the current manifest into a
+// fresh deploy id. A half-written `packages/<newDeployId>/` left by a
+// crash mid-build is therefore self-healing — the next boot
+// re-materializes into a new id and the prelude sweep reclaims the
+// orphan. Only `active-deploy-id` needs durability, and the caller owns
+// that. Consequently this module fsyncs nothing.
 //
-// Constraint for tool package authors: a top-level package's
-// `interchange.tools` module is dynamic-imported from a path under
-// `<instanceDir>/pending/` that the swap step renames to
-// `<instanceDir>/active/`. Modules loaded this way therefore have
-// `import.meta.url` bound to the pending path; any call-time dynamic
-// import resolved relative to `import.meta.url` will fail after the
-// swap completes because the original path is gone. Top-level
-// imports (resolved at module-init time, before the swap) are
-// unaffected. Future work may lift this constraint by realpath-
-// resolving the import location or by re-loading from `active/`
-// after the swap; until then, package authors must keep their
-// dynamic imports module-relative through the bundler / package
-// exports, not relative to `import.meta.url`.
-//
-// Cross-apply ESM module-identity: Node keys its ESM cache by
-// resolved URL. Reapplying a manifest whose `(name, version)` pair is
-// reused but whose bytes have changed (operator rebuild, hot-fix
-// republish) would otherwise serve the previously-imported module
-// until the sidecar restarts. The loader cache-busts each import URL
-// with an `?integrity=<sri>` query string so distinct bytes resolve
-// to distinct ESM cache entries.
+// Cross-apply ESM module-identity: Node keys its ESM cache by resolved
+// URL. Per-deploy-id directories already make every apply's import URL
+// unique, so a reused `(name, version)` whose bytes changed across
+// applies resolves to a distinct path. The loader additionally
+// cache-busts each import URL with an `?integrity=<sri>` query string;
+// that remains correct (and harmless) under per-deploy-id paths.
 
 import { promises as fs } from "node:fs";
 import path from "node:path";
@@ -65,11 +79,7 @@ import {
 
 const logger = getLogger(["sidecar", "tool-packaging", "atomic-apply"]);
 
-const PENDING_DIR = "pending";
-const ACTIVE_DIR = "active";
-const PREVIOUS_DIR = "previous";
-const PREVIOUS_STAGED_DIR = "previous.staged";
-const PREVIOUS_REAP_DIR = "previous.reap";
+const PACKAGES_DIR = "packages";
 
 export interface ApplyAtomicArgs {
   readonly manifest: ToolPackageManifest;
@@ -83,14 +93,22 @@ export interface ApplyAtomicArgs {
    */
   readonly assetMounts: ReadonlyMap<string, string>;
   readonly attemptId: string;
+  /**
+   * The deploy id the instance is currently running. Retained on disk
+   * through this apply (its `packages/<previousDeployId>/` tree is not
+   * swept) and carried back on a failure so the caller can confirm the
+   * prior deploy is unchanged.
+   */
   readonly previousDeployId: string;
-  /** New deploy id; on success becomes the active deploy id. */
+  /** New deploy id; on the caller's commit becomes the active deploy id. */
   readonly newDeployId: string;
 }
 
 export interface ApplyAtomicSuccess {
   readonly status: "ok";
   readonly activeDeployId: string;
+  /** Absolute path of the staged, never-renamed deploy directory. */
+  readonly deployDir: string;
   readonly loaded: readonly LoadedToolPackage[];
 }
 
@@ -100,14 +118,12 @@ export interface ApplyAtomicFailure {
   readonly message: string;
   readonly package?: { readonly name: string; readonly version: string };
   /**
-   * The deploy id the instance is now running. For every category
-   * except `apply.previous-rotation.failed` this equals the input
-   * `previousDeployId` (the prior deploy is untouched). For
-   * `apply.previous-rotation.failed` the pending→active swap
-   * committed before the post-swap rotation failed, so the new
-   * deploy is live on disk and this field carries the input
-   * `newDeployId` — the caller persists that as the instance's
-   * active id before emitting the failure.
+   * The deploy id the instance is still running. The apply never wrote
+   * `active-deploy-id`, so a failure always leaves the prior deploy
+   * live: this equals the input `previousDeployId`. (The caller owns
+   * the commit and is the only layer that can advance the active id;
+   * the persist-degraded case it handles there carries its own
+   * inverted meaning, but that case does not originate in this module.)
    */
   readonly previousDeployId: string;
   readonly attemptId: string;
@@ -117,52 +133,70 @@ export interface ApplyAtomicFailure {
 export type ApplyAtomicResult = ApplyAtomicSuccess | ApplyAtomicFailure;
 
 /**
- * Stage-and-swap a tool-package manifest into the per-instance
- * `instanceDir`. The orchestration is single-threaded per instance:
- * the swap, rollback, and post-swap-rotation steps each assume
- * exclusive write access to `<instanceDir>/{pending,active,previous,
- * previous.staged}/`. The hub-side session manager already
- * serializes applies per agent (one apply per `agentAddress` at a
- * time); host-side callers that bypass that serialization must
- * provide their own per-`instanceDir` lock.
+ * Stage a tool-package manifest into a per-deploy-id directory under
+ * `instanceDir` and return the loaded packages. The orchestration is
+ * single-threaded per instance: the prelude sweep assumes exclusive
+ * write access to `<instanceDir>/packages/`. The hub-side session
+ * manager already serializes applies per agent (one apply per
+ * `agentAddress` at a time); host-side callers that bypass that
+ * serialization must provide their own per-`instanceDir` lock, because
+ * the prelude sweep deletes sibling deploy directories and a racing
+ * apply could delete a directory the other just committed.
  */
 export async function applyAtomic(
   args: ApplyAtomicArgs,
 ): Promise<ApplyAtomicResult> {
-  const pendingDir = path.join(args.instanceDir, PENDING_DIR);
-  const activeDir = path.join(args.instanceDir, ACTIVE_DIR);
-  const previousDir = path.join(args.instanceDir, PREVIOUS_DIR);
-  const stagedDir = path.join(args.instanceDir, PREVIOUS_STAGED_DIR);
-  const reapDir = path.join(args.instanceDir, PREVIOUS_REAP_DIR);
+  const packagesDir = path.join(args.instanceDir, PACKAGES_DIR);
+  const deployDir = path.join(packagesDir, args.newDeployId);
 
-  // A pending dir left behind by a prior failure must be cleared
-  // before staging; the rename-to-active step assumes it owns the path.
-  // The previous.staged and previous.reap dirs are also swept here so
-  // a leftover from a crashed previous apply (active→staged rename
-  // committed but pending→active never ran, or post-swap rotation
-  // failed after the prior-previous moved aside to reapDir) cannot
-  // survive into this apply's swap window — the swap below assumes
-  // it owns both paths. Sweeping at the top rather than mid-swap also
-  // means a sidecar that boots with leftover staged/reap trees clears
-  // them on the first apply regardless of whether the load step
-  // succeeds.
-  await Promise.all([
-    fs.rm(pendingDir, { recursive: true, force: true }),
-    fs.rm(stagedDir, { recursive: true, force: true }),
-    fs.rm(reapDir, { recursive: true, force: true }),
-  ]);
-  await fs.mkdir(pendingDir, { recursive: true });
+  // Prelude sweep. Reclaim every prior deploy directory except the one
+  // we are about to build (`newDeployId`) and the one still live
+  // (`previousDeployId`). `previousDeployId` may be the "no prior
+  // deploy" sentinel, which simply matches no directory. The sweep is
+  // best-effort per stray: an EIO/EPERM reclaiming one old deploy is a
+  // disk-reclamation concern, not a correctness one, and must not fail
+  // an otherwise-valid apply — the next apply's prelude retries the
+  // reclaim. The deploy directory we then build, by contrast, must be
+  // a clean tree, so its removal+mkdir below propagate on failure.
+  const keep = new Set([args.newDeployId, args.previousDeployId]);
+  let existing: string[];
+  try {
+    existing = await fs.readdir(packagesDir);
+  } catch (err) {
+    if (!isENOENT(err)) throw err;
+    existing = [];
+  }
+  await Promise.all(
+    existing
+      .filter((id) => !keep.has(id))
+      .map(async (id) => {
+        try {
+          await fs.rm(path.join(packagesDir, id), {
+            recursive: true,
+            force: true,
+          });
+        } catch (err) {
+          logger.warn`apply prelude sweep could not reclaim stale deploy ${id} under ${packagesDir}: ${err instanceof Error ? err.message : String(err)}; next apply will retry`;
+        }
+      }),
+  );
+
+  // A leftover directory under this exact `newDeployId` (a crash mid-
+  // build, or the astronomically unlikely uuid reuse) must be cleared
+  // before staging so the loader builds into a clean tree.
+  await fs.rm(deployDir, { recursive: true, force: true });
+  await fs.mkdir(deployDir, { recursive: true });
 
   let loaded: readonly LoadedToolPackage[];
   try {
     loaded = await args.loader.loadManifest({
       manifest: args.manifest,
-      instanceScratchDir: pendingDir,
+      instanceScratchDir: deployDir,
       assetRoot: args.assetRoot,
       assetMounts: args.assetMounts,
     });
   } catch (err) {
-    await fs.rm(pendingDir, { recursive: true, force: true });
+    await fs.rm(deployDir, { recursive: true, force: true });
     if (err instanceof ToolLoaderError) {
       logger.warn`apply rejected (${err.category}) for attempt ${args.attemptId}; previous deploy ${args.previousDeployId} retained`;
       const out: ApplyAtomicFailure = {
@@ -191,11 +225,12 @@ export async function applyAtomic(
 
   // Check for duplicate factory ids across loaded bundles. The plan's
   // taxonomy distinguishes `tool.name.duplicate` from other
-  // categories, so this check fires after a successful load but
-  // before swap. The loader has already prefixed each tool factory id
-  // with its bundle id by the time we see it here, so a collision in
-  // `factory.id` means two pinned packages shared a bundle id (the
-  // per-bundle prefix did not produce unique ids across the load).
+  // categories, so this check fires after a successful load but before
+  // the caller commits. The loader has already prefixed each tool
+  // factory id with its bundle id by the time we see it here, so a
+  // collision in `factory.id` means two pinned packages shared a bundle
+  // id (the per-bundle prefix did not produce unique ids across the
+  // load).
   //
   // Plugin factories carry their own `id` (not bundle-prefixed) and
   // are addressed by id at harness construction; a collision between
@@ -208,7 +243,7 @@ export async function applyAtomic(
   for (const pkg of loaded) {
     for (const factory of pkg.factories) {
       if (toolIdsSeen.has(factory.id)) {
-        await fs.rm(pendingDir, { recursive: true, force: true });
+        await fs.rm(deployDir, { recursive: true, force: true });
         const out: ApplyAtomicFailure = {
           status: "failed",
           category: "tool.name.duplicate",
@@ -224,7 +259,7 @@ export async function applyAtomic(
     }
     for (const plugin of pkg.plugins) {
       if (pluginIdsSeen.has(plugin.id)) {
-        await fs.rm(pendingDir, { recursive: true, force: true });
+        await fs.rm(deployDir, { recursive: true, force: true });
         const out: ApplyAtomicFailure = {
           status: "failed",
           category: "tool.name.duplicate",
@@ -240,202 +275,20 @@ export async function applyAtomic(
     }
   }
 
-  // Swap. Order:
-  //   1. Remove any existing previous/ (prior backup we no longer need).
-  //   2. Move active/ to previous/ if active/ exists (first apply has none).
-  //   3. Move pending/ to active/.
-  // If step 3 fails after step 2 committed, roll back step 2 so on-disk
-  // state matches the unchanged previousDeployId. Without the rollback
-  // the instance would be left with no active/ directory while the
-  // recorded deploy id still points at the previous deploy — a partial
-  // state the caller has no clean way to recover from.
-  //
-  // The swap stages the prior-active aside under `stagedDir` rather
-  // than overwriting `previousDir` directly. If the pending→active
-  // rename fails the rollback can put the prior-active back without
-  // having ever touched the prior-previous tree, so the safety net
-  // documented at the top of this file ("the previous-deploy tree
-  // is retained as a safety net") survives swap failures.
-  //
-  // CRASH WINDOW: power loss between the active→staged rename below
-  // and the pending→active rename that follows leaves the prior-
-  // active tree at `previous.staged` with no `active` tree on disk.
-  // The next boot is deploy-less by design (the active-deploy-id
-  // file still points at the prior id; the active tree is absent),
-  // and the next apply's prelude sweeps the stale `previous.staged`
-  // before it would conflict. The prior `previous/` tree (the safety
-  // net) is preserved through this window, but the further-back
-  // `previous.staged` content from this apply is lost — acceptable
-  // because the agent restarts deploy-less rather than half-applied.
-  //
-  // The sweep depends on a follow-up applyAtomic invocation ever
-  // occurring. If the sidecar boots and the next operator action is
-  // an undeploy (no apply, ever), the leftover `previous.staged`
-  // persists in the instance directory harmlessly — it occupies disk
-  // but participates in no boot path and is reaped by the next apply
-  // if one eventually lands. (`stagedDir` and `reapDir` were already
-  // swept in the prelude above; nothing to do here.)
-  let activeExists = true;
-  try {
-    await fs.access(activeDir);
-  } catch {
-    activeExists = false;
-  }
-  if (activeExists) {
-    try {
-      await fs.rename(activeDir, stagedDir);
-    } catch (err) {
-      // The active tree is still in place on disk (rename either moved
-      // it or did nothing). Sweep the pending tree so the next apply's
-      // prelude does not have to inherit a fully-staged bundle from
-      // the rejected attempt, then route through the structured-failure
-      // path so the caller's audit-trail + WS-frame plumbing fires
-      // the same way it would for any other rejected category.
-      await fs.rm(pendingDir, { recursive: true, force: true });
-      const out: ApplyAtomicFailure = {
-        status: "failed",
-        category: "apply.swap.failed",
-        message: `active→staged swap failed: ${err instanceof Error ? err.message : String(err)}`,
-        previousDeployId: args.previousDeployId,
-        attemptId: args.attemptId,
-        occurredAt: new Date().toISOString(),
-      };
-      return out;
-    }
-  }
-  try {
-    await fs.rename(pendingDir, activeDir);
-  } catch (err) {
-    if (activeExists) {
-      try {
-        await fs.rename(stagedDir, activeDir);
-      } catch (rollbackErr) {
-        // Both renames failed: on-disk state is no longer
-        // {active=previousDeployId} and the structured-failure path
-        // cannot honestly claim `previousDeployId: args.previousDeployId`
-        // (the docstring at ApplyAtomicFailure.previousDeployId
-        // promises that field reflects the instance's current
-        // disk-state deploy id). Surface this as a thrown exception
-        // so the caller tears the harness down instead of writing an
-        // audit entry asserting an invariant the filesystem no
-        // longer satisfies. The next boot's first apply will rebuild
-        // from a deploy-less instance.
-        logger.error`atomic apply swap failed in both directions for attempt ${args.attemptId}: ${err instanceof Error ? err.message : String(err)} / rollback: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`;
-        throw new Error(
-          `atomic apply diverged on disk for attempt ${args.attemptId}: ` +
-            `pending→active rename failed (${err instanceof Error ? err.message : String(err)}) ` +
-            `and staged→active rollback also failed (${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}); ` +
-            `harness must abort, next boot starts deploy-less`,
-          { cause: err },
-        );
-      }
-    }
-    // Rollback succeeded (or there was no prior active to roll back).
-    // `previousDir` is untouched in this branch — the prior-previous
-    // safety net survives swap failure. Return through the
-    // structured-failure path so the caller routes the failure to
-    // emitDeployApplyError + audit-trail just like any other
-    // rejected category. Match the loader-error and duplicate-id
-    // branches by sweeping the leftover pendingDir before returning
-    // so an aborted apply does not leave a fully-staged bundle tree
-    // on disk until the next attempt. (A leftover `previous.staged`
-    // here is swept by the next apply's `fs.rm(stagedDir, ...)` at
-    // the top of the swap block.)
-    await fs.rm(pendingDir, { recursive: true, force: true });
-    const out: ApplyAtomicFailure = {
-      status: "failed",
-      category: "apply.swap.failed",
-      message: `pending→active swap failed: ${err instanceof Error ? err.message : String(err)}`,
-      previousDeployId: args.previousDeployId,
-      attemptId: args.attemptId,
-      occurredAt: new Date().toISOString(),
-    };
-    return out;
-  }
-
-  // Swap succeeded. Retire the prior-previous and promote the
-  // newly-staged prior-active into its slot.
-  //
-  // The new active tree is already live on disk. If the prior-previous
-  // rm or the staged→previous rename fails (EBUSY, EPERM, EXDEV on a
-  // cross-fs rename, etc.) the caller's contract is to receive a
-  // structured failure that travels through the same audit-trail /
-  // WS-frame channel as every other rejected apply, not an exception
-  // that bypasses the apply-error pipeline and leaves
-  // active-deploy-id un-bumped while the on-disk tree advanced.
-  // Surface the cleanup failure as apply.previous-rotation.failed so
-  // the caller emits a deploy.apply.error frame referencing the
-  // newly-active deploy id.
-  //
-  // The rotation moves the prior-previous tree aside to `reapDir`
-  // before the staged→previous rename so the safety-net tree is not
-  // destroyed by a rename that later fails — a sequence of rm-then-
-  // rename would leave the slot empty if the rename failed. On rename
-  // failure the prior-previous is restored from `reapDir`; on rename
-  // success the prior-previous is reaped. The `reapDir` slot is swept
-  // at the top of every apply alongside `stagedDir`, so a crash that
-  // leaves an unreaped `reapDir` is cleaned up by the next apply.
-  if (activeExists) {
-    let priorPreviousMovedAside = false;
-    try {
-      await fs.access(previousDir);
-      await fs.rename(previousDir, reapDir);
-      priorPreviousMovedAside = true;
-    } catch (err) {
-      const code =
-        err !== null &&
-        typeof err === "object" &&
-        "code" in err &&
-        typeof err.code === "string"
-          ? err.code
-          : null;
-      if (code !== "ENOENT") {
-        logger.warn`apply post-swap rotation failed for attempt ${args.attemptId} (move-aside): ${err instanceof Error ? err.message : String(err)}; active deploy ${args.newDeployId} is live on disk, previous safety net retained`;
-        const out: ApplyAtomicFailure = {
-          status: "failed",
-          category: "apply.previous-rotation.failed",
-          message: `post-swap previous-dir rotation failed: ${err instanceof Error ? err.message : String(err)}`,
-          previousDeployId: args.newDeployId,
-          attemptId: args.attemptId,
-          occurredAt: new Date().toISOString(),
-        };
-        return out;
-      }
-    }
-    try {
-      await fs.rename(stagedDir, previousDir);
-    } catch (err) {
-      if (priorPreviousMovedAside) {
-        try {
-          await fs.rename(reapDir, previousDir);
-        } catch (rollbackErr) {
-          logger.error`apply post-swap rotation rollback failed for attempt ${args.attemptId}: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}; previous-deploy safety net lost on disk`;
-        }
-      }
-      logger.warn`apply post-swap rotation failed for attempt ${args.attemptId}: ${err instanceof Error ? err.message : String(err)}; active deploy ${args.newDeployId} is live on disk`;
-      const out: ApplyAtomicFailure = {
-        status: "failed",
-        category: "apply.previous-rotation.failed",
-        message: `post-swap previous-dir rotation failed: ${err instanceof Error ? err.message : String(err)}`,
-        previousDeployId: args.newDeployId,
-        attemptId: args.attemptId,
-        occurredAt: new Date().toISOString(),
-      };
-      return out;
-    }
-    if (priorPreviousMovedAside) {
-      try {
-        await fs.rm(reapDir, { recursive: true, force: true });
-      } catch (err) {
-        logger.warn`apply post-rotation reap of previous.reap failed for attempt ${args.attemptId}: ${err instanceof Error ? err.message : String(err)}; next apply prelude will sweep it`;
-      }
-    }
-  }
-
-  logger.info`apply ok: attempt ${args.attemptId} active as ${args.newDeployId}`;
+  logger.info`apply staged: attempt ${args.attemptId} ready as ${args.newDeployId} (caller commits via active-deploy-id)`;
   return {
     status: "ok",
     activeDeployId: args.newDeployId,
+    deployDir,
     loaded,
   };
+}
+
+function isENOENT(err: unknown): boolean {
+  return (
+    err !== null &&
+    typeof err === "object" &&
+    "code" in err &&
+    (err as { code: unknown }).code === "ENOENT"
+  );
 }

--- a/packages/tool-packaging/src/index.ts
+++ b/packages/tool-packaging/src/index.ts
@@ -19,8 +19,9 @@
 //       store keyed by SRI integrity.
 //       createToolLoader({ cache, registries, host, … }) — fetches,
 //       extracts, and dynamic-imports each pinned package.
-//       applyAtomic({ manifest, loader, … }) — stage-and-swap apply
-//       protocol that maps every loader failure category onto an
+//       applyAtomic({ manifest, loader, … }) — per-deploy-id apply
+//       protocol that stages each deploy into its own never-renamed
+//       directory and maps every loader failure category onto an
 //       `ApplyAtomicFailure` the caller routes to the
 //       `deploy.apply.error` frame channel.
 

--- a/packages/tool-packaging/src/loader.test.ts
+++ b/packages/tool-packaging/src/loader.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import * as tar from "tar";
 import ssri from "ssri";
 
+import { applyAtomic } from "./atomic-apply";
 import { createTarballCache } from "./cache";
 import {
   type LoadedDirectorFactory,
@@ -3038,5 +3039,157 @@ export const main = Object.assign(
         /dynamic import of dir-import-fail@1\.0\.0 interchange\.directors failed/,
       );
     }
+  });
+});
+
+// End-to-end coverage for the per-deploy-id apply layout: a tool
+// package whose `interchange.tools` module performs a CALL-TIME
+// `await import("./other.js")` must resolve that sibling against the
+// on-disk path it was loaded from. Because each apply materializes into
+// a stable `packages/<deploy-id>/` directory that is never renamed, the
+// loaded module's URL stays valid across subsequent applies for as long
+// as its deploy directory is retained — and stops resolving once the
+// prelude sweep reaps it. These tests drive the real native importer
+// (no `importModule` seam) so the dynamic import hits disk.
+describe("applyAtomic per-deploy-id late-import liveness", () => {
+  // A factory whose tool `run` lazily imports a sibling module and
+  // returns its marker. The import is call-time, not load-time, so it
+  // resolves against the deploy directory only when the tool runs —
+  // after any number of intervening applies.
+  const lateImportEntry = `
+export const factory = Object.assign(
+  () => ({
+    definitions: [{ name: "probe", description: "", inputSchema: {} }],
+    run: async (call) => {
+      const m = await import("./other.js");
+      return { callId: call.id, content: m.marker };
+    },
+  }),
+  { id: "late/main", requires: [] },
+);
+`;
+
+  async function buildLateImportLoader(): Promise<{
+    loader: ReturnType<typeof createToolLoader>;
+    manifest: ToolPackageManifest;
+  }> {
+    const cache = createTarballCache({
+      rootDir: cacheDir,
+      maxBytes: 10_000_000,
+    });
+    const pkg = await packFixture({
+      name: "@late/pkg",
+      version: "1.0.0",
+      interchangeToolsRelPath: "./index.js",
+      entryModuleSource: lateImportEntry,
+      type: "module",
+      extraFiles: { "other.js": `export const marker = "late-import-ok";` },
+    });
+    await cache.put(pkg.integrity, pkg.bytes);
+    const loader = createToolLoader({
+      cache,
+      registries: new Map([["test", { url: "https://example.test" }]]),
+      host: { os: process.platform, cpu: process.arch },
+      fetchTarball: async () => pkg.bytes,
+    });
+    const manifest: ToolPackageManifest = {
+      schemaVersion: "1",
+      topLevel: [{ name: "@late/pkg", version: "1.0.0" }],
+      entries: [
+        {
+          name: "@late/pkg",
+          version: "1.0.0",
+          integrity: pkg.integrity,
+          source: { kind: "registry", registry: "test" },
+        },
+      ],
+    };
+    return { loader, manifest };
+  }
+
+  function applyArgs(
+    loader: ReturnType<typeof createToolLoader>,
+    manifest: ToolPackageManifest,
+    previousDeployId: string,
+    newDeployId: string,
+  ) {
+    return {
+      manifest,
+      loader,
+      instanceDir,
+      assetRoot,
+      assetMounts: new Map<string, string>(),
+      attemptId: `atp-${newDeployId}`,
+      previousDeployId,
+      newDeployId,
+    };
+  }
+
+  // Invoke the loaded factory's `probe` tool, whose `run` performs the
+  // call-time sibling import. The namespaced tool name carries the
+  // bundle-id prefix the loader applied.
+  function runProbe(factory: LoadedToolFactory): Promise<{ content: unknown }> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- BaseEnv is satisfied by an empty object for this stub; the factory does not read env, only the call-time sibling import.
+    const bundle = factory({} as Parameters<typeof factory>[0]);
+    return bundle.run(
+      { id: "c1", name: "late/main:probe", arguments: {} },
+      new AbortController().signal,
+    );
+  }
+
+  async function deployDirExists(id: string): Promise<boolean> {
+    try {
+      await fs.stat(path.join(instanceDir, "packages", id));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  test("a retained previous deploy still resolves a call-time sibling import", async () => {
+    const { loader, manifest } = await buildLateImportLoader();
+
+    const first = await applyAtomic(applyArgs(loader, manifest, "none", "d1"));
+    expect(first.status).toBe("ok");
+    if (first.status !== "ok") return;
+    const d1Factory = first.loaded[0]?.factories[0];
+    if (d1Factory === undefined) throw new Error("expected a loaded factory");
+
+    // A second apply makes d1 the retained previous deploy. The prelude
+    // keeps {d2, d1}, so d1's tree survives.
+    const second = await applyAtomic(applyArgs(loader, manifest, "d1", "d2"));
+    expect(second.status).toBe("ok");
+    expect(await deployDirExists("d1")).toBe(true);
+
+    // d1's tool runs for the first time AFTER the second apply; its
+    // call-time `import("./other.js")` resolves against the still-present
+    // packages/d1/ tree.
+    const result = await runProbe(d1Factory);
+    expect(result.content).toBe("late-import-ok");
+  });
+
+  test("a reaped deploy can no longer resolve a call-time sibling import", async () => {
+    const { loader, manifest } = await buildLateImportLoader();
+
+    const first = await applyAtomic(applyArgs(loader, manifest, "none", "d1"));
+    expect(first.status).toBe("ok");
+    if (first.status !== "ok") return;
+    const d1Factory = first.loaded[0]?.factories[0];
+    if (d1Factory === undefined) throw new Error("expected a loaded factory");
+
+    // d2 retains d1; d3 then reaps d1 (keep-set becomes {d3, d2}).
+    const second = await applyAtomic(applyArgs(loader, manifest, "d1", "d2"));
+    expect(second.status).toBe("ok");
+    const third = await applyAtomic(applyArgs(loader, manifest, "d2", "d3"));
+    expect(third.status).toBe("ok");
+
+    // d1's tree is gone, bounding disk to the two retained deploys.
+    expect(await deployDirExists("d1")).toBe(false);
+
+    // d1's tool runs for the FIRST time only now — its sibling module
+    // was never imported before the reap, so the ESM cache cannot mask
+    // the missing file. The call-time import fails against the absent
+    // packages/d1/ tree.
+    await expect(runProbe(d1Factory)).rejects.toThrow();
   });
 });

--- a/packages/tool-packaging/src/loader.ts
+++ b/packages/tool-packaging/src/loader.ts
@@ -1526,7 +1526,7 @@ function applyNamespacePrefix(
         // (agent construction at sidecar boot), NOT at apply time. The
         // loader cannot read `bundle.definitions` without invoking the
         // factory, and the `BaseEnv` the factory needs is constructed
-        // by the sidecar harness only after the swap completes. As a
+        // by the sidecar harness only after the apply commits. As a
         // consequence, an intra-bundle duplicate surfaces on the
         // runtime construct-failure channel rather than as an
         // apply-error frame. The cross-bundle case (in atomic-apply.ts)

--- a/packages/types/src/sidecar.ts
+++ b/packages/types/src/sidecar.ts
@@ -592,47 +592,46 @@ export type PackRejectFrame = typeof PackRejectFrame.infer;
  *                              cross-bundle case (two pinned packages
  *                              share a bundle id, producing colliding
  *                              prefixed tool names) is rejected at
- *                              apply time, before the swap. The
- *                              intra-bundle case (one package exports
- *                              two definitions sharing a raw name)
- *                              surfaces at first agent construction
- *                              with the same category instead of
- *                              apply rejection: the loader cannot see
- *                              `bundle.definitions` without invoking
- *                              the factory, and the `BaseEnv` the
- *                              factory needs is constructed by the
- *                              sidecar harness AFTER the swap. Both
+ *                              apply time, before the caller commits.
+ *                              The intra-bundle case (one package
+ *                              exports two definitions sharing a raw
+ *                              name) surfaces at first agent
+ *                              construction with the same category
+ *                              instead of apply rejection: the loader
+ *                              cannot see `bundle.definitions` without
+ *                              invoking the factory, and the `BaseEnv`
+ *                              the factory needs is constructed by the
+ *                              sidecar harness AFTER the commit. Both
  *                              paths carry the same category so the
  *                              operator-facing failure shape is
  *                              uniform regardless of which check
  *                              fired; only the channel (apply.error
  *                              frame vs runtime construct failure)
  *                              differs.
- *   apply.swap.failed        — every loaded factory validated, but the
- *                              pending→active filesystem rename failed
- *                              (e.g. EXDEV, EPERM). The prior active
- *                              tree was restored via rollback, so the
- *                              instance still runs `previousDeployId`.
- *                              A double-rename failure where rollback
- *                              also fails does not surface as this
- *                              category — the sidecar throws and tears
- *                              the harness down, because no structured
- *                              failure can honestly report
- *                              `previousDeployId` once on-disk state
- *                              has diverged from it.
+ *   apply.swap.failed        — DEPRECATED, no longer emitted. The apply
+ *                              protocol stages each deploy into a stable
+ *                              per-deploy-id directory and commits via a
+ *                              single `active-deploy-id` file write, so
+ *                              there is no filesystem rename that can
+ *                              fail. The value is retained in the enum
+ *                              for wire compatibility: during a rolling
+ *                              upgrade an older sidecar can still emit
+ *                              it, and dropping the member would make a
+ *                              newer hub's frame validator reject that
+ *                              frame.
  *   apply.previous-rotation.failed
- *                            — the pending→active swap succeeded (the
- *                              new deploy is live on disk), but the
- *                              post-swap rotation that retires the
- *                              prior-previous tree and promotes the
- *                              just-staged prior-active into the
- *                              previous slot failed. The instance is
- *                              now running the new deploy, so
- *                              `previousDeployId` on this failure
- *                              carries the NEW deploy id rather than
- *                              the pre-apply one. The on-disk
- *                              leftover (`previous.staged`) is swept
- *                              by the next apply's pending-clear step.
+ *                            — every loaded factory validated and the
+ *                              new deploy was staged, but persisting the
+ *                              instance's `active-deploy-id` file (the
+ *                              commit) degraded: the id was written
+ *                              through the no-fsync / dirty-marker
+ *                              fallback ladder rather than durably
+ *                              flushed. The new deploy is logically
+ *                              live, so `previousDeployId` on this
+ *                              failure carries the NEW deploy id rather
+ *                              than the pre-apply one. The next boot
+ *                              reconciles the recorded id from the dirty
+ *                              marker.
  */
 export const DeployApplyErrorCategory = type.enumerated(
   "tarball.missing",
@@ -661,13 +660,14 @@ export type DeployApplyErrorCategory = typeof DeployApplyErrorCategory.infer;
  * frame is emitted the instance continues to run that deploy untouched.
  *
  * For `apply.previous-rotation.failed` the field has inverted meaning.
- * The pending→active swap committed before the post-swap rotation
- * failed, so the new deploy is live on disk; the field carries the
- * **new** deploy id so the hub can record the on-disk truth rather
+ * The new deploy was staged and its `active-deploy-id` commit was
+ * written through the degradation ladder (so the new deploy is live)
+ * before the persist was found to be non-durable; the field carries
+ * the **new** deploy id so the hub can record the on-disk truth rather
  * than a stale pre-apply id. The atomicity contract is preserved in
  * the sense that the field always reflects the deploy id the instance
  * is now running — what shifts is whether "now" is pre-apply or
- * post-apply, depending on whether the swap committed before the
+ * post-apply, depending on whether the commit landed before the
  * failure. Renaming the field to make this explicit would break the
  * wire shape; the category's semantics document the override instead.
  *


### PR DESCRIPTION
## Summary

- Tool-package applies materialize each deploy into a stable
  `packages/<deploy-id>/` directory that is never renamed; a single
  `active-deploy-id` file write is the commit point.
- Loaded modules keep a valid on-disk URL for the life of the deploy, so a
  tool package can resolve its own files at call time (`import.meta.url`,
  `require.resolve`, `await import("./sibling.js")`).
- A prelude sweep retains only the current and previous deploys, bounding
  disk while keeping the prior tree resolvable for a session still draining
  against it.

## Verification

- `make all` passes: lint, type-check, admin-ui bundle, and both test
  passes (exit 0).
- `loader.test.ts` drives the real native importer end-to-end — a retained
  previous deploy resolves a call-time sibling import, and a reaped deploy
  does not.

Closes INTR-176