### PR TITLE
Replace Node Buffer with Web-standard codecs in non-crypto code

### DIFF
--- a/apps/sidecar/src/agent-key-registration-lifecycle.test.ts
+++ b/apps/sidecar/src/agent-key-registration-lifecycle.test.ts
@@ -16,6 +16,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { createEd25519Crypto, generateKeyPair } from "@intx/crypto";
+import { hexEncode } from "@intx/types";
 import { createInMemoryTransport } from "@intx/mail-memory";
 import type { RepoId, RepoStore } from "@intx/hub-sessions";
 import {
@@ -307,7 +308,7 @@ describe("agent signing-key registration lifecycle on the host transport", () =>
       type: "ready",
       data: {
         childPid: spawn.handle.pid,
-        childPublicKey: Buffer.from(childIpcKeyPair.publicKey).toString("hex"),
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
       },
     });
     await deployPromise;

--- a/apps/sidecar/src/index.ts
+++ b/apps/sidecar/src/index.ts
@@ -9,6 +9,7 @@ import {
   verifySSHSignature,
 } from "@intx/crypto";
 import { createSidecarOrchestrator, type HubLink } from "@intx/hub-agent";
+import { hexEncode } from "@intx/types";
 import { createAgentRepoStore } from "@intx/hub-sessions";
 import { createTarballCache } from "@intx/tool-packaging";
 
@@ -288,12 +289,8 @@ const sidecarToken = requireEnv("SIDECAR_TOKEN");
 // lookup but invisible to the typed `SubstrateConfig` shape.
 const multistepSubstrateEnv: Record<string, string> = {
   SIDECAR_DATA_DIR: dataDir,
-  SIDECAR_SIGNING_PUBLIC_KEY: Buffer.from(sidecarSigningKey.publicKey).toString(
-    "hex",
-  ),
-  SIDECAR_SIGNING_PRIVATE_KEY: Buffer.from(
-    sidecarSigningKey.privateKey,
-  ).toString("hex"),
+  SIDECAR_SIGNING_PUBLIC_KEY: hexEncode(sidecarSigningKey.publicKey),
+  SIDECAR_SIGNING_PRIVATE_KEY: hexEncode(sidecarSigningKey.privateKey),
   HUB_WS_URL: hubWsUrl,
   SIDECAR_ID: sidecarId,
   SIDECAR_TOKEN: sidecarToken,

--- a/apps/sidecar/src/workflow-host-wiring-undeploy-supervisor.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring-undeploy-supervisor.test.ts
@@ -16,6 +16,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { createEd25519Crypto, generateKeyPair } from "@intx/crypto";
+import { hexEncode } from "@intx/types";
 import { createInMemoryTransport } from "@intx/mail-memory";
 import type { RepoId, RepoStore } from "@intx/hub-sessions";
 import {
@@ -336,7 +337,7 @@ describe("createSidecarDeployRouter multi-step undeploy shuts the supervisor dow
       type: "ready",
       data: {
         childPid: spawn.handle.pid,
-        childPublicKey: Buffer.from(childIpcKeyPair.publicKey).toString("hex"),
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
       },
     });
 

--- a/apps/sidecar/src/workflow-host-wiring.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { createEd25519Crypto, generateKeyPair } from "@intx/crypto";
+import { hexEncode } from "@intx/types";
 import { createInMemoryTransport } from "@intx/mail-memory";
 import type { RepoId, RepoStore } from "@intx/hub-sessions";
 import {
@@ -1296,7 +1297,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
       type: "ready",
       data: {
         childPid: 7321,
-        childPublicKey: Buffer.from(childIpcKeyPair.publicKey).toString("hex"),
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
       },
     });
 
@@ -1308,9 +1309,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
 
     // Sanity check: re-deriving the public key from the keypair lines
     // up with the router's returned value.
-    expect(result.publicKey).toBe(
-      Buffer.from(keyPair.publicKey).toString("hex"),
-    );
+    expect(result.publicKey).toBe(hexEncode(keyPair.publicKey));
 
     // Teardown: kill the child so the spawn-time pumps unwind.
     // Use unused supervisorToChild to silence the linter.
@@ -1393,7 +1392,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
       type: "ready",
       data: {
         childPid: 9123,
-        childPublicKey: Buffer.from(childIpcKeyPair.publicKey).toString("hex"),
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
       },
     });
 
@@ -1604,9 +1603,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
         type: "ready",
         data: {
           childPid: 4400 + spawns.length,
-          childPublicKey: Buffer.from(childIpcKeyPair.publicKey).toString(
-            "hex",
-          ),
+          childPublicKey: hexEncode(childIpcKeyPair.publicKey),
         },
       });
       if (opts.sendRecycleRequest) {
@@ -1720,7 +1717,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
       type: "ready",
       data: {
         childPid: 7600,
-        childPublicKey: Buffer.from(childIpcKeyPair.publicKey).toString("hex"),
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
       },
     });
     await deployPromise;
@@ -1823,9 +1820,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
         type: "ready",
         data: {
           childPid,
-          childPublicKey: Buffer.from(childIpcKeyPair.publicKey).toString(
-            "hex",
-          ),
+          childPublicKey: hexEncode(childIpcKeyPair.publicKey),
         },
       });
     }

--- a/bin/dev.ts
+++ b/bin/dev.ts
@@ -7,6 +7,10 @@
 // server in the correct order, with colored log prefixes and graceful
 // shutdown.
 //
+// This module is Node-bound: it spawns child processes via zx (which
+// wraps `node:child_process`), so it cannot run under a non-Node
+// runtime regardless of whether it references Buffer.
+//
 // Usage:
 //   bun bin/dev.ts                       # start hub + sidecar + admin-ui
 //   bun bin/dev.ts --seed                # also seed the database after hub is ready
