### PR TITLE
Keep the database and orchestrator out of the workflow-child boot graph

### DIFF
--- a/apps/sidecar/src/conversation-state.ts
+++ b/apps/sidecar/src/conversation-state.ts
@@ -130,8 +130,12 @@ import { type } from "arktype";
 import { getLogger } from "@intx/log";
 import { createConnectorRouter } from "@intx/harness";
 import { createIsogitStore } from "@intx/storage-isogit";
-import type { Principal, RepoId, RepoStore } from "@intx/hub-sessions";
-import { WORKFLOW_RUN_AGENT_STATE_PREFIX } from "@intx/hub-sessions";
+import type {
+  Principal,
+  RepoId,
+  RepoStore,
+} from "@intx/hub-sessions/substrate";
+import { WORKFLOW_RUN_AGENT_STATE_PREFIX } from "@intx/hub-sessions/substrate";
 import {
   ConnectorThreadState,
   TokenUsage,

--- a/apps/sidecar/src/step-agent-tools.ts
+++ b/apps/sidecar/src/step-agent-tools.ts
@@ -41,7 +41,7 @@ import {
   readDeployTree,
   sanitizeAddress,
   type DeployApplyErrorEmitter,
-} from "@intx/hub-agent";
+} from "@intx/hub-agent/paths";
 import { getLogger } from "@intx/log";
 import type { LoadedToolFactory } from "@intx/tool-packaging";
 import { deriveStepAddress } from "@intx/workflow-deploy";

--- a/apps/sidecar/src/tool-materialization.ts
+++ b/apps/sidecar/src/tool-materialization.ts
@@ -19,7 +19,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { type } from "arktype";
 import { type AnnotatedPluginFactory } from "@intx/agent";
