### PR TITLE
Emit valid action sets on the director abort and halt paths

### DIFF
--- a/packages/inference/src/default-director.test.ts
+++ b/packages/inference/src/default-director.test.ts
@@ -20,6 +20,7 @@ import type {
   DefaultDirectorPolicy,
 } from "./default-director";
 import { createCapabilities } from "./director";
+import { validateActions } from "./actions";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -136,7 +137,7 @@ describe("DefaultDirector — afterInferenceDone hook", () => {
     ]);
   });
 
-  test("abort: returns [checkpoint, reply, done] with the policy reason", async () => {
+  test("abort: returns [checkpoint, done], reason not surfaced", async () => {
     const hook: AfterInferenceHook = () => ({
       type: "abort",
       reason: "budget exhausted",
@@ -147,12 +148,12 @@ describe("DefaultDirector — afterInferenceDone hook", () => {
     );
     expect(actions).toEqual([
       { type: "checkpoint", message: "checkpoint: after-inference-abort" },
-      { type: "reply", content: "budget exhausted" },
       { type: "done" },
     ]);
+    expect(validateActions(actions).ok).toBe(true);
   });
 
-  test("halt: returns [checkpoint, reply, wait] with the policy reason", async () => {
+  test("halt: returns [checkpoint, reply] with the policy reason", async () => {
     const hook: AfterInferenceHook = () => ({
       type: "halt",
       reason: "paused for top-up",
@@ -164,8 +165,8 @@ describe("DefaultDirector — afterInferenceDone hook", () => {
     expect(actions).toEqual([
       { type: "checkpoint", message: "checkpoint: after-inference-halt" },
       { type: "reply", content: "paused for top-up" },
-      { type: "wait" },
     ]);
+    expect(validateActions(actions).ok).toBe(true);
   });
 
   test("hook not set: existing behavior preserved", async () => {
@@ -179,7 +180,7 @@ describe("DefaultDirector — afterInferenceDone hook", () => {
     ]);
   });
 
-  test("hook throws: caught, routed to abort with synthesized reason", async () => {
+  test("hook throws: caught, routed to abort (terminates)", async () => {
     const hook: AfterInferenceHook = () => {
       throw new Error("policy died");
     };
@@ -189,10 +190,6 @@ describe("DefaultDirector — afterInferenceDone hook", () => {
     );
     expect(actions).toEqual([
       { type: "checkpoint", message: "checkpoint: after-inference-abort" },
-      {
-        type: "reply",
-        content: "afterInferenceDone policy threw: policy died",
-      },
       { type: "done" },
     ]);
   });
@@ -212,7 +209,6 @@ describe("DefaultDirector — afterInferenceDone hook", () => {
     );
     expect(actions).toEqual([
       { type: "checkpoint", message: "checkpoint: after-inference-abort" },
-      { type: "reply", content: "async abort" },
       { type: "done" },
     ]);
   });
@@ -251,7 +247,6 @@ describe("DefaultDirector — afterInferenceDone hook", () => {
     // policy authors about this; the test pins the behavior.
     expect(actions).toEqual([
       { type: "checkpoint", message: "checkpoint: after-inference-abort" },
-      { type: "reply", content: "stop now" },
       { type: "done" },
     ]);
   });

--- a/packages/inference/src/default-director.ts
+++ b/packages/inference/src/default-director.ts
@@ -1,6 +1,7 @@
 // Default conversational director — reference ReactorDirector implementation.
 //
-// Implements the decision table from INFERENCE.md § Director Decision Function:
+// Inbound-event → action map (see INFERENCE.md § Director Decision Function
+// for the director contract and action-validation rules):
 //
 //   message.received          → infer
 //   inference.done (tools)    → checkpoint + execute_tools
@@ -9,6 +10,10 @@
 //   inference.error           → checkpoint + reply (error message to user)
 //   abort                     → done
 //   reactor.gate.cleared      → checkpoint + infer (resume after gate)
+//
+// The inference.done branch additionally runs the optional afterInferenceDone
+// policy hook, whose continue/abort/halt decisions route independently of the
+// event map above. See AfterInferenceDecision for that contract.
 //
 // The director never throws. Inference errors are surfaced to the user as a
 // reply so the problem is visible, and the agent remains alive for retries.

--- a/packages/inference/src/default-director.ts
+++ b/packages/inference/src/default-director.ts
@@ -32,21 +32,24 @@ const logger = getLogger(["interchange", "inference", "default-director"]);
  *
  *   continue — proceed with the director's normal post-inference logic
  *              (tool extraction, reply, or wait per the existing flow).
- *   abort    — terminate the agent. Routes to `[checkpoint, reply, done]`
- *              and the reactor shuts down. Stronger than the
+ *   abort    — terminate the agent. Routes to `[checkpoint, done]` and
+ *              the reactor shuts down. Stronger than the
  *              `inference.error` branch, which only replies and stays
  *              alive — `abort` is for "session is over, do not accept
  *              further inputs."
  *   halt     — pause the current cycle without terminating. Routes to
- *              `[checkpoint, reply, wait]`. Reactor stays alive waiting
- *              for the next inbound event. There is no auto-resume; an
- *              external event (mail, gate clearance, etc.) must reach
- *              the reactor for the agent to make progress again.
+ *              `[checkpoint, reply]`; the reply returns the reactor to
+ *              waiting for the next inbound event, so it stays alive.
+ *              There is no auto-resume; an external event (mail, gate
+ *              clearance, etc.) must reach the reactor for the agent to
+ *              make progress again.
  *
- * `reason` becomes the connector reply text verbatim — policy authors
- * choose what is safe to surface to the user. There is no separate
- * private-reason / user-message split today; add one if a real need
- * appears.
+ * `reason` on a `halt` becomes the connector reply text verbatim, so
+ * policy authors choose what is safe to surface to the user. On an
+ * `abort` the reason is not surfaced: a terminal action cannot carry a
+ * reply, since a reply invites continuation. Delivering an abort reason
+ * to the user needs a dedicated terminal-notice path, which does not
+ * exist today.
  */
 export type AfterInferenceDecision =
   | { type: "continue" }
@@ -237,17 +240,21 @@ export class DefaultDirector implements ReactorDirector {
             };
           }
           if (decision.type === "abort") {
+            // A reply invites the next inbound message, but abort is
+            // terminal — the reactor rejects reply paired with done. The
+            // reason is therefore not surfaced on this path.
             return [
               capabilities.checkpoint("after-inference-abort"),
-              capabilities.reply(decision.reason),
               capabilities.done(),
             ];
           }
           if (decision.type === "halt") {
+            // A reply already returns the reactor to waiting for the next
+            // inbound message, so no separate wait is needed (and the
+            // reactor rejects reply paired with wait).
             return [
               capabilities.checkpoint("after-inference-halt"),
               capabilities.reply(decision.reason),
-              capabilities.wait(),
             ];
           }
           // decision.type === "continue" — fall through.

--- a/packages/inference/src/reactor.test.ts
+++ b/packages/inference/src/reactor.test.ts
@@ -5,6 +5,7 @@ import { createGateManager } from "./gates";
 import { createCorrelationRegistry } from "./correlation";
 import { createReactor } from "./reactor";
 import { createDefaultDependencies } from "./providers";
+import { createDefaultDirector } from "./default-director";
 import { createInboundMessage } from "@intx/mime";
 
 import type {
@@ -32,6 +33,7 @@ import type {
 import type { ReactorConfig, Reactor, ReactorEmittedEvent } from "./reactor";
 import type { Dependencies, InferenceHarnessOptions } from "./harness";
 import type { CorrelationValidator } from "./correlation";
+import type { AfterInferenceHook } from "./default-director";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -2584,6 +2586,98 @@ function makeInferenceRunner(
     }
   };
 }
+
+// ---------------------------------------------------------------------------
+// afterInferenceDone abort/halt policy, end to end
+//
+// These drive the real DefaultDirector so the action sets its abort and
+// halt branches build are validated by the reactor, not just asserted in
+// isolation. The bug was that those sets were rejected, so the reactor
+// crashed with a fatal "Invalid action set" instead of terminating
+// (abort) or pausing and replying (halt).
+// ---------------------------------------------------------------------------
+
+describe("createReactor — afterInferenceDone abort and halt", () => {
+  test("abort terminates without an invalid action set", async () => {
+    const hook: AfterInferenceHook = () => ({
+      type: "abort",
+      reason: "budget exhausted",
+    });
+    const { reactor, events, waitFor } = createTestReactor({
+      director: createDefaultDirector("test agent", [], {
+        afterInferenceDone: hook,
+      }),
+      inferenceRunner: makeInferenceRunner({
+        type: "done",
+        turn: makeAssistantTurn("ignored"),
+        usage: emptyUsage(),
+      }),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    expect(
+      events.some(
+        (e) =>
+          e.type === "reactor.error" &&
+          /invalid action set/i.test(e.data.error),
+      ),
+    ).toBe(false);
+    // Abort is terminal and does not surface the reason, so no reply.
+    expect(events.some((e) => e.type === "connector.reply")).toBe(false);
+  });
+
+  test("halt replies and keeps the reactor alive", async () => {
+    let hookCalls = 0;
+    const hook: AfterInferenceHook = () => {
+      hookCalls++;
+      return { type: "halt", reason: "paused for top-up" };
+    };
+    const { reactor, events, waitFor } = createTestReactor({
+      director: createDefaultDirector("test agent", [], {
+        afterInferenceDone: hook,
+      }),
+      inferenceRunner: makeInferenceRunner({
+        type: "done",
+        turn: makeAssistantTurn("ignored"),
+        usage: emptyUsage(),
+      }),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitForEvent(events, (e) => e.type === "connector.reply");
+
+    // Halt returned the reactor to waiting rather than shutting down, so a
+    // second message must still be processed — that is the liveness proof.
+    reactor.deliver(makeInboundMessage());
+    await waitForEvent(
+      events,
+      () => events.filter((e) => e.type === "connector.reply").length >= 2,
+    );
+
+    // The reactor is still alive; abort it so the test does not leak it.
+    reactor.abort("admin_kill");
+    await waitFor("reactor.done");
+
+    const replies = events.filter((e) => e.type === "connector.reply");
+    expect(replies.length).toBe(2);
+    expect(hookCalls).toBe(2);
+    for (const reply of replies) {
+      if (reply.type !== "connector.reply") throw new Error("unreachable");
+      expect(reply.data.content).toBe("paused for top-up");
+    }
+    expect(
+      events.some(
+        (e) =>
+          e.type === "reactor.error" &&
+          /invalid action set/i.test(e.data.error),
+      ),
+    ).toBe(false);
+  });
+});
 
 describe("createReactor — inference path", () => {
   test("infer action drives inference.done through to director and accumulates usage", async () => {

--- a/packages/inference/src/reactor.test.ts
+++ b/packages/inference/src/reactor.test.ts
@@ -686,6 +686,32 @@ describe("validateActions", () => {
     if (result.ok) throw new Error("unreachable");
     expect(result.error).toMatch(/reply.*suspend/i);
   });
+
+  // The director builds action sets with a leading checkpoint. The
+  // reply+done and wait+reply invariants must hold for that emitted
+  // three-action shape, not only the bare pairs above, so a checkpoint
+  // prefix cannot smuggle a contradictory set past the validator.
+  test("checkpoint + reply + done is invalid", () => {
+    const result = validateActions([
+      { type: "checkpoint", message: "checkpoint: after-inference-abort" },
+      { type: "reply", content: "budget exhausted" },
+      { type: "done" },
+    ]);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toMatch(/reply.*done/i);
+  });
+
+  test("checkpoint + reply + wait is invalid", () => {
+    const result = validateActions([
+      { type: "checkpoint", message: "checkpoint: after-inference-halt" },
+      { type: "reply", content: "paused for top-up" },
+      { type: "wait" },
+    ]);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toMatch(/wait.*reply/i);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `DefaultDirector.afterInferenceDone` emits `[checkpoint, done]` on an
  abort decision and `[checkpoint, reply]` on a halt decision — action
  sets the reactor accepts, so an abort terminates the session and a halt
  pauses it and replies, instead of crashing the reactor with a fatal
  "Invalid action set".
- The abort path does not surface its `reason`: a reply invites
  continuation, which a terminating action cannot honor. The `reason`
  remains a policy input.
- The director header comment scopes its event map to inbound events and
  points the `afterInferenceDone` continue/abort/halt decisions at the
  `AfterInferenceDecision` contract.
- Tests lock the `reply`+`done` and `wait`+`reply` validator invariants
  for the director's checkpoint-prefixed action shape, and drive the real
  director through the reactor to prove abort terminates cleanly and halt
  replies while staying alive.

## Verification

- The full build passes: `make all` exits clean (unit 3956 pass / 0 fail,
  integration 361 pass / 0 fail).
- The abort path reaches `reactor.done` and the halt path emits
  `connector.reply` while staying alive, with no fatal "Invalid action
  set" error in either case.

Closes INTR-201