### PR TITLE
Encode package-qualified tool names for provider wire charsets

### DIFF
--- a/packages/inference-testing/src/wire/openai.test.ts
+++ b/packages/inference-testing/src/wire/openai.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "bun:test";
+import { type } from "arktype";
 
 import { parseSSE } from "@intx/inference";
 import { createOpenAIAdapter } from "@intx/inference/providers";
@@ -11,6 +12,20 @@ const TEST_SOURCE: LastCycleSource = {
 };
 
 import * as openai from "./openai";
+
+const ToolsBody = type({
+  tools: type({ function: type({ name: "string" }) }).array(),
+});
+
+function wireToolName(builtBody: string): string {
+  const parsed = ToolsBody(JSON.parse(builtBody));
+  if (parsed instanceof type.errors) {
+    throw new Error(`unexpected request body shape: ${parsed.summary}`);
+  }
+  const name = parsed.tools[0]?.function.name;
+  if (name === undefined) throw new Error("request body carried no tool");
+  return name;
+}
 
 async function drive(chunks: Uint8Array[]): Promise<InferenceEvent[]> {
   const stream = new ReadableStream<Uint8Array>({
@@ -193,5 +208,38 @@ describe("openai wire DSL", () => {
     ]);
     expect(events).toHaveLength(1);
     expect(events[0]?.type).toBe("inference.text.delta");
+  });
+});
+
+describe("openai tool-name codec round-trip", () => {
+  const PREFIXED = "@intx/tools-posix/sidecar-bundle:run_shell";
+
+  test("buildRequest emits a wire-charset-safe function name", () => {
+    const built = createOpenAIAdapter(TEST_SOURCE).buildRequest([], "m", {
+      tools: [
+        { name: PREFIXED, description: "run a shell command", inputSchema: {} },
+      ],
+    });
+    const wireName = wireToolName(built.body);
+    expect(wireName).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(built.body).not.toContain(PREFIXED);
+  });
+
+  test("a tool call echoing the encoded name decodes back to the prefixed name", async () => {
+    const built = createOpenAIAdapter(TEST_SOURCE).buildRequest([], "m", {
+      tools: [
+        { name: PREFIXED, description: "run a shell command", inputSchema: {} },
+      ],
+    });
+    const wireName = wireToolName(built.body);
+    const events = await drive([
+      openai.toolCallStart(0, "call_1", wireName),
+      openai.done(),
+    ]);
+    const start = events.find((e) => e.type === "inference.tool_call.start");
+    expect(start?.type).toBe("inference.tool_call.start");
+    if (start?.type === "inference.tool_call.start") {
+      expect(start.data.name).toBe(PREFIXED);
+    }
   });
 });

--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -1,4 +1,6 @@
 export { parseSSE } from "./sse";
+export { encodeToolName, decodeToolName } from "./tool-name";
+export type { ToolNameLimit } from "./tool-name";
 export {
   runInference,
   createDependencies,

--- a/packages/inference/src/providers/anthropic.test.ts
+++ b/packages/inference/src/providers/anthropic.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { type } from "arktype";
 
 import type {
   ConversationTurn,
@@ -767,5 +768,52 @@ describe("Anthropic adapter — responseFormat boundary", () => {
         },
       }),
     ).toThrow(/json-schema/);
+  });
+});
+
+describe("Anthropic adapter — tool-name codec round-trip", () => {
+  const PREFIXED = "@intx/tools-posix/sidecar-bundle:run_shell";
+  const ToolsBody = type({ tools: type({ name: "string" }).array() });
+
+  function wireToolName(body: string): string {
+    const parsed = ToolsBody(JSON.parse(body));
+    if (parsed instanceof type.errors) {
+      throw new Error(`unexpected request body shape: ${parsed.summary}`);
+    }
+    const name = parsed.tools[0]?.name;
+    if (name === undefined) throw new Error("request body carried no tool");
+    return name;
+  }
+
+  test("buildRequest encodes a package-qualified tool name to the wire charset", () => {
+    const req = createAnthropicAdapter(TEST_SOURCE).buildRequest([], "claude", {
+      maxTokens: 100,
+      tools: [
+        { name: PREFIXED, description: "run a shell command", inputSchema: {} },
+      ],
+    });
+    expect(wireToolName(req.body)).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(req.body).not.toContain(PREFIXED);
+  });
+
+  test("a tool_use start echoing the encoded name decodes back to the prefixed name", () => {
+    const adapter = createAnthropicAdapter(TEST_SOURCE);
+    const req = adapter.buildRequest([], "claude", {
+      maxTokens: 100,
+      tools: [
+        { name: PREFIXED, description: "run a shell command", inputSchema: {} },
+      ],
+    });
+    const events = parse(adapter, {
+      type: "content_block_start",
+      index: 0,
+      content_block: {
+        type: "tool_use",
+        id: "toolu_1",
+        name: wireToolName(req.body),
+        input: {},
+      },
+    });
+    expect(pickFirstToolCallStart(events).data.name).toBe(PREFIXED);
   });
 });

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -14,6 +14,19 @@ import { CitationBlock as CitationBlockType } from "@intx/types/runtime";
 import type { ProviderAdapter, BuiltRequest } from "../adapter";
 import { CREDENTIAL_SENTINEL } from "../auth";
 import { ProtocolMismatchError } from "../errors";
