### PR TITLE
Drain in-flight repo operations before deleting an agent directory

### DIFF
--- a/packages/hub-agent/src/session-manager.test.ts
+++ b/packages/hub-agent/src/session-manager.test.ts
@@ -14,7 +14,7 @@ import type {
 } from "@intx/types/runtime";
 
 import { createAgentKeyStore } from "./agent-key-store";
-import { createAgentRepoStore } from "./agent-repo-store";
+import { createAgentRepoStore, type AgentRepoStore } from "./agent-repo-store";
 import { createSessionManager } from "./session-manager";
 import type {
   BuildHarnessArgs,
@@ -632,5 +632,156 @@ describe("SessionManager.restoreSessions bounded parallelism", () => {
       "healthy1@local",
       "healthy2@local",
     ]);
+  });
+});
+
+function makeStubRepoStore(opts: {
+  dataDir: string;
+  createStatePack: AgentRepoStore["createStatePack"];
+  remove: AgentRepoStore["remove"];
+}): AgentRepoStore {
+  const unused = (name: string) => (): never => {
+    throw new Error(`${name} is not exercised by this test`);
+  };
+  return {
+    getAgentDir: (address) => path.join(opts.dataDir, address),
+    initRepo: unused("initRepo"),
+    applyDeployPack: unused("applyDeployPack"),
+    createStatePack: opts.createStatePack,
+    getDeployRef: unused("getDeployRef"),
+    remove: opts.remove,
+    persistConfig: unused("persistConfig"),
+    persistPairing: unused("persistPairing"),
+    scanConfigs: unused("scanConfigs"),
+  };
+}
+
+function makeManagerWithRepoStore(
+  dataDir: string,
+  repoStore: AgentRepoStore,
+): ReturnType<typeof createSessionManager> {
+  return createSessionManager({
+    transport: createInMemoryTransport(),
+    repoStore,
+    keyStore: createAgentKeyStore({
+      dataDir,
+      generateKeyPair: async () => makeKeyPair(11),
+      signEd25519: () => new Uint8Array(64),
+      verifySSHSig: () => true,
+    }),
+    buildHarness: makeRecordingBuilder({}),
+    createAgentCrypto: (kp) => makeCrypto(kp),
+    onEvent: () => {
+      /* no-op */
+    },
+    onConnectorStateChanged: () => {
+      /* no-op */
+    },
+  });
+}
+
+describe("SessionManager repo-operation serialization", () => {
+  test("deleteAgentDir removes the directory only after an in-flight state-pack read completes", async () => {
+    const dataDir = await tempDir();
+    const events: string[] = [];
+
+    let releaseStatePack!: () => void;
+    const statePackGate = new Promise<void>((resolve) => {
+      releaseStatePack = resolve;
+    });
+
+    const repoStore = makeStubRepoStore({
+      dataDir,
+      async createStatePack() {
+        events.push("createStatePack:start");
+        await statePackGate;
+        events.push("createStatePack:end");
+        return {
+          pack: new Uint8Array(),
+          commitSha: "0".repeat(40),
+          ref: "refs/heads/main",
+        };
+      },
+      async remove() {
+        events.push("remove");
+      },
+    });
+
+    const manager = makeManagerWithRepoStore(dataDir, repoStore);
+
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", onRejection);
+    try {
+      const statePack = manager.createStatePack("agent@local");
+      const deletion = manager.deleteAgentDir("agent@local");
+
+      // Let the state-pack read enter its gate and the deletion reach its
+      // drain await. With the gate still closed, the removal must not run.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      expect(events).toEqual(["createStatePack:start"]);
+
+      releaseStatePack();
+      await Promise.all([statePack, deletion]);
+
+      expect(events).toEqual([
+        "createStatePack:start",
+        "createStatePack:end",
+        "remove",
+      ]);
+    } finally {
+      process.off("unhandledRejection", onRejection);
+    }
+
+    // A pending unhandled rejection surfaces on the next macrotask.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(rejections).toEqual([]);
+  });
+
+  test("a rejecting repo operation propagates to its caller without poisoning the chain", async () => {
+    const dataDir = await tempDir();
+    let calls = 0;
+
+    const repoStore = makeStubRepoStore({
+      dataDir,
+      async createStatePack() {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error("state pack boom");
+        }
+        return {
+          pack: new Uint8Array(),
+          commitSha: "1".repeat(40),
+          ref: "refs/heads/main",
+        };
+      },
+      async remove() {
+        /* unused in this test */
+      },
+    });
+
+    const manager = makeManagerWithRepoStore(dataDir, repoStore);
+
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", onRejection);
+    try {
+      // The failing op's rejection reaches its own caller.
+      await expect(manager.createStatePack("agent@local")).rejects.toThrow(
+        "state pack boom",
+      );
+
+      // The chain is not poisoned: the next op runs and resolves normally.
+      const second = await manager.createStatePack("agent@local");
+      expect(second.commitSha).toBe("1".repeat(40));
+      expect(calls).toBe(2);
+    } finally {
+      process.off("unhandledRejection", onRejection);
+    }
+
+    // The rejection-swallowing tail must not surface as an unhandled
+    // rejection on the next macrotask.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(rejections).toEqual([]);
   });
 });

