### PR TITLE
Flush an action's StepStarted durably before invoking it

### DIFF
--- a/packages/workflow/src/runtime/dag.ts
+++ b/packages/workflow/src/runtime/dag.ts
@@ -93,22 +93,17 @@ export function isResumableReceivedAwaitSignalStep(
 /**
  * An `in-flight` step whose primitive is an invocation boundary -- an
  * agent `step` or a deterministic `action` -- is a crash
- * mid-invocation, not a resumable coordination primitive: a
- * durable `StepStarted` with no `StepCompleted`, whose invoked
- * primitive is non-deterministic (agent) or already dedup-owned by its
- * effect ledger (action) and has no runtime-body re-arm surface, so it
- * cannot be re-invoked safely. The resume guard settles such a step as
- * a terminal `StepFailed` (at-most-once refusal) rather than throwing.
- *
- * How the `StepStarted` became durable differs by kind. An agent `step`
- * flushes its own before invoking (the `commitDurable` barrier in
- * `runStep`), so a lone crashed agent always leaves this residual. An
- * `action` does not: `runAction` commits `StepStarted` buffered, so a
- * lone crashed action drops it with the pending buffer and leaves no
- * residual at all. An action reaches this branch only incidentally --
- * when a concurrently-running step's `commitDurable` flush persisted the
- * action's buffered `StepStarted` first (the pending buffer is shared
- * per run). Settling that residual terminal still beats the prior stall.
+ * mid-invocation, not a resumable coordination primitive: a durable
+ * `StepStarted` with no `StepCompleted`, whose invoked primitive was
+ * dispatched once and has no runtime-body re-arm surface, so it cannot
+ * be re-invoked safely. Both kinds flush their `StepStarted` durably
+ * before invoking (the `commitDurable` barrier in `runStep` and
+ * `runAction`), so a lone crash of either always leaves this residual.
+ * The resume guard settles such a step as a terminal `StepFailed`
+ * (at-most-once refusal) rather than throwing. For an `action` the
+ * per-effect ledger is a deeper exactly-once line of defense for effects
+ * routed through the EffectContext; the barrier is what makes the action
+ * non-re-invocable at this layer.
  *
  * Container/coordination primitives left `in-flight` -- a `map` outer
  * step, a timeout-bearing `awaitSignal` reduced to `in-flight`, a

--- a/packages/workflow/src/runtime/resume-mid-action-step.test.ts
+++ b/packages/workflow/src/runtime/resume-mid-action-step.test.ts
@@ -1,0 +1,132 @@
+// Property: an action step's side effect runs at most once across a
+// mid-invocation crash. `runAction` flushes `StepStarted` durably before
+// it invokes the action handler, so the durable log at the instant of
+// invocation already carries `StepStarted` with no `StepCompleted`. A
+// crash there leaves that residual, which resume settles as a terminal
+// `StepFailed` (the action is NOT re-invoked) and the run settles
+// `RunFailed`.
+//
+// The crash is modelled by capturing the durable log at the first line of
+// `invokeAction` -- the exact state a power-loss at that instant would
+// leave -- and resuming from it. This is faithful where truncating a
+// completed run's log is not: a completed run flushes its whole buffer at
+// the terminal boundary, so its log carries the action's `StepStarted`
+// regardless of whether `runAction` made it durable at invoke time.
+// Without the barrier a lone action's `StepStarted` is buffered, unflushed
+// at invoke time, and absent from the captured snapshot -- so the resume
+// has no residual to settle and the property does not hold.
+
+import { describe, test, expect } from "bun:test";
+
+import { createDefaultDirectorRegistry } from "@intx/agent";
+
+import {
+  action,
+  createInMemoryBlobSubstrate,
+  createInMemoryRepoStore,
+  createInMemoryScheduler,
+  createInMemorySignalChannel,
+  createNoopDrainController,
+  defineWorkflow,
+  runtimeRun,
+  type ActionInvoker,
+  type StepInvoker,
+  type WorkflowEvent,
+  type WorkflowRuntimeEnv,
+} from "@intx/workflow";
+
+describe("resume mid-action-step", () => {
+  test("a lone action flushes StepStarted durably before invoking, so a mid-invocation crash settles RunFailed without re-invoking the action", async () => {
+    const def = defineWorkflow({
+      id: "midaction-resume",
+      trigger: { type: "manual" },
+      steps: {
+        act: action({ handler: "noop" }),
+      },
+    });
+
+    const runId = "midaction-run-fixed";
+    let invocations = 0;
+    // Capture the durable log at the instant the action is invoked: this
+    // is the true mid-invocation crash boundary. The barrier's effect is
+    // that this snapshot already carries the action's `StepStarted`.
+    let snapshotAtInvoke: readonly WorkflowEvent[] = [];
+    const invokeAction: ActionInvoker = async ({ input }) => {
+      invocations += 1;
+      // Copy to freeze the point-in-time view: the in-memory store's
+      // `read` returns its live array, which later appends mutate in
+      // place, so an un-copied reference would grow to the full log.
+      snapshotAtInvoke = [...(await env1.repoStore.read(runId))];
+      return { output: { processed: input } };
+    };
+    // Never invoked: the workflow has no agent step. Fail loudly if the
+    // runtime ever routes here, rather than masking a mis-wired test.
+    const invokeStep: StepInvoker = async () => {
+      throw new Error("invokeStep must not run for an action-only workflow");
+    };
+    const clock = () => new Date();
+    const blobs = createInMemoryBlobSubstrate();
+    const repoStore1 = createInMemoryRepoStore();
+    const env1: WorkflowRuntimeEnv = {
+      repoStore: repoStore1,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore1, clock }),
+      signalChannel: createInMemorySignalChannel(),
+      blobs,
+      directors: createDefaultDirectorRegistry(),
+      authorize: async () => ({
+        effect: "allow",
+        matchingGrants: [],
+        resolvedBy: null,
+      }),
+      invokeStep,
+      invokeAction,
+      spawnChild: async () => ({ terminalStatus: "completed" }),
+      clock,
+      newId: (prefix) => `${prefix}-${Math.random().toString(36).slice(2, 8)}`,
+      drain: createNoopDrainController(def),
+    };
+
+    await runtimeRun(def, env1, { runId }).complete;
+    expect(invocations).toBe(1);
+
+    // Load-bearing assertion: the barrier flushed `StepStarted` durably
+    // BEFORE the handler ran. Without the barrier the snapshot is empty
+    // (both `RunStarted` and the buffered `StepStarted` are unflushed at
+    // invoke time), and this fails -- which is what proves the test
+    // exercises the barrier rather than the kind-agnostic settle path.
+    expect(
+      snapshotAtInvoke.some(
+        (e) => e.kind === "StepStarted" && e.stepId === "act",
+      ),
+    ).toBe(true);
+
+    // Resume from the durable state as of the crash instant, against a
+    // FRESH repo store but the SAME blob substrate so the snapshot's blob
+    // refs resolve.
+    const repoStore2 = createInMemoryRepoStore();
+    const env2: WorkflowRuntimeEnv = {
+      ...env1,
+      repoStore: repoStore2,
+      blobs,
+      scheduler: createInMemoryScheduler({ repoStore: repoStore2, clock }),
+      signalChannel: createInMemorySignalChannel(),
+    };
+
+    const result2 = await runtimeRun(def, env2, {
+      runId,
+      resumeFromEvents: [...snapshotAtInvoke],
+    }).complete;
+
+    // The action is invoked at most once: the resume did not re-invoke it.
+    expect(invocations).toBe(1);
+    expect(result2.terminalStatus).toBe("failed");
+    expect(result2.events.some((e) => e.kind === "RunFailed")).toBe(true);
+
+    const failures = result2.events.filter((e) => e.kind === "StepFailed");
+    expect(failures.length).toBeGreaterThan(0);
+    for (const f of failures) {
+      if (f.kind !== "StepFailed") throw new Error("unreachable");
+      expect(f.error.code).toBe("crash-mid-invocation");
+    }
+  });
+});

--- a/packages/workflow/src/runtime/run.ts
+++ b/packages/workflow/src/runtime/run.ts
@@ -409,8 +409,7 @@ async function executeRunBody(
       // A crashed-mid-invocation step (agent step or action). Collect it
       // for terminal settling AFTER this loop -- committing StepFailed
       // inline would leave `state` stale and merely relocate the stall to
-      // the main loop. A crashed in-flight action lands here too and is
-      // settled terminal (it stalls today; this is strictly better).
+      // the main loop.
       if (isCrashedInvocationStep(definition, stepId, stepState.phase)) {
         crashedInFlight.push({
           stepId,
@@ -1209,14 +1208,24 @@ async function runStep(
 }
 
 /**
- * Execute a deterministic effect node. Mirrors the audit bracket the
- * other non-step runners use (StepStarted -> invoke -> StepCompleted via
- * the shared emit helpers) but calls `env.invokeAction` instead of
- * `env.invokeStep`. No retry loop: an action is single-attempt, so a
- * thrown effect lands `StepFailed` through `runPrimitiveSafe` like every
- * other non-step runner. Exactly-once lives in the handler's
- * EffectContext (per-effect ledger dedup), not here; the runtime records
- * only the audit events and the node output.
+ * Execute a deterministic effect node -- the action invocation boundary.
+ * Like `runStep`, the action's `StepStarted` is flushed durably via
+ * `commitDurable` BEFORE `env.invokeAction` runs, not left in the run-body
+ * buffer. An action handler can perform observable side effects the
+ * runtime cannot record exactly-once: the EffectContext ledger dedups
+ * only effects routed through `perform`, which is an author obligation the
+ * runtime cannot enforce. Flushing the marker first means a crash
+ * mid-invocation leaves a durable `StepStarted` with no `StepCompleted`,
+ * which the recovery path in `executeRunBody` settles as a terminal
+ * failure rather than re-invoking the handler (at-most-once). On a fresh
+ * single-action run this flush carries the still-buffered `RunStarted` to
+ * durable storage together with the `StepStarted` in one batch.
+ *
+ * No retry loop: an action is single-attempt, so a thrown effect lands
+ * `StepFailed` through `runPrimitiveSafe` like every other non-step
+ * runner. The per-effect ledger is a deeper exactly-once line of defense
+ * for effects routed through `perform`; the barrier here is what makes the
+ * action non-re-invocable at the runtime layer.
  */
 async function runAction(
   env: WorkflowRuntimeEnv,
@@ -1236,7 +1245,26 @@ async function runAction(
       ? evaluate(primitive.input, selectorCtx)
       : null;
   const input = rawInput === undefined ? null : rawInput;
-  await emitStepStartedWithValue(env, runId, primitive.id, input);
+  // Action-invoke durability barrier: flush `StepStarted` durably before
+  // `invokeAction` runs, inline like `runStep` rather than through the
+  // buffered `emitStepStartedWithValue` the coordination runners share.
+  // An action is single-attempt, so `attempt` is 1.
+  const { ref: inputRef } = await env.blobs.recordOutput(
+    `${primitive.id}.input`,
+    1,
+    input,
+  );
+  let started = await reloadState(env, runId);
+  const startedEvent: WorkflowEvent = {
+    kind: "StepStarted",
+    seq: started.lastSeq + 1,
+    at: env.clock().toISOString(),
+    stepId: primitive.id,
+    attempt: 1,
+    input: { ref: inputRef },
+  };
+  started = await commitDurable(env, runId, startedEvent);
+  void started;
 
   const actionAbort = new AbortController();
   const onOuter = (): void => {


### PR DESCRIPTION
## Summary

- `runAction` flushes the action's `StepStarted` durably before
  `env.invokeAction`, mirroring the agent-step barrier in `runStep`, so a
  lone action that crashes mid-invocation leaves a durable residual.
- The crash-recovery pass settles that residual as a terminal
  `StepFailed` (`crash-mid-invocation`) instead of silently re-invoking
  the handler, giving actions the same at-most-once crash semantics as
  agent steps.

## Verification

- `make all` passes: lint, `tsc -b --force`, the admin-ui bundle, and
  both test passes exit 0.
- `resume-mid-action-step.test.ts` captures the durable log at the
  instant of invocation and resumes from it, asserting the action is
  invoked at most once and the run settles `RunFailed`; the test fails
  when the barrier is reverted.

Closes INTR-284