+import {
+  decodeToolName,
+  encodeToolName,
+  type ToolNameLimit,
+} from "../tool-name";
+
+// Anthropic's tool-name constraint is `^[a-zA-Z0-9_-]{1,128}$`, which rejects
+// the raw package-qualified names for the same out-of-charset characters as
+// the OpenAI family.
+const ANTHROPIC_TOOL_NAME_LIMIT: ToolNameLimit = {
+  provider: "anthropic",
+  maxLength: 128,
+};
 
 // ---------------------------------------------------------------------------
 // Request building
@@ -73,7 +86,7 @@ function buildRequest(
 
   if (options.tools !== undefined && options.tools.length > 0) {
     const tools: Record<string, unknown>[] = options.tools.map((t) => ({
-      name: t.name,
+      name: encodeToolName(t.name, ANTHROPIC_TOOL_NAME_LIMIT),
       description: t.description,
       input_schema: t.inputSchema,
     }));
@@ -330,7 +343,7 @@ function toAnthropicBlock(block: ContentBlock): Record<string, unknown> {
       return {
         type: "tool_use",
         id: block.id,
-        name: block.name,
+        name: encodeToolName(block.name, ANTHROPIC_TOOL_NAME_LIMIT),
         input: block.arguments,
       };
 
@@ -636,7 +649,7 @@ function parseResponse(
         const { index } = event;
         const callId = block.id ?? String(index);
         blockIndexToCallId.set(index, callId);
-        const name = block.name ?? "";
+        const name = decodeToolName(block.name ?? "");
         return [
           {
             type: "inference.tool_call.start",

--- a/packages/inference/src/providers/google-genai.ts
+++ b/packages/inference/src/providers/google-genai.ts
@@ -15,6 +15,19 @@ import type {
 import type { ProviderAdapter, BuiltRequest } from "../adapter";
 import { CREDENTIAL_SENTINEL } from "../auth";
 import { ProtocolMismatchError } from "../errors";
+import {
+  decodeToolName,
+  encodeToolName,
+  type ToolNameLimit,
+} from "../tool-name";
+
+// Gemini rejects function names with out-of-charset characters and requires a
+// letter/underscore leading character; the raw package-qualified names fail
+// both. The documented function-name limit is 64 characters.
+const GOOGLE_TOOL_NAME_LIMIT: ToolNameLimit = {
+  provider: "google-genai",
+  maxLength: 64,
+};
 
 // Runtime validator for "parsed JSON value is a plain object." Used
 // by `tryParseJSONObject` to narrow `JSON.parse(string)` from its
@@ -89,7 +102,7 @@ function buildRequest(
     body["tools"] = [
       {
         functionDeclarations: options.tools.map((t) => ({
-          name: t.name,
+          name: encodeToolName(t.name, GOOGLE_TOOL_NAME_LIMIT),
           description: t.description,
           parameters: t.inputSchema,
         })),
@@ -296,7 +309,10 @@ function toGeminiPart(
 
     case "tool_call":
       return {
-        functionCall: { name: block.name, args: block.arguments },
+        functionCall: {
+          name: encodeToolName(block.name, GOOGLE_TOOL_NAME_LIMIT),
+          args: block.arguments,
+        },
       };
 
     case "tool_result":
@@ -444,7 +460,12 @@ function toGeminiFunctionResponse(
     response = { result: text };
   }
 
-  return { functionResponse: { name, response } };
+  return {
+    functionResponse: {
+      name: encodeToolName(name, GOOGLE_TOOL_NAME_LIMIT),
+      response,
+    },
+  };
 }
 
 // Returns the parsed value when `text` is a JSON-encoded plain
@@ -1002,7 +1023,7 @@ function emitPart(
       seq,
       data: {
         callId,
-        name: fc.name,
+        name: decodeToolName(fc.name),
         partial: EMPTY_PARTIAL,
         index,
       },

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -12,6 +12,19 @@ import type {
 import type { ProviderAdapter, BuiltRequest } from "../adapter";
 import { BEARER_CREDENTIAL_SENTINEL } from "../auth";
 import { ProtocolMismatchError } from "../errors";
+import {
+  decodeToolName,
+  encodeToolName,
+  type ToolNameLimit,
+} from "../tool-name";
+
+// OpenAI's function-name constraint is `^[a-zA-Z0-9_-]{1,64}$`; the
+// OpenAI-compatible backends this adapter also serves (DeepSeek, Kimi) share
+// that charset and reject the raw package-qualified names outright.
+const OPENAI_TOOL_NAME_LIMIT: ToolNameLimit = {
+  provider: "openai",
+  maxLength: 64,
+};
 
 // ---------------------------------------------------------------------------
 // Request building
@@ -39,7 +52,7 @@ function buildRequest(
     body["tools"] = options.tools.map((t) => ({
       type: "function",
       function: {
-        name: t.name,
+        name: encodeToolName(t.name, OPENAI_TOOL_NAME_LIMIT),
         description: t.description,
         parameters: t.inputSchema,
       },
@@ -189,7 +202,7 @@ function toOpenAIMessage(msg: ConversationTurn): unknown[] {
         id: tc.id,
         type: "function",
         function: {
-          name: tc.name,
+          name: encodeToolName(tc.name, OPENAI_TOOL_NAME_LIMIT),
           arguments: JSON.stringify(tc.arguments),
         },
       }));
@@ -560,7 +573,9 @@ function parseResponse(
       // absent so the start / fragment branches below remain simple.
       const id = tcDelta.id ?? undefined;
       const fn = tcDelta.function;
-      const name = fn?.name ?? undefined;
+      const wireName = fn?.name ?? undefined;
+      const name =
+        wireName !== undefined ? decodeToolName(wireName) : undefined;
       const argFragment = fn?.arguments ?? undefined;
 
       // Different providers shape these deltas differently:

--- a/packages/inference/src/tool-name.test.ts
+++ b/packages/inference/src/tool-name.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  decodeToolName,
+  encodeToolName,
+  type ToolNameLimit,
+} from "./tool-name";
+
+const OPENAI: ToolNameLimit = { provider: "openai", maxLength: 64 };
+const TIGHT: ToolNameLimit = { provider: "tight", maxLength: 8 };
+
+// Package-qualified ids: the namespace segment charset `[A-Za-z0-9._-]` plus
+// the `@`, `/`, and `:` separators. These carry out-of-charset characters and
+// must be rewritten.
+const REWRITTEN_NAMES = [
+  "@intx/tools-posix/sidecar-bundle:run_shell",
+  "@intx/tools-mail/sidecar-bundle:send_message",
+  "@intx/tools-lsp/sidecar-bundle:find_references",
+  "tools-posix/sidecar-bundle:run_shell",
+  "a.b.c",
+];
+
+// Names already valid on the wire. The codec must leave these untouched, in
+// both directions — a provider echoes back exactly what it was sent.
+const WIRE_SAFE_NAMES = [
+  "toolA",
+  "run_shell",
+  "get_weather",
+  "noisy-d",
+  "agentATool",
+  "_internal",
+];
+
+const WIRE_CHARSET = /^[A-Za-z0-9_-]+$/;
+
+describe("encodeToolName", () => {
+  test("leaves already-valid names untouched", () => {
+    for (const name of WIRE_SAFE_NAMES) {
+      expect(encodeToolName(name, OPENAI)).toBe(name);
+    }
+  });
+
+  test("rewrites out-of-charset names to a letter-leading wire-safe form", () => {
+    for (const name of REWRITTEN_NAMES) {
+      const wire = encodeToolName(name, OPENAI);
+      expect(wire).toMatch(WIRE_CHARSET);
+      expect(wire.charAt(0)).toMatch(/[A-Za-z]/);
+      expect(wire).not.toBe(name);
+    }
+  });
+
+  test("escapes each out-of-charset character as its uppercase hex byte", () => {
+    expect(
+      encodeToolName("@intx/tools-posix/sidecar-bundle:run_shell", OPENAI),
+    ).toBe("IX_-40intx-2Ftools-2Dposix-2Fsidecar-2Dbundle-3Arun_shell");
+  });
+
+  test("rewrites a leading-digit name so it is valid where a letter lead is required", () => {
+    expect(encodeToolName("2fast", OPENAI)).toBe("IX_2fast");
+  });
+
+  test("force-encodes a valid name that collides with the marker prefix", () => {
+    // Otherwise it would pass through, and decode would strip the marker.
+    expect(encodeToolName("IX_foo", OPENAI)).toBe("IX_IX_foo");
+  });
+
+  test("throws with an actionable message when the encoding exceeds the limit", () => {
+    expect(() =>
+      encodeToolName("@intx/tools-posix/sidecar-bundle:run_shell", TIGHT),
+    ).toThrow(/exceeds the 8-char limit for provider "tight"/);
+  });
+
+  test("throws naming the source tool name so the diagnostic is fixable", () => {
+    expect(() => encodeToolName("a/b/c/d/e/f", TIGHT)).toThrow(
+      /a\/b\/c\/d\/e\/f/,
+    );
+  });
+
+  test("throws when an already-valid name exceeds the limit on the passthrough path", () => {
+    // A wire-safe name is never rewritten, but it can still be too long; the
+    // length check must cover the passthrough path, not just rewrites.
+    expect(() => encodeToolName("aaaaaaaaaaaa", TIGHT)).toThrow(
+      /exceeds the 8-char limit for provider "tight"/,
+    );
+  });
+});
+
+describe("decodeToolName", () => {
+  test("round-trips every rewritten name back to the exact original", () => {
+    for (const name of [...REWRITTEN_NAMES, "2fast", "IX_foo"]) {
+      expect(decodeToolName(encodeToolName(name, OPENAI))).toBe(name);
+    }
+  });
+
+  test("returns a wire-safe name unchanged in both directions", () => {
+    for (const name of WIRE_SAFE_NAMES) {
+      // A provider echoes the name it was sent; a name that never needed
+      // encoding must survive decode verbatim. `toolA` starts with the letter
+      // the marker escape once collided on — pin that it is not mangled.
+      expect(decodeToolName(name)).toBe(name);
+    }
+  });
+
+  test("passes through a marker-prefixed name that is not a valid encoding", () => {
+    // Malformed hex escape.
+    expect(decodeToolName("IX_-zz")).toBe("IX_-zz");
+    // Lowercase hex is never emitted, so this is not one of our encodings; it
+    // still decodes structurally, but the passthrough guard is on the marker.
+    expect(decodeToolName("IX_-2f")).toBe("/");
+  });
+
+  test("passes through an out-of-charset name unchanged", () => {
+    expect(decodeToolName("@intx/tools-posix/sidecar-bundle:run_shell")).toBe(
+      "@intx/tools-posix/sidecar-bundle:run_shell",
+    );
+  });
+});

--- a/packages/inference/src/tool-name.ts
+++ b/packages/inference/src/tool-name.ts
@@ -1,0 +1,128 @@
+// Invertible codec for tool names on the provider wire.
+//
+// Internal tool names are package-qualified ids like
+// `@intx/tools-posix/sidecar-bundle:run_shell`. Provider function-name
+// charsets are narrow (OpenAI `^[a-zA-Z0-9_-]{1,64}$`, Anthropic 128, Gemini
+// with a leading-letter rule), and reject the `@`, `/`, `:`, and `.`
+// characters these ids carry. This codec maps such a name to a
+// wire-charset-safe form and back.
+//
+// Invariant: `decodeToolName(encodeToolName(x, ...)) === x`. It is
+// load-bearing. Tool-call dispatch keys on the exact prefixed name in two
+// places (the agent's `byName` map and the tool-package loader's per-bundle
+// `nameMap`), so a name that does not round-trip lands as an `unknown tool`
+// with no error at the point of the fault. The `encode`/`decode` naming
+// advertises the invertibility on purpose: a `sanitize`-style name invites a
+// future lossy "cleanup" that would break dispatch.
+//
+// Names that are already valid on the wire pass through untouched — the codec
+// only rewrites names that genuinely need it. Rewritten names carry a
+// distinctive `MARKER` prefix, and `decode` transforms only marker-prefixed
+// names, so an ordinary wire-valid name a provider echoes (a tool the model
+// named that never needed encoding, or a hallucination) is returned verbatim.
+// The marker is what makes the round-trip unambiguous: a name that is already
+// valid but happens to begin with the marker is force-encoded too, so a
+// marker prefix on the wire always denotes an encoding.
+//
+// Rewriting escapes each out-of-charset character (and, so the sentinel stays
+// unambiguous, each literal `-`) as `-XX`, its uppercase two-digit hex byte:
+// `@`->`-40`, `/`->`-2F`, `:`->`-3A`, `.`->`-2E`, `-`->`-2D`. A `base64url`
+// encoding (reusing `@intx/types/base64url`) was considered and rejected: it
+// renders every name fully opaque, hurting both model tool-selection and
+// debugging, and it would encode even the already-legible names this scheme
+// leaves alone.
+
+// A distinctive, letter-leading prefix that ordinary tool names do not start
+// with. Letter-leading satisfies providers (Gemini) that require a
+// letter/underscore leading character on every function name.
+const MARKER = "IX_";
+
+// Characters that survive a rewrite verbatim. `-` is deliberately excluded so
+// it can serve as the escape sentinel inside a rewritten name.
+const ESCAPE_PASSTHROUGH = /^[A-Za-z0-9_]$/;
+// The provider wire charset. A name already matching this, that starts with a
+// letter or underscore and does not collide with the marker, needs no rewrite.
+const WIRE_SAFE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+const HEX_PAIR = /^[0-9A-Fa-f]{2}$/;
+
+// The wire-name length ceiling for a provider, with a label used in the loud
+// error a too-long name raises. The limit is provider-specific, so the
+// adapter that binds the provider owns the constant and passes it in.
+export type ToolNameLimit = {
+  readonly provider: string;
+  readonly maxLength: number;
+};
+
+function needsRewrite(name: string): boolean {
+  return !WIRE_SAFE.test(name) || name.startsWith(MARKER);
+}
+
+function rewrite(name: string): string {
+  let out = MARKER;
+  for (const ch of name) {
+    if (ESCAPE_PASSTHROUGH.test(ch)) {
+      out += ch;
+      continue;
+    }
+    const code = ch.charCodeAt(0);
+    if (code > 0xff) {
+      throw new Error(
+        `Cannot encode tool name "${name}": character "${ch}" is outside the ` +
+          `single-byte range the wire codec supports.`,
+      );
+    }
+    out += "-" + code.toString(16).toUpperCase().padStart(2, "0");
+  }
+  return out;
+}
+
+// Encode a tool name into a form valid for the provider's function-name
+// charset. Names already valid on the wire pass through unchanged. Throws if
+// the resulting wire name exceeds the provider's length limit — on the
+// passthrough path too, since an already-valid name can still be too long — so
+// a name too long for a provider surfaces as a fixable diagnostic rather than
+// truncation, a silent collision, or an opaque upstream 400.
+export function encodeToolName(name: string, limit: ToolNameLimit): string {
+  const wire = needsRewrite(name) ? rewrite(name) : name;
+  if (wire.length > limit.maxLength) {
+    throw new Error(
+      `Tool name "${name}" is ${wire.length} chars on the wire, which ` +
+        `exceeds the ${limit.maxLength}-char limit for provider ` +
+        `"${limit.provider}". Shorten the tool bundle id or tool name.`,
+    );
+  }
+  return wire;
+}
+
+// Invert `encodeToolName`. Total: a wire name without the marker prefix, or a
+// marker-prefixed name whose body is not a valid escaping, is returned
+// unchanged. That covers both names that never needed encoding and
+// hallucinated or provider-mangled names, which then fall through to the
+// existing `unknown tool` handling — giving the model feedback to retry —
+// rather than throwing and tearing down the stream over a bad tool name.
+export function decodeToolName(wire: string): string {
+  if (!wire.startsWith(MARKER)) {
+    return wire;
+  }
+  const body = wire.slice(MARKER.length);
+  let out = "";
+  let i = 0;
+  while (i < body.length) {
+    const ch = body.charAt(i);
+    if (ch === "-") {
+      const hex = body.slice(i + 1, i + 3);
+      if (!HEX_PAIR.test(hex)) {
+        return wire;
+      }
+      out += String.fromCharCode(parseInt(hex, 16));
+      i += 3;
+      continue;
+    }
+    if (!ESCAPE_PASSTHROUGH.test(ch)) {
+      return wire;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}

--- a/tests/hub-agent/lib/deploy-flow-env.ts
+++ b/tests/hub-agent/lib/deploy-flow-env.ts
@@ -70,6 +70,7 @@ import {
   type WorkflowRepoWriter,
 } from "@intx/workflow-deploy";
 import { createDefaultDirectorRegistry } from "@intx/agent";
+import { decodeToolName } from "@intx/inference";
 import type { HarnessConfig } from "@intx/types/runtime";
 import type { ToolPackagePin } from "@intx/types/tool-packages";
 import type { ApprovalSet } from "@intx/workflow-deploy";
@@ -281,6 +282,13 @@ export function startMockInference(
     async fetch(req) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- this is a test mock server that only receives requests from the sidecar under test; the shape is known
       const body = (await req.json()) as InferenceRequest;
+      // The adapter encodes tool names for the provider wire charset. Decode
+      // them back to the qualified names the rest of the mock — and the tests
+      // asserting on `requests` — reason about, so this double stays in terms
+      // of the logical tool identity rather than the on-wire form.
+      for (const tool of body.tools ?? []) {
+        tool.name = decodeToolName(tool.name);
+      }
       requests.push(body);
 
       const toolNames = (body.tools ?? []).map((t) => t.name);

--- a/tests/inference/providers/google-genai.test.ts
+++ b/tests/inference/providers/google-genai.test.ts
@@ -4133,3 +4133,73 @@ describe("Google GenAI adapter: harness round trip with code execution", () => {
     expect(request.id).toBe("synth-1");
   });
 });
+
+describe("Google GenAI adapter: tool-name codec round-trip", () => {
+  const PREFIXED = "@intx/tools-posix/sidecar-bundle:run_shell";
+  const ToolsDecl = type({
+    tools: type({
+      functionDeclarations: type({ name: "string" }).array(),
+    }).array(),
+  });
+
+  function wireToolName(body: string): string {
+    const parsed = ToolsDecl(JSON.parse(body));
+    if (parsed instanceof type.errors) {
+      throw new Error(`unexpected request body shape: ${parsed.summary}`);
+    }
+    const name = parsed.tools[0]?.functionDeclarations[0]?.name;
+    if (name === undefined) throw new Error("request body carried no tool");
+    return name;
+  }
+
+  function requestWithTool(): string {
+    return adapter.buildRequest(
+      [{ role: "user", content: [{ type: "text", text: "hi" }], timestamp: 0 }],
+      "gemini-2.5-flash",
+      {
+        tools: [
+          {
+            name: PREFIXED,
+            description: "run a shell command",
+            inputSchema: {},
+          },
+        ],
+      },
+    ).body;
+  }
+
+  test("buildRequest encodes a package-qualified tool name to the wire charset", () => {
+    const body = requestWithTool();
+    const wireName = wireToolName(body);
+    expect(wireName).toMatch(/^[A-Za-z_][A-Za-z0-9_-]*$/);
+    expect(body).not.toContain(PREFIXED);
+  });
+
+  test("a functionCall echoing the encoded name decodes back to the prefixed name", async () => {
+    const wireName = wireToolName(requestWithTool());
+    const events = await parseWire(adapter, [
+      sseFrame({
+        candidates: [
+          {
+            content: {
+              role: "model",
+              parts: [{ functionCall: { name: wireName, args: {} } }],
+            },
+            finishReason: "STOP",
+            index: 0,
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 5,
+          candidatesTokenCount: 3,
+          totalTokenCount: 8,
+        },
+      }),
+    ]);
+    const start = events[0];
+    if (start?.type !== "inference.tool_call.start") {
+      throw new Error("expected inference.tool_call.start");
+    }
+    expect(start.data.name).toBe(PREFIXED);
+  });
+});


### PR DESCRIPTION
## Summary

- Add an invertible codec that rewrites tool names into a provider's
  function-name charset and inverts them on the way back, so
  package-qualified ids like `@intx/tools-posix/sidecar-bundle:run_shell`
  reach DeepSeek, Kimi/Moonshot, Anthropic, and Gemini as valid names.
- Wire the codec into the OpenAI, Anthropic, and Google GenAI adapters at
  every tool-name emission site and decode at every parse site, so
  tool-call dispatch still keys on the original prefixed name.
- Leave already-valid names untouched; only names with out-of-charset
  characters or a leading non-letter are rewritten, and an over-long wire
  name throws rather than reaching the provider as an opaque 400.

## Verification

- `make all` passes (lint, `tsc -b`, admin-ui bundle, tests); exits 0.
- Each adapter carries a round-trip test proving a package-qualified name
  survives buildRequest → parseResponse back to the prefixed form; the
  codec has unit coverage for passthrough, rewrite, marker collision,
  leading digit, the over-limit throw, and total decode.

Closes INTR-217