--- a/packages/hub-agent/src/session-manager.ts
+++ b/packages/hub-agent/src/session-manager.ts
@@ -267,28 +267,66 @@ export function createSessionManager(
   // before the handler reads it.
   const lastCheckpointHashes = new Map<string, string>();
 
-  // Per-agent promise chain to serialize mail commits and avoid concurrent
-  // git operations on the same repository.
-  const mailCommitQueues = new Map<string, Promise<void>>();
+  // Per-agent promise chain that serializes the operations against an agent's
+  // on-disk directory that can be in flight during a live session -- mail-audit
+  // commits, state-pack and deploy-ref reads, and deploy/asset-pack applies all
+  // run one-at-a-time per agent. The chain exists for teardown: drainRepoOps
+  // awaits it before deleting the directory, so an operation that was valid
+  // when it started never runs against a path that has since vanished
+  // underneath it. Serializing additionally avoids corruption for the members
+  // that share the agent's `.git/` object store (mail commits, state-pack and
+  // deploy-ref reads, deploy-pack applies), which isogit, lacking a
+  // cross-process lock, would otherwise let interleave. Asset-pack applies are
+  // on the chain only for the teardown reason -- they materialize into a
+  // workspace subtree, not the agent repo's object store.
+  const repoOpQueues = new Map<string, Promise<void>>();
+
+  function runRepoOp<T>(
+    agentAddress: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const prev = repoOpQueues.get(agentAddress) ?? Promise.resolve();
+    // Run fn once prev settles. prev is either the initial Promise.resolve()
+    // or the rejection-swallowing tail stored below, so it never rejects;
+    // passing fn as both the fulfilled and rejected handler keeps this op
+    // independent of that detail and guarantees fn runs exactly once after the
+    // previous op completes.
+    const result = prev.then(fn, fn);
+    // Store a rejection-swallowing tail so one failed op does not poison the
+    // chain for the next caller. The caller still observes this op's own
+    // result or rejection through `result`.
+    repoOpQueues.set(
+      agentAddress,
+      result.then(
+        () => undefined,
+        () => undefined,
+      ),
+    );
+    return result;
+  }
 
   function enqueueMailCommit(
     agentAddress: string,
     fn: () => Promise<void>,
   ): void {
-    const prev = mailCommitQueues.get(agentAddress) ?? Promise.resolve();
-    const next = prev
-      .catch(() => undefined)
-      .then(fn)
-      .catch((err: unknown) => {
-        const msg = err instanceof Error ? err.message : String(err);
-        logger.error`Mail audit commit failed for ${agentAddress}: ${msg}`;
-      });
-    mailCommitQueues.set(agentAddress, next);
+    void runRepoOp(agentAddress, fn).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error`Mail audit commit failed for ${agentAddress}: ${msg}`;
+    });
   }
 
