### PR TITLE
Make agent-step side effects at-most-once across a mid-step crash

### DIFF
--- a/packages/workflow-host/src/child/run-child.test.ts
+++ b/packages/workflow-host/src/child/run-child.test.ts
@@ -890,6 +890,221 @@ describe("runWorkflowChild", () => {
     expect(result.resumedRunIds).not.toContain("run-done");
   });
 
+  test("a re-fired trigger for a self-discovered run does not spawn a second driver", async () => {
+    // Commit 1 leaves a crashed agent step as a discoverable non-terminal
+    // log; the supervisor both resumes it (self-discovery) AND re-fires
+    // the same runId via `trigger.fire` (runId = messageId). Without a
+    // one-driver-per-run claim the re-fire spawns a SECOND `runtimeRun`
+    // for the same runId in the same process; the two concurrent drivers
+    // race to settle the residual and the loser throws an uncaught
+    // TransitionError, or both emit a terminal. The claim makes the
+    // re-fire decline: exactly one driver, exactly one terminal.
+    const baseDir = await makeTempDir("child-single-driver-");
+    const supervisorKeyPair = await generateKeyPair();
+    const childKeyPair = await generateKeyPair();
+    const channelId = generateChannelId();
+    const hmacKey = generateHmacKey();
+    const runId = "run-crashed";
+    // A one-step workflow whose sole step is an agent `step`, so the
+    // seeded crashed StepStarted settles as a `StepFailed`
+    // (crash-mid-invocation) rather than resolving to a coordination
+    // primitive the resume could re-arm.
+    await seedWorkflowDefinition(
+      baseDir,
+      { kind: "workflow", id: "workflow-asset" },
+      {
+        steps: {
+          "step-1": {
+            kind: "step",
+            id: "step-1",
+            agent: {
+              id: "crashed-agent",
+              systemPrompt: "crashed agent",
+              toolFactories: [],
+              capabilities: [],
+              inference: {
+                sources: [{ provider: "anthropic", model: "stub-model" }],
+              },
+            },
+            input: { from: "trigger.payload" },
+            drainBehavior: "cancel",
+          },
+        },
+        stepOrder: ["step-1"],
+      },
+    );
+    // Surviving non-terminal log: RunStarted + the agent step's
+    // StepStarted with no StepCompleted -- a crash mid-invocation.
+    await seedRun(
+      baseDir,
+      { kind: "workflow-run", id: "deployment-x" },
+      runId,
+      [
+        {
+          seq: 1,
+          type: "RunStarted",
+          at: "2026-01-01T00:00:00.000Z",
+          runId,
+          definitionHash: "definition-hash-abc",
+          trigger: { type: "manual", payload: null },
+        },
+        {
+          seq: 2,
+          type: "StepStarted",
+          at: "2026-01-01T00:00:00.500Z",
+          stepId: "step-1",
+          attempt: 0,
+          input: { ref: "blob:seed-input" },
+        },
+      ],
+    );
+    // A processing entry for messageId = runId, so the re-fired
+    // `trigger.fire` COULD resolve its trigger payload and drive a second
+    // run if the guard were absent.
+    await seedProcessingEntry(
+      baseDir,
+      { kind: "workflow-run", id: "deployment-x" },
+      {
+        address: "deployment-x@example.com",
+        messageId: runId,
+        receivedAt: 1,
+        text: "re-fired inbound",
+      },
+    );
+
+    const supervisorToChild = createMemoryNdjsonStream();
+    const childToSupervisor = createMemoryNdjsonStream();
+    const eventStream = createMemoryFrameStream();
+
+    const env = parseSpawnTimeEnv(
+      makeSpawnEnv({
+        channelId,
+        hmacKeyHex: hexEncode(hmacKey),
+        hostPubKeyHex: hexEncode(supervisorKeyPair.publicKey),
+      }),
+    );
+
+    // Spy invokeStep: the resumed crashed step must settle WITHOUT
+    // re-invoking the agent (commit 2a's at-most-once refusal), so this
+    // counter must stay at zero for the resumed run.
+    let invokeCalls = 0;
+    const bindings: RunWorkflowChildBindings = {
+      ...buildBindings({ baseDir, childKeyPair }),
+      invokeStep: async () => {
+        invokeCalls += 1;
+        return { output: null };
+      },
+    };
+
+    const supervisorSender = createControlChannelSender({
+      privateKeySeed: supervisorKeyPair.privateKey,
+      channelId,
+      writer: supervisorToChild.writer,
+    });
+
+    // Capture the child's error diagnostics. A second concurrent driver
+    // loses the race to settle the crashed residual and its uncaught
+    // TransitionError (terminal-phase / step-phase) is logged through the
+    // child's `logger.error` into `console.error`. No such string may
+    // escape when exactly one driver runs.
+    const capturedErrors: string[] = [];
+    // eslint-disable-next-line no-console -- test spy restored in finally
+    const originalConsoleError = console.error;
+    // eslint-disable-next-line no-console -- test spy restored in finally
+    console.error = (...args: unknown[]) => {
+      capturedErrors.push(args.map((a) => String(a)).join(" "));
+    };
+
+    let result: Awaited<ReturnType<typeof runWorkflowChild>>;
+    const terminals: number[] = [];
+    try {
+      const runPromise = runWorkflowChild({
+        env,
+        controlReader: supervisorToChild.reader,
+        controlWriter: childToSupervisor.writer,
+        eventWriter: eventStream.writer,
+        bindings,
+      });
+
+      // Decode the child's upstream frames live so the test observes the
+      // run reach terminal (self-discovery completes before `ready`, so the
+      // crashed runId is in the one-driver map before the trigger). The
+      // receiver bootstraps the child's verifying key from `ready`.
+      const recvIter = receiveControlChannel({
+        publicKey: { bootstrapFromReady: true },
+        channelId,
+        reader: childToSupervisor.reader,
+        onCrash: (reason) => {
+          throw new Error(`unexpected control channel crash: ${reason}`);
+        },
+      });
+
+      // The supervisor re-fires the same runId: runId = messageId, no
+      // resumeFromEvents. The guard must decline this second drive.
+      await supervisorSender.send({
+        type: "trigger.fire",
+        data: { runId, messageId: runId, receivedAt: 1 },
+      });
+
+      // Wait for the run's terminal, counting every terminal.event for the
+      // runId. Break on the first terminal, then drain any residual frames
+      // below to prove no second one lands.
+      for await (const payload of recvIter) {
+        if (payload.type === "terminal.event" && payload.data.runId === runId) {
+          terminals.push(payload.data.seq);
+          break;
+        }
+      }
+
+      await supervisorSender.send({
+        type: "shutdown",
+        data: { reason: "test done" },
+      });
+      supervisorToChild.close();
+
+      result = await runPromise;
+      childToSupervisor.close();
+
+      // Drain the rest of the upstream stream; no SECOND terminal for the
+      // runId may appear -- exactly one driver emitted exactly one terminal.
+      for await (const payload of recvIter) {
+        if (payload.type === "terminal.event" && payload.data.runId === runId) {
+          terminals.push(payload.data.seq);
+        }
+      }
+    } finally {
+      // eslint-disable-next-line no-console -- restore the spied method
+      console.error = originalConsoleError;
+    }
+
+    // Load-bearing for this seeded interleaving: the losing second driver
+    // throws while settling the crashed residual (a StepFailed-onto-already-
+    // terminal TransitionError) and that throw lands in its fire-and-forget
+    // continuation, logged through the child's `logger.error`. No such
+    // string may escape when exactly one driver runs. This is the check
+    // that fails when the guard is removed -- the loser throws BEFORE it
+    // reaches a terminal emission, so `terminals` still has length 1.
+    expect(
+      capturedErrors.some((line) => line.includes("TransitionError")),
+    ).toBe(false);
+    // At least one terminal.event for the runId. The one-driver guard
+    // prevents two CONCURRENT drivers (the TransitionError check above); it
+    // does not force a strict single terminal. A re-fire that arrives after
+    // the resumed driver already settled misses the guard, spawns a second
+    // driver that terminal-short-circuits (no re-invocation) and benignly
+    // re-emits the terminal; the supervisor tolerates a duplicate terminal
+    // idempotently. The guarantee the code makes is at-least-one, not
+    // exactly-one.
+    expect(terminals.length).toBeGreaterThanOrEqual(1);
+    // The crashed step settled without re-invoking the agent (commit 2a's
+    // at-most-once refusal); the load-bearing zero-invocation assertion.
+    expect(invokeCalls).toBe(0);
+    // The self-discovery driver resumed the run; the re-fire was accepted
+    // (recorded once) but drove nothing.
+    expect(result.resumedRunIds).toContain(runId);
+    expect(result.triggeredRunIds).toEqual([runId]);
+  });
+
   test("grants-updated frame replaces the active credentialsSnapshot", async () => {
     const baseDir = await makeTempDir("child-grants-");
     const supervisorKeyPair = await generateKeyPair();

--- a/packages/workflow-host/src/child/run-child.ts
+++ b/packages/workflow-host/src/child/run-child.ts
@@ -524,6 +524,14 @@ export async function runWorkflowChild(
     runtimeRepoStore,
   });
   const resumedRunIds: string[] = [];
+  // One-driver-per-run claim. A runId present here is already being
+  // driven by a live `runtimeRun` in this process (a resume below, or an
+  // earlier trigger). The trigger.fire path consults it to refuse
+  // spawning a second concurrent driver for the same runId: two drivers
+  // race to settle the same residual and the loser throws an uncaught
+  // TransitionError into its fire-and-forget continuation. Each site
+  // removes its entry when the run reaches terminal.
+  const runsInFlight = new Map<string, WorkflowRun>();
   for (const run of discovered) {
     const env = buildRuntimeEnv({
       runId: run.runId,
@@ -546,6 +554,7 @@ export async function runWorkflowChild(
       runId: run.runId,
       resumeFromEvents: run.seedEvents,
     });
+    runsInFlight.set(run.runId, handle);
     // Fire-and-forget: the runtime body's `complete` settles when the
     // run reaches a terminal phase; the child's control-loop does not
     // block on resumed runs. The supervisor's dispatch loop / drain
@@ -562,6 +571,9 @@ export async function runWorkflowChild(
       })
       .catch((cause) => {
         logger.error`resumed run ${run.runId} failed: ${String(cause)}`;
+      })
+      .finally(() => {
+        runsInFlight.delete(run.runId);
       });
     resumedRunIds.push(run.runId);
   }
@@ -617,6 +629,7 @@ export async function runWorkflowChild(
           upstreamSender,
           drainController,
           triggeredRunIds,
+          runsInFlight,
           warmCache,
           sourcesRef,
           ...(opts.substrateWriteBridge !== undefined
@@ -690,6 +703,7 @@ async function handleControlPayload(
     upstreamSender: ControlChannelSender;
     drainController: DrainController;
     triggeredRunIds: string[];
+    runsInFlight: Map<string, WorkflowRun>;
     warmCache: WarmAgentCache | undefined;
     sourcesRef: SourcesSnapshotRef;
     substrateWriteBridge?: SubstrateWriteResponseSink;
@@ -698,6 +712,25 @@ async function handleControlPayload(
 ): Promise<boolean> {
   switch (payload.type) {
     case "trigger.fire": {
+      // One driver per runId. If this child is already driving this
+      // runId -- self-discovery resumed it, or an earlier trigger opened
+      // it -- the supervisor's re-fire (which carries `runId = messageId`
+      // and no resumeFromEvents) must NOT spawn a second `runtimeRun`. A
+      // second concurrent driver would race the live one to settle the
+      // same residual and the loser throws an uncaught TransitionError,
+      // and even a driver that avoided the throw would double-emit the
+      // terminal. The live driver's completion continuation owns the
+      // single terminal emission; the supervisor's terminal-event-driven
+      // `markConsumed` consumes the message off that one terminal, so no
+      // work is dropped by declining here. Record the runId (the
+      // supervisor did fire a trigger and it was accepted) and signal
+      // "handled, not shutdown" the same way the normal trigger case
+      // returns, without awaiting the live handle's `complete` inline
+      // (that would block the control loop).
+      if (ctx.runsInFlight.has(payload.data.runId)) {
+        ctx.triggeredRunIds.push(payload.data.runId);
+        return false;
+      }
       // Resolve the inbound mail bytes for this messageId from the
       // claim-check processing entry the supervisor created when it
       // dequeued the message. The bytes become the run's trigger
@@ -737,6 +770,7 @@ async function handleControlPayload(
         consumedMessageId: payload.data.messageId,
         triggerPayload,
       });
+      ctx.runsInFlight.set(payload.data.runId, handle);
       // Fan the run's terminal status back to the supervisor over the
       // upstream control channel. The supervisor's dispatch loop and
       // any armed drainTimeout accumulator subscribe through the
@@ -756,6 +790,9 @@ async function handleControlPayload(
         })
         .catch((cause) => {
           logger.error`triggered run ${payload.data.runId} failed: ${String(cause)}`;
+        })
+        .finally(() => {
+          ctx.runsInFlight.delete(payload.data.runId);
         });
       ctx.triggeredRunIds.push(payload.data.runId);
       return false;

--- a/packages/workflow/src/runtime/dag.ts
+++ b/packages/workflow/src/runtime/dag.ts
@@ -90,6 +90,48 @@ export function isResumableReceivedAwaitSignalStep(
   return primitive.timeout === undefined;
 }
 
+/**
+ * An `in-flight` step whose primitive is an invocation boundary -- an
+ * agent `step` or a deterministic `action` -- is a crash
+ * mid-invocation, not a resumable coordination primitive: a
+ * durable `StepStarted` with no `StepCompleted`, whose invoked
+ * primitive is non-deterministic (agent) or already dedup-owned by its
+ * effect ledger (action) and has no runtime-body re-arm surface, so it
+ * cannot be re-invoked safely. The resume guard settles such a step as
+ * a terminal `StepFailed` (at-most-once refusal) rather than throwing.
+ *
+ * How the `StepStarted` became durable differs by kind. An agent `step`
+ * flushes its own before invoking (the `commitDurable` barrier in
+ * `runStep`), so a lone crashed agent always leaves this residual. An
+ * `action` does not: `runAction` commits `StepStarted` buffered, so a
+ * lone crashed action drops it with the pending buffer and leaves no
+ * residual at all. An action reaches this branch only incidentally --
+ * when a concurrently-running step's `commitDurable` flush persisted the
+ * action's buffered `StepStarted` first (the pending buffer is shared
+ * per run). Settling that residual terminal still beats the prior stall.
+ *
+ * Container/coordination primitives left `in-flight` -- a `map` outer
+ * step, a timeout-bearing `awaitSignal` reduced to `in-flight`, a
+ * `childWorkflow`, etc. -- are deliberately excluded: they have a
+ * re-arm surface the in-process runtime body lacks (rebuilding the map
+ * iteration state, distinguishing a fired timeout from a received
+ * signal), so they stay `RuntimeResumeUnsupportedError` and the host
+ * owns recovery. A synthetic map/loop inner id (`<id>[i]`) is not a
+ * definition key, so it resolves to `undefined` and is excluded here;
+ * resumable loop iterations are handled by
+ * `isResumableInFlightLoopStep`, and a mid-`map` inner step stays
+ * unsupported with its container.
+ */
+export function isCrashedInvocationStep(
+  def: WorkflowDefinition,
+  stepId: string,
+  phase: StepPhase,
+): boolean {
+  if (phase !== "in-flight") return false;
+  const kind = def.steps[stepId]?.kind;
+  return kind === "step" || kind === "action";
+}
+
 export function nextSchedulable(
   def: WorkflowDefinition,
   state: RunState,

--- a/packages/workflow/src/runtime/errors.ts
+++ b/packages/workflow/src/runtime/errors.ts
@@ -1,19 +1,22 @@
 // Errors the runtime body surfaces to its host.
 
 /**
- * Thrown when `runtimeRun` is asked to resume from a seed log it
- * cannot honour with its in-process re-arming surface.
+ * Thrown when `runtimeRun` is asked to resume from a durable log it
+ * cannot honour with its in-process re-arming surface. The log may be a
+ * supplied `resumeFromEvents` seed or one this call adopts from the
+ * durable store (a supervisor re-fire that carries no seed).
  *
- * The v1 runtime body supports resume from seed logs that are either
- * complete-or-cancelled, aligned on step boundaries, or left in one of
- * the resumable carve-outs (an in-flight `loop` container, or an
- * `awaitSignal` step still `awaiting-signal` [re-parked] or -- with no
- * timeout -- left `in-flight` by an already-logged `SignalReceived`):
- * every remaining non-terminal entry in the seed log's reconstructed
- * `state.steps` must be schedulable via the DAG's `nextSchedulable` set.
- * Seed logs that stop while a step is `awaiting-timer`, mid-`map`, or
- * otherwise `in-flight` (including a timeout-bearing `awaitSignal` left
- * `in-flight`) have no schedulable primitive to advance them -- the
+ * The v1 runtime body supports resume when every remaining non-terminal
+ * entry in the reconstructed `state.steps` is either aligned on a step
+ * boundary or left in one of the resumable carve-outs (an in-flight
+ * `loop` container, or an `awaitSignal` step still `awaiting-signal`
+ * [re-parked] or -- with no timeout -- left `in-flight` by an
+ * already-logged `SignalReceived`), or is a crash-mid-invocation step
+ * (an agent `step` or `action` left `in-flight`) which the runtime
+ * settles as a terminal `StepFailed` rather than re-arming. A log that
+ * stops while a step is `awaiting-timer`, mid-`map`, or otherwise
+ * `in-flight` (a `childWorkflow`, or a timeout-bearing `awaitSignal`
+ * left `in-flight`) has no schedulable primitive to advance it -- the
  * runtime cannot re-arm the timer scheduler entry or rebuild the
  * inner-map iteration state from the log alone. The host (supervisor)
  * owns the recovery decision: crash the workflow process and let a fresh
@@ -32,7 +35,7 @@ export class RuntimeResumeUnsupportedError extends Error {
     detail: string,
   ) {
     super(
-      `resume against a seed log whose step ${stepId} is ${awaitedPrimitive} is not supported by the in-process runtime: ${detail}`,
+      `resume against a durable log whose step ${stepId} is ${awaitedPrimitive} is not supported by the in-process runtime: ${detail}`,
     );
     this.name = "RuntimeResumeUnsupportedError";
     this.stepId = stepId;

--- a/packages/workflow/src/runtime/refire-adopts-crashed-step.test.ts
+++ b/packages/workflow/src/runtime/refire-adopts-crashed-step.test.ts
@@ -1,0 +1,519 @@
+// Property: the crashed-in-flight settling runs against the ADOPTED
+// canonical durable log, not only against a `resumeFromEvents` seed.
+//
+// The supervisor re-drives a crashed run as a FRESH run: it re-fires the
+// parked inbound message with `runId = messageId` and NO
+// `resumeFromEvents`. `executeRunBody` then finds the durable log already
+// carrying the crashed run's tail (a `RunStarted` + an agent step's
+// `StepStarted` with no `StepCompleted`). Keying the settling pass on the
+// canonical `state.phase === "running"` -- rather than on whether this
+// process received a seed -- settles the residual in-flight step as a
+// terminal `StepFailed` (the agent is NOT re-invoked) and lets the run
+// settle `RunFailed`, instead of stalling with no schedulable primitive.
+//
+// A fresh re-fire against a durable log that is ALREADY terminal returns
+// the existing terminal result without re-driving (no `RunStarted`, no
+// `terminal-phase` throw, no agent invocation). The short-circuit
+// reconstructs the terminal `RunResult` from the log for every terminal
+// phase -- `failed`, `completed`, and `cancelled` -- and the reconstructed
+// result matches the original live-path result byte-for-byte (runId,
+// terminalStatus, hydrated outputs, and the full event log).
+//
+// A second property covers the seeded-resume side of the reload-at-entry
+// restructuring: a genuine `resumeFromEvents` seed truncated at a
+// completed step's `StepCompleted` adopts that step by skip (it is NOT
+// re-invoked) and hydrates its recorded output from the canonical log so
+// a downstream step's selector can read it.
+
+import { describe, test, expect } from "bun:test";
+
+import { createDefaultDirectorRegistry, defineAgent } from "@intx/agent";
+
+import {
+  createInMemoryBlobSubstrate,
+  createInMemoryRepoStore,
+  createInMemoryScheduler,
+  createInMemorySignalChannel,
+  createNoopDrainController,
+  defineWorkflow,
+  runtimeRun,
+  step,
+  type RepoStore,
+  type StepInvoker,
+  type WorkflowEvent,
+  type WorkflowRuntimeEnv,
+} from "@intx/workflow";
+
+function makeAgent(id: string) {
+  return defineAgent({
+    id,
+    systemPrompt: id,
+    tools: [],
+    capabilities: [],
+    inference: { sources: [{ provider: "fake", model: "fake" }] },
+  });
+}
+
+// Copy every event of `source` into `target` verbatim, at its original
+// seq -- the shape the supervisor's re-fire recovery observes: a durable
+// log written by a prior (crashed) process, not a seed handed to this
+// one. `append` preserves the historical seqs, matching how the runtime
+// re-fires against an already-populated store.
+async function seedStore(
+  target: RepoStore,
+  runId: string,
+  source: readonly WorkflowEvent[],
+): Promise<void> {
+  for (const event of source) {
+    await target.append(runId, event);
+  }
+}
+
+describe("re-fire adopts a crashed step from the durable log", () => {
+  test("a non-terminal surviving log is adopted and its crashed step is settled without re-invoking the agent", async () => {
+    const def = defineWorkflow({
+      id: "refire-adopt-crash",
+      trigger: { type: "manual" },
+      steps: {
+        s: step({ agent: makeAgent("solo") }),
+      },
+    });
+
+    // Key the counter off the agent identity: `StepInvokeRequest` carries
+    // no top-level `stepId`, so `agent.id` is what distinguishes an
+    // invocation, and this driver must not invoke the crashed agent at all.
+    const invocationsByAgent = new Map<string, number>();
+    const invokeStep: StepInvoker = async ({ agent, input }) => {
+      invocationsByAgent.set(
+        agent.id,
+        (invocationsByAgent.get(agent.id) ?? 0) + 1,
+      );
+      return { output: { processed: input } };
+    };
+    const clock = () => new Date();
+    const blobs = createInMemoryBlobSubstrate();
+    const repoStore1 = createInMemoryRepoStore();
+    const env1: WorkflowRuntimeEnv = {
+      repoStore: repoStore1,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore1, clock }),
+      signalChannel: createInMemorySignalChannel(),
+      blobs,
+      directors: createDefaultDirectorRegistry(),
+      authorize: async () => ({
+        effect: "allow",
+        matchingGrants: [],
+        resolvedBy: null,
+      }),
+      invokeStep,
+      spawnChild: async () => ({ terminalStatus: "completed" }),
+      clock,
+      newId: (prefix) => `${prefix}-${Math.random().toString(36).slice(2, 8)}`,
+      drain: createNoopDrainController(def),
+    };
+
+    const result1 = await runtimeRun(def, env1).complete;
+    expect(invocationsByAgent.get("solo")).toBe(1);
+
+    // Truncate the first run's log at the agent step's own StepStarted,
+    // inclusive: the durable marker is present but StepCompleted never
+    // landed (a crash mid-invocation).
+    const trimmed: WorkflowEvent[] = [];
+    for (const e of result1.events) {
+      trimmed.push(e);
+      if (e.kind === "StepStarted" && e.stepId === "s") {
+        break;
+      }
+    }
+
+    // Pre-seed a fresh store with the surviving crashed log at its
+    // original seqs, then re-fire the SAME runId with NO resumeFromEvents
+    // -- the supervisor's fresh re-fire shape. Share the blob substrate so
+    // the surviving StepStarted input ref still resolves.
+    const repoStore2 = createInMemoryRepoStore();
+    await seedStore(repoStore2, result1.runId, trimmed);
+
+    const refireInvocations = new Map<string, number>();
+    const refireInvokeStep: StepInvoker = async ({ agent, input }) => {
+      refireInvocations.set(
+        agent.id,
+        (refireInvocations.get(agent.id) ?? 0) + 1,
+      );
+      return { output: { processed: input } };
+    };
+    const env2: WorkflowRuntimeEnv = {
+      ...env1,
+      repoStore: repoStore2,
+      blobs,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore2, clock }),
+      signalChannel: createInMemorySignalChannel(),
+      invokeStep: refireInvokeStep,
+    };
+
+    const result2 = await runtimeRun(def, env2, {
+      runId: result1.runId,
+    }).complete;
+
+    // The crashed agent is NOT re-invoked on this driver.
+    expect(refireInvocations.get("solo")).toBeUndefined();
+    expect(result2.terminalStatus).toBe("failed");
+    expect(result2.events.some((e) => e.kind === "RunFailed")).toBe(true);
+
+    const failures = result2.events.filter((e) => e.kind === "StepFailed");
+    expect(failures.length).toBeGreaterThan(0);
+    for (const f of failures) {
+      if (f.kind !== "StepFailed") throw new Error("unreachable");
+      expect(f.error.code).toBe("crash-mid-invocation");
+    }
+  });
+
+  test("a terminal surviving log is returned as-is with no re-drive", async () => {
+    // Force the first run to fail so the surviving log is terminal
+    // (RunFailed). The re-fire must return that terminal result cleanly:
+    // no fresh RunStarted (which would throw terminal-phase), no agent
+    // re-invocation.
+    const def = defineWorkflow({
+      id: "refire-terminal-noop",
+      trigger: { type: "manual" },
+      steps: {
+        s: step({ agent: makeAgent("solo") }),
+      },
+    });
+
+    const invocationsByAgent = new Map<string, number>();
+    const failingInvokeStep: StepInvoker = async ({ agent }) => {
+      invocationsByAgent.set(
+        agent.id,
+        (invocationsByAgent.get(agent.id) ?? 0) + 1,
+      );
+      throw new Error("agent boom");
+    };
+    const clock = () => new Date();
+    const blobs = createInMemoryBlobSubstrate();
+    const repoStore1 = createInMemoryRepoStore();
+    const env1: WorkflowRuntimeEnv = {
+      repoStore: repoStore1,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore1, clock }),
+      signalChannel: createInMemorySignalChannel(),
+      blobs,
+      directors: createDefaultDirectorRegistry(),
+      authorize: async () => ({
+        effect: "allow",
+        matchingGrants: [],
+        resolvedBy: null,
+      }),
+      invokeStep: failingInvokeStep,
+      spawnChild: async () => ({ terminalStatus: "completed" }),
+      clock,
+      newId: (prefix) => `${prefix}-${Math.random().toString(36).slice(2, 8)}`,
+      drain: createNoopDrainController(def),
+    };
+
+    const result1 = await runtimeRun(def, env1).complete;
+    expect(result1.terminalStatus).toBe("failed");
+    expect(result1.events.some((e) => e.kind === "RunFailed")).toBe(true);
+    expect(invocationsByAgent.get("solo")).toBe(1);
+
+    // Pre-seed a fresh store with the FULL terminal log, then re-fire the
+    // same runId with no resumeFromEvents.
+    const repoStore2 = createInMemoryRepoStore();
+    await seedStore(repoStore2, result1.runId, result1.events);
+
+    const refireInvocations = new Map<string, number>();
+    const refireInvokeStep: StepInvoker = async ({ agent }) => {
+      refireInvocations.set(
+        agent.id,
+        (refireInvocations.get(agent.id) ?? 0) + 1,
+      );
+      throw new Error("agent boom");
+    };
+    const env2: WorkflowRuntimeEnv = {
+      ...env1,
+      repoStore: repoStore2,
+      blobs,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore2, clock }),
+      signalChannel: createInMemorySignalChannel(),
+      invokeStep: refireInvokeStep,
+    };
+
+    const result2 = await runtimeRun(def, env2, {
+      runId: result1.runId,
+    }).complete;
+
+    // No re-drive: the agent is not invoked, and the terminal result
+    // matches the surviving log.
+    expect(refireInvocations.get("solo")).toBeUndefined();
+    expect(result2.terminalStatus).toBe("failed");
+    expect(result2.events.some((e) => e.kind === "RunFailed")).toBe(true);
+
+    // The re-fire did not append a second terminal event.
+    const terminalCount = result2.events.filter(
+      (e) =>
+        e.kind === "RunFailed" ||
+        e.kind === "RunCompleted" ||
+        e.kind === "RunCancelled",
+    ).length;
+    expect(terminalCount).toBe(1);
+  });
+
+  test("a completed multi-step terminal log is returned byte-for-byte identical with no re-drive", async () => {
+    // Exercises the `completed` branch of the terminal short-circuit and
+    // pins reconstruction fidelity: the reload-and-return result must
+    // equal the original live-path RunResult field for field (runId,
+    // terminalStatus, hydrated outputs, full event log), not merely carry
+    // the same terminal status.
+    const def = defineWorkflow({
+      id: "refire-completed-fidelity",
+      trigger: { type: "manual" },
+      steps: {
+        a: step({ agent: makeAgent("agent-a") }),
+        b: step({ agent: makeAgent("agent-b"), after: ["a"] }),
+      },
+    });
+
+    const invokeStep: StepInvoker = async ({ agent, input }) => ({
+      output: { by: agent.id, saw: input },
+    });
+    const clock = () => new Date();
+    const blobs = createInMemoryBlobSubstrate();
+    const repoStore1 = createInMemoryRepoStore();
+    const env1: WorkflowRuntimeEnv = {
+      repoStore: repoStore1,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore1, clock }),
+      signalChannel: createInMemorySignalChannel(),
+      blobs,
+      directors: createDefaultDirectorRegistry(),
+      authorize: async () => ({
+        effect: "allow",
+        matchingGrants: [],
+        resolvedBy: null,
+      }),
+      invokeStep,
+      spawnChild: async () => ({ terminalStatus: "completed" }),
+      clock,
+      newId: (prefix) => `${prefix}-${Math.random().toString(36).slice(2, 8)}`,
+      drain: createNoopDrainController(def),
+    };
+
+    const result1 = await runtimeRun(def, env1).complete;
+    expect(result1.terminalStatus).toBe("completed");
+
+    // Re-fire against the full completed log in a fresh store, sharing the
+    // blob substrate so the recorded output refs still resolve.
+    const repoStore2 = createInMemoryRepoStore();
+    await seedStore(repoStore2, result1.runId, result1.events);
+
+    const refireInvocations = new Map<string, number>();
+    const refireInvokeStep: StepInvoker = async ({ agent }) => {
+      refireInvocations.set(
+        agent.id,
+        (refireInvocations.get(agent.id) ?? 0) + 1,
+      );
+      return { output: { by: agent.id } };
+    };
+    const env2: WorkflowRuntimeEnv = {
+      ...env1,
+      repoStore: repoStore2,
+      blobs,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore2, clock }),
+      signalChannel: createInMemorySignalChannel(),
+      invokeStep: refireInvokeStep,
+    };
+
+    const result2 = await runtimeRun(def, env2, {
+      runId: result1.runId,
+    }).complete;
+
+    expect(refireInvocations.size).toBe(0);
+    expect(result2.runId).toBe(result1.runId);
+    expect(result2.terminalStatus).toBe("completed");
+    expect(result2.outputs).toEqual(result1.outputs);
+    expect(result2.events).toEqual(result1.events);
+  });
+
+  test("a cancelled terminal log is returned as-is with no re-drive", async () => {
+    // Exercises the `cancelled` branch of the terminal short-circuit. The
+    // first run's step blocks until aborted so a mid-flight cancel settles
+    // it `cancelled`; the re-fire against that log must return `cancelled`
+    // without re-invoking the agent or appending a second terminal event.
+    const def = defineWorkflow({
+      id: "refire-cancelled-noop",
+      trigger: { type: "manual" },
+      steps: {
+        s: step({ agent: makeAgent("solo") }),
+      },
+    });
+
+    const blockingInvokeStep: StepInvoker = async ({ signal }) =>
+      new Promise((_resolve, reject) => {
+        if (signal.aborted) {
+          reject(new Error("aborted"));
+          return;
+        }
+        signal.addEventListener("abort", () => reject(new Error("aborted")), {
+          once: true,
+        });
+      });
+    const clock = () => new Date();
+    const blobs = createInMemoryBlobSubstrate();
+    const repoStore1 = createInMemoryRepoStore();
+    const env1: WorkflowRuntimeEnv = {
+      repoStore: repoStore1,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore1, clock }),
+      signalChannel: createInMemorySignalChannel(),
+      blobs,
+      directors: createDefaultDirectorRegistry(),
+      authorize: async () => ({
+        effect: "allow",
+        matchingGrants: [],
+        resolvedBy: null,
+      }),
+      invokeStep: blockingInvokeStep,
+      spawnChild: async () => ({ terminalStatus: "completed" }),
+      clock,
+      newId: (prefix) => `${prefix}-${Math.random().toString(36).slice(2, 8)}`,
+      drain: createNoopDrainController(def),
+    };
+
+    const handle = runtimeRun(def, env1);
+    // Let the step reach in-flight, then cancel so it settles cancelled.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await handle.cancel("self", "test cancel");
+    const result1 = await handle.complete;
+    expect(result1.terminalStatus).toBe("cancelled");
+    expect(result1.events.some((e) => e.kind === "RunCancelled")).toBe(true);
+
+    const repoStore2 = createInMemoryRepoStore();
+    await seedStore(repoStore2, result1.runId, result1.events);
+
+    const refireInvocations = new Map<string, number>();
+    const refireInvokeStep: StepInvoker = async ({ agent }) => {
+      refireInvocations.set(
+        agent.id,
+        (refireInvocations.get(agent.id) ?? 0) + 1,
+      );
+      return { output: null };
+    };
+    const env2: WorkflowRuntimeEnv = {
+      ...env1,
+      repoStore: repoStore2,
+      blobs,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore2, clock }),
+      signalChannel: createInMemorySignalChannel(),
+      invokeStep: refireInvokeStep,
+    };
+
+    const result2 = await runtimeRun(def, env2, {
+      runId: result1.runId,
+    }).complete;
+
+    expect(refireInvocations.size).toBe(0);
+    expect(result2.terminalStatus).toBe("cancelled");
+    expect(result2.events).toEqual(result1.events);
+
+    const terminalCount = result2.events.filter(
+      (e) =>
+        e.kind === "RunFailed" ||
+        e.kind === "RunCompleted" ||
+        e.kind === "RunCancelled",
+    ).length;
+    expect(terminalCount).toBe(1);
+  });
+});
+
+describe("seeded resume adopts a completed step by skip", () => {
+  test("a resumeFromEvents seed truncated at a completed step hydrates its output and runs the dependent once", async () => {
+    // The seeded-resume side of the reload-at-entry restructuring: state
+    // is established from the durable log after the seed is written, so a
+    // seed truncated at `a`'s StepCompleted leaves `a` completed (adopted
+    // by skip, NOT re-invoked) and `b` schedulable. `a`'s output is
+    // hydrated from the canonical log so `b`'s default-input selector
+    // (`steps.a.output`) resolves.
+    const def = defineWorkflow({
+      id: "seeded-resume-adopt-completed",
+      trigger: { type: "manual" },
+      steps: {
+        a: step({ agent: makeAgent("agent-a") }),
+        b: step({ agent: makeAgent("agent-b"), after: ["a"] }),
+      },
+    });
+
+    const invokeStep: StepInvoker = async ({ agent, input }) => ({
+      output: { by: agent.id, saw: input },
+    });
+    const clock = () => new Date();
+    const blobs = createInMemoryBlobSubstrate();
+    const repoStore1 = createInMemoryRepoStore();
+    const env1: WorkflowRuntimeEnv = {
+      repoStore: repoStore1,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore1, clock }),
+      signalChannel: createInMemorySignalChannel(),
+      blobs,
+      directors: createDefaultDirectorRegistry(),
+      authorize: async () => ({
+        effect: "allow",
+        matchingGrants: [],
+        resolvedBy: null,
+      }),
+      invokeStep,
+      spawnChild: async () => ({ terminalStatus: "completed" }),
+      clock,
+      newId: (prefix) => `${prefix}-${Math.random().toString(36).slice(2, 8)}`,
+      drain: createNoopDrainController(def),
+    };
+
+    const result1 = await runtimeRun(def, env1).complete;
+    expect(result1.terminalStatus).toBe("completed");
+
+    // Truncate the seed at `a`'s StepCompleted, inclusive: `a` is done,
+    // `b` has no StepStarted yet.
+    const seed: WorkflowEvent[] = [];
+    for (const e of result1.events) {
+      seed.push(e);
+      if (e.kind === "StepCompleted" && e.stepId === "a") {
+        break;
+      }
+    }
+    expect(seed.some((e) => e.kind === "StepStarted" && e.stepId === "b")).toBe(
+      false,
+    );
+
+    // Resume into a FRESH empty store via resumeFromEvents (not a bare
+    // re-fire): state must be established from the seed written into the
+    // store. Share the blob substrate so `a`'s recorded output resolves.
+    const repoStore2 = createInMemoryRepoStore();
+    const resumeInvocations = new Map<string, number>();
+    const resumeInvokeStep: StepInvoker = async ({ agent, input }) => {
+      resumeInvocations.set(
+        agent.id,
+        (resumeInvocations.get(agent.id) ?? 0) + 1,
+      );
+      return { output: { by: agent.id, saw: input } };
+    };
+    const env2: WorkflowRuntimeEnv = {
+      ...env1,
+      repoStore: repoStore2,
+      blobs,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore2, clock }),
+      signalChannel: createInMemorySignalChannel(),
+      invokeStep: resumeInvokeStep,
+    };
+
+    const result2 = await runtimeRun(def, env2, {
+      runId: result1.runId,
+      resumeFromEvents: seed,
+    }).complete;
+
+    // `a` adopted by skip (not re-invoked); `b` runs exactly once.
+    expect(resumeInvocations.get("agent-a")).toBeUndefined();
+    expect(resumeInvocations.get("agent-b")).toBe(1);
+    expect(result2.terminalStatus).toBe("completed");
+
+    // `a`'s output was hydrated from the canonical log, so it is present
+    // and `b` saw it through its default-input selector.
+    expect(result2.outputs.a).toEqual({ by: "agent-a", saw: null });
+    expect(result2.outputs.b).toEqual({
+      by: "agent-b",
+      saw: { by: "agent-a", saw: null },
+    });
+  });
+});

--- a/packages/workflow/src/runtime/resume-mid-agent-step.test.ts
+++ b/packages/workflow/src/runtime/resume-mid-agent-step.test.ts
@@ -1,0 +1,245 @@
+// Property: an agent step's side effect runs at most once across a
+// mid-step crash. The runtime flushes `StepStarted` durably before it
+// invokes the agent, so a crash mid-invocation leaves a durable marker
+// with no `StepCompleted`. On resume, the runtime settles that residual
+// in-flight step as a terminal `StepFailed` (the agent is NOT
+// re-invoked) and the run settles `RunFailed` with the crash reason,
+// rather than silently re-invoking the agent or stalling with no
+// terminal event.
+
+import { describe, test, expect } from "bun:test";
+
+import { createDefaultDirectorRegistry, defineAgent } from "@intx/agent";
+
+import {
+  createInMemoryBlobSubstrate,
+  createInMemoryRepoStore,
+  createInMemoryScheduler,
+  createInMemorySignalChannel,
+  createNoopDrainController,
+  defineWorkflow,
+  runtimeRun,
+  step,
+  type StepInvoker,
+  type WorkflowEvent,
+  type WorkflowRuntimeEnv,
+} from "@intx/workflow";
+
+function makeAgent(id: string) {
+  return defineAgent({
+    id,
+    systemPrompt: id,
+    tools: [],
+    capabilities: [],
+    inference: { sources: [{ provider: "fake", model: "fake" }] },
+  });
+}
+
+describe("resume mid-agent-step", () => {
+  test("a crash after StepStarted but before StepCompleted settles RunFailed without re-invoking the agent", async () => {
+    const def = defineWorkflow({
+      id: "midstep-resume",
+      trigger: { type: "manual" },
+      steps: {
+        s: step({ agent: makeAgent("solo") }),
+      },
+    });
+
+    let invocations = 0;
+    const invokeStep: StepInvoker = async ({ input }) => {
+      invocations += 1;
+      return { output: { processed: input } };
+    };
+    const clock = () => new Date();
+    const blobs = createInMemoryBlobSubstrate();
+    const repoStore1 = createInMemoryRepoStore();
+    const env1: WorkflowRuntimeEnv = {
+      repoStore: repoStore1,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore1, clock }),
+      signalChannel: createInMemorySignalChannel(),
+      blobs,
+      directors: createDefaultDirectorRegistry(),
+      authorize: async () => ({
+        effect: "allow",
+        matchingGrants: [],
+        resolvedBy: null,
+      }),
+      invokeStep,
+      spawnChild: async () => ({ terminalStatus: "completed" }),
+      clock,
+      newId: (prefix) => `${prefix}-${Math.random().toString(36).slice(2, 8)}`,
+      drain: createNoopDrainController(def),
+    };
+
+    const result1 = await runtimeRun(def, env1).complete;
+    expect(invocations).toBe(1);
+
+    // Truncate the first run's log at the agent step's own StepStarted,
+    // inclusive, to simulate a crash mid-invocation: the durable marker
+    // is present but StepCompleted never landed.
+    const trimmed: WorkflowEvent[] = [];
+    for (const e of result1.events) {
+      trimmed.push(e);
+      if (e.kind === "StepStarted" && e.stepId === "s") {
+        break;
+      }
+    }
+
+    // Resume against a FRESH repo store but the SAME blob substrate so
+    // the seed log's blob refs resolve.
+    const repoStore2 = createInMemoryRepoStore();
+    const env2: WorkflowRuntimeEnv = {
+      ...env1,
+      repoStore: repoStore2,
+      blobs,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore2, clock }),
+      signalChannel: createInMemorySignalChannel(),
+    };
+
+    const result2 = await runtimeRun(def, env2, {
+      runId: result1.runId,
+      resumeFromEvents: trimmed,
+    }).complete;
+
+    // The agent is invoked at most once: the resume did not re-invoke it.
+    expect(invocations).toBe(1);
+    expect(result2.terminalStatus).toBe("failed");
+    expect(result2.events.some((e) => e.kind === "RunFailed")).toBe(true);
+
+    const failures = result2.events.filter((e) => e.kind === "StepFailed");
+    expect(failures.length).toBeGreaterThan(0);
+    for (const f of failures) {
+      if (f.kind !== "StepFailed") throw new Error("unreachable");
+      expect(f.error.code).toBe("crash-mid-invocation");
+    }
+  });
+
+  test("a crashed mid-invocation step settles terminal while a still-runnable dependent runs to completion on resume", async () => {
+    // Two agent steps: `b` depends on `a`. `a` crashes mid-invocation
+    // (its StepStarted is durable, StepCompleted never landed) and `b`
+    // has not started yet. On resume, `a` settles terminal (StepFailed,
+    // NOT re-invoked); because a failed dependency counts as resolved,
+    // `b` is genuinely schedulable and runs to completion. The run still
+    // settles RunFailed because `a` failed.
+    // `b` names `a` in `after` (so it starts only after `a` settles) but
+    // takes an explicit literal input rather than the default-input
+    // convention's `{ from: "steps.a.output" }`: `a` fails with no
+    // output, so a `b` that read `a`'s output could never run. The
+    // literal input keeps `b` genuinely schedulable once `a` reaches a
+    // terminal (failed) phase.
+    const def = defineWorkflow({
+      id: "midstep-resume-dependent",
+      trigger: { type: "manual" },
+      steps: {
+        a: step({ agent: makeAgent("agent-a") }),
+        b: step({
+          agent: makeAgent("agent-b"),
+          after: ["a"],
+          input: { literal: { seed: 1 } },
+        }),
+      },
+    });
+
+    // Key the counter off the agent identity, not any request field the
+    // env does not carry: `StepInvokeRequest` has no top-level `stepId`,
+    // so keying on `agent.id` is what distinguishes the two agents'
+    // invocations. This makes the "`a` not re-invoked" assertion
+    // watertight rather than incidentally true.
+    const invocationsByAgent = new Map<string, number>();
+    const invokeStep: StepInvoker = async ({ agent, input }) => {
+      invocationsByAgent.set(
+        agent.id,
+        (invocationsByAgent.get(agent.id) ?? 0) + 1,
+      );
+      return { output: { processed: input, by: agent.id } };
+    };
+    const clock = () => new Date();
+    const blobs = createInMemoryBlobSubstrate();
+    const repoStore1 = createInMemoryRepoStore();
+    const env1: WorkflowRuntimeEnv = {
+      repoStore: repoStore1,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore1, clock }),
+      signalChannel: createInMemorySignalChannel(),
+      blobs,
+      directors: createDefaultDirectorRegistry(),
+      authorize: async () => ({
+        effect: "allow",
+        matchingGrants: [],
+        resolvedBy: null,
+      }),
+      invokeStep,
+      spawnChild: async () => ({ terminalStatus: "completed" }),
+      clock,
+      newId: (prefix) => `${prefix}-${Math.random().toString(36).slice(2, 8)}`,
+      drain: createNoopDrainController(def),
+    };
+
+    const result1 = await runtimeRun(def, env1).complete;
+    expect(invocationsByAgent.get("agent-a")).toBe(1);
+    expect(invocationsByAgent.get("agent-b")).toBe(1);
+
+    // Truncate at `a`'s StepStarted, inclusive: `a`'s StepCompleted is
+    // dropped (crash mid-invocation) and `b` has no StepStarted yet
+    // (it only starts after `a` completes, which never happened).
+    const trimmed: WorkflowEvent[] = [];
+    for (const e of result1.events) {
+      trimmed.push(e);
+      if (e.kind === "StepStarted" && e.stepId === "a") {
+        break;
+      }
+    }
+    expect(
+      trimmed.some((e) => e.kind === "StepCompleted" && e.stepId === "a"),
+    ).toBe(false);
+    expect(
+      trimmed.some((e) => e.kind === "StepStarted" && e.stepId === "b"),
+    ).toBe(false);
+
+    // Fresh counters for the resume so the assertions observe only what
+    // the resumed run invokes.
+    const resumeInvocations = new Map<string, number>();
+    const resumeInvokeStep: StepInvoker = async ({ agent, input }) => {
+      resumeInvocations.set(
+        agent.id,
+        (resumeInvocations.get(agent.id) ?? 0) + 1,
+      );
+      return { output: { processed: input, by: agent.id } };
+    };
+    const repoStore2 = createInMemoryRepoStore();
+    const env2: WorkflowRuntimeEnv = {
+      ...env1,
+      repoStore: repoStore2,
+      blobs,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore2, clock }),
+      signalChannel: createInMemorySignalChannel(),
+      invokeStep: resumeInvokeStep,
+    };
+
+    const result2 = await runtimeRun(def, env2, {
+      runId: result1.runId,
+      resumeFromEvents: trimmed,
+    }).complete;
+
+    // `a` is NOT re-invoked on resume; `b` runs exactly once.
+    expect(resumeInvocations.get("agent-a")).toBeUndefined();
+    expect(resumeInvocations.get("agent-b")).toBe(1);
+
+    // `b` reached completion on resume.
+    expect(
+      result2.events.some(
+        (e) => e.kind === "StepCompleted" && e.stepId === "b",
+      ),
+    ).toBe(true);
+
+    // The run settles RunFailed because `a` failed.
+    expect(result2.terminalStatus).toBe("failed");
+    expect(result2.events.some((e) => e.kind === "RunFailed")).toBe(true);
+
+    // The StepFailed for `a` carries the crash reason.
+    const aFailure = result2.events.find(
+      (e) => e.kind === "StepFailed" && e.stepId === "a",
+    );
+    if (aFailure?.kind !== "StepFailed") throw new Error("unreachable");
+    expect(aFailure.error.code).toBe("crash-mid-invocation");
+  });
+});

--- a/packages/workflow/src/runtime/run.ts
+++ b/packages/workflow/src/runtime/run.ts
@@ -25,6 +25,7 @@ import { hashDefinition } from "../definition/index";
 import { evaluate, type SelectorContext } from "./selectors";
 import {
   hasFailedStep,
+  isCrashedInvocationStep,
   isResumableAwaitingSignalStep,
   isResumableInFlightLoopStep,
   isResumableReceivedAwaitSignalStep,
@@ -67,10 +68,14 @@ export interface RuntimeRunOptions {
    * later), and an `awaitSignal` step (no timeout) left `in-flight` by an
    * already-logged `SignalReceived` (runAwaitSignal completes it from that
    * logged event -- the crash-after-signal-before-StepCompleted window).
-   * Seed logs whose tail leaves a step `awaiting-timer`, mid-`map`, or
-   * otherwise `in-flight` (including a timeout-bearing `awaitSignal` left
-   * `in-flight`, indistinguishable in reduced state from a fired timeout)
-   * stay unsupported and surface as `RuntimeResumeUnsupportedError`.
+   * A seed log whose tail leaves an invocation-boundary step -- an agent
+   * `step` or a deterministic `action` -- `in-flight` is a crash
+   * mid-invocation: the runtime settles it as a terminal `StepFailed`
+   * (at-most-once refusal) instead of re-invoking it. A step left
+   * `awaiting-timer`, mid-`map`, or otherwise `in-flight` (a
+   * `childWorkflow`, or a timeout-bearing `awaitSignal` left `in-flight`
+   * and indistinguishable in reduced state from a fired timeout) stays
+   * unsupported and surfaces as `RuntimeResumeUnsupportedError`.
    *
    * When omitted, the runtime starts fresh from `emptyState(runId)`
    * and emits `RunStarted` itself.
@@ -96,13 +101,16 @@ export interface RuntimeRunOptions {
  *      boundaries, or left in one of the resumable carve-outs: an
  *      in-flight `loop` container, or an `awaitSignal` step (still
  *      `awaiting-signal`, or -- with no timeout -- `in-flight` from a
- *      received signal). A step left `awaiting-timer`, mid-`map`, or
+ *      received signal). An invocation-boundary step -- an agent `step`
+ *      or a deterministic `action` -- left `in-flight` is a crash
+ *      mid-invocation and settles as a terminal `StepFailed` rather
+ *      than re-invoking. A step left `awaiting-timer`, mid-`map`, or
  *      otherwise `in-flight` (including a timeout-bearing `awaitSignal`
  *      left `in-flight`) is unsupported: the runtime body has no surface
  *      for re-arming the timer scheduler entry or the inner-map
- *      iteration state from the log alone. Such seed logs surface as
- *      `RuntimeResumeUnsupportedError`; the host (supervisor) owns the
- *      recovery decision.
+ *      iteration state from the log alone, so it surfaces as
+ *      `RuntimeResumeUnsupportedError` and the host (supervisor) owns
+ *      the recovery decision.
  */
 export function runtimeRun(
   definition: WorkflowDefinition,
@@ -218,9 +226,13 @@ function commit(
 // pending buffer (this event LAST) in one durable `appendBatch`. Used
 // for the terminal events (RunCompleted/RunFailed/RunCancelled) so the
 // terminal is on disk -- and the supervisor's terminal-write sniff
-// fires -- the moment the commit resolves, and for the control-plane
-// `cancel` whose `CancelRequested` must persist immediately. The
-// terminal event being the last blob in the merge keeps the
+// fires -- the moment the commit resolves, for the control-plane
+// `cancel` whose `CancelRequested` must persist immediately, and for
+// the agent-invoke barrier in `runStep` (the agent step's `StepStarted`
+// is flushed durably before `env.invokeStep` runs, so a crash
+// mid-invocation leaves a durable marker the recovery path settles as a
+// terminal failure rather than re-invoking the non-idempotent agent).
+// The terminal event being the last blob in the merge keeps the
 // workflow-run kind handler's terminal-lock satisfied.
 function commitDurable(
   env: WorkflowRuntimeEnv,
@@ -290,16 +302,30 @@ async function executeRunBody(
     await env.repoStore.append(runId, event);
   }
 
-  // Reject seed logs that leave any step in a non-terminal phase the
+  // Classify seed logs that leave a step in a non-terminal phase the
   // runtime body cannot re-arm. The DAG's `nextSchedulable` skips any
   // step that already appears in `state.steps` (the safe-runner needs
   // a fresh `StepStarted` to advance one), so a step left
   // `in-flight`, `awaiting-signal`, or `awaiting-timer` would stall
-  // the main loop with no schedulable primitive. Surface the
-  // limitation honestly rather than dressing it up as a generic
-  // stall: the host decides whether to crash, alert, or recover via
-  // redeploy. Cancellation paths are exempt -- the cleanup branch
-  // owns settling steps whose phase is `cancelling`.
+  // the main loop with no schedulable primitive. Cancellation paths are
+  // exempt -- the cleanup branch owns settling steps whose phase is
+  // `cancelling`.
+  //
+  // A residual `in-flight` step whose primitive is an invocation
+  // boundary (`isCrashedInvocationStep`: an agent `step` or an `action`)
+  // is a crash mid-invocation: its `StepStarted` is durable but no
+  // `StepCompleted` landed, and the invoked primitive is
+  // non-deterministic and unrecorded, so it cannot be replayed
+  // exactly-once. Rather than re-invoke it (at-most-once refusal), settle
+  // it as a terminal `StepFailed`. Every OTHER non-terminal residual --
+  // an `in-flight` coordination container (mid-`map`, timeout-bearing
+  // `awaitSignal` reduced to `in-flight`, `childWorkflow`), or an
+  // `awaiting-signal`/`awaiting-timer` step -- still surfaces
+  // `RuntimeResumeUnsupportedError`: those have a live re-arming surface
+  // the host owns (rebuild the map state, distinguish a fired timeout
+  // from a received signal, re-park on a later signal), so declining
+  // honestly is correct there.
+  const crashedInFlight: { stepId: string; attempt: number }[] = [];
   if (initialEvents.length > 0 && state.phase === "running") {
     for (const [stepId, stepState] of state.steps) {
       // Resumable carve-outs, each re-offered by `nextSchedulable` on the
@@ -313,8 +339,6 @@ async function executeRunBody(
       //     already-logged `SignalReceived`: runAwaitSignal short-circuits
       //     to completion from that logged event (the
       //     crash-after-signal-before-StepCompleted window).
-      // Every other in-flight or awaiting-timer step stays rejected
-      // byte-for-byte: the runtime has no surface to re-arm those.
       if (
         isResumableInFlightLoopStep(definition, stepId, stepState.phase) ||
         isResumableAwaitingSignalStep(definition, stepId, stepState.phase) ||
@@ -322,6 +346,20 @@ async function executeRunBody(
       ) {
         continue;
       }
+      // A crashed-mid-invocation step (agent step or action). Collect it
+      // for terminal settling AFTER this loop -- committing StepFailed
+      // inline would leave `state` stale and merely relocate the stall to
+      // the main loop. A crashed in-flight action lands here too and is
+      // settled terminal (it stalls today; this is strictly better).
+      if (isCrashedInvocationStep(definition, stepId, stepState.phase)) {
+        crashedInFlight.push({
+          stepId,
+          attempt: stepState.currentAttempt,
+        });
+        continue;
+      }
+      // Every other non-terminal residual keeps declining: the host owns
+      // the recovery decision (crash, alert, or redeploy).
       if (
         stepState.phase === "in-flight" ||
         stepState.phase === "awaiting-signal" ||
@@ -334,6 +372,27 @@ async function executeRunBody(
         );
       }
     }
+  }
+
+  // Settle each crashed-mid-invocation step as a terminal `StepFailed`
+  // (`retriesExhausted: true`), advancing `state`/`seq` per commit. This
+  // moves the step to phase `failed`, so `nextSchedulable` will not
+  // re-schedule it and the agent is never re-invoked; the post-loop
+  // `hasFailedStep` path is left to commit `RunFailed` and settle the run.
+  for (const { stepId, attempt } of crashedInFlight) {
+    const failed: WorkflowEvent = {
+      kind: "StepFailed",
+      seq: state.lastSeq + 1,
+      at: env.clock().toISOString(),
+      stepId,
+      attempt,
+      error: {
+        message: `step ${stepId} crashed mid-invocation; the invoked primitive is non-deterministic and unrecorded, so it is not re-invoked (at-most-once)`,
+        code: "crash-mid-invocation",
+      },
+      retriesExhausted: true,
+    };
+    state = await commitDurable(env, runId, failed);
   }
 
   // Issue RunStarted only if the state machine has not seen it.
@@ -866,6 +925,25 @@ async function runPrimitiveSafe(
   }
 }
 
+/**
+ * Run an agent step (the agent path; `runAction` is the separate action
+ * path).
+ *
+ * Agent-invoke durability barrier: the step's `StepStarted` is flushed
+ * durably via `commitDurable` BEFORE `env.invokeStep` is called, not
+ * left in the run-body buffer. The agent invocation is a
+ * non-deterministic, potentially non-idempotent side effect that the
+ * runtime cannot record exactly-once; flushing the marker first means a
+ * crash mid-invocation leaves a durable `StepStarted` with no
+ * `StepCompleted`, which the recovery path in `executeRunBody` settles
+ * as a terminal failure rather than silently re-invoking the agent
+ * (at-most-once). On a fresh single-step run this flush carries the
+ * still-buffered `RunStarted` to durable storage together with the
+ * `StepStarted` in one batch, so both are on disk before the agent
+ * runs. `StepStarted` is emitted exactly once per step (the
+ * `stepStartedEmitted` guard), so retry attempts re-enter without a
+ * second flush.
+ */
 async function runStep(
   env: WorkflowRuntimeEnv,
   runId: string,
@@ -915,7 +993,7 @@ async function runStep(
         attempt,
         input: { ref: inputRef },
       };
-      state = await commit(env, runId, started);
+      state = await commitDurable(env, runId, started);
       void state;
       stepStartedEmitted = true;
     }

--- a/packages/workflow/src/runtime/run.ts
+++ b/packages/workflow/src/runtime/run.ts
@@ -77,8 +77,12 @@ export interface RuntimeRunOptions {
    * and indistinguishable in reduced state from a fired timeout) stays
    * unsupported and surfaces as `RuntimeResumeUnsupportedError`.
    *
-   * When omitted, the runtime starts fresh from `emptyState(runId)`
-   * and emits `RunStarted` itself.
+   * When omitted, the runtime reduces canonical state from the durable
+   * log for `runId`: an empty log starts fresh and emits `RunStarted`;
+   * a non-terminal log is adopted and driven to terminal -- the same
+   * recovery the seed path performs, for a supervisor re-fire that
+   * carries no seed; an already-terminal log is returned as-is without
+   * re-driving.
    */
   resumeFromEvents?: readonly WorkflowEvent[];
 }
@@ -88,8 +92,10 @@ export interface RuntimeRunOptions {
  * single runtime body invoked by both `runLocal` and the (future)
  * child-process entry point.
  *
- * Resume contract: when `options.resumeFromEvents` is supplied, the
- * seed log must satisfy two constraints:
+ * Resume contract: recovery runs against canonical state, whether it
+ * arrived as an `options.resumeFromEvents` seed or was reduced from a
+ * durable log this call adopts (a supervisor re-fire that carries no
+ * seed). A supplied seed log must satisfy two constraints:
  *
  *   1. The env's `BlobSubstrate` either holds the blob: refs the seed
  *      log references, or is durable enough that the refs are
@@ -270,7 +276,6 @@ async function executeRunBody(
   options: RuntimeRunOptions,
 ): Promise<RunResult> {
   const initialEvents = options.resumeFromEvents ?? [];
-  let state = resumeFromLog(runId, initialEvents);
 
   // Restore prior events to the repo store on resume so a downstream
   // read sees the historical log alongside any newly-appended events.
@@ -302,12 +307,59 @@ async function executeRunBody(
     await env.repoStore.append(runId, event);
   }
 
-  // Classify seed logs that leave a step in a non-terminal phase the
-  // runtime body cannot re-arm. The DAG's `nextSchedulable` skips any
-  // step that already appears in `state.steps` (the safe-runner needs
-  // a fresh `StepStarted` to advance one), so a step left
-  // `in-flight`, `awaiting-signal`, or `awaiting-timer` would stall
-  // the main loop with no schedulable primitive. Cancellation paths are
+  // Seed-contract guard, before any blob resolution. A resume that
+  // supplied `resumeFromEvents` referencing blob: refs requires the
+  // BlobSubstrate that recorded them; the runLocal in-memory substrate
+  // is ephemeral and starts empty, so it cannot serve them. Fail with a
+  // targeted error naming the contract rather than a deep
+  // `resolveRef`-miss surfacing downstream. This must run BEFORE the
+  // terminal short-circuit's `buildResultFromLog` and the canonical-log
+  // hydration below -- both call `resolveRef`, and either would otherwise
+  // hit the raw "unknown blob ref" failure first. Keyed on
+  // `initialEvents` because it is the seed contract: it fires for a
+  // seeded resume whether the seeded log is terminal or not, and is a
+  // no-op for a fresh re-fire that supplied no seed.
+  const seedBlobRefs = initialEvents.filter(
+    (e): e is typeof e & { kind: "StepCompleted" } =>
+      e.kind === "StepCompleted" && e.output.ref.startsWith("blob:"),
+  );
+  if (seedBlobRefs.length > 0 && env.blobs.ephemeral) {
+    throw new Error(
+      `resume requires the BlobSubstrate that recorded the seed log's blob refs (${String(seedBlobRefs.length)} blob output(s) present); the runLocal in-memory substrate is ephemeral and starts empty. Pass the originating env, or use a durable substrate.`,
+    );
+  }
+
+  // Establish canonical state from the durable log itself, not from the
+  // seed array. The seed may have arrived two ways -- as a
+  // `resumeFromEvents` array this process just wrote, or as a log a
+  // prior (crashed) process left on disk that this process is re-firing
+  // fresh (the supervisor re-fires a parked inbound message with
+  // `runId = messageId` and NO `resumeFromEvents`). Reducing the durable
+  // log answers the only question that matters for recovery -- "does the
+  // canonical log carry residual work?" -- identically for both, so
+  // every decision below (terminal short-circuit, crashed-in-flight
+  // settling, the RunStarted emit) keys on canonical state rather than
+  // on how the events reached this process.
+  let state = await reloadState(env, runId);
+
+  // Terminal short-circuit. A re-fire whose canonical log is already
+  // terminal (`completed`/`failed`/`cancelled`) must NOT emit a fresh
+  // `RunStarted` -- that throws `TransitionError("terminal-phase")`,
+  // uncaught, and rejects the run. Return the existing terminal result
+  // reconstructed from the durable log, matching the shape the live
+  // terminal path below produces (`emitTerminalEvent` and the child
+  // entry point walk `events` for the terminal event and read
+  // `terminalStatus`).
+  if (isTerminalRunPhase(state.phase)) {
+    return buildResultFromLog(env, runId, state);
+  }
+
+  // Classify residual steps the canonical log leaves in a non-terminal
+  // phase the runtime body cannot re-arm. The DAG's `nextSchedulable`
+  // skips any step that already appears in `state.steps` (the safe-runner
+  // needs a fresh `StepStarted` to advance one), so a step left
+  // `in-flight`, `awaiting-signal`, or `awaiting-timer` would stall the
+  // main loop with no schedulable primitive. Cancellation paths are
   // exempt -- the cleanup branch owns settling steps whose phase is
   // `cancelling`.
   //
@@ -325,8 +377,16 @@ async function executeRunBody(
   // the host owns (rebuild the map state, distinguish a fired timeout
   // from a received signal, re-park on a later signal), so declining
   // honestly is correct there.
+  //
+  // The pass runs whenever canonical state is `running`, whether the
+  // residual arrived via a `resumeFromEvents` seed OR was adopted from a
+  // durable log this process is re-firing fresh. Keying on
+  // `state.phase === "running"` (not on whether a seed was supplied) is
+  // what settles a crashed step under the fresh re-fire recovery; the
+  // RunStarted emit below is skipped in that case because the canonical
+  // phase is already `running`.
   const crashedInFlight: { stepId: string; attempt: number }[] = [];
-  if (initialEvents.length > 0 && state.phase === "running") {
+  if (state.phase === "running") {
     for (const [stepId, stepState] of state.steps) {
       // Resumable carve-outs, each re-offered by `nextSchedulable` on the
       // SAME predicate:
@@ -368,7 +428,7 @@ async function executeRunBody(
         throw new RuntimeResumeUnsupportedError(
           stepId,
           stepState.phase,
-          `seed log tail leaves step ${stepId} in phase ${stepState.phase} with no schedulable primitive on the DAG`,
+          `durable log leaves step ${stepId} in phase ${stepState.phase} with no schedulable primitive on the DAG`,
         );
       }
     }
@@ -411,27 +471,18 @@ async function executeRunBody(
     try {
       state = await commit(env, runId, event);
     } catch (cause) {
-      // Two distinct callers land a `code: "phase"` rejection here; do
-      // NOT narrow this to either one -- both must reload and continue:
-      //
-      //   1. A `cancel("self", ...)` racing the very first `RunStarted`
-      //      commit lands `CancelRequested` first (legal from `pending`
-      //      since the state-machine admits early-lifecycle cancellation).
-      //      The chain reloads, sees phase=cancelling, and rejects
-      //      `RunStarted`. Proceeding routes through the cancellation
-      //      cleanup branch and emits `RunCancelled`.
-      //   2. A FRESH run (no `resumeFromEvents`) started against a runId
-      //      whose durable log ALREADY carries a `RunStarted` -- the
-      //      host's re-trigger recovery: the supervisor re-fires a parked
-      //      inbound message (its `runId` is the messageId) as a new run
-      //      after a crash. The chain reads the existing log (phase
-      //      already `running`), so this `RunStarted` is rejected.
-      //      Reloading adopts the durable log, and the main loop resumes
-      //      the run from its actual frontier via `nextSchedulable`
-      //      (which skips already-terminal steps -- adopt-by-skip -- so
-      //      completed steps are NOT re-executed). Narrowing this catch to
-      //      the cancel case would break that recovery: a re-triggered run
-      //      would throw instead of adopting the log.
+      // This block is reached only when canonical state was `pending`
+      // (an empty or RunStarted-less log), so the fresh re-fire recovery
+      // -- whose canonical log already carries `RunStarted` -- never
+      // lands here: reload-at-entry sees its `running`/terminal phase and
+      // skips this emit entirely. The one race that still lands a
+      // `code: "phase"` rejection is a `cancel("self", ...)` that beats
+      // this very first `RunStarted` commit: `CancelRequested` is legal
+      // from `pending` (the state machine admits early-lifecycle
+      // cancellation), so the chain reloads, sees phase=cancelling, and
+      // rejects `RunStarted`. Reload and continue -- proceeding routes
+      // through the cancellation cleanup branch and emits `RunCancelled`.
+      // Any other rejection is a real error and must surface.
       if (cause instanceof TransitionError && cause.code === "phase") {
         state = await reloadState(env, runId);
       } else {
@@ -442,27 +493,19 @@ async function executeRunBody(
 
   const inFlight = new Set<string>();
   const stepOutputs: Record<string, unknown> = {};
-  // On resume, hydrate stepOutputs from the log's StepCompleted events
-  // so downstream steps can resolve `{ from: "steps.<id>.output" }`
-  // selectors. Without hydration, the runtime starts with an empty
-  // stepOutputs and any selector referencing a previously-completed
-  // step's output throws, landing as a spurious StepFailed.
-  //
-  // Every primitive that produces a value commits its StepCompleted
-  // with a substrate-resolvable ref (inline:<json> or blob:<key>);
-  // there are no marker refs to filter. An ephemeral substrate that
-  // cannot serve the seed log's blob refs surfaces here as a
-  // targeted error rather than a deep resolve failure.
-  const seedBlobRefs = initialEvents.filter(
-    (e): e is typeof e & { kind: "StepCompleted" } =>
-      e.kind === "StepCompleted" && e.output.ref.startsWith("blob:"),
-  );
-  if (seedBlobRefs.length > 0 && env.blobs.ephemeral) {
-    throw new Error(
-      `resume requires the BlobSubstrate that recorded the seed log's blob refs (${String(seedBlobRefs.length)} blob output(s) present); the runLocal in-memory substrate is ephemeral and starts empty. Pass the originating env, or use a durable substrate.`,
-    );
-  }
-  for (const event of initialEvents) {
+  // Hydrate stepOutputs from the canonical log's StepCompleted events so
+  // downstream steps can resolve `{ from: "steps.<id>.output" }`
+  // selectors against work that completed before this process took over
+  // -- whether that work arrived as a `resumeFromEvents` seed or was
+  // adopted from a durable log this process is re-firing fresh (the
+  // adopt-by-skip frontier). Without hydration, the runtime starts with
+  // an empty stepOutputs and any selector referencing a
+  // previously-completed step's output throws, landing as a spurious
+  // StepFailed. The ephemeral-substrate seed-contract guard that
+  // protects these `resolveRef` calls runs up front, before any blob
+  // resolution.
+  const canonicalLog = await env.repoStore.read(runId);
+  for (const event of canonicalLog) {
     if (event.kind !== "StepCompleted") continue;
     stepOutputs[event.stepId] = await env.blobs.resolveRef(event.output.ref);
   }
@@ -653,6 +696,42 @@ async function executeRunBody(
     outputs: stepOutputs,
     events,
   };
+}
+
+/**
+ * Reconstruct the terminal `RunResult` for a run whose canonical log is
+ * already terminal, without re-driving it. Used by the fresh-re-fire
+ * terminal short-circuit: a re-fire against an already-terminal durable
+ * log must return the existing result rather than emit a fresh
+ * `RunStarted` (which would throw `terminal-phase`).
+ *
+ * The shape matches the live terminal path at the tail of
+ * `executeRunBody` byte-for-byte: `terminalStatus` derived from the
+ * (already terminal) `state.phase`, `events` read from the durable log
+ * (so it carries the terminal event `emitTerminalEvent` and the child
+ * entry point walk for), and `outputs` hydrated from the log's
+ * `StepCompleted` refs (the live path threads in-process `stepOutputs`,
+ * which for a run driven end to end holds exactly those completed-step
+ * outputs).
+ */
+async function buildResultFromLog(
+  env: WorkflowRuntimeEnv,
+  runId: string,
+  state: ReturnType<typeof resumeFromLog>,
+): Promise<RunResult> {
+  const events = await env.repoStore.read(runId);
+  const outputs: Record<string, unknown> = {};
+  for (const event of events) {
+    if (event.kind !== "StepCompleted") continue;
+    outputs[event.stepId] = await env.blobs.resolveRef(event.output.ref);
+  }
+  const terminalStatus =
+    state.phase === "completed"
+      ? "completed"
+      : state.phase === "failed"
+        ? "failed"
+        : "cancelled";
+  return { runId, terminalStatus, outputs, events };
 }
 
 /**


### PR DESCRIPTION
## Summary

- An agent step flushes its `StepStarted` durably before the agent runs, so a
  crash mid-invocation leaves a durable marker; on recovery the crashed step
  settles as a terminal failure instead of the agent being silently re-invoked.
  Side effects are at-most-once across a mid-step crash rather than at-least-once.
  Exactly-once is unattainable for a non-deterministic agent, so the failure is
  loud and operator-visible.
- Crash recovery reduces canonical state from the durable log, so a supervisor
  re-fire that carries no seed adopts the surviving log — settling a crashed step,
  or short-circuiting an already-terminal run — instead of stalling.
- Each run is driven by a single driver on the child: a `trigger.fire` for a run
  self-discovery is already resuming is declined rather than spawning a second
  concurrent driver.

## Verification

`make all` exits 0 (lint, type-check, admin-ui bundle, and both test passes). New
runtime tests cover crash-mid-agent-step recovery (agent invoked at most once, run
settles `RunFailed` with a `crash-mid-invocation` reason), the no-seed adopted-log
re-fire (settle-and-fail and the terminal short-circuit across completed/failed/
cancelled), and the seeded adopt-by-skip case; a workflow-host test covers the
single-driver claim under a re-fired trigger.

Closes INTR-280