-import { type DeployApplyErrorEmitter } from "@intx/hub-agent";
+import { type DeployApplyErrorEmitter } from "@intx/hub-agent/paths";
 import { getLogger } from "@intx/log";
 import {
   type LoadedToolFactory,

--- a/apps/sidecar/src/workflow-child-boot-graph.test.ts
+++ b/apps/sidecar/src/workflow-child-boot-graph.test.ts
@@ -1,0 +1,179 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+// Boot-graph guard for the spawned workflow-child.
+//
+// The workflow-child evaluates its whole module graph on every cold start. It
+// must never pull the control-plane database layer (`@intx/db` / `drizzle`) or
+// the sidecar orchestrator (`@intx/hub-agent`) into that graph: the child
+// never executes either, the database dependency is a layering violation, and
+// importing the orchestrator that spawns the child is a backwards dependency.
+// The db-free substrate is reachable via `@intx/hub-sessions/substrate` and
+// the path helpers via `@intx/hub-agent/paths`; the package barrels are not.
+//
+// This walks the child's VALUE-import graph and fails if any forbidden module
+// is reachable. `Bun.build` erases `import type` and type-only specifiers
+// before resolution (the project's `verbatimModuleSyntax` + `isolatedModules`
+// guarantee every value-syntax import that survives is a real runtime import),
+// so the captured graph is exactly what the child evaluates at runtime.
+// Dynamic `import()` edges are included too, so even a lazy import of a
+// forbidden module is caught. npm and `node:` packages are recorded but not
+// traversed; workspace (`@intx/*`) packages are resolved to their real source
+// (honoring `exports` subpaths) and walked through.
+
+const repoRoot = process.cwd();
+
+// The binary the sidecar spawns as the workflow-child. The graph walk derives
+// its entrypoints from this file's actual imports, so anything the binary
+// loads -- in any import form -- is part of the checked graph.
+const CHILD_BINARY = "apps/sidecar/bin/workflow-child";
+
+// The roots the binary is expected to import. The drift guard asserts the
+// binary imports exactly these; a new root trips it so a human confirms the
+// addition (and the walk covers the new root regardless).
+const EXPECTED_CHILD_ROOTS = [
+  "../src/workflow-substrate-factory",
+  "@intx/workflow-host",
+];
+
+// The module specifiers the binary VALUE-imports, in every runtime form
+// (static `from`, side-effect `import`, dynamic `import()`, `require`). Bun's
+// transpiler is the same machinery the bundler uses, so it ignores comments,
+// strings, and member expressions like `Array.from(...)`, and -- crucially --
+// erases `import type` / type-only specifiers, keeping this list aligned with
+// the runtime value graph the walk below captures.
+function binaryImportSpecifiers(): string[] {
+  const raw = readFileSync(join(repoRoot, CHILD_BINARY), "utf8");
+  // The transpiler does not accept the binary's `#!/usr/bin/env bun` shebang.
+  const source = raw.replace(/^#![^\n]*\n/, "");
+  const transpiler = new Bun.Transpiler({ loader: "ts" });
+  const specs = new Set(transpiler.scanImports(source).map((i) => i.path));
+  return [...specs].sort();
+}
+
+// Resolve the binary's imports to real entrypoint files. A root that cannot
+// resolve throws here and fails the test loudly rather than yielding a graph
+// built from an incomplete root set.
+function binaryEntrypoints(): string[] {
+  const binDir = dirname(join(repoRoot, CHILD_BINARY));
+  return binaryImportSpecifiers().map((spec) => Bun.resolveSync(spec, binDir));
+}
+
+/**
+ * Returns the package reason if a value-import specifier is forbidden in the
+ * child boot graph, or null otherwise. `@intx/db` / `drizzle-orm` are banned
+ * entirely; the `@intx/hub-sessions` and `@intx/hub-agent` *barrels* are banned
+ * (their `/substrate` and `/paths` subpaths are the supported db-free doors).
+ */
+function forbiddenReason(spec: string): string | null {
+  if (spec === "@intx/db" || spec.startsWith("@intx/db/")) {
+    return "control-plane database layer";
+  }
+  if (spec === "drizzle-orm" || spec.startsWith("drizzle-orm/")) {
+    return "database ORM";
+  }
+  if (spec === "@intx/hub-sessions") {
+    return "control-plane barrel; import @intx/hub-sessions/substrate instead";
+  }
+  if (spec === "@intx/hub-agent") {
+    return "sidecar orchestrator barrel; import @intx/hub-agent/paths instead";
+  }
+  return null;
+}
+
+async function childValueImportGraph(entrypoints: string[]): Promise<{
+  importers: Map<string, Set<string>>;
+  resolveFailures: string[];
+  success: boolean;
+}> {
+  const importers = new Map<string, Set<string>>();
+  const resolveFailures: string[] = [];
+  const relativize = (p: string) => p.replace(`${repoRoot}/`, "");
+
+  const result = await Bun.build({
+    entrypoints,
+    target: "bun",
+    throw: false,
+    plugins: [
+      {
+        name: "track-value-imports",
+        setup(build) {
+          build.onResolve({ filter: /.*/ }, (args) => {
+            const spec = args.path;
+            const from = args.importer ? relativize(args.importer) : "entry";
+            const seenFrom = importers.get(spec) ?? new Set<string>();
+            seenFrom.add(from);
+            importers.set(spec, seenFrom);
+
+            // Relative imports: let Bun traverse natively.
+            if (spec.startsWith(".") || spec.startsWith("/")) return undefined;
+            // Leaves we record but do not walk into.
+            if (spec.startsWith("node:")) return { path: spec, external: true };
+            if (!spec.startsWith("@intx/")) {
+              return { path: spec, external: true };
+            }
+            // Workspace packages: resolve to real source so traversal continues
+            // through them (honoring `exports` subpaths like `/substrate`). A
+            // failure here would silently leave the subtree unwalked, so record
+            // it -- the test asserts there are none.
+            const fromDir = args.importer ? dirname(args.importer) : repoRoot;
+            try {
+              return { path: Bun.resolveSync(spec, fromDir) };
+            } catch {
+              resolveFailures.push(`${spec} (from ${from})`);
+              return { path: spec, external: true };
+            }
+          });
+        },
+      },
+    ],
+  });
+
+  return { importers, resolveFailures, success: result.success };
+}
+
+describe("workflow-child boot graph", () => {
+  test("the child binary imports only the two known roots", () => {
+    expect(binaryImportSpecifiers()).toEqual([...EXPECTED_CHILD_ROOTS].sort());
+  });
+
+  test("never value-imports the control-plane database or the orchestrator", async () => {
+    const { importers, resolveFailures, success } =
+      await childValueImportGraph(binaryEntrypoints());
+
+    expect(success).toBe(true);
+    // A workspace specifier that fails to resolve would drop its subtree from
+    // the walk while the build still succeeds; surface it rather than silently
+    // un-guarding that subtree.
+    expect(resolveFailures).toEqual([]);
+
+    const reached = new Set(importers.keys());
+    // Anti-vacuity: a workflow-child necessarily evaluates the workflow
+    // runtime, so a graph that did not reach it never walked the real child
+    // (e.g. empty entrypoints) and the forbidden check would pass over nothing.
+    expect(reached).toContain("@intx/workflow");
+
+    const violations = [...reached]
+      .map((spec) => ({ spec, reason: forbiddenReason(spec) }))
+      .filter((v): v is { spec: string; reason: string } => v.reason !== null);
+
+    if (violations.length > 0) {
+      const detail = violations
+        .map((v) => {
+          const from = [...(importers.get(v.spec) ?? new Set())].join(
+            "\n      ",
+          );
+          return `  ${v.spec} -- ${v.reason}\n    imported by:\n      ${from}`;
+        })
+        .join("\n");
+      throw new Error(
+        `The workflow-child boot graph reached forbidden modules:\n${detail}\n\n` +
+          "The spawned child must not evaluate the control-plane database or the " +
+          "sidecar orchestrator at boot. Use @intx/hub-sessions/substrate for the " +
+          "db-free repo/substrate symbols and @intx/hub-agent/paths for the deploy-tree " +
+          "and address helpers.",
+      );
+    }
+  });
+});

--- a/apps/sidecar/src/workflow-substrate-factory.ts
+++ b/apps/sidecar/src/workflow-substrate-factory.ts
@@ -50,7 +50,7 @@ import {
   type RepoId,
   type RepoStore,
   type WorkflowRunWorkflowProcessPrincipal,
-} from "@intx/hub-sessions";
+} from "@intx/hub-sessions/substrate";
 import { createIsogitStore } from "@intx/storage-isogit";
 import {
   adaptHostScheduler,

--- a/packages/hub-agent/package.json
+++ b/packages/hub-agent/package.json
@@ -7,6 +7,10 @@
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./paths": {
+      "types": "./src/paths.ts",
+      "default": "./src/paths.ts"
     }
   },
   "dependencies": {

--- a/packages/hub-agent/src/paths.ts
+++ b/packages/hub-agent/src/paths.ts
@@ -1,0 +1,18 @@
+// Dependency-light entry for an agent's on-disk layout helpers.
+//
+// `@intx/hub-agent` is the sidecar orchestrator. Importing its barrel
+// (`index.ts`) evaluates the orchestrator's own module graph -- the session
+// manager, the hub-link WebSocket layer, the sidecar orchestrator -- plus
+// `@intx/pack-transport`. A few consumers need only the small filesystem
+// helpers for an agent's on-disk deploy state -- reading the deploy tree
+// under an agent's directory and deriving that directory's name from the
+// agent address. For the spawned workflow-child loading the orchestrator to
+// get them is both wasted module-evaluation and a backwards dependency on the
+// very component that launches it. Neither helper's module imports the
+// orchestrator graph, so this entry exposes them without it.
+
+export { readDeployTree, type DeployTree } from "./deploy-tree";
+export { sanitizeAddress } from "./agent-paths";
+// Type-only re-export: `export type` is erased under `verbatimModuleSyntax`,
+// so it adds no runtime import edge to `harness-builder`.
+export type { DeployApplyErrorEmitter } from "./harness-builder";

--- a/packages/hub-sessions/package.json
+++ b/packages/hub-sessions/package.json
@@ -7,6 +7,10 @@
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./substrate": {
+      "types": "./src/substrate.ts",
+      "default": "./src/substrate.ts"
     }
   },
   "dependencies": {

--- a/packages/hub-sessions/src/substrate.ts
+++ b/packages/hub-sessions/src/substrate.ts
@@ -1,0 +1,58 @@
+// The db-free substrate layer of this package.
+//
+// `@intx/hub-sessions` holds two layers: the git-backed repo-store substrate
+// (the `RepoStore`, the workflow-run claim-check and event-log primitives, the
+// kind-handler protocol) and the db-backed control-plane services (sessions,
+// credential push, the websocket layer). The substrate layer never imports
+// `@intx/db`; the services layer does. The package barrel (`index.ts`)
+// re-exports both, so importing any symbol through it pulls drizzle and the
+// rest of the hub data layer into module-evaluation.
+//
+// This entry exposes only the substrate layer, so any consumer that needs
+// repo/substrate access without the control-plane services -- for example a
+// process that reads and writes the agent-state and workflow-run repos but
+// runs nowhere near a database -- can import it without dragging `@intx/db`
+// into its boot graph. Every symbol re-exported here is defined in a db-free
+// module. The barrel still re-exports all of these for hub-side consumers.
+
+export {
+  DEFAULT_CONSUMED_RETENTION_MS,
+  dequeueToProcessing,
+  enqueueInbox,
+  markConsumed,
+  readProcessingEntry,
+  replayProcessingToInbox,
+  WORKFLOW_RUN_AGENT_STATE_PREFIX,
+} from "./workflow-run-kind";
+export type {
+  WorkflowRunSupervisorPrincipal,
+  WorkflowRunWorkflowProcessPrincipal,
+  DequeueToProcessingResult,
+  EnqueueInboxArgs,
+  EnqueueInboxResult,
+  MarkConsumedArgs,
+  MarkConsumedResult,
+  ReplayProcessingToInboxResult,
+} from "./workflow-run-kind";
+
+export {
+  encodeCombinedEventLog,
+  splitCombinedEventLog,
+  WORKFLOW_RUN_EVENTS_FILE,
+} from "./workflow-run-event-log";
+
+export { workflowDefinitionEnvelopeSchema } from "./workflow-kind";
+
+export { subscribeKind } from "./repo-store/subscribe-kind";
+export type { SubscribeKindEntry } from "./repo-store/subscribe-kind";
+
+export { createAgentRepoStore } from "./agent-repo";
+
+export type {
+  Principal,
+  RepoId,
+  RepoStore,
+  WriteResult,
+  InitRepoOpts,
+  NewlyTerminalRun,
+} from "./repo-store/types";

--- a/packages/workflow-host/src/adapters/blob-substrate.ts
+++ b/packages/workflow-host/src/adapters/blob-substrate.ts
@@ -31,7 +31,7 @@ import type {
   Principal,
   RepoId,
   RepoStore as SubstrateRepoStore,
-} from "@intx/hub-sessions";
+} from "@intx/hub-sessions/substrate";
 import type { BlobSubstrate } from "@intx/workflow";
 
 const ONE_MIB = 1024 * 1024;