@@ -126,14 +130,14 @@ function spawnLabeled(
 
   const prefix = `${color}[${label}]\x1b[0m`;
 
-  proc.stdout.on("data", (chunk: Buffer) => {
-    for (const line of chunk.toString().split("\n")) {
+  proc.stdout.on("data", (chunk: Uint8Array) => {
+    for (const line of new TextDecoder().decode(chunk).split("\n")) {
       if (line) process.stdout.write(`${prefix} ${line}\n`);
     }
   });
 
-  proc.stderr.on("data", (chunk: Buffer) => {
-    for (const line of chunk.toString().split("\n")) {
+  proc.stderr.on("data", (chunk: Uint8Array) => {
+    for (const line of new TextDecoder().decode(chunk).split("\n")) {
       if (line) process.stderr.write(`${prefix} ${line}\n`);
     }
   });

--- a/bin/seed.ts
+++ b/bin/seed.ts
@@ -1,6 +1,12 @@
 #!/usr/bin/env bun
 /* eslint-disable no-console */
 
+// Seed script for the local development database.
+//
+// This module is Node-bound: it spawns child processes via
+// `node:child_process`, so it cannot run under a non-Node runtime
+// regardless of whether it references Buffer.
+
 import { spawn } from "node:child_process";
 import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { readdirSync, readFileSync } from "node:fs";
@@ -1345,11 +1351,11 @@ async function runGit(
     });
     let stdout = "";
     let stderr = "";
-    child.stdout.on("data", (c: Buffer) => {
-      stdout += c.toString("utf-8");
+    child.stdout.on("data", (c: Uint8Array) => {
+      stdout += new TextDecoder().decode(c);
     });
-    child.stderr.on("data", (c: Buffer) => {
-      stderr += c.toString("utf-8");
+    child.stderr.on("data", (c: Uint8Array) => {
+      stderr += new TextDecoder().decode(c);
     });
     child.on("error", reject);
     child.on("close", (code) => {

--- a/examples/agent-gemini-image/src/cli.ts
+++ b/examples/agent-gemini-image/src/cli.ts
@@ -25,6 +25,7 @@ import { join } from "node:path";
 
 import { runInference } from "@intx/inference";
 import { createDefaultDependencies } from "@intx/inference/providers";
+import { base64Decode } from "@intx/types";
 import type { InferenceEvent, InferenceSource } from "@intx/types/runtime";
 
 export interface MainOptions {
@@ -171,7 +172,7 @@ function handleEvent(
       const ext = mimeToExtension(src.mimeType);
       const filename = `gemini-image-${String(Date.now())}-${String(index)}${ext}`;
       const path = join(outputDir, filename);
-      const bytes = Buffer.from(src.data, "base64");
+      const bytes = base64Decode(src.data);
       writeFileSync(path, bytes);
       process.stdout.write(
         `\nagent-gemini-image: wrote ${String(bytes.length)} bytes ` +

--- a/packages/db/src/schema/git-tokens.ts
+++ b/packages/db/src/schema/git-tokens.ts
@@ -11,12 +11,12 @@ import { user } from "./auth";
 import { principal } from "./principals";
 import { tenant } from "./tenants";
 
-const bytea = customType<{ data: Uint8Array; driverData: Buffer }>({
+const bytea = customType<{ data: Uint8Array; driverData: Uint8Array }>({
   dataType() {
     return "bytea";
   },
   toDriver(value) {
-    return Buffer.from(value);
+    return value;
   },
   fromDriver(value) {
     return new Uint8Array(value);

--- a/packages/db/src/schema/messages.ts
+++ b/packages/db/src/schema/messages.ts
@@ -12,12 +12,12 @@ import { agentInstance } from "./instances";
 import { agentSession } from "./sessions";
 import { tenant } from "./tenants";
 
-const bytea = customType<{ data: Uint8Array; driverData: Buffer }>({
+const bytea = customType<{ data: Uint8Array; driverData: Uint8Array }>({
   dataType() {
     return "bytea";
   },
   toDriver(value) {
-    return Buffer.from(value);
+    return value;
   },
   fromDriver(value) {
     return new Uint8Array(value);

--- a/packages/hub-api/src/attachment-validation.test.ts
+++ b/packages/hub-api/src/attachment-validation.test.ts
@@ -1,4 +1,7 @@
 import { describe, test, expect } from "bun:test";
+
+import { base64Encode } from "@intx/types";
+
 import {
   validateAttachments,
   type AttachmentInput,
@@ -6,11 +9,11 @@ import {
 } from "./attachment-validation";
 
 function b64(bytes: number[]): string {
-  return Buffer.from(new Uint8Array(bytes)).toString("base64");
+  return base64Encode(new Uint8Array(bytes));
 }
 
 function bytesOfLength(n: number): string {
-  return Buffer.alloc(n, 0x61).toString("base64");
+  return base64Encode(new Uint8Array(n).fill(0x61));
 }
 
 // Small limits so oversize cases need only tiny buffers.

--- a/packages/hub-api/src/middleware/git-token-auth.test.ts
+++ b/packages/hub-api/src/middleware/git-token-auth.test.ts
@@ -10,6 +10,7 @@ import { Hono } from "hono";
 
 import type { DB } from "@intx/db";
 import { configureSync, getConfig, resetSync } from "@intx/log";
+import { base64Encode } from "@intx/types";
 
 import { createGitTokenAuth, type GitTokenAuthEnv } from "./git-token-auth";
 
@@ -189,7 +190,7 @@ function buildApp(db: DB["db"]) {
 
 function basicAuthHeader(username: string, password: string): string {
   return (
-    "Basic " + Buffer.from(`${username}:${password}`, "utf8").toString("base64")
+    "Basic " + base64Encode(new TextEncoder().encode(`${username}:${password}`))
   );
 }
 

--- a/packages/hub-api/src/middleware/git-token-auth.ts
+++ b/packages/hub-api/src/middleware/git-token-auth.ts
@@ -8,6 +8,7 @@ import { gitToken, principal, tenant } from "@intx/db/schema";
 import { PAT_PREFIX, SVC_PREFIX } from "@intx/hub-common";
 import { getLogger } from "@intx/log";
 import type { RepoAction } from "@intx/hub-sessions";
+import { base64Decode } from "@intx/types";
 
 import type { AppEnv, PrincipalRow, TenantRow } from "../context";
 
@@ -258,7 +259,7 @@ function parseAuthorizationHeader(
 
 function decodeBase64Utf8(input: string): string | null {
   try {
-    return Buffer.from(input, "base64").toString("utf8");
+    return new TextDecoder().decode(base64Decode(input));
   } catch {
     return null;
   }

--- a/packages/hub-api/src/pagination.test.ts
+++ b/packages/hub-api/src/pagination.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "bun:test";
+
+import { base64urlEncode } from "@intx/types";
+
+import { paginatedResponse, parsePageParams } from "./pagination";
+
+describe("pagination cursors", () => {
+  test("round-trips a cursor emitted by paginatedResponse", () => {
+    const createdAt = new Date("2024-01-02T03:04:05.678Z");
+    const rows = [{ createdAt, id: "tok_abc" }];
+    const { nextCursor } = paginatedResponse(["item"], rows, 1);
+    if (nextCursor === null) throw new Error("expected a non-null cursor");
+
+    const { cursor } = parsePageParams({
+      cursor: nextCursor,
+      limit: undefined,
+    });
+    expect(cursor).toEqual({ t: createdAt.toISOString(), id: "tok_abc" });
+  });
+
+  test("rejects a cursor that is not valid base64url as no cursor", () => {
+    const { cursor } = parsePageParams({ cursor: "!!!!", limit: undefined });
+    expect(cursor).toBeNull();
+  });
+
+  test("rejects a base64url cursor whose payload is not JSON", () => {
+    const bad = base64urlEncode(new TextEncoder().encode("not json"));
+    const { cursor } = parsePageParams({ cursor: bad, limit: undefined });
+    expect(cursor).toBeNull();
+  });
+
+  test("rejects a base64url cursor whose JSON has the wrong shape", () => {
+    const bad = base64urlEncode(
+      new TextEncoder().encode(JSON.stringify({ t: "not-a-timestamp", id: 5 })),
+    );
+    const { cursor } = parsePageParams({ cursor: bad, limit: undefined });
+    expect(cursor).toBeNull();
+  });
+});

--- a/packages/hub-api/src/pagination.ts
+++ b/packages/hub-api/src/pagination.ts
@@ -10,6 +10,8 @@ import {
 } from "drizzle-orm";
 import { type } from "arktype";
 
+import { base64urlDecode, base64urlEncode } from "@intx/types";
+
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
 
@@ -21,12 +23,12 @@ type CursorData = typeof CursorData.infer;
 
 function encodeCursor(createdAt: Date, id: string): string {
   const data: CursorData = { t: createdAt.toISOString(), id };
-  return Buffer.from(JSON.stringify(data)).toString("base64url");
+  return base64urlEncode(new TextEncoder().encode(JSON.stringify(data)));
 }
 
 function decodeCursor(cursor: string): CursorData | null {
   try {
-    const json = Buffer.from(cursor, "base64url").toString();
+    const json = new TextDecoder().decode(base64urlDecode(cursor));
     const parsed: unknown = JSON.parse(json);
     const data = CursorData(parsed);
     if (data instanceof type.errors) return null;

--- a/packages/hub-api/src/routes/assets.ts
+++ b/packages/hub-api/src/routes/assets.ts
@@ -29,7 +29,6 @@ import { Hono, type Context } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
 import { type } from "arktype";
 
-import { Buffer } from "node:buffer";
 import ssri from "ssri";
 
 import { authorize } from "@intx/authz";
@@ -754,7 +753,7 @@ export function createAssetRoutes({
       // post-commit blob; otherwise the value returned here lies
       // about what the asset will serve back on GET.
       const integrity = ssri
-        .fromData(Buffer.from(bytes), { algorithms: ["sha512"] })
+        .fromData(bytes, { algorithms: ["sha512"] })
         .toString();
 
       // Read-then-write happens inside the substrate's per-repo lock so
@@ -855,7 +854,7 @@ export function createAssetRoutes({
           path: `${TARBALLS_PREFIX}${name}`,
         });
         const integrity = ssri
-          .fromData(Buffer.from(blob), { algorithms: ["sha512"] })
+          .fromData(blob, { algorithms: ["sha512"] })
           .toString();
         out.push({ filename: name, size: blob.byteLength, integrity });
       }

--- a/packages/hub-api/src/routes/git-tokens.ts
+++ b/packages/hub-api/src/routes/git-tokens.ts
@@ -16,7 +16,7 @@ import {
 } from "@intx/hub-common";
 import { getLogger } from "@intx/log";
 import type { RepoAction } from "@intx/types/sidecar";
-import { ErrorResponse, paginatedSchema } from "@intx/types";
+import { base64urlEncode, ErrorResponse, paginatedSchema } from "@intx/types";
 
 import type { AppEnv, TenantEnv } from "../context";
 import { ts } from "../format";
@@ -168,7 +168,7 @@ function generateSecret(kind: "pat" | "svc"): string {
   // `crypto.getRandomValues` is the Web Crypto API and is exposed on
   // the global `crypto` object in both Node and Bun.
   crypto.getRandomValues(bytes);
-  return `${prefix}${Buffer.from(bytes).toString("base64url")}`;
+  return `${prefix}${base64urlEncode(bytes)}`;
 }
 
 async function sha256(input: string): Promise<Uint8Array> {

--- a/packages/hub-api/src/routes/instances.test.ts
+++ b/packages/hub-api/src/routes/instances.test.ts
@@ -7,6 +7,7 @@ import {
   type MessageHeaders,
 } from "@intx/mime";
 import type { GrantRule } from "@intx/types/authz";
+import { base64Encode } from "@intx/types";
 import type { SessionStatus } from "@intx/types";
 import type {
   ConnectorThreadState,
@@ -868,9 +869,9 @@ describe("POST /agents/instances/:instanceId/mail attachments", () => {
       sessionService: service,
     });
 
-    const data = Buffer.from(
+    const data = base64Encode(
       new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]),
-    ).toString("base64");
+    );
     const res = await postMailWith(app, [
       { mimeType: "image/png", data, name: "shot.png" },
     ]);
@@ -899,7 +900,7 @@ describe("POST /agents/instances/:instanceId/mail attachments", () => {
       sessionService: service,
     });
 
-    const data = Buffer.from(new Uint8Array([1, 2, 3])).toString("base64");
+    const data = base64Encode(new Uint8Array([1, 2, 3]));
     const res = await postMailWith(app, [{ mimeType: "image/tiff", data }]);
 
     expect(res.status).toBe(400);
@@ -936,7 +937,7 @@ describe("POST /agents/instances/:instanceId/mail attachments", () => {
       sessionService: service,
     });
 
-    const data = Buffer.from(new Uint8Array([1, 2, 3])).toString("base64");
+    const data = base64Encode(new Uint8Array([1, 2, 3]));
     const res = await postMailWith(app, [
       { mimeType: "image/png", data, name: 'a"b.png' },
     ]);
@@ -958,8 +959,8 @@ describe("POST /agents/instances/:instanceId/mail attachments", () => {
       sessionService: service,
     });
 
-    const small = Buffer.from(new Uint8Array([1, 2, 3])).toString("base64");
-    const oversize = Buffer.alloc(11 * 1024 * 1024, 0x61).toString("base64");
+    const small = base64Encode(new Uint8Array([1, 2, 3]));
+    const oversize = base64Encode(new Uint8Array(11 * 1024 * 1024).fill(0x61));
     const res = await postMailWith(app, [
       { mimeType: "image/png", data: small },
       { mimeType: "image/png", data: oversize },
@@ -981,7 +982,7 @@ describe("POST /agents/instances/:instanceId/mail attachments", () => {
 
     // A disallowed attachment would be a 400 if validation ran first; with
     // no write grant the route must reject with its auth failure instead.
-    const data = Buffer.from(new Uint8Array([1, 2, 3])).toString("base64");
+    const data = base64Encode(new Uint8Array([1, 2, 3]));
     const res = await postMailWith(app, [{ mimeType: "image/tiff", data }]);
 
     expect(res.status).toBe(403);

--- a/packages/hub-api/src/routes/workflows.test.ts
+++ b/packages/hub-api/src/routes/workflows.test.ts
@@ -6,7 +6,7 @@ import git from "isomorphic-git";
 import { type, type Type } from "arktype";
 
 import { createInMemoryGrantStore } from "@intx/authz";
-import { ErrorResponse } from "@intx/types";
+import { base64Decode, ErrorResponse } from "@intx/types";
 import type { GrantRule } from "@intx/types/authz";
 import {
   deriveDeploymentAddress,
@@ -699,7 +699,7 @@ describe("POST /workflows/:deploymentId/mail", () => {
     if (call === undefined) throw new Error("missing routeMail call");
     expect(call.address).toBe(`ins_${DEPLOYMENT_ID}@${DOMAIN}`);
     // The wire payload is base64-encoded MIME carrying the body text.
-    const decoded = Buffer.from(call.rawMessage, "base64").toString("utf8");
+    const decoded = new TextDecoder().decode(base64Decode(call.rawMessage));
     expect(decoded).toContain("kick off");
     // A run trigger is threading-less: no In-Reply-To / References.
     expect(decoded).not.toContain("In-Reply-To");

--- a/packages/hub-api/src/routes/workflows.ts
+++ b/packages/hub-api/src/routes/workflows.ts
@@ -13,7 +13,7 @@ import {
   type MessageHeaders,
 } from "@intx/mime";
 import { generateKeyPair, createEd25519Crypto } from "@intx/crypto";
-import { ErrorResponse, SendMessage } from "@intx/types";
+import { base64Encode, ErrorResponse, SendMessage } from "@intx/types";
 import { InferenceSource } from "@intx/types/runtime";
 import type { HarnessConfig } from "@intx/types/runtime";
 import {
@@ -548,7 +548,7 @@ export function createWorkflowRoutes({
         crypto,
       );
       const rawMessage = assembleMessage(headers, signedContent, signature);
-      const base64 = Buffer.from(rawMessage).toString("base64");
+      const base64 = base64Encode(rawMessage);
 
       const delivered = sidecarRouter.routeMail(address, base64);
       if (!delivered) {

--- a/packages/hub-sessions/src/session-service.test.ts
+++ b/packages/hub-sessions/src/session-service.test.ts
@@ -8,6 +8,7 @@ import type {
   HarnessConfig,
   MessageAttachment,
 } from "@intx/types/runtime";
+import { base64Decode, hexEncode } from "@intx/types";
 import { extractAttachments } from "@intx/mime";
 import {
   grant as grantTable,
@@ -548,7 +549,7 @@ describe("SessionService", () => {
 
     const rawArg = call.args[1];
     if (typeof rawArg !== "string") throw new Error("expected string arg");
-    const decoded = Buffer.from(rawArg, "base64").toString("utf-8");
+    const decoded = new TextDecoder().decode(base64Decode(rawArg));
     expect(decoded).toContain("From: user@test.local");
     expect(decoded).toContain(`To: ${AGENT_ADDRESS}`);
     expect(decoded).toContain("Message-ID: <msg-1@test.local>");
@@ -575,7 +576,7 @@ describe("SessionService", () => {
 
     const rawArg1 = call.args[1];
     if (typeof rawArg1 !== "string") throw new Error("expected string arg");
-    const decoded = Buffer.from(rawArg1, "base64").toString("utf-8");
+    const decoded = new TextDecoder().decode(base64Decode(rawArg1));
     expect(decoded).toContain("In-Reply-To: <prev@test.local>");
     expect(decoded).toContain(
       "References: <root@test.local> <prev@test.local>",
@@ -602,7 +603,7 @@ describe("SessionService", () => {
     if (call === undefined) throw new Error("unreachable");
     const rawArg = call.args[1];
     if (typeof rawArg !== "string") throw new Error("expected string arg");
-    const raw = new Uint8Array(Buffer.from(rawArg, "base64"));
+    const raw = base64Decode(rawArg);
 
     const extracted = extractAttachments(raw);
     expect(extracted).toHaveLength(1);
@@ -747,9 +748,11 @@ describe("SessionService", () => {
     expect(greetRow.sourceCommitSha).toBe("c".repeat(40));
     expect(greetRow.instanceId).toBe(INSTANCE_ID);
     expect(greetRow.assetPackSha).toBe(
-      Buffer.from(
-        await crypto.subtle.digest("SHA-256", new Uint8Array([10, 11, 12])),
-      ).toString("hex"),
+      hexEncode(
+        new Uint8Array(
+          await crypto.subtle.digest("SHA-256", new Uint8Array([10, 11, 12])),
+        ),
+      ),
     );
 
     const searchRow = captured.find((r) => r.agentAssetId === "aas_search");
@@ -1141,9 +1144,11 @@ describe("SessionService", () => {
     expect(row.sourceCommitSha).toBe("e".repeat(40));
     expect(row.instanceId).toBe(INSTANCE_ID);
     expect(row.assetPackSha).toBe(
-      Buffer.from(
-        await crypto.subtle.digest("SHA-256", new Uint8Array([42, 43, 44])),
-      ).toString("hex"),
+      hexEncode(
+        new Uint8Array(
+          await crypto.subtle.digest("SHA-256", new Uint8Array([42, 43, 44])),
+        ),
+      ),
     );
   });
 

--- a/packages/hub-sessions/src/session-service.ts
+++ b/packages/hub-sessions/src/session-service.ts
@@ -17,7 +17,7 @@ import {
   grant as grantTable,
   workflowDeployment as workflowDeploymentTable,
 } from "@intx/db/schema";
-import { hexEncode } from "@intx/types";
+import { base64Encode, hexEncode } from "@intx/types";
 import { generateId } from "@intx/hub-common";
 import {
   sessionAsset as sessionAssetTable,
@@ -1380,7 +1380,7 @@ export function createSessionService(deps: SessionServiceDeps): SessionService {
       cryptoProvider,
     );
     const rawMessage = assembleMessage(headers, signedContent, signature);
-    const base64 = Buffer.from(rawMessage).toString("base64");
+    const base64 = base64Encode(rawMessage);
 
     const delivered = sidecarRouter.routeMail(agentAddress, base64);
     if (!delivered) {

--- a/packages/mail-memory/src/fetch.ts
+++ b/packages/mail-memory/src/fetch.ts
@@ -10,6 +10,7 @@ import type {
   MessageRef,
 } from "@intx/types/runtime";
 import { InterchangeType } from "@intx/types/runtime";
+import { base64Decode } from "@intx/types";
 import type { MailboxStore } from "./mailbox";
 import { requireMessage } from "./mailbox";
 import {
@@ -72,7 +73,7 @@ export function fetchPart(
 
   if (enc.toLowerCase() === "base64") {
     const b64 = new TextDecoder().decode(part.body).replace(/\s/g, "");
-    content = new Uint8Array(Buffer.from(b64, "base64"));
+    content = base64Decode(b64);
   } else {
     content = part.body;
   }

--- a/packages/pack-transport/src/chunker.ts
+++ b/packages/pack-transport/src/chunker.ts
@@ -2,6 +2,8 @@
 //
 // Splits a packfile into base64-encoded chunks suitable for repo.pack.push frames.
 
+import { base64Encode } from "@intx/types";
+
 export const PACK_CHUNK_SIZE = 64 * 1024;
 
 export type PackChunk = {
@@ -20,7 +22,7 @@ export function chunkPack(pack: Uint8Array): PackChunk[] {
     const slice = pack.slice(offset, offset + PACK_CHUNK_SIZE);
     chunks.push({
       seq: seq++,
-      data: Buffer.from(slice).toString("base64"),
+      data: base64Encode(slice),
     });
   }
   return chunks;

--- a/packages/pack-transport/src/receiver.test.ts
+++ b/packages/pack-transport/src/receiver.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { createPackReceiver } from "./receiver";
+import { base64Encode } from "@intx/types";
 import type { PackPushFrame, PackDoneFrame } from "@intx/types/sidecar";
 
 function makePush(overrides: Partial<PackPushFrame> = {}): PackPushFrame {
@@ -10,7 +11,7 @@ function makePush(overrides: Partial<PackPushFrame> = {}): PackPushFrame {
     repoId: { kind: "agent-state", id: agentAddress },
     transferId: "t1",
     seq: 0,
-    data: Buffer.from("chunk-data").toString("base64"),
+    data: base64Encode(new TextEncoder().encode("chunk-data")),
     ...overrides,
   };
 }
@@ -45,8 +46,8 @@ describe("PackReceiver", () => {
 
   test("handleDone assembles chunks into a single pack", () => {
     const receiver = createPackReceiver();
-    const chunk1 = Buffer.from("hello").toString("base64");
-    const chunk2 = Buffer.from(" world").toString("base64");
+    const chunk1 = base64Encode(new TextEncoder().encode("hello"));
+    const chunk2 = base64Encode(new TextEncoder().encode(" world"));
 
     receiver.handlePush(makePush({ seq: 0, data: chunk1 }));
     receiver.handlePush(makePush({ seq: 1, data: chunk2 }));
@@ -95,6 +96,28 @@ describe("PackReceiver", () => {
     // New transfer for same agent is now allowed
     const reason = receiver.handlePush(makePush({ transferId: "t2", seq: 0 }));
     expect(reason).toBeNull();
+  });
+
+  test("returns corrupt for malformed base64 data instead of throwing", () => {
+    const receiver = createPackReceiver();
+    let reason: string | null = null;
+    let threw = false;
+    try {
+      reason = receiver.handlePush(
+        makePush({ seq: 0, data: "@@@not-valid@@@" }),
+      );
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
+    expect(reason).toBe("corrupt");
+
+    // The malformed frame cleaned the transfer up, mirroring the seq-gap
+    // path, so a fresh transfer for the same agent is accepted.
+    expect(receiver.hasTransfer("t1")).toBe(false);
+    expect(
+      receiver.handlePush(makePush({ transferId: "t2", seq: 0 })),
+    ).toBeNull();
   });
 
   test("cleans up after seq gap rejection", () => {

--- a/packages/pack-transport/src/receiver.ts
+++ b/packages/pack-transport/src/receiver.ts
@@ -5,6 +5,7 @@
 // frames followed by a repo.pack.done. The receiver validates seq continuity
 // and rejects concurrent transfers for the same agent.
 
+import { base64Decode } from "@intx/types";
 import type {
   PackPushFrame,
   PackDoneFrame,
@@ -59,8 +60,20 @@ export function createPackReceiver(): PackReceiver {
       return "corrupt";
     }
 
-    const chunk = Buffer.from(frame.data, "base64");
-    transfer.chunks.push(new Uint8Array(chunk));
+    // `base64Decode` throws on malformed input. `handlePush` is a wire-
+    // boundary validator whose contract is to RETURN a reject reason for a
+    // bad frame, so a peer-controlled decode failure is converted to
+    // "corrupt" the same way the seq-gap path above is, rather than
+    // escaping past the caller's reject reply.
+    let chunk: Uint8Array;
+    try {
+      chunk = base64Decode(frame.data);
+    } catch {
+      cleanup(frame.transferId, frame.agentAddress);
+      return "corrupt";
+    }
+
+    transfer.chunks.push(chunk);
     transfer.nextSeq++;
     return null;
   }

--- a/packages/storage-isogit/src/store.test.ts
+++ b/packages/storage-isogit/src/store.test.ts
@@ -11,6 +11,7 @@ import {
   listBranches,
   logHistory,
 } from "./index";
+import { base64Encode } from "@intx/types";
 import { IsogitStore } from "./store";
 import { initAgentRepo } from "./init";
 import type {
@@ -764,7 +765,7 @@ describe("commit signing", () => {
     await initAgentRepo(dir);
 
     const signer = async (payload: string) =>
-      `-----BEGIN SSH SIGNATURE-----\n${Buffer.from(payload).toString("base64").slice(0, 70)}\n-----END SSH SIGNATURE-----`;
+      `-----BEGIN SSH SIGNATURE-----\n${base64Encode(new TextEncoder().encode(payload)).slice(0, 70)}\n-----END SSH SIGNATURE-----`;
 
     const store = new IsogitStore(dir, signer);
     await store.writeTurns([]);
@@ -798,7 +799,7 @@ describe("commit signing", () => {
     await initAgentRepo(dir);
 
     const signer = async (payload: string) =>
-      `-----BEGIN SSH SIGNATURE-----\n${Buffer.from(payload).toString("base64").slice(0, 70)}\n-----END SSH SIGNATURE-----`;
+      `-----BEGIN SSH SIGNATURE-----\n${base64Encode(new TextEncoder().encode(payload)).slice(0, 70)}\n-----END SSH SIGNATURE-----`;
 
     const store = new IsogitStore(dir, signer);
     await store.commitAudit([makeAuditRecord()]);
@@ -815,7 +816,7 @@ describe("commit signing", () => {
     await initAgentRepo(dir);
 
     const signer = async (payload: string) =>
-      `-----BEGIN SSH SIGNATURE-----\n${Buffer.from(payload).toString("base64").slice(0, 70)}\n-----END SSH SIGNATURE-----`;
+      `-----BEGIN SSH SIGNATURE-----\n${base64Encode(new TextEncoder().encode(payload)).slice(0, 70)}\n-----END SSH SIGNATURE-----`;
 
     const store = new IsogitStore(dir, signer);
     await store.commitErrors([makeErrorRecord()]);

--- a/packages/tool-packaging/src/cache.test.ts
+++ b/packages/tool-packaging/src/cache.test.ts
@@ -17,8 +17,8 @@ afterEach(async () => {
   await fs.rm(scratch, { recursive: true, force: true });
 });
 
-function makeBytes(seed: string): { bytes: Buffer; integrity: string } {
-  const bytes = Buffer.from(`tarball-bytes-${seed}`);
+function makeBytes(seed: string): { bytes: Uint8Array; integrity: string } {
+  const bytes = new TextEncoder().encode(`tarball-bytes-${seed}`);
   const integrity = ssri.fromData(bytes, { algorithms: ["sha512"] }).toString();
   return { bytes, integrity };
 }
@@ -38,7 +38,7 @@ describe("get / put round-trip", () => {
     await cache.put(integrity, bytes);
     const fetched = await cache.get(integrity);
     expect(fetched).not.toBeNull();
-    expect(fetched?.equals(bytes)).toBe(true);
+    expect(fetched).toEqual(bytes);
   });
 
   test("get returns null on miss", async () => {
@@ -50,7 +50,7 @@ describe("get / put round-trip", () => {
   test("put with mismatched bytes throws TarballIntegrityMismatchError", async () => {
     const cache = createTarballCache({ rootDir: scratch, maxBytes: 10_000 });
     const { integrity } = makeBytes("a");
-    const wrongBytes = Buffer.from("not the right bytes");
+    const wrongBytes = new TextEncoder().encode("not the right bytes");
     let caught: unknown;
     try {
       await cache.put(integrity, wrongBytes);
@@ -356,7 +356,7 @@ async function probeEntrySize(scratch: string): Promise<number> {
 async function packFixtureTarball(
   cwd: string,
   files: Record<string, string>,
-): Promise<{ bytes: Buffer; integrity: string }> {
+): Promise<{ bytes: Uint8Array; integrity: string }> {
   const staging = await fs.mkdtemp(path.join(cwd, "stage-"));
   const packageDir = path.join(staging, "package");
   await fs.mkdir(packageDir, { recursive: true });

--- a/packages/tool-packaging/src/cache.ts
+++ b/packages/tool-packaging/src/cache.ts
@@ -58,7 +58,7 @@ export interface TarballCacheConfig {
 }
 
 export interface TarballCache {
-  get(integrity: string): Promise<Buffer | null>;
+  get(integrity: string): Promise<Uint8Array | null>;
   /**
    * Presence probe. Returns true when an entry for `integrity` is
    * resident on disk. Cheaper than `get` for callers that only need
@@ -66,7 +66,7 @@ export interface TarballCache {
    * existence without reading bytes or touching atime.
    */
   has(integrity: string): Promise<boolean>;
-  put(integrity: string, bytes: Buffer): Promise<void>;
+  put(integrity: string, bytes: Uint8Array): Promise<void>;
   /**
    * Mark the cache entry for `integrity` as poisoned and remove its
    * tarball bytes immediately so a subsequent `extractTarball` call
@@ -489,7 +489,7 @@ export function createTarballCache(config: TarballCacheConfig): TarballCache {
   return {
     async get(integrity) {
       const file = entryPath(integrity);
-      let bytes: Buffer;
+      let bytes: Uint8Array;
       try {
         bytes = await fs.readFile(file);
       } catch (err) {

--- a/packages/tool-packaging/src/loader.test.ts
+++ b/packages/tool-packaging/src/loader.test.ts
@@ -63,7 +63,7 @@ interface FixtureSpec {
  */
 async function packFixture(
   spec: FixtureSpec,
-): Promise<{ bytes: Buffer; integrity: string }> {
+): Promise<{ bytes: Uint8Array; integrity: string }> {
   const stagingDir = path.join(
     fixtureSourceRoot,
     `${spec.name.replace("/", "_")}-${spec.version}`,
@@ -799,7 +799,7 @@ describe("loader error categories", () => {
       version: "1.0.0",
       entryModuleSource: "",
     });
-    const wrongBytes = Buffer.from("not the right bytes");
+    const wrongBytes = new TextEncoder().encode("not the right bytes");
     await expectCategory(
       {
         manifest: {
@@ -832,7 +832,7 @@ describe("loader error categories", () => {
       rootDir: cacheDir,
       maxBytes: 10_000_000,
     });
-    const garbage = Buffer.from("definitely not a tarball");
+    const garbage = new TextEncoder().encode("definitely not a tarball");
     const integrity = ssri
       .fromData(garbage, { algorithms: ["sha512"] })
       .toString();
@@ -1064,7 +1064,7 @@ describe("loader error categories", () => {
       cache,
       registries: new Map([["npmjs", { url: "https://r.test" }]]),
       host: { os: "linux", cpu: "x64" },
-      fetchTarball: async () => Buffer.from(bytes),
+      fetchTarball: async () => bytes,
     });
     let caught: unknown;
     try {
@@ -1129,7 +1129,7 @@ describe("loader error categories", () => {
       cache,
       registries: new Map([["npmjs", { url: "https://r.test" }]]),
       host: { os: "linux", cpu: "x64" },
-      fetchTarball: async () => Buffer.from(bytes),
+      fetchTarball: async () => bytes,
     });
     let caught: unknown;
     try {
@@ -1191,7 +1191,7 @@ describe("loader error categories", () => {
       cache,
       registries: new Map([["npmjs", { url: "https://r.test" }]]),
       host: { os: "linux", cpu: "x64" },
-      fetchTarball: async () => Buffer.from(bytes),
+      fetchTarball: async () => bytes,
     });
     let caught: unknown;
     try {
@@ -2005,7 +2005,7 @@ describe("entry-path containment", () => {
       cache,
       registries: new Map([["npmjs", { url: "https://r.test" }]]),
       host: { os: "linux", cpu: "x64" },
-      fetchTarball: async () => Buffer.from(finalBytes),
+      fetchTarball: async () => finalBytes,
     });
 
     const manifest: ToolPackageManifest = {
@@ -2075,7 +2075,7 @@ describe("entry-path containment", () => {
       cache,
       registries: new Map([["npmjs", { url: "https://r.test" }]]),
       host: { os: "linux", cpu: "x64" },
-      fetchTarball: async () => Buffer.from(fixture.bytes),
+      fetchTarball: async () => fixture.bytes,
     });
 
     const manifest: ToolPackageManifest = {
@@ -2156,7 +2156,7 @@ describe("entry-path containment", () => {
       cache,
       registries: new Map([["npmjs", { url: "https://r.test" }]]),
       host: { os: "linux", cpu: "x64" },
-      fetchTarball: async () => Buffer.from(fixture.bytes),
+      fetchTarball: async () => fixture.bytes,
     });
 
     const manifest: ToolPackageManifest = {
@@ -2232,7 +2232,7 @@ export const main = Object.assign(
       cache,
       registries: new Map([["npmjs", { url: "https://r.test" }]]),
       host: { os: "linux", cpu: "x64" },
-      fetchTarball: async () => Buffer.from(fixture.bytes),
+      fetchTarball: async () => fixture.bytes,
     });
 
     const manifest: ToolPackageManifest = {
@@ -2291,7 +2291,7 @@ export const main = Object.assign(
       cache,
       registries: new Map([["npmjs", { url: "https://r.test" }]]),
       host: { os: "linux", cpu: "x64" },
-      fetchTarball: async () => Buffer.from(fixture.bytes),
+      fetchTarball: async () => fixture.bytes,
     });
 
     const manifest: ToolPackageManifest = {
@@ -2803,7 +2803,7 @@ describe("interchange.directors walker", () => {
       cache,
       registries: new Map([["npmjs", { url: "https://r.test" }]]),
       host: { os: "linux", cpu: "x64" },
-      fetchTarball: async () => Buffer.from(bytes),
+      fetchTarball: async () => bytes,
     });
     let caught: unknown;
     try {
@@ -2872,7 +2872,7 @@ describe("interchange.directors walker", () => {
       cache,
       registries: new Map([["npmjs", { url: "https://r.test" }]]),
       host: { os: "linux", cpu: "x64" },
-      fetchTarball: async () => Buffer.from(finalBytes),
+      fetchTarball: async () => finalBytes,
       importModule: async () => ({
         main: makeFakeFactory("@vendor/tools-stub"),
       }),
@@ -2943,7 +2943,7 @@ export const main = Object.assign(
       cache,
       registries: new Map([["npmjs", { url: "https://r.test" }]]),
       host: { os: "linux", cpu: "x64" },
-      fetchTarball: async () => Buffer.from(fixture.bytes),
+      fetchTarball: async () => fixture.bytes,
       importModule: async () => ({
         main: makeFakeFactory("@vendor/evil-dir-symlink"),
       }),

--- a/packages/tool-packaging/src/loader.ts
+++ b/packages/tool-packaging/src/loader.ts
@@ -190,7 +190,7 @@ export type TarballFetcher = (
     assetRoot: string;
     assetMounts: ReadonlyMap<string, string>;
   },
-) => Promise<Buffer>;
+) => Promise<Uint8Array>;
 
 export interface LoadManifestArgs {
   readonly manifest: ToolPackageManifest;
@@ -817,7 +817,7 @@ function defaultTarballUrl(
 }
 
 /**
- * Read an HTTP-registry tarball response into a Buffer while enforcing
+ * Read an HTTP-registry tarball response into a Uint8Array while enforcing
  * `maxBytes`. Two guards:
  *
  *   1. If the upstream sent a `Content-Length` header, parse it (digit-
@@ -848,7 +848,7 @@ export async function readResponseWithLimit(
     readonly version: string;
   },
   signal?: AbortSignal,
-): Promise<Buffer> {
+): Promise<Uint8Array> {
   const declaredLengthRaw = res.headers.get("content-length");
   if (declaredLengthRaw !== null) {
     if (!/^\d+$/.test(declaredLengthRaw)) {
@@ -874,7 +874,7 @@ export async function readResponseWithLimit(
     // tarball. The cache and tar-extract layers will reject the
     // resulting bytes as non-tar content, but the fetch itself didn't
     // fail — keep this path simple rather than over-rejecting.
-    return Buffer.alloc(0);
+    return new Uint8Array(0);
   }
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
@@ -920,7 +920,7 @@ export async function readResponseWithLimit(
     signal?.removeEventListener("abort", onAbort);
     reader.releaseLock();
   }
-  const out = Buffer.allocUnsafe(total);
+  const out = new Uint8Array(total);
   let offset = 0;
   for (const chunk of chunks) {
     out.set(chunk, offset);

--- a/packages/tool-packaging/src/package-json-extract.ts
+++ b/packages/tool-packaging/src/package-json-extract.ts
@@ -14,13 +14,16 @@
 // reason string on the kind-handler side) without losing the
 // failure-class distinction.
 
-import { Buffer } from "node:buffer";
+// This module is Node-bound: it streams through node:stream and the tar
+// library, which are not portable to environments without those APIs.
+
 import { Readable } from "node:stream";
 
 import { type } from "arktype";
 import { Parser as TarParser } from "tar/parse";
 import type { ReadEntry } from "tar/read-entry";
 
+import { concatBytes } from "@intx/types";
 import { PackageJSON } from "@intx/types/package-json";
 
 /**
@@ -70,8 +73,8 @@ export async function extractTarballPackageJSON(
 ): Promise<ExtractPackageJSONOutcome> {
   return new Promise<ExtractPackageJSONOutcome>((resolve) => {
     let resolved = false;
-    let pkgJsonBuf: Buffer | null = null;
-    const collectChunks: Buffer[] = [];
+    let pkgJsonBuf: Uint8Array | null = null;
+    const collectChunks: Uint8Array[] = [];
     // Capture every top-level `<seg>/package.json` path we see during
     // the walk so the kind handler can reject ambiguous archives. The
     // hub's resolver and the sidecar's tarball extractor resolve
@@ -84,7 +87,7 @@ export async function extractTarballPackageJSON(
     // resolved at the validation boundary by refusing the upload.
     const topLevelPackageJSONPaths: string[] = [];
 
-    const source = Readable.from(Buffer.from(bytes));
+    const source = Readable.from([bytes]);
 
     const finalize = (outcome: ExtractPackageJSONOutcome): void => {
       if (resolved) return;
@@ -101,11 +104,11 @@ export async function extractTarballPackageJSON(
         topLevelPackageJSONPaths.push(entry.path);
       }
       if (isTopLevelPackageJSON && pkgJsonBuf === null) {
-        entry.on("data", (chunk: Buffer) => {
+        entry.on("data", (chunk: Uint8Array) => {
           collectChunks.push(chunk);
         });
         entry.on("end", () => {
-          pkgJsonBuf = Buffer.concat(collectChunks);
+          pkgJsonBuf = concatBytes(collectChunks);
         });
       } else {
         entry.resume();
@@ -129,7 +132,7 @@ export async function extractTarballPackageJSON(
       }
       let raw: unknown;
       try {
-        raw = JSON.parse(pkgJsonBuf.toString("utf-8"));
+        raw = JSON.parse(new TextDecoder().decode(pkgJsonBuf));
       } catch (cause) {
         finalize({
           kind: "json-error",

--- a/packages/tool-packaging/src/resolver.test.ts
+++ b/packages/tool-packaging/src/resolver.test.ts
@@ -1,5 +1,4 @@
 import { describe, test, expect } from "bun:test";
-import { Buffer } from "node:buffer";
 import ssri from "ssri";
 import * as tar from "tar";
 import { promises as fs } from "node:fs";
@@ -965,7 +964,7 @@ describe("AssetRegistrySource", () => {
       }
       const bytes = await fixture.readBlob(entry.source.path);
       const expected = ssri
-        .fromData(Buffer.from(bytes), { algorithms: ["sha512"] })
+        .fromData(bytes, { algorithms: ["sha512"] })
         .toString();
       expect(entry.integrity).toBe(expected);
     }

--- a/packages/tool-packaging/src/resolver.ts
+++ b/packages/tool-packaging/src/resolver.ts
@@ -33,8 +33,6 @@
 //     walk so validation does not require a second pass over the
 //     network.
 
-import { Buffer } from "node:buffer";
-
 import npmPickManifest from "npm-pick-manifest";
 import npmRegistryFetch from "npm-registry-fetch";
 import npmPackageArg from "npm-package-arg";
@@ -384,7 +382,7 @@ export class AssetRegistrySource implements RegistrySource {
       const repoPath = `tarballs/${filename}`;
       const bytes = await this.#readBlob(repoPath);
       const integrity = ssri
-        .fromData(Buffer.from(bytes), { algorithms: ["sha512"] })
+        .fromData(bytes, { algorithms: ["sha512"] })
         .toString();
       const extracted = await extractPackageJSON(this.name, filename, bytes);
       const validated = extracted.parsed;

--- a/packages/tools-posix/src/grep.ts
+++ b/packages/tools-posix/src/grep.ts
@@ -1,3 +1,6 @@
+// This module is Node-bound: it reads the filesystem through node:fs and is
+// not portable to environments without that API.
+
 import type { Dirent } from "node:fs";
 import { readFile, readdir, stat } from "node:fs/promises";
 import { resolve, relative, join } from "node:path";
@@ -27,7 +30,7 @@ type FileSearchResult = {
   lines: string[];
 };
 
-function isBinary(buf: Buffer): boolean {
+function isBinary(buf: Uint8Array): boolean {
   return buf.includes(0);
 }
 
@@ -38,7 +41,7 @@ async function searchFile(
 ): Promise<FileSearchResult | null> {
   signal.throwIfAborted();
 
-  let buf: Buffer;
+  let buf: Uint8Array;
   try {
     buf = await readFile(filePath, { signal });
   } catch (err) {
@@ -53,7 +56,7 @@ async function searchFile(
 
   if (isBinary(buf)) return null;
 
-  const lines = buf.toString("utf8").split("\n");
+  const lines = new TextDecoder().decode(buf).split("\n");
   const matches: Match[] = [];
 
   for (let i = 0; i < lines.length; i++) {

--- a/packages/tools-posix/src/run-shell.ts
+++ b/packages/tools-posix/src/run-shell.ts
@@ -1,3 +1,6 @@
+// This module is Node-bound: it spawns subprocesses through node:child_process
+// and is not portable to environments without that API.
+
 import { spawn } from "node:child_process";
 
 export type RunShellArgs = {
@@ -34,12 +37,12 @@ export async function runShell(
     // same collector as data arrives. Node emits data events from both streams
     // on the same event loop tick order that the OS delivers them, so appending
     // to a shared array preserves temporal ordering.
-    child.stdout.on("data", (chunk: Buffer) => {
-      chunks.push(chunk.toString("utf8"));
+    child.stdout.on("data", (chunk: Uint8Array) => {
+      chunks.push(new TextDecoder().decode(chunk));
     });
 
-    child.stderr.on("data", (chunk: Buffer) => {
-      chunks.push(chunk.toString("utf8"));
+    child.stderr.on("data", (chunk: Uint8Array) => {
+      chunks.push(new TextDecoder().decode(chunk));
     });
 
     let settled = false;

--- a/packages/tools-posix/src/tools-posix.test.ts
+++ b/packages/tools-posix/src/tools-posix.test.ts
@@ -912,7 +912,7 @@ describe("grep", () => {
     const grepDir = join(tmpDir, "grep-binary");
     await mkdir(grepDir);
     await writeFile(join(grepDir, "text.txt"), "findme\n");
-    await writeFile(join(grepDir, "binary.bin"), Buffer.from([0x00, 0x01]));
+    await writeFile(join(grepDir, "binary.bin"), new Uint8Array([0x00, 0x01]));
 
     const result = await tools.run(
       {

--- a/packages/tools-posix/src/write-file.ts
+++ b/packages/tools-posix/src/write-file.ts
@@ -28,7 +28,7 @@ export async function runWriteFile(
 
   signal.throwIfAborted();
 
-  const bytes = Buffer.byteLength(args.content, "utf8");
+  const bytes = new TextEncoder().encode(args.content).length;
 
   try {
     await writeFile(args.path, args.content, { encoding: "utf8", signal });

--- a/packages/types/src/base64url.test.ts
+++ b/packages/types/src/base64url.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from "bun:test";
+
+import { base64urlEncode, base64urlDecode } from "./base64url";
+
+function makeBytes(len: number): Uint8Array {
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    bytes[i] = (i * 31 + len * 17) % 256;
+  }
+  return bytes;
+}
+
+// Known-answer vectors pinning exact byte->string output. Chosen to cover the
+// empty input, the 1/2/3-byte padding-strip boundaries, inputs whose standard
+// base64 output carries `+` and `/` (so the `-`/`_` substitution is exercised),
+// and high bytes 0x80-0xFF.
+const VECTORS: { bytes: number[]; b64url: string }[] = [
+  { bytes: [], b64url: "" },
+  { bytes: [0x66], b64url: "Zg" },
+  { bytes: [0x66, 0x6f], b64url: "Zm8" },
+  { bytes: [0x66, 0x6f, 0x6f], b64url: "Zm9v" },
+  { bytes: [0xfb, 0xf0], b64url: "-_A" },
+  { bytes: [0x3e, 0x3f, 0xbf], b64url: "Pj-_" },
+  { bytes: [0xff, 0xff, 0xff], b64url: "____" },
+  { bytes: [0x80, 0x81, 0xfe, 0xff], b64url: "gIH-_w" },
+];
+
+describe("base64url", () => {
+  test("round-trips encode then decode across lengths 0-300", () => {
+    for (let len = 0; len <= 300; len++) {
+      const bytes = makeBytes(len);
+      const roundTripped = base64urlDecode(base64urlEncode(bytes));
+      expect(roundTripped).toEqual(bytes);
+    }
+  });
+
+  test("encodes and decodes known-answer vectors", () => {
+    for (const v of VECTORS) {
+      const bytes = new Uint8Array(v.bytes);
+      expect(base64urlEncode(bytes)).toBe(v.b64url);
+      expect(base64urlDecode(v.b64url)).toEqual(bytes);
+    }
+  });
+
+  test("throws on input with non-base64 characters", () => {
+    expect(() => base64urlDecode("@@@@")).toThrow();
+    expect(() => base64urlDecode("not valid base64!!!")).toThrow();
+  });
+});

--- a/packages/types/src/base64url.ts
+++ b/packages/types/src/base64url.ts
@@ -1,0 +1,22 @@
+// Base64url codec for byte strings (RFC 4648 section 5).
+//
+// URL- and filename-safe base64: standard base64 with `+`/`/` replaced by
+// `-`/`_` and trailing `=` padding stripped. Used for opaque pagination
+// cursors and git PAT secrets that ride in URLs and HTTP basic-auth headers,
+// where the standard `+`, `/`, and `=` characters are unsafe. Reuses the
+// base64 core so the two encodings stay byte-compatible.
+
+import { base64Decode, base64Encode } from "./base64";
+
+export function base64urlEncode(bytes: Uint8Array): string {
+  return base64Encode(bytes)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export function base64urlDecode(s: string): Uint8Array {
+  const translated = s.replace(/-/g, "+").replace(/_/g, "/");
+  const padLength = (4 - (translated.length % 4)) % 4;
+  return base64Decode(translated + "=".repeat(padLength));
+}

--- a/packages/types/src/concat.test.ts
+++ b/packages/types/src/concat.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "bun:test";
+
+import { concatBytes } from "./concat";
+
+describe("concatBytes", () => {
+  test("returns an empty array for an empty list", () => {
+    const out = concatBytes([]);
+    expect(out).toEqual(new Uint8Array(0));
+  });
+
+  test("returns the single chunk unchanged in content", () => {
+    const out = concatBytes([new Uint8Array([1, 2, 3])]);
+    expect(out).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  test("joins multiple chunks preserving order and bytes", () => {
+    const out = concatBytes([
+      new Uint8Array([1, 2]),
+      new Uint8Array([3]),
+      new Uint8Array([4, 5, 6]),
+    ]);
+    expect(out).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6]));
+  });
+
+  test("skips empty chunks without disturbing the result", () => {
+    const out = concatBytes([
+      new Uint8Array([0xff]),
+      new Uint8Array(0),
+      new Uint8Array([0x00, 0x80]),
+    ]);
+    expect(out).toEqual(new Uint8Array([0xff, 0x00, 0x80]));
+  });
+});

--- a/packages/types/src/concat.ts
+++ b/packages/types/src/concat.ts
@@ -1,0 +1,19 @@
+// Concatenate byte arrays into a single Uint8Array.
+//
+// A Web-standard replacement for Node's `Buffer.concat`: sum the chunk
+// lengths, allocate the result once, and copy each chunk in at its
+// running offset so the bytes land in input order.
+
+export function concatBytes(chunks: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const chunk of chunks) {
+    total += chunk.length;
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -21,6 +21,7 @@ export * from "./agent-address";
 export * from "./agent-data";
 export * from "./hex";
 export * from "./base64";
+export * from "./base64url";
 export * from "./has-code";
 export * from "./audit";
 export * from "./sidecars";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -22,6 +22,7 @@ export * from "./agent-data";
 export * from "./hex";
 export * from "./base64";
 export * from "./base64url";
+export * from "./concat";
 export * from "./has-code";
 export * from "./audit";
 export * from "./sidecars";

--- a/packages/types/src/sessions.test.ts
+++ b/packages/types/src/sessions.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect } from "bun:test";
 import { type } from "arktype";
 import { SendMessage, AttachmentError } from "./sessions";
+import { base64Encode } from "./base64";
 
-const okData = Buffer.from("hello world").toString("base64");
+const okData = base64Encode(new TextEncoder().encode("hello world"));
 
 describe("SendMessage attachments schema", () => {
   test("accepts a message with no attachments", () => {

--- a/packages/workflow-host/src/child/outbound-mail-bridge.test.ts
+++ b/packages/workflow-host/src/child/outbound-mail-bridge.test.ts
@@ -2,6 +2,8 @@ import { describe, test, expect } from "bun:test";
 
 import { type } from "arktype";
 
+import { base64Decode } from "@intx/types";
+
 import { createChildOutboundMailBridge } from "./outbound-mail-bridge";
 import { createSupervisorBackedTransport } from "./supervisor-backed-transport";
 import {
@@ -120,7 +122,7 @@ describe("createChildOutboundMailBridge", () => {
     const att = frame.message.attachments?.[0];
     if (att === undefined) throw new Error("attachment not projected");
     expect(att.name).toBe("f.bin");
-    expect(Buffer.from(att.dataBase64, "base64")).toEqual(Buffer.from(data));
+    expect(base64Decode(att.dataBase64)).toEqual(data);
   });
 });
 

--- a/packages/workflow-host/src/child/outbound-mail-bridge.ts
+++ b/packages/workflow-host/src/child/outbound-mail-bridge.ts
@@ -33,6 +33,7 @@
 
 import { getLogger } from "@intx/log";
 
+import { base64Encode } from "@intx/types";
 import type { OutboundMessage, SendReceipt } from "@intx/types/runtime";
 
 import type {
@@ -188,7 +189,7 @@ function projectOutboundMessage(
 }
 
 function bytesToBase64(bytes: Uint8Array): string {
-  return Buffer.from(bytes).toString("base64");
+  return base64Encode(bytes);
 }
 
 function defaultRequestIdAllocator(): () => string {

--- a/packages/workflow-host/src/child/run-child.test.ts
+++ b/packages/workflow-host/src/child/run-child.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { generateKeyPair } from "@intx/crypto";
-import { hexEncode } from "@intx/types";
+import { base64Encode, hexEncode } from "@intx/types";
 import type { KeyPair } from "@intx/types/runtime";
 import type {
   AuthorizeFn,
@@ -256,7 +256,7 @@ async function seedProcessingEntry(
     receivedAt: opts.receivedAt,
     address: opts.address,
     mailAuditRef: { store: "test", path: opts.messageId },
-    rawMessage: Buffer.from(rawMessage).toString("base64"),
+    rawMessage: base64Encode(rawMessage),
   };
   await fs.writeFile(
     path.join(dir, `${String(opts.receivedAt)}-${opts.messageId}.json`),
@@ -962,7 +962,7 @@ describe("runWorkflowChild", () => {
     }
     expect(readyPayload?.type).toBe("ready");
     expect(readyPayload?.childPublicKey).toBe(
-      Buffer.from(childKeyPair.publicKey).toString("hex"),
+      hexEncode(childKeyPair.publicKey),
     );
     expect(crashes).toHaveLength(0);
 
@@ -1063,8 +1063,8 @@ describe("runWorkflowChildFromProcessEnv", () => {
     const hostKeypair = await generateKeyPair();
     const env = makeSpawnEnv({
       channelId,
-      hmacKeyHex: Buffer.from(hmacKey).toString("hex"),
-      hostPubKeyHex: Buffer.from(hostKeypair.publicKey).toString("hex"),
+      hmacKeyHex: hexEncode(hmacKey),
+      hostPubKeyHex: hexEncode(hostKeypair.publicKey),
     });
     const { runWorkflowChildFromProcessEnv } = await import("./index");
     await expect(
@@ -1270,7 +1270,7 @@ async function seedProcessingEntryInDir(
     receivedAt: opts.receivedAt,
     address: opts.address,
     mailAuditRef: { store: "test", path: opts.messageId },
-    rawMessage: Buffer.from(rawMessage).toString("base64"),
+    rawMessage: base64Encode(rawMessage),
   };
   await fs.writeFile(
     path.join(dir, `${String(opts.receivedAt)}-${opts.messageId}.json`),

--- a/packages/workflow-host/src/child/run-child.ts
+++ b/packages/workflow-host/src/child/run-child.ts
@@ -52,7 +52,7 @@ import { type } from "arktype";
 
 import { getLogger } from "@intx/log";
 import { generateKeyPair } from "@intx/crypto";
-import { hexEncode } from "@intx/types";
+import { base64Decode, hexEncode } from "@intx/types";
 
 import type {
   Principal,
@@ -1138,7 +1138,7 @@ async function resolveTriggerPayload(args: {
       `workflow-child trigger.fire: processing entry for messageId ${args.messageId} carries no inlined rawMessage; the supervisor must inline the inbound mail bytes for the child to deliver them as the step input`,
     );
   }
-  const raw = new Uint8Array(Buffer.from(rawMessageBase64, "base64"));
+  const raw = base64Decode(rawMessageBase64);
   return extractConversationText(raw, args.messageId);
 }
 

--- a/packages/workflow-host/src/child/substrate-write-bridge.test.ts
+++ b/packages/workflow-host/src/child/substrate-write-bridge.test.ts
@@ -175,23 +175,19 @@ describe("ChildSubstrateWriteBridge: malformed substrate.merge.response", () => 
     expect(bridge.pendingCount).toBe(0);
   });
 
-  test("a merge response shape that fails base64 decoding throws inside the awaiter's merge callback", async () => {
+  test("a substrate.merge.request carrying malformed base64 replies with a structured failure", async () => {
     const mock = createMockSender();
     const bridge = createChildSubstrateWriteBridge({
       upstreamSender: mock.sender,
       allocateRequestId: () => "rid-merge",
     });
 
-    // The bridge stores the caller's merge closure. When the
-    // supervisor emits `substrate.merge.request`, the bridge invokes
-    // the closure with the decoded existing entries. If the
-    // supervisor's payload carries a non-base64 string for
-    // `contentBase64`, `Buffer.from(value, "base64")` silently
-    // ignores invalid characters -- but a downstream consumer that
-    // expected specific bytes will see corruption. Pin the bridge's
-    // observable contract: the merge closure receives whatever the
-    // standard decoder produces, and the awaiter resolves through
-    // the merge round-trip without leaving a leaked pending entry.
+    // The supervisor ships the existing tree as base64. A non-base64
+    // string is a corrupt payload: the shared decoder throws rather
+    // than silently yielding garbage bytes, so the bridge never runs
+    // the caller's merge closure on bad input. It converts the decode
+    // failure into a structured merge response the supervisor can act
+    // on, leaving the write pending for its terminal response.
     let observedExisting: ReadonlyMap<string, Uint8Array> | null = null;
     const submitPromise = bridge.submit({
       repoId: { kind: "workflow-run", id: "deployment-x" },
@@ -214,12 +210,27 @@ describe("ChildSubstrateWriteBridge: malformed substrate.merge.response", () => 
     // settles. The bridge's fire-and-forget body uses awaits, so
     // multiple microtask cycles are required to flush the chain.
     for (let i = 0; i < 5; i += 1) await Promise.resolve();
-    expect(observedExisting).not.toBeNull();
-    if (observedExisting === null) throw new Error("merge closure missed");
-    const captured: ReadonlyMap<string, Uint8Array> = observedExisting;
-    expect(captured.has("runs/r-3/events/prior.json")).toBe(true);
 
-    // Terminate the write so the test does not leak a pending entry.
+    // The corrupt base64 short-circuits before the merge closure runs.
+    expect(observedExisting).toBeNull();
+
+    const mergeResponse = mock.sent.find(
+      (s) => s.type === "substrate.merge.response",
+    );
+    if (mergeResponse === undefined) {
+      throw new Error("merge.response not emitted");
+    }
+    const validated = MergeResponseFailureShape(mergeResponse.data);
+    if (validated instanceof type.errors) {
+      throw new Error(
+        `merge.response payload failed shape check: ${validated.summary}`,
+      );
+    }
+    expect(validated.requestId).toBe("rid-merge");
+    expect(validated.result.ok).toBe(false);
+
+    // The pending write survives the merge failure. Terminate it so
+    // the test does not leak a pending entry.
     bridge.handleWriteResponse({
       requestId: "rid-merge",
       result: { ok: true, commitSha: "deadbeef" },

--- a/packages/workflow-host/src/child/substrate-write-bridge.ts
+++ b/packages/workflow-host/src/child/substrate-write-bridge.ts
@@ -35,6 +35,7 @@
 // the closure produces, both base64-encoded.
 
 import { getLogger } from "@intx/log";
+import { base64Decode, base64Encode } from "@intx/types";
 
 import type {
   ControlChannelSender,
@@ -266,11 +267,11 @@ function encodeFiles(
 }
 
 function bytesToBase64(bytes: Uint8Array): string {
-  return Buffer.from(bytes).toString("base64");
+  return base64Encode(bytes);
 }
 
 function base64ToBytes(value: string): Uint8Array {
-  return new Uint8Array(Buffer.from(value, "base64"));
+  return base64Decode(value);
 }
 
 function defaultRequestIdAllocator(): () => string {

--- a/packages/workflow-host/src/supervisor/lifecycle-races.test.ts
+++ b/packages/workflow-host/src/supervisor/lifecycle-races.test.ts
@@ -19,6 +19,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { generateKeyPair } from "@intx/crypto";
+import { hexEncode } from "@intx/types";
 import type { RepoId, RepoStore } from "@intx/hub-sessions";
 
 import {
@@ -470,7 +471,7 @@ describe("waitForReady -> pumpUpstreamControl iterator handoff (Gap A)", () => {
       type: "ready",
       data: {
         childPid: first.pid,
-        childPublicKey: Buffer.from(childIpcKeypair.publicKey).toString("hex"),
+        childPublicKey: hexEncode(childIpcKeypair.publicKey),
       },
     });
     await childSender.send({
@@ -511,7 +512,7 @@ describe("waitForReady -> pumpUpstreamControl iterator handoff (Gap A)", () => {
       type: "ready",
       data: {
         childPid: second.pid,
-        childPublicKey: Buffer.from(childIpcKeypair.publicKey).toString("hex"),
+        childPublicKey: hexEncode(childIpcKeypair.publicKey),
       },
     });
 

--- a/packages/workflow-host/src/supervisor/outbound-signed-send.test.ts
+++ b/packages/workflow-host/src/supervisor/outbound-signed-send.test.ts
@@ -26,6 +26,7 @@ import path from "node:path";
 import { type } from "arktype";
 
 import { createEd25519Crypto, generateKeyPair } from "@intx/crypto";
+import { hexEncode } from "@intx/types";
 import { createInMemoryTransport } from "@intx/mail-memory";
 import type { RepoId, RepoStore } from "@intx/hub-sessions";
 
@@ -307,7 +308,7 @@ describe("supervisor-backed outbound signed send (Phase 4.3)", () => {
       type: "ready",
       data: {
         childPid: 9100,
-        childPublicKey: Buffer.from(childIpcKeyPair.publicKey).toString("hex"),
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
       },
     });
     await spawnPromise;

--- a/packages/workflow-host/src/supervisor/recycle.test.ts
+++ b/packages/workflow-host/src/supervisor/recycle.test.ts
@@ -18,6 +18,7 @@ import path from "node:path";
 import { type } from "arktype";
 
 import { generateKeyPair } from "@intx/crypto";
+import { hexEncode } from "@intx/types";
 import type { RepoId, RepoStore } from "@intx/hub-sessions";
 
 import {
@@ -328,7 +329,7 @@ async function driveReady(
     type: "ready",
     data: {
       childPid: child.pid,
-      childPublicKey: Buffer.from(ipcKeypair.publicKey).toString("hex"),
+      childPublicKey: hexEncode(ipcKeypair.publicKey),
     },
   });
   return childSender;

--- a/packages/workflow-host/src/supervisor/spawn-replay-fifo.test.ts
+++ b/packages/workflow-host/src/supervisor/spawn-replay-fifo.test.ts
@@ -34,6 +34,7 @@ import path from "node:path";
 import { type } from "arktype";
 
 import { generateKeyPair } from "@intx/crypto";
+import { hexEncode } from "@intx/types";
 import type { RepoId, RepoStore } from "@intx/hub-sessions";
 
 import {
@@ -588,7 +589,7 @@ async function boot(opts: { prefix: string }): Promise<
   while (!mailBus.registered().includes(deploymentMailAddress)) {
     await new Promise((r) => setTimeout(r, 1));
   }
-  const childPublicKey = Buffer.from(childIpcKeyPair.publicKey).toString("hex");
+  const childPublicKey = hexEncode(childIpcKeyPair.publicKey);
   return {
     supervisor,
     childSender,

--- a/packages/workflow-host/src/supervisor/stale-cohort-routing.test.ts
+++ b/packages/workflow-host/src/supervisor/stale-cohort-routing.test.ts
@@ -32,6 +32,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { generateKeyPair } from "@intx/crypto";
+import { hexEncode } from "@intx/types";
 import type { RepoId, RepoStore } from "@intx/hub-sessions";
 
 import {
@@ -402,7 +403,7 @@ async function driveReady(
     type: "ready",
     data: {
       childPid: child.pid,
-      childPublicKey: Buffer.from(ipcKp.publicKey).toString("hex"),
+      childPublicKey: hexEncode(ipcKp.publicKey),
     },
   });
   return sender;

--- a/packages/workflow-host/src/supervisor/substrate-write.test.ts
+++ b/packages/workflow-host/src/supervisor/substrate-write.test.ts
@@ -35,6 +35,7 @@ import path from "node:path";
 import { type } from "arktype";
 
 import { generateKeyPair } from "@intx/crypto";
+import { base64Encode, hexEncode } from "@intx/types";
 import type { RepoId, RepoStore } from "@intx/hub-sessions";
 
 import {
@@ -565,7 +566,7 @@ async function bootSupervisor(opts: {
     type: "ready",
     data: {
       childPid: 7777,
-      childPublicKey: Buffer.from(childIpcKeyPair.publicKey).toString("hex"),
+      childPublicKey: hexEncode(childIpcKeyPair.publicKey),
     },
   });
   const spawnResult = await spawnPromise;
@@ -709,7 +710,9 @@ describe("substrate-write watchdog", () => {
           files: [
             {
               path: `runs/${runId}/events/0.json`,
-              contentBase64: Buffer.from(terminalBlob).toString("base64"),
+              contentBase64: base64Encode(
+                new TextEncoder().encode(terminalBlob),
+              ),
             },
           ],
         },
@@ -1068,7 +1071,9 @@ describe("substrate-write cohort abort cleanup", () => {
           files: [
             {
               path: `runs/${runId}/events/0.json`,
-              contentBase64: Buffer.from(terminalBlob).toString("base64"),
+              contentBase64: base64Encode(
+                new TextEncoder().encode(terminalBlob),
+              ),
             },
           ],
         },
@@ -1110,5 +1115,153 @@ describe("substrate-write cohort abort cleanup", () => {
     expect(abortResponse.result.reason).toMatch(/cohort aborted|markConsumed/);
 
     await shutdownPromise;
+  });
+});
+
+describe("substrate-write malformed merge response", () => {
+  test("a malformed contentBase64 fails the pending merge without tearing down the upstream pump", async () => {
+    // The supervisor decodes the child's `substrate.merge.response`
+    // `contentBase64` from inside `pumpUpstreamControl`'s `for await`.
+    // A malformed value makes the decoder throw; that throw must be
+    // caught and surfaced as a FAILED merge (a structured
+    // substrate.write.response) instead of escaping the loop and
+    // stopping the supervisor from draining every other upstream
+    // control frame for the cohort.
+    const harness = await bootSupervisor({
+      prefix: "supv-merge-decode-",
+      invokeMerge: true,
+    });
+
+    // First write: drive its merge round-trip, then answer with a
+    // malformed contentBase64.
+    const badRequestId = "merge-decode-bad-1";
+    await harness.childSender.send({
+      type: "substrate.write.request",
+      data: {
+        requestId: badRequestId,
+        repoId: { kind: "workflow-run", id: "deployment-x" },
+        ref: "refs/heads/main",
+        preservePrefix: "state/some-step/",
+        message: "write whose merge response carries malformed base64",
+      },
+    });
+    const badMergeDeadline = Date.now() + 2_000;
+    let badMergeSeen = false;
+    while (!badMergeSeen && Date.now() < badMergeDeadline) {
+      const merges = readPayloadsOfType(
+        harness.supervisorToChild.flushed(),
+        "substrate.merge.request",
+      );
+      if (merges.some((m) => m.data.requestId === badRequestId)) {
+        badMergeSeen = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    expect(badMergeSeen).toBe(true);
+    await harness.childSender.send({
+      type: "substrate.merge.response",
+      data: {
+        requestId: badRequestId,
+        result: {
+          ok: true,
+          files: [
+            { path: "state/some-step/x", contentBase64: "@@@not-valid@@@" },
+          ],
+        },
+      },
+    });
+
+    const badResponseDeadline = Date.now() + 2_000;
+    let badResponse: {
+      requestId: string;
+      result: { ok: boolean; reason?: string };
+    } | null = null;
+    while (badResponse === null && Date.now() < badResponseDeadline) {
+      const responses = readPayloadsOfType(
+        harness.supervisorToChild.flushed(),
+        "substrate.write.response",
+      );
+      const matched = responses.find((r) => r.data.requestId === badRequestId);
+      if (matched !== undefined) {
+        badResponse = {
+          requestId: matched.data.requestId,
+          result: matched.data.result,
+        };
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    if (badResponse === null) {
+      throw new Error(
+        "supervisor did not surface a substrate.write.response for the malformed merge in time",
+      );
+    }
+    expect(badResponse.result.ok).toBe(false);
+    expect(badResponse.result.reason).toMatch(/decode failed/);
+
+    // Liveness: a SUBSEQUENT upstream frame must still be processed. If
+    // the malformed decode had escaped the `for await`, the pump would
+    // be dead and this second write would never receive a merge.request.
+    const goodRequestId = "merge-decode-good-1";
+    await harness.childSender.send({
+      type: "substrate.write.request",
+      data: {
+        requestId: goodRequestId,
+        repoId: { kind: "workflow-run", id: "deployment-x" },
+        ref: "refs/heads/main",
+        preservePrefix: "state/other-step/",
+        message: "subsequent write proving the pump survived",
+      },
+    });
+    const goodMergeDeadline = Date.now() + 2_000;
+    let goodMergeSeen = false;
+    while (!goodMergeSeen && Date.now() < goodMergeDeadline) {
+      const merges = readPayloadsOfType(
+        harness.supervisorToChild.flushed(),
+        "substrate.merge.request",
+      );
+      if (merges.some((m) => m.data.requestId === goodRequestId)) {
+        goodMergeSeen = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    expect(goodMergeSeen).toBe(true);
+    await harness.childSender.send({
+      type: "substrate.merge.response",
+      data: {
+        requestId: goodRequestId,
+        result: { ok: true, files: [] },
+      },
+    });
+    const goodResponseDeadline = Date.now() + 2_000;
+    let goodResponse: {
+      requestId: string;
+      result: { ok: boolean; reason?: string };
+    } | null = null;
+    while (goodResponse === null && Date.now() < goodResponseDeadline) {
+      const responses = readPayloadsOfType(
+        harness.supervisorToChild.flushed(),
+        "substrate.write.response",
+      );
+      const matched = responses.find((r) => r.data.requestId === goodRequestId);
+      if (matched !== undefined) {
+        goodResponse = {
+          requestId: matched.data.requestId,
+          result: matched.data.result,
+        };
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    if (goodResponse === null) {
+      throw new Error(
+        "upstream pump did not process the subsequent write; it appears to have torn down",
+      );
+    }
+    expect(goodResponse.result.ok).toBe(true);
+
+    await harness.supervisor.shutdown();
   });
 });

--- a/packages/workflow-host/src/supervisor/supervisor.test.ts
+++ b/packages/workflow-host/src/supervisor/supervisor.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { type } from "arktype";
 
 import { generateKeyPair } from "@intx/crypto";
-import { hexDecode } from "@intx/types";
+import { hexDecode, hexEncode } from "@intx/types";
 import type { RepoId, RepoStore } from "@intx/hub-sessions";
 
 import {
@@ -666,7 +666,7 @@ describe("createWorkflowSupervisor", () => {
       type: "ready",
       data: {
         childPid: 4321,
-        childPublicKey: Buffer.from(childIpcKeyPair.publicKey).toString("hex"),
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
       },
     });
 
@@ -880,7 +880,7 @@ describe("createWorkflowSupervisor", () => {
       type: "ready",
       data: {
         childPid: 9999,
-        childPublicKey: Buffer.from(childIpcKeyPair.publicKey).toString("hex"),
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
       },
     });
     await spawnPromise;
@@ -1089,7 +1089,7 @@ describe("createWorkflowSupervisor", () => {
       type: "ready",
       data: {
         childPid: 8888,
-        childPublicKey: Buffer.from(childIpcKeyPair.publicKey).toString("hex"),
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
       },
     });
     await spawnPromise;
@@ -1579,7 +1579,7 @@ describe("createWorkflowSupervisor", () => {
       type: "ready",
       data: {
         childPid: 7777,
-        childPublicKey: Buffer.from(childIpcKeyPair.publicKey).toString("hex"),
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
       },
     });
     await spawnPromise;
@@ -1736,7 +1736,7 @@ describe("createWorkflowSupervisor", () => {
       type: "ready",
       data: {
         childPid: 6666,
-        childPublicKey: Buffer.from(childIpcKeyPair.publicKey).toString("hex"),
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
       },
     });
     await spawnPromise;
@@ -2029,7 +2029,7 @@ describe("IPC integration smoke", () => {
       type: "ready",
       data: {
         childPid: 1,
-        childPublicKey: Buffer.from(keyPair.publicKey).toString("hex"),
+        childPublicKey: hexEncode(keyPair.publicKey),
       },
     });
     expect(upstream.flushed()).toHaveLength(1);
@@ -2167,7 +2167,7 @@ describe("supervisor inbox FIFO dispatch loop", () => {
       type: "ready",
       data: {
         childPid: 11111,
-        childPublicKey: Buffer.from(childIpcKeyPair.publicKey).toString("hex"),
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
       },
     });
     await spawnPromise;

--- a/packages/workflow-host/src/supervisor/supervisor.ts
+++ b/packages/workflow-host/src/supervisor/supervisor.ts
@@ -62,7 +62,7 @@ import {
   type WorkflowRunSupervisorPrincipal,
   type WorkflowRunWorkflowProcessPrincipal,
 } from "@intx/hub-sessions/substrate";
-import { hexEncode } from "@intx/types";
+import { base64Decode, base64Encode, hexEncode } from "@intx/types";
 import { RepoId } from "@intx/types/sidecar";
 import type { OutboundMessage } from "@intx/types/runtime";
 import type { CancelOrigin } from "@intx/workflow";
@@ -671,7 +671,7 @@ export function createWorkflowSupervisor(
     // and has no separate durable byte store the child reads; the bytes
     // survive the inbox->processing transition verbatim and are dropped
     // when `markConsumed` writes the dedup index.
-    const rawMessageBase64 = Buffer.from(rawMessage).toString("base64");
+    const rawMessageBase64 = base64Encode(rawMessage);
     // D2 leg: `enqueueInbox` runs in `onMailMessage` BEFORE dispatch, so
     // it is paid OUTSIDE the dispatch-start..reply-produced window -- its
     // growth is invisible to the 4.7 bracket. The leg mark, keyed by the
@@ -835,8 +835,24 @@ export function createWorkflowSupervisor(
     pendingMerges.delete(data.requestId);
     if (data.result.ok) {
       const files: Record<string, string | Uint8Array> = {};
-      for (const file of data.result.files) {
-        files[file.path] = base64ToBytes(file.contentBase64);
+      try {
+        for (const file of data.result.files) {
+          files[file.path] = base64ToBytes(file.contentBase64);
+        }
+      } catch (cause) {
+        // `base64ToBytes` throws loudly on malformed child-supplied
+        // content. This runs synchronously from `pumpUpstreamControl`'s
+        // `for await`, so an escaping throw would tear the pump down and
+        // stop draining every other upstream control frame for the
+        // cohort. Mirror the child-side `decodeMergeRequest` hardening:
+        // resolve the pending merge as a failure so the write handler
+        // surfaces it as a structured substrate.write.response.
+        const reason = cause instanceof Error ? cause.message : String(cause);
+        entry.resolve({
+          ok: false,
+          reason: `supervisor substrate.merge.response: decode failed: ${reason}`,
+        });
+        return;
       }
       entry.resolve({ ok: true, files });
       return;
@@ -2671,9 +2687,9 @@ function outboundMessageFromPayload(
 }
 
 function bytesToBase64(bytes: Uint8Array): string {
-  return Buffer.from(bytes).toString("base64");
+  return base64Encode(bytes);
 }
 
 function base64ToBytes(value: string): Uint8Array {
-  return new Uint8Array(Buffer.from(value, "base64"));
+  return base64Decode(value);
 }

--- a/packages/workflow/src/definition/workflow.test.ts
+++ b/packages/workflow/src/definition/workflow.test.ts
@@ -163,7 +163,7 @@ describe("hashDefinition", () => {
     });
     const h1 = hashDefinition(def);
     const h2 = hashDefinition(def);
-    expect(Buffer.from(h1).equals(Buffer.from(h2))).toBe(true);
+    expect(h1).toEqual(h2);
   });
 
   test("hashes a definition whose agent carries tool factories", () => {

--- a/tests/db/bytea-round-trip.test.ts
+++ b/tests/db/bytea-round-trip.test.ts
@@ -1,0 +1,122 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { eq } from "drizzle-orm";
+
+import { agentSession, gitToken, sessionMail, user } from "@intx/db/schema";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import { seedAgent, seedPrincipal, seedTenants } from "@intx/test-harness/seed";
+
+// The bytea columns serialize through a Uint8Array customType; postgres.js
+// hex-encodes on the way out and parses back to a driver Buffer the
+// customType copies into a plain Uint8Array. A flipped or dropped byte
+// in a token hash or mail body is a silent integrity failure, so each
+// boundary the encoding could mangle gets an explicit case: an empty
+// payload, the high half of the byte range (0x80-0xFF, where a signed or
+// latin1 round-trip would corrupt), and an embedded NUL (where a
+// C-string round-trip would truncate).
+const byteCases: { name: string; bytes: Uint8Array }[] = [
+  { name: "an empty payload", bytes: new Uint8Array(0) },
+  {
+    name: "high bytes 0x80-0xFF",
+    bytes: new Uint8Array([0x80, 0x9f, 0xa5, 0xc3, 0xfe, 0xff]),
+  },
+  {
+    name: "an embedded NUL",
+    bytes: new Uint8Array([0x01, 0x00, 0x02, 0x00, 0xff, 0x00]),
+  },
+];
+
+describe.skipIf(!harnessDbEnvAvailable())("bytea round-trip (real DB)", () => {
+  let h: TestDb;
+
+  beforeAll(async () => {
+    h = await createTestDb();
+  });
+
+  afterAll(async () => {
+    await h.close();
+  });
+
+  beforeEach(async () => {
+    await h.reset();
+  });
+
+  describe("git_token.tokenHashSha256", () => {
+    for (const c of byteCases) {
+      test(`round-trips ${c.name}`, async () => {
+        await h.db.insert(user).values({
+          id: "usr_1",
+          name: "Test User",
+          email: "user@example.test",
+        });
+        await h.db.insert(gitToken).values({
+          id: "gt_1",
+          userId: "usr_1",
+          name: "laptop",
+          kind: "pat",
+          tokenHashSha256: c.bytes,
+          resource: "agent-state:ins_1",
+          refPattern: "*",
+          actions: ["resolveRef"],
+          expiresAt: new Date(Date.now() + 3_600_000),
+        });
+
+        const rows = await h.db
+          .select({ hash: gitToken.tokenHashSha256 })
+          .from(gitToken)
+          .where(eq(gitToken.id, "gt_1"));
+        expect(rows).toHaveLength(1);
+        const got = rows[0]?.hash;
+        expect(got).toBeInstanceOf(Uint8Array);
+        expect(got).toEqual(c.bytes);
+      });
+    }
+  });
+
+  describe("session_mail.raw", () => {
+    for (const c of byteCases) {
+      test(`round-trips ${c.name}`, async () => {
+        await seedTenants(h.db, [{ id: "tnt_1" }]);
+        await seedPrincipal(h.db, { id: "prc_1", tenantId: "tnt_1" });
+        await seedAgent(h.db, {
+          id: "agt_1",
+          tenantId: "tnt_1",
+          creatorPrincipalId: "prc_1",
+        });
+        await h.db.insert(agentSession).values({
+          id: "ses_1",
+          tenantId: "tnt_1",
+          agentId: "agt_1",
+          principalId: "prc_1",
+        });
+        await h.db.insert(sessionMail).values({
+          id: "mail_1",
+          sessionId: "ses_1",
+          tenantId: "tnt_1",
+          direction: "inbound",
+          status: "pending",
+          raw: c.bytes,
+        });
+
+        const rows = await h.db
+          .select({ raw: sessionMail.raw })
+          .from(sessionMail)
+          .where(eq(sessionMail.id, "mail_1"));
+        expect(rows).toHaveLength(1);
+        const got = rows[0]?.raw;
+        expect(got).toBeInstanceOf(Uint8Array);
+        expect(got).toEqual(c.bytes);
+      });
+    }
+  });
+});

--- a/tests/hub-agent/deploy-flow.test.ts
+++ b/tests/hub-agent/deploy-flow.test.ts
@@ -26,6 +26,7 @@ import {
 import { generateKeyPair, createEd25519Crypto } from "@intx/crypto";
 import { parseAgentId } from "@intx/hub-sessions";
 import { createAgentRepoStore as createSidecarRepoStore } from "@intx/hub-agent";
+import { base64Encode } from "@intx/types";
 import type { HarnessConfig } from "@intx/types/runtime";
 import git from "isomorphic-git";
 
@@ -138,10 +139,7 @@ beforeAll(async () => {
     messageSignedContent,
     messageSignature,
   );
-  env.hub.router.routeMail(
-    AGENT_ADDRESS,
-    Buffer.from(messageRaw).toString("base64"),
-  );
+  env.hub.router.routeMail(AGENT_ADDRESS, base64Encode(messageRaw));
 
   // Wait for the FULL message lifecycle to land so the downstream
   // sync test sees populated agent state on disk. The inference

--- a/tests/hub-agent/lib/deploy-flow-env.ts
+++ b/tests/hub-agent/lib/deploy-flow-env.ts
@@ -62,7 +62,7 @@ import {
   type WorkflowRunHubPrincipal,
   type WsHandle,
 } from "@intx/hub-sessions";
-import { hexEncode } from "@intx/types";
+import { base64Encode, hexEncode } from "@intx/types";
 import { createEd25519Crypto, generateKeyPair } from "@intx/crypto";
 import {
   createWorkflowDeployOrchestrator,
@@ -1359,7 +1359,7 @@ export async function fireMailTrigger(
     crypto,
   );
   const rawMessage = assembleMessage(headers, signedContent, signature);
-  const base64 = Buffer.from(rawMessage).toString("base64");
+  const base64 = base64Encode(rawMessage);
   const delivered = env.hub.router.routeMail(address, base64);
   if (!delivered) {
     throw new Error(

--- a/tests/hub-api/git-asset-clone.test.ts
+++ b/tests/hub-api/git-asset-clone.test.ts
@@ -13,6 +13,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import { base64Decode, base64Encode } from "@intx/types";
 import {
   harnessHubEnvAvailable,
   installSshAllowedSigner,
@@ -83,7 +84,7 @@ function extractOpenSshPublicKey(armored: string): string {
   const body = armored
     .slice(begin + SSHSIG_BEGIN.length, end)
     .replace(/\s+/g, "");
-  const blob = new Uint8Array(Buffer.from(body, "base64"));
+  const blob = base64Decode(body);
 
   let off = 0;
   // magic "SSHSIG"
@@ -105,7 +106,7 @@ function extractOpenSshPublicKey(armored: string): string {
   if (new TextDecoder().decode(keyType) !== "ssh-ed25519") {
     throw new Error("only ssh-ed25519 keys are supported");
   }
-  return `ssh-ed25519 ${Buffer.from(pubKeyBlob).toString("base64")}`;
+  return `ssh-ed25519 ${base64Encode(pubKeyBlob)}`;
 }
 
 /**

--- a/tests/hub-api/git-bearer-failure-modes.test.ts
+++ b/tests/hub-api/git-bearer-failure-modes.test.ts
@@ -39,6 +39,7 @@ import {
   type HubHandle,
 } from "./lib/git-harness";
 import { loadHarnessDbConfig } from "@intx/test-harness/db-harness";
+import { base64Encode } from "@intx/types";
 import {
   apiCall,
   assetSmartHttpUrl,
@@ -108,8 +109,8 @@ async function probeInfoRefs(
   assetUrl: string,
   token: string,
 ): Promise<{ status: number; body: typeof ErrorBody.infer }> {
-  const basic = Buffer.from(`x-access-token:${token}`, "utf-8").toString(
-    "base64",
+  const basic = base64Encode(
+    new TextEncoder().encode(`x-access-token:${token}`),
   );
   const res = await fetch(`${assetUrl}/info/refs?service=git-upload-pack`, {
     headers: { authorization: `Basic ${basic}` },

--- a/tests/hub-api/git-protocol-compat.test.ts
+++ b/tests/hub-api/git-protocol-compat.test.ts
@@ -12,6 +12,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import { base64Encode } from "@intx/types";
 import {
   harnessHubEnvAvailable,
   runGit,
@@ -93,7 +94,7 @@ describe.skipIf(!harnessHubEnvAvailable())(
       // first ref line carries the advertised v0 capabilities.
       const info = await fetch(`${url}/info/refs?service=git-upload-pack`, {
         headers: {
-          Authorization: `Basic ${Buffer.from(`x:${token.secret}`).toString("base64")}`,
+          Authorization: `Basic ${base64Encode(new TextEncoder().encode(`x:${token.secret}`))}`,
         },
       });
       expect(info.status).toBe(200);

--- a/tests/hub-api/lib/git-harness.ts
+++ b/tests/hub-api/lib/git-harness.ts
@@ -1,6 +1,10 @@
 // Integration-test harness for hub-API tests that need a real hub
 // subprocess plus per-test postgres-schema isolation.
 //
+// This module is Node-bound: it spawns child processes via
+// `node:child_process`, so it cannot run under a non-Node runtime
+// regardless of whether it references Buffer.
+//
 // Purpose
 // -------
 // Hub-API integration tests exercise the running hub end-to-end
@@ -288,11 +292,11 @@ export async function runGit(
       });
       let stdout = "";
       let stderr = "";
-      child.stdout.on("data", (c: Buffer) => {
-        stdout += c.toString("utf-8");
+      child.stdout.on("data", (c: Uint8Array) => {
+        stdout += new TextDecoder().decode(c);
       });
-      child.stderr.on("data", (c: Buffer) => {
-        stderr += c.toString("utf-8");
+      child.stderr.on("data", (c: Uint8Array) => {
+        stderr += new TextDecoder().decode(c);
       });
       child.on("error", (e: Error) => {
         reject(e);
@@ -515,11 +519,11 @@ export async function startHub(
 
   // Bucket stdout/stderr for diagnostics on failure.
   const logs: string[] = [];
-  child.stdout.on("data", (c: Buffer) => {
-    logs.push(c.toString("utf-8"));
+  child.stdout.on("data", (c: Uint8Array) => {
+    logs.push(new TextDecoder().decode(c));
   });
-  child.stderr.on("data", (c: Buffer) => {
-    logs.push(c.toString("utf-8"));
+  child.stderr.on("data", (c: Uint8Array) => {
+    logs.push(new TextDecoder().decode(c));
   });
 
   let exited = false;

--- a/tests/skill-attachment-flow.test.ts
+++ b/tests/skill-attachment-flow.test.ts
@@ -41,6 +41,7 @@ import path from "node:path";
 import { applyAssetPack } from "@intx/hub-agent";
 import { generateKeyPair } from "@intx/crypto";
 import { generateId } from "@intx/hub-common";
+import { hexEncode } from "@intx/types";
 import {
   buildAvailableSkillsStanza,
   createAgentRepoStore,
@@ -531,9 +532,11 @@ describe("skill attachment flow (end-to-end)", () => {
       repoId,
       ASSET_REF,
     );
-    const assetPackSha = Buffer.from(
-      await crypto.subtle.digest("SHA-256", new Uint8Array(packResult.pack)),
-    ).toString("hex");
+    const assetPackSha = hexEncode(
+      new Uint8Array(
+        await crypto.subtle.digest("SHA-256", new Uint8Array(packResult.pack)),
+      ),
+    );
     expect(assetPackSha).toMatch(/^[0-9a-f]{64}$/);
 
     const workspaceRoot = await mkTemp("intr95-ws-");

--- a/tests/tool-packaging/build-determinism.test.ts
+++ b/tests/tool-packaging/build-determinism.test.ts
@@ -135,7 +135,7 @@ describe("build-builtins determinism", () => {
 
     const bytesA = await fs.readFile(outA);
     const bytesB = await fs.readFile(outB);
-    expect(Buffer.compare(bytesA, bytesB)).toBe(0);
+    expect(bytesA).toEqual(bytesB);
   });
 
   test("packing two staging trees with different mtimes still yields identical SRI", async () => {

--- a/tests/tool-packaging/end-to-end.test.ts
+++ b/tests/tool-packaging/end-to-end.test.ts
@@ -69,7 +69,7 @@ afterEach(async () => {
 interface Fixture {
   name: string;
   version: string;
-  bytes: Buffer;
+  bytes: Uint8Array;
   integrity: string;
   tarballUrl: string;
 }
@@ -258,7 +258,8 @@ describe("hub→sidecar pipeline (failure paths)", () => {
       registries,
       host: { os: "linux", cpu: "x64" },
       // Hand back bytes that do not match the pinned integrity.
-      fetchTarball: async () => Buffer.from("definitely the wrong bytes"),
+      fetchTarball: async () =>
+        new TextEncoder().encode("definitely the wrong bytes"),
     });
 
     const result = await applyAtomic({

--- a/tests/workflow-deploy/mail-edge-cases.test.ts
+++ b/tests/workflow-deploy/mail-edge-cases.test.ts
@@ -53,6 +53,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
 import { defineAgent, createDefaultDirectorRegistry } from "@intx/agent";
+import { base64Encode, hexEncode } from "@intx/types";
 import type { HarnessConfig } from "@intx/types/runtime";
 import { defineWorkflow, step, type WorkflowDefinition } from "@intx/workflow";
 import {
@@ -531,7 +532,7 @@ function buildMinimalMail(opts: {
  * sidecar's hub-link decode unchanged.
  */
 function routeRaw(env: DeployFlowEnv, address: string, raw: Uint8Array): void {
-  const base64 = Buffer.from(raw).toString("base64");
+  const base64 = base64Encode(raw);
   const delivered = env.hub.router.routeMail(address, base64);
   if (!delivered) {
     throw new Error(
@@ -542,7 +543,7 @@ function routeRaw(env: DeployFlowEnv, address: string, raw: Uint8Array): void {
 
 async function sha256Hex(bytes: Uint8Array): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", new Uint8Array(bytes));
-  return Buffer.from(digest).toString("hex");
+  return hexEncode(new Uint8Array(digest));
 }
 
 /**

--- a/tests/workflow-deploy/single-step-conversation-durability.test.ts
+++ b/tests/workflow-deploy/single-step-conversation-durability.test.ts
@@ -41,7 +41,7 @@ import path from "node:path";
 import { type } from "arktype";
 
 import { generateKeyPair } from "@intx/crypto";
-import { hexEncode } from "@intx/types";
+import { base64Encode, hexEncode } from "@intx/types";
 import {
   createDefaultDirectorRegistry,
   type Agent,
@@ -285,7 +285,7 @@ async function seedProcessingEntry(
     receivedAt: opts.receivedAt,
     address: MAILBOX,
     mailAuditRef: { store: "test", path: opts.messageId },
-    rawMessage: Buffer.from(rawMessage).toString("base64"),
+    rawMessage: base64Encode(rawMessage),
   };
   await fs.writeFile(
     path.join(dir, `${String(opts.receivedAt)}-${opts.messageId}.json`),


### PR DESCRIPTION
## Summary

- Non-crypto packages, tests, and `bin` scripts contain no Node-only `Buffer`; byte handling runs on `Uint8Array` and the shared `@intx/types` codecs (`base64Encode`/`base64Decode`, `hexEncode`/`hexDecode`, the new `base64urlEncode`/`base64urlDecode`, and an N-ary `concatBytes`), with inline `TextEncoder`/`TextDecoder` for the utf8 leg.
- The `db` bytea columns, the tarball cache/loader, and the package-json extractor carry `Uint8Array` end to end; the pagination cursor and git PAT secret keep their exact base64url wire format through the new codec.
- Modules that stay Node-bound for other reasons (`tar`, `node:stream`, `child_process`) are documented as such, so the absence of `Buffer` is not mistaken for portability.

## Verification

- `make all` passes (lint, `tsc -b --force`, admin-ui bundle, tests): unit suite 3711 pass / 0 fail, integration suite 444 pass / 28 skip / 0 fail.
- base64url encode/decode is byte-compatible with Node's `"base64url"` across lengths 0–300 and round-trips (fixed-vector test); malformed input throws at the codec and is caught at each decode boundary.
- The `db` bytea round-trip is exercised against a real database across empty, high-byte, and embedded-NUL inputs.
- No `Buffer` usage remains outside `packages/crypto` (tree-wide grep; only doc comments mention it).

Closes INTR-253