-  async function drainMailQueue(agentAddress: string): Promise<void> {
-    const inflight = mailCommitQueues.get(agentAddress);
-    mailCommitQueues.delete(agentAddress);
+  // Await the agent's current operation chain so teardown removes the
+  // directory only after in-flight git work finishes. Capturing the tail and
+  // clearing the entry means an op enqueued AFTER this point starts a fresh
+  // chain this drain does not await. That is safe only because every caller
+  // invokes runRepoOp synchronously, before its first await, inside the
+  // serialized frame dispatch -- so by the time a later agent.undeploy frame
+  // reaches deleteAgentDir, every racing op is already on the chain. A handler
+  // that deferred its runRepoOp call past an await would reopen the
+  // delete-under-in-flight-op race.
+  async function drainRepoOps(agentAddress: string): Promise<void> {
+    const inflight = repoOpQueues.get(agentAddress);
+    repoOpQueues.delete(agentAddress);
     if (inflight !== undefined) await inflight;
   }
 
@@ -448,7 +486,7 @@ export function createSessionManager(
       logger.info`Started session for ${agentAddress} (session ${sessionId})`;
     } catch (err) {
       sessions.delete(agentAddress);
-      mailCommitQueues.delete(agentAddress);
+      repoOpQueues.delete(agentAddress);
       try {
         transport.unregister(agentAddress);
       } catch (cleanupErr) {
@@ -496,7 +534,7 @@ export function createSessionManager(
     }
     await session.harness.close();
     const disposerErrors = await runDisposers(session, agentAddress);
-    await drainMailQueue(agentAddress);
+    await drainRepoOps(agentAddress);
     sessions.delete(agentAddress);
     transport.unregister(agentAddress);
     if (disposerErrors.length > 0) {
@@ -521,7 +559,7 @@ export function createSessionManager(
     }
     await session.harness.close();
     const disposerErrors = await runDisposers(session, agentAddress);
-    await drainMailQueue(agentAddress);
+    await drainRepoOps(agentAddress);
     sessions.delete(agentAddress);
     transport.unregister(agentAddress);
     if (disposerErrors.length > 0) {
@@ -698,7 +736,7 @@ export function createSessionManager(
             verifyCommit,
           }
         : { address: agentAddress, pack, ref, commitSha, transferId };
-    await repoStore.applyDeployPack(args);
+    await runRepoOp(agentAddress, () => repoStore.applyDeployPack(args));
   }
 
   async function applyAssetPack(
@@ -712,22 +750,27 @@ export function createSessionManager(
       repoStore.getAgentDir(agentAddress),
       "workspace",
     );
-    await applyAssetPackFn({
-      workspaceRoot,
-      mountPath,
-      pack,
-      ref,
-      commitSha,
-    });
+    await runRepoOp(agentAddress, () =>
+      applyAssetPackFn({
+        workspaceRoot,
+        mountPath,
+        pack,
+        ref,
+        commitSha,
+      }),
+    );
   }
 
   async function createStatePack(
     agentAddress: string,
   ): Promise<{ pack: Uint8Array; commitSha: string; ref: string }> {
-    return repoStore.createStatePack(agentAddress);
+    return runRepoOp(agentAddress, () =>
+      repoStore.createStatePack(agentAddress),
+    );
   }
 
   async function deleteAgentDir(agentAddress: string): Promise<void> {
+    await drainRepoOps(agentAddress);
     await repoStore.remove(agentAddress);
   }
 
@@ -764,7 +807,7 @@ export function createSessionManager(
   }
 
   async function getDeployRef(agentAddress: string): Promise<string | null> {
-    return repoStore.getDeployRef(agentAddress);
+    return runRepoOp(agentAddress, () => repoStore.getDeployRef(agentAddress));
   }
 
   return {

--- a/tests/hub-agent/deploy-flow.test.ts
+++ b/tests/hub-agent/deploy-flow.test.ts
@@ -311,7 +311,18 @@ describe("deploy flow integration", () => {
     expect(commit.tree).toMatch(/^[0-9a-f]{40}$/);
   });
 
-  test("endSession undeploys agent and cleans up sidecar", async () => {
+  test("endSession drains an in-flight state read before tearing down the sidecar agent dir", async () => {
+    const failuresBefore = env.hub.statePackReceiveFailures.filter(
+      (f) => f.agentAddress === AGENT_ADDRESS,
+    ).length;
+    const packCountBefore = env.hub.statePacks.length;
+    const sidecarLogBefore = env.sidecar.stderr.length;
+
+    // Race the teardown: the sync request makes the sidecar read the agent
+    // repo (createStatePack) at the same moment endSession deletes that
+    // repo's directory. The drain serializes the read ahead of the rm, so
+    // the read runs against a live directory instead of a vanishing one.
+    env.hub.router.sendSyncRequest(AGENT_ADDRESS);
     await env.hub.sessionService.endSession(AGENT_ADDRESS, "test_complete");
 
     // Agent should no longer be routable after ack.
@@ -327,5 +338,28 @@ describe("deploy flow integration", () => {
       .then(() => true)
       .catch(() => false);
     expect(dirExists).toBe(false);
+
+    // Teardown still pushes agent state to the hub; wait for it to land so
+    // any sidecar-side read failure has had time to drain into the log.
+    await waitFor(() => env.hub.statePacks.length > packCountBefore, {
+      timeoutMs: 30_000,
+      diagnostics: env.sidecarDiagnostics,
+    });
+
+    // Teardown must log no state-push read failure. Both the undeploy push
+    // and the sync push log "State push failed for <address>" when their read
+    // hits a deleted directory; the drain keeps the read ahead of the rm, so
+    // with the fix this log never appears. This is a one-sided guard: on a
+    // fast machine the sync read can finish before the rm regardless, so a
+    // pass does not prove the read raced -- but a build that drops the drain
+    // and loses the race fails here. The deterministic ordering check is the
+    // session-manager unit test. The hub-side counter stays flat too, since a
+    // sidecar-side read throw never reaches the receive boundary.
+    const newSidecarLog = env.sidecar.stderr.slice(sidecarLogBefore).join("");
+    expect(newSidecarLog).not.toContain("State push failed");
+    const failuresAfter = env.hub.statePackReceiveFailures.filter(
+      (f) => f.agentAddress === AGENT_ADDRESS,
+    ).length;
+    expect(failuresAfter).toBe(failuresBefore);
   });
 });


### PR DESCRIPTION
## Summary

- Routes the sidecar agent repo's git operations — mail-audit commits,
  state-pack and deploy-ref reads, and deploy/asset-pack applies — through
  one per-agent serialization chain.
- Drains that chain in `deleteAgentDir` before removing the directory, so a
  state-pack read racing an `agent.undeploy` finishes before the `rm` instead
  of failing against a vanished path.
- Keeps the hub's structured-rejection catch as a defence-in-depth boundary;
  the directory-teardown case no longer reaches it.

## Verification

- `make all` passes (exits 0): lint, type-check, admin-ui bundle, and tests.
- A session-manager unit test asserts `deleteAgentDir` removes the directory
  only after an in-flight read completes, and that a rejecting operation
  propagates to its caller without poisoning the chain.
- The deploy-flow integration test races a sync-request state read against
  `endSession`: the sidecar directory is removed, agent state still pushes to
  the hub, and no state-push read failure is logged.

Closes INTR-150