--- a/packages/workflow-host/src/adapters/repo-store.ts
+++ b/packages/workflow-host/src/adapters/repo-store.ts
@@ -33,12 +33,12 @@ import type {
   Principal,
   RepoId,
   RepoStore as SubstrateRepoStore,
-} from "@intx/hub-sessions";
+} from "@intx/hub-sessions/substrate";
 import {
   subscribeKind,
   WORKFLOW_RUN_EVENTS_FILE,
   splitCombinedEventLog,
-} from "@intx/hub-sessions";
+} from "@intx/hub-sessions/substrate";
 import type { RepoStore, WorkflowEvent } from "@intx/workflow";
 
 /**

--- a/packages/workflow-host/src/adapters/spawn-child.ts
+++ b/packages/workflow-host/src/adapters/spawn-child.ts
@@ -62,8 +62,8 @@
 
 import { type } from "arktype";
 
-import type { Principal, RepoStore } from "@intx/hub-sessions";
-import { workflowDefinitionEnvelopeSchema } from "@intx/hub-sessions";
+import type { Principal, RepoStore } from "@intx/hub-sessions/substrate";
+import { workflowDefinitionEnvelopeSchema } from "@intx/hub-sessions/substrate";
 import type { SpawnChildWorkflow, WorkflowDefinition } from "@intx/workflow";
 
 const WORKFLOW_JSON_PATH = "workflow.json";

--- a/packages/workflow-host/src/child/proxy-repo-store.ts
+++ b/packages/workflow-host/src/child/proxy-repo-store.ts
@@ -33,7 +33,7 @@ import type {
   RepoId,
   RepoStore,
   WriteResult,
-} from "@intx/hub-sessions";
+} from "@intx/hub-sessions/substrate";
 
 import type { ChildSubstrateWriteBridge } from "./substrate-write-bridge";
 

--- a/packages/workflow-host/src/child/run-child.ts
+++ b/packages/workflow-host/src/child/run-child.ts
@@ -58,11 +58,11 @@ import type {
   Principal,
   RepoId,
   RepoStore as SubstrateRepoStore,
-} from "@intx/hub-sessions";
+} from "@intx/hub-sessions/substrate";
 import {
   readProcessingEntry,
   workflowDefinitionEnvelopeSchema,
-} from "@intx/hub-sessions";
+} from "@intx/hub-sessions/substrate";
 import {
   extractPartByPath,
   parseHeaderSection,

--- a/packages/workflow-host/src/child/self-discovery.ts
+++ b/packages/workflow-host/src/child/self-discovery.ts
@@ -18,7 +18,7 @@
 import type {
   RepoId,
   RepoStore as SubstrateRepoStore,
-} from "@intx/hub-sessions";
+} from "@intx/hub-sessions/substrate";
 import {
   isTerminalRunPhase,
   resumeFromLog,

--- a/packages/workflow-host/src/seams/scheduler.ts
+++ b/packages/workflow-host/src/seams/scheduler.ts
@@ -38,8 +38,12 @@
 
 import { type } from "arktype";
 
-import type { Principal, RepoId, RepoStore } from "@intx/hub-sessions";
-import { subscribeKind } from "@intx/hub-sessions";
+import type {
+  Principal,
+  RepoId,
+  RepoStore,
+} from "@intx/hub-sessions/substrate";
+import { subscribeKind } from "@intx/hub-sessions/substrate";
 
 /**
  * Substrate-shape envelope for the workflow-event blob committed to

--- a/packages/workflow-host/src/seams/signal-channel.ts
+++ b/packages/workflow-host/src/seams/signal-channel.ts
@@ -29,8 +29,8 @@ import type {
   RepoId,
   RepoStore,
   SubscribeKindEntry,
-} from "@intx/hub-sessions";
-import { subscribeKind } from "@intx/hub-sessions";
+} from "@intx/hub-sessions/substrate";
+import { subscribeKind } from "@intx/hub-sessions/substrate";
 import type { RunState, SignalChannel } from "@intx/workflow";
 
 /**

--- a/packages/workflow-host/src/supervisor/cancel-signing.ts
+++ b/packages/workflow-host/src/supervisor/cancel-signing.ts
@@ -30,7 +30,7 @@ import type {
   RepoId,
   RepoStore as SubstrateRepoStore,
   WorkflowRunSupervisorPrincipal,
-} from "@intx/hub-sessions";
+} from "@intx/hub-sessions/substrate";
 import type { CancelOrigin } from "@intx/workflow";
 import { hexEncode } from "@intx/types";
 

--- a/packages/workflow-host/src/supervisor/credentials.ts
+++ b/packages/workflow-host/src/supervisor/credentials.ts
@@ -30,7 +30,11 @@
 import { type } from "arktype";
 
 import { hexEncode } from "@intx/types";
-import type { Principal, RepoId, RepoStore } from "@intx/hub-sessions";
+import type {
+  Principal,
+  RepoId,
+  RepoStore,
+} from "@intx/hub-sessions/substrate";
 
 /**
  * Path inside each step's `agent-state` repo that carries the step's

--- a/packages/workflow-host/src/supervisor/drain-timeout.ts
+++ b/packages/workflow-host/src/supervisor/drain-timeout.ts
@@ -34,7 +34,7 @@ import type { PrincipalSigner, TerminalEventSource } from "./types";
 import type {
   RepoId,
   RepoStore as SubstrateRepoStore,
-} from "@intx/hub-sessions";
+} from "@intx/hub-sessions/substrate";
 
 const logger = getLogger(["workflow-host", "supervisor", "drain-timeout"]);
 

--- a/packages/workflow-host/src/supervisor/run-event-signing.ts
+++ b/packages/workflow-host/src/supervisor/run-event-signing.ts
@@ -18,11 +18,11 @@ import type {
   RepoId,
   RepoStore as SubstrateRepoStore,
   WorkflowRunSupervisorPrincipal,
-} from "@intx/hub-sessions";
+} from "@intx/hub-sessions/substrate";
 import {
   WORKFLOW_RUN_EVENTS_FILE,
   encodeCombinedEventLog,
-} from "@intx/hub-sessions";
+} from "@intx/hub-sessions/substrate";
 import { hexEncode } from "@intx/types";
 
 import { SUPERVISOR_PRINCIPAL_KIND } from "./cancel-signing";

--- a/packages/workflow-host/src/supervisor/supervisor.ts
+++ b/packages/workflow-host/src/supervisor/supervisor.ts
@@ -61,7 +61,7 @@ import {
   type Principal,
   type WorkflowRunSupervisorPrincipal,
   type WorkflowRunWorkflowProcessPrincipal,
-} from "@intx/hub-sessions";
+} from "@intx/hub-sessions/substrate";
 import { hexEncode } from "@intx/types";
 import { RepoId } from "@intx/types/sidecar";
 import type { OutboundMessage } from "@intx/types/runtime";

--- a/packages/workflow-host/src/supervisor/types.ts
+++ b/packages/workflow-host/src/supervisor/types.ts
@@ -18,7 +18,7 @@ import type {
   RepoId,
   RepoStore as SubstrateRepoStore,
   ReplayProcessingToInboxResult,
-} from "@intx/hub-sessions";
+} from "@intx/hub-sessions/substrate";
 import type {
   InferenceSource,
   OutboundMessage,

--- a/tests/hub-api/asset-routes.test.ts
+++ b/tests/hub-api/asset-routes.test.ts
@@ -12,7 +12,7 @@ import path from "node:path";
 import { type } from "arktype";
 
 import { createInMemoryGrantStore } from "@intx/authz";
-import { createSSHSignature, generateKeyPair } from "@intx/crypto-node";
+import { createSSHSignature, generateKeyPair } from "@intx/crypto";
 import { createApp, type GetSession } from "@intx/hub-api";
 import {
   createAssetService,


### PR DESCRIPTION
## Summary

- The spawned workflow-child's boot module graph no longer evaluates the
  control-plane database layer (`@intx/db`/drizzle) or the sidecar
  orchestrator (`@intx/hub-agent`). Both packages are reached only through
  narrow db-free subpath entries — `@intx/hub-sessions/substrate` and
  `@intx/hub-agent/paths` — and the package barrels are unchanged for
  hub-side consumers.
- `@intx/hub-sessions/substrate` exposes the package's db-free substrate
  layer (workflow-run claim-check, event-log, repo-store protocol, and the
  workflow-definition schema); `@intx/hub-agent/paths` exposes the
  deploy-tree reader and address helper without the orchestrator's module
  graph.
- A hub-api test imports the crypto provider under its current package
  name `@intx/crypto`.

## Verification

- `make all` passes: lint, `tsc -b --noEmit --force`, the admin-ui
  production bundle, and tests (3696 + 339 tests, 0 failures).
- A module-load probe importing both workflow-child roots confirms
  `@intx/db`, `drizzle-orm`, and `@intx/hub-agent` are absent from the
  child's module graph (each re-imports cold; the `@intx/workflow` control
  re-imports cached).

Closes INTR-254