### PR TITLE
Publish interactively so the npm 2FA prompt is visible

### DIFF
--- a/bin/publish.ts
+++ b/bin/publish.ts
@@ -353,7 +353,22 @@ async function main(repoRoot: string, execute: boolean): Promise<void> {
     if (execute) {
       for (const t of ordered) {
         console.log(`publishing ${t.name}@${version}`);
-        run(["bun", "publish"], t.dir);
+        // Inherit the terminal so an interactive npm 2FA one-time-password
+        // prompt is visible and answerable. The pre-publish steps capture
+        // their output to surface errors, but a publish that needs an OTP
+        // would then block on a prompt the operator cannot see.
+        const proc = Bun.spawnSync(["bun", "publish"], {
+          cwd: t.dir,
+          stdin: "inherit",
+          stdout: "inherit",
+          stderr: "inherit",
+        });
+        if (proc.exitCode !== 0) {
+          throw new Error(
+            `publish: bun publish failed for ${t.name}@${version} ` +
+              `(exit ${proc.exitCode ?? "signal"})`,
+          );
+        }
       }
       console.log(
         `publish: published ${ordered.length} packages at ${version}`,


### PR DESCRIPTION
## Summary

- Runs the `--execute` publish step with the terminal inherited (`stdin`/`stdout`/`stderr`) instead of capturing its output. On a two-factor `auth-and-writes` npm account, `bun publish` prompts for a one-time password per write; capturing the output hid that prompt, so the publish blocked on input the operator could not see and appeared to hang. The prompt is now visible and answerable, and a non-zero exit surfaces the registry's error instead of hanging.
- The pre-publish pack/install/load steps keep capturing their output (they need no interaction and their captured output is how errors surface); only the interactive `bun publish` upload inherits the terminal.

## Verification

- `tsc --noEmit -p bin/tsconfig.json` is clean.
- `make lint` passes (via the pre-commit hook).
- The dry-run path is unchanged.
