### PR TITLE
Add a description to every workspace package and enforce it

### DIFF
--- a/apps/admin-ui/package.json
+++ b/apps/admin-ui/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/admin-ui",
+  "description": "Browser single-page app operators use to manage the Interchange control plane",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/hub-app",
+  "description": "Interchange control-plane server process that wires the hub packages into one HTTP application",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/apps/sidecar/package.json
+++ b/apps/sidecar/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/sidecar-app",
+  "description": "Host process running a fleet of hub-orchestrated agent runtimes in one Bun process",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/bin/check-deps.test.ts
+++ b/bin/check-deps.test.ts
@@ -6,9 +6,12 @@ import { dirname, join } from "node:path";
 import { checkWorkspace } from "./check-deps";
 
 // Each fixture is a throwaway workspace on disk: a root package.json carrying
-// the catalog, plus members under packages/apps/examples with their manifests,
-// source files, and optional tsconfig. checkWorkspace runs the static checks
-// (phantom imports + catalog convergence) against it.
+// the catalog and a `workspaces` array derived from the members it declares,
+// plus those members with their manifests, source files, and optional
+// tsconfig. checkWorkspace enumerates members through the root `workspaces`
+// globs and runs the static checks (phantom imports + catalog convergence)
+// against them; files under `bin`/`tests` that are not members are checked
+// against the root manifest.
 
 type MemberSpec = {
   manifest: Record<string, unknown>;
@@ -40,11 +43,21 @@ function writeFile(root: string, rel: string, content: string): void {
 function makeWorkspace(spec: WorkspaceSpec): string {
   const root = mkdtempSync(join(tmpdir(), "check-deps-"));
   roots.push(root);
+  // The root manifest declares exactly the members the fixture writes, as
+  // literal `workspaces` entries — the same single source of truth
+  // `checkWorkspace` reads via `readWorkspaceManifestPaths`. Literal entries
+  // (rather than `<dir>/*` globs) mirror how the real root lists `tests/lib`
+  // and let a fixture place a non-member directory beside a member — e.g. a
+  // non-member `tests/db` next to member `tests/lib` — the shape that
+  // matters for the root-scripts exclusion. A memberless fixture gets `[]`,
+  // which the enumerator accepts (it just finds no members).
+  const workspaces = Object.keys(spec.members ?? {});
   writeFile(
     root,
     "package.json",
     JSON.stringify({
       name: "@fixture/root",
+      workspaces,
       catalog: spec.catalog ?? {},
       devDependencies: spec.rootDeps ?? {},
     }),
@@ -346,4 +359,81 @@ test("a bin/ import of the bun runtime module is accepted", async () => {
     extraFiles: { "bin/tool.ts": 'import { Glob } from "bun";\n' },
   });
   expect(v).toEqual([]);
+});
+
+test("a workspace member under tests/ is checked against its own manifest, not twice against root", async () => {
+  const v = await violationsFor({
+    members: {
+      "tests/lib": {
+        manifest: { name: "@x/harness" },
+        files: { "h.ts": 'import { x } from "member-undeclared";\n' },
+      },
+    },
+  });
+  // Exactly one violation, in the member shape. Without the member-subtree
+  // exclusion the root-scripts scan would add a second, root-shaped
+  // violation for the same import.
+  expect(v).toEqual([
+    '@x/harness: imports "member-undeclared" (tests/lib/h.ts) but does not declare it in package.json',
+  ]);
+});
+
+test("a member under tests/ importing an external it declares is not re-flagged against root", async () => {
+  const v = await violationsFor({
+    members: {
+      "tests/lib": {
+        manifest: {
+          name: "@x/harness",
+          dependencies: { "only-in-member": "^1" },
+        },
+        files: { "h.ts": 'import { x } from "only-in-member";\n' },
+      },
+    },
+  });
+  // "only-in-member" is declared in the member's own manifest and absent
+  // from root. As a member it is accepted; without the exclusion the
+  // root-scripts pass would wrongly flag it as undeclared in root.
+  expect(v).toEqual([]);
+});
+
+test("a non-member directory whose name is a prefix of a member is still checked against root", async () => {
+  const v = await violationsFor({
+    members: {
+      "tests/lib": { manifest: { name: "@x/harness" } },
+    },
+    extraFiles: {
+      "tests/library/x.ts": 'import { x } from "undeclared-sibling-dep";\n',
+    },
+  });
+  // tests/library is not tests/lib. A boundary-matched exclusion must not
+  // swallow it, so its import is validated against the root manifest. A
+  // naive prefix check (without the trailing slash) would wrongly exclude it.
+  expect(
+    v.some(
+      (m) =>
+        m.includes("undeclared-sibling-dep") && m.includes("root package.json"),
+    ),
+  ).toBe(true);
+});
+
+test("a non-member directory with its own package.json under tests/ is checked against root", async () => {
+  const v = await violationsFor({
+    members: {
+      "tests/lib": { manifest: { name: "@x/harness" } },
+    },
+    // tests/db has a manifest but is not in `workspaces`, mirroring the real
+    // repo where tests/lib is the only member under tests/. It is a
+    // non-member, so its files resolve against the root manifest.
+    extraFiles: {
+      "tests/db/package.json": JSON.stringify({ name: "@x/db-tests" }),
+      "tests/db/x.test.ts": 'import { x } from "undeclared-nonmember-dep";\n',
+    },
+  });
+  expect(
+    v.some(
+      (m) =>
+        m.includes("undeclared-nonmember-dep") &&
+        m.includes("root package.json"),
+    ),
+  ).toBe(true);
 });

--- a/bin/check-deps.ts
+++ b/bin/check-deps.ts
@@ -27,9 +27,11 @@
 // tests; the lockfile check and CLI gate run only when this file is the entry
 // point. Exits non-zero with a list of violations, or zero when clean.
 
-import { join, relative } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { type } from "arktype";
 import ts from "typescript";
+
+import { readWorkspaceManifestPaths } from "./lib/packages";
 
 const NODE_BUILTINS = new Set([
   "assert",
@@ -196,16 +198,18 @@ export async function checkWorkspace(
   let memberCount = 0;
   let fileCount = 0;
 
-  const manifestPaths = [
-    ...new Bun.Glob("packages/*/package.json").scanSync(repoRoot),
-    ...new Bun.Glob("apps/*/package.json").scanSync(repoRoot),
-    ...new Bun.Glob("examples/*/package.json").scanSync(repoRoot),
-  ].sort();
+  const manifestPaths = readWorkspaceManifestPaths(repoRoot);
+  // Member directories, repo-relative, used below to exclude member subtrees
+  // from the root-scripts scan: a member is checked against its own manifest
+  // here, not a second time against the root manifest.
+  const memberDirs: string[] = [];
 
-  for (const manifestRel of manifestPaths) {
-    const dir = join(repoRoot, manifestRel.replace(/\/package\.json$/, ""));
-    const manifest = await readManifest(join(repoRoot, manifestRel));
-    const self = manifest.name ?? manifestRel;
+  for (const manifestPath of manifestPaths) {
+    const dir = dirname(manifestPath);
+    const rel = relative(repoRoot, dir);
+    memberDirs.push(rel);
+    const manifest = await readManifest(manifestPath);
+    const self = manifest.name ?? rel;
     const declared = declaredNames(manifest);
     const { aliases, outDir } = memberConfig(dir);
     workspaceNames.add(self);
@@ -244,7 +248,7 @@ export async function checkWorkspace(
           continue;
         if (!declared.has(name)) {
           violations.push(
-            `${self}: imports "${name}" (${manifestRel.replace(/\/package\.json$/, "")}/${file}) but does not declare it in package.json`,
+            `${self}: imports "${name}" (${rel}/${file}) but does not declare it in package.json`,
           );
         }
       }
@@ -298,10 +302,14 @@ export async function checkWorkspace(
     }
   }
 
-  // --- check 1 for the root scripts: bin/ and tests/ are not workspace
-  // members (no package.json of their own) and are never published, so their
-  // imports resolve against the root manifest. Workspace packages are always
-  // available to them; only external imports must be declared in root. ---
+  // --- check 1 for the root scripts: files under bin/ and tests/ that are
+  // not part of a workspace member. These have no package.json of their own
+  // and are never published, so their imports resolve against the root
+  // manifest. Files that DO sit under a member directory — e.g. tests/lib,
+  // the @intx/test-harness package — are already checked against that
+  // member's own manifest in the loop above and are excluded here. Workspace
+  // packages are always available to root scripts; only external imports must
+  // be declared in root. ---
   const rootDeclared = declaredNames(rootManifest);
   for (const area of ["bin", "tests"]) {
     const areaDir = join(repoRoot, area);
@@ -309,6 +317,11 @@ export async function checkWorkspace(
     for (const file of new Bun.Glob(
       "**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}",
     ).scanSync(areaDir)) {
+      // A member's own files are checked against its manifest above; match
+      // on a path boundary so `tests/lib` never swallows a `tests/library`.
+      const repoRel = `${area}/${file}`;
+      if (memberDirs.some((m) => repoRel === m || repoRel.startsWith(`${m}/`)))
+        continue;
       const segments = file.split("/");
       if (segments.includes("node_modules") || segments.includes("dist"))
         continue;

--- a/bin/lib/packages.test.ts
+++ b/bin/lib/packages.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
-import { readWorkspacePackages } from "./packages";
+import { readWorkspaceManifestPaths, readWorkspacePackages } from "./packages";
 
 function repoWith(pkgs: Record<string, unknown | undefined>): string {
   const repo = mkdtempSync(join(tmpdir(), "packages-"));
@@ -123,6 +123,96 @@ describe("readWorkspacePackages", () => {
     const repo = repoWith({ a: { version: "0.2.0" } }); // missing name
     try {
       expect(() => readWorkspacePackages(repo)).toThrow(/well-formed/);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+/** A repo with a root manifest declaring `workspaces`, plus a manifest at
+ *  each `dir`. A `dir` mapped to `undefined` is created without a
+ *  `package.json` (a directory that is not a member). */
+function repoWithWorkspaces(
+  workspaces: string[],
+  members: Record<string, Record<string, unknown> | undefined>,
+): string {
+  const repo = mkdtempSync(join(tmpdir(), "manifest-paths-"));
+  writeFileSync(
+    join(repo, "package.json"),
+    JSON.stringify({ name: "root", private: true, workspaces }),
+  );
+  for (const [dir, manifest] of Object.entries(members)) {
+    const d = join(repo, dir);
+    mkdirSync(d, { recursive: true });
+    if (manifest !== undefined) {
+      writeFileSync(join(d, "package.json"), JSON.stringify(manifest));
+    }
+  }
+  return repo;
+}
+
+describe("readWorkspaceManifestPaths", () => {
+  test("enumerates every member across all globs, private and tests/lib included", () => {
+    const repo = repoWithWorkspaces(
+      ["packages/*", "apps/*", "examples/*", "tests/lib"],
+      {
+        "packages/a": { name: "@intx/a" },
+        "packages/secret": { name: "@intx/secret", private: true },
+        "apps/ui": { name: "@intx/ui", private: true },
+        "examples/demo": { name: "@intx/demo", private: true },
+        "tests/lib": { name: "@intx/test-harness", private: true },
+      },
+    );
+    try {
+      expect(readWorkspaceManifestPaths(repo)).toEqual(
+        [
+          join(repo, "packages/a/package.json"),
+          join(repo, "packages/secret/package.json"),
+          join(repo, "apps/ui/package.json"),
+          join(repo, "examples/demo/package.json"),
+          join(repo, "tests/lib/package.json"),
+        ].sort(),
+      );
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("skips a glob-matched directory that has no package.json", () => {
+    const repo = repoWithWorkspaces(["packages/*"], {
+      "packages/a": { name: "@intx/a" },
+      "packages/empty": undefined,
+    });
+    try {
+      expect(readWorkspaceManifestPaths(repo)).toEqual([
+        join(repo, "packages/a/package.json"),
+      ]);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("de-duplicates a member matched by overlapping globs", () => {
+    const repo = repoWithWorkspaces(["packages/*", "packages/a"], {
+      "packages/a": { name: "@intx/a" },
+    });
+    try {
+      expect(readWorkspaceManifestPaths(repo)).toEqual([
+        join(repo, "packages/a/package.json"),
+      ]);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("throws when the root manifest has no workspaces array", () => {
+    const repo = mkdtempSync(join(tmpdir(), "manifest-paths-"));
+    writeFileSync(
+      join(repo, "package.json"),
+      JSON.stringify({ name: "root", private: true }),
+    );
+    try {
+      expect(() => readWorkspaceManifestPaths(repo)).toThrow(/workspaces/);
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }

--- a/bin/lib/packages.ts
+++ b/bin/lib/packages.ts
@@ -36,6 +36,38 @@ export const manifestSchema = type({
 
 export type PackageManifest = typeof manifestSchema.infer;
 
+// Only the `workspaces` globs are read from the root manifest here; the rest
+// of its shape is irrelevant to enumerating members.
+const rootManifestSchema = type({ workspaces: "string[]" });
+
+/** Every workspace member's `package.json` path, absolute and sorted,
+ *  derived from the root manifest's `workspaces` globs — private members and
+ *  non-`packages/` members (apps, examples, `tests/lib`) included.
+ *
+ *  This is the authoritative member set. Unlike {@link readWorkspacePackages}
+ *  it neither filters by private status nor restricts to `packages/`, because
+ *  callers that enforce a per-member invariant on every declared member — a
+ *  required `description`, dependency hygiene — must see exactly the members
+ *  the workspace declares, no more and no less. Deriving from root
+ *  `workspaces` keeps that set in one authoritative place rather than a
+ *  hardcoded directory list each caller can drift from. */
+export function readWorkspaceManifestPaths(repoRoot: string): string[] {
+  const rootPath = join(repoRoot, "package.json");
+  const parsed = rootManifestSchema(JSON.parse(readFileSync(rootPath, "utf8")));
+  if (parsed instanceof type.errors) {
+    throw new Error(
+      `packages: ${rootPath} has no well-formed "workspaces" array: ${parsed.summary}`,
+    );
+  }
+  const paths = new Set<string>();
+  for (const glob of parsed.workspaces) {
+    for (const rel of new Bun.Glob(`${glob}/package.json`).scanSync(repoRoot)) {
+      paths.add(join(repoRoot, rel));
+    }
+  }
+  return [...paths].sort();
+}
+
 /** A non-private workspace package under `packages/`. */
 export interface WorkspacePackage {
   name: string;

--- a/bin/publish-metadata.test.ts
+++ b/bin/publish-metadata.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import {
+  checkWorkspaceDescriptions,
   checkWorkspaceMetadata,
   expectedFiles,
   expectedSideEffects,
@@ -24,11 +25,33 @@ afterEach(() => {
     rmSync(root, { recursive: true, force: true });
 });
 
-function makeWorkspace(packages: PackageSpec[]): string {
+// The `packages` array is placed under `packages/pN`; `extra` places a
+// manifest at an explicit workspace-relative dir (e.g. `apps/ui`,
+// `tests/lib`) so the description check — which enumerates every member the
+// root `workspaces` globs declare — can be exercised across all member
+// kinds. A root manifest with those globs is always written, since
+// `checkWorkspaceDescriptions` derives its member set from it.
+function makeWorkspace(
+  packages: PackageSpec[],
+  extra: Record<string, PackageSpec> = {},
+): string {
   const root = mkdtempSync(join(tmpdir(), "publish-metadata-"));
   roots.push(root);
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*", "apps/*", "examples/*", "tests/lib"],
+    }),
+  );
   for (const [i, pkg] of packages.entries()) {
     const path = join(root, "packages", `p${i}`, "package.json");
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(pkg));
+  }
+  for (const [dir, pkg] of Object.entries(extra)) {
+    const path = join(root, dir, "package.json");
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, JSON.stringify(pkg));
   }
@@ -135,4 +158,76 @@ test("fix sets the fields, then check passes; log gets its glob list", async () 
 test("fix is idempotent on an already-canonical workspace", async () => {
   const root = makeWorkspace([canonical("@x/a")]);
   expect(await fixWorkspaceMetadata(root)).toEqual([]);
+});
+
+test("a member with a non-empty description passes", async () => {
+  const { violations, manifestCount } = await checkWorkspaceDescriptions(
+    makeWorkspace([{ name: "@x/a", description: "does a thing" }]),
+  );
+  expect(violations).toEqual([]);
+  expect(manifestCount).toBe(1);
+});
+
+test("a missing description is flagged", async () => {
+  const { violations } = await checkWorkspaceDescriptions(
+    makeWorkspace([{ name: "@x/a" }]),
+  );
+  expect(violations).toEqual([
+    '@x/a: "description" must be a non-empty string',
+  ]);
+});
+
+test("an empty or whitespace-only description is flagged", async () => {
+  const { violations } = await checkWorkspaceDescriptions(
+    makeWorkspace([
+      { name: "@x/empty", description: "" },
+      { name: "@x/blank", description: "   " },
+    ]),
+  );
+  expect(violations.some((v) => v.startsWith("@x/empty:"))).toBe(true);
+  expect(violations.some((v) => v.startsWith("@x/blank:"))).toBe(true);
+});
+
+test("a non-string description is flagged", async () => {
+  const { violations } = await checkWorkspaceDescriptions(
+    makeWorkspace([{ name: "@x/a", description: 123 }]),
+  );
+  expect(violations).toEqual([
+    '@x/a: "description" must be a non-empty string',
+  ]);
+});
+
+test("the description check covers private members and every workspace dir", async () => {
+  const privateMember = (name: string): PackageSpec => ({
+    name,
+    private: true,
+  });
+  const { violations, manifestCount } = await checkWorkspaceDescriptions(
+    makeWorkspace([{ name: "@x/pkg", private: true }], {
+      "apps/ui": privateMember("@x/app"),
+      "examples/e": privateMember("@x/example"),
+      "tests/lib": privateMember("@x/harness"),
+    }),
+  );
+  // Four members, all private, none with a description — the description
+  // check does not skip private members the way the tarball-field check does.
+  expect(manifestCount).toBe(4);
+  expect(violations.map((v) => v.split(":")[0]).sort()).toEqual([
+    "@x/app",
+    "@x/example",
+    "@x/harness",
+    "@x/pkg",
+  ]);
+});
+
+test("a private member is skipped by the metadata check but not the description check", async () => {
+  const root = makeWorkspace([
+    { name: "@x/private", private: true, description: "a private member" },
+  ]);
+  // The tarball-field check ignores the private package entirely.
+  expect((await checkWorkspaceMetadata(root)).packageCount).toBe(0);
+  // The description check still counts it, and it passes because it has one.
+  const { violations, manifestCount } = await checkWorkspaceDescriptions(root);
+  expect(manifestCount).toBe(1);
+  expect(violations).toEqual([]);
 });

--- a/bin/publish-metadata.ts
+++ b/bin/publish-metadata.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /* eslint-disable no-console */
 
-// Publish-metadata guard for the non-private workspace packages.
+// Publish-metadata guard for the workspace.
 //
 // Three fields must be present and correct on every package published to
 // npm, or the tarball misbehaves:
@@ -18,16 +18,32 @@
 //     entry points import the default console sink), so it names those
 //     files instead.
 //
-// This module is both the one-time transform that sets these fields and
-// the check that keeps them, mirroring `exports-shape`. It runs in
-// `make lint`, so a package added later without the fields fails the gate
-// rather than shipping a broken or oversized tarball. Private packages
-// are skipped.
+// Those three are publish-tarball concerns, so they apply only to the
+// non-private packages under `packages/` (the ones that ship). A fourth
+// requirement has a different scope:
+//
+//   - `description`: a non-empty summary. npm shows it in search results
+//     and on the package page, and it documents the package for anyone
+//     reading the manifest. Every workspace member should carry one —
+//     private members included — so this check enumerates all members the
+//     root `workspaces` globs declare, not just the publishable packages.
+//
+// This module is both the one-time transform that sets the three tarball
+// fields and the check that keeps them, mirroring `exports-shape`. It runs
+// in `make lint`, so a package added later without the fields fails the
+// gate rather than shipping a broken or oversized tarball. The transform
+// never authors a `description` — wording is written by hand — so `--fix`
+// sets the three mechanical fields and then fails loudly on any member
+// still missing one rather than reporting a success a later check-mode run
+// would contradict.
 
 import { join } from "node:path";
 import { type } from "arktype";
 
-import { readWorkspacePackages } from "./lib/packages";
+import {
+  readWorkspaceManifestPaths,
+  readWorkspacePackages,
+} from "./lib/packages";
 
 const ACCESS = "public";
 
@@ -109,6 +125,35 @@ export async function checkWorkspaceMetadata(
   return { violations, packageCount: list.length };
 }
 
+export type DescriptionReport = {
+  violations: string[];
+  manifestCount: number;
+};
+
+/** A `description` must be a present, non-whitespace string. */
+function hasDescription(raw: Record<string, unknown>): boolean {
+  const value = raw["description"];
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/** Require a non-empty `description` on every workspace member the root
+ *  `workspaces` globs declare — private members included. A malformed
+ *  member manifest surfaces from `readRaw` rather than being skipped. */
+export async function checkWorkspaceDescriptions(
+  repoRoot: string,
+): Promise<DescriptionReport> {
+  const violations: string[] = [];
+  const paths = readWorkspaceManifestPaths(repoRoot);
+  for (const manifestPath of paths) {
+    const raw = await readRaw(manifestPath);
+    if (!hasDescription(raw)) {
+      const name = typeof raw["name"] === "string" ? raw["name"] : manifestPath;
+      violations.push(`${name}: "description" must be a non-empty string`);
+    }
+  }
+  return { violations, manifestCount: paths.length };
+}
+
 /** Set the three fields on every non-private package. Returns the packages
  *  changed. */
 export async function fixWorkspaceMetadata(
@@ -145,18 +190,31 @@ if (import.meta.main) {
     const changed = await fixWorkspaceMetadata(repoRoot);
     for (const name of changed) console.log(`  set metadata on ${name}`);
     console.log(`publish-metadata: updated ${changed.length} package(s)`);
+    // `--fix` never authors a description. A member left without one is a
+    // real failure, so surface it and exit non-zero rather than reporting a
+    // success that the check-mode run in `make lint` would contradict.
+    const { violations } = await checkWorkspaceDescriptions(repoRoot);
+    if (violations.length > 0) {
+      console.error(
+        `\npublish-metadata: ${violations.length} member(s) still need a hand-written "description":\n`,
+      );
+      for (const v of violations) console.error(`  - ${v}`);
+      process.exit(1);
+    }
   } else {
-    const { violations, packageCount } = await checkWorkspaceMetadata(repoRoot);
+    const metadata = await checkWorkspaceMetadata(repoRoot);
+    const descriptions = await checkWorkspaceDescriptions(repoRoot);
+    const violations = [...metadata.violations, ...descriptions.violations];
     if (violations.length > 0) {
       console.error(`publish-metadata: ${violations.length} violation(s)\n`);
       for (const v of violations) console.error(`  - ${v}`);
       console.error(
-        `\nRun \`bun bin/publish-metadata.ts --fix\` to set the publish metadata.`,
+        `\nRun \`bun bin/publish-metadata.ts --fix\` to set the mechanical publish metadata; a "description" must be written by hand.`,
       );
       process.exit(1);
     }
     console.log(
-      `publish-metadata: ok (${packageCount} non-private package(s))`,
+      `publish-metadata: ok (${metadata.packageCount} non-private package(s), ${descriptions.manifestCount} manifest(s) with a description)`,
     );
   }
 }

--- a/examples/agent-audit-log/package.json
+++ b/examples/agent-audit-log/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/example-agent-audit-log",
+  "description": "Example: an @intx/agent audit record is a real git repo with one commit per reactor cycle",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/examples/agent-blob-spill/package.json
+++ b/examples/agent-blob-spill/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/example-agent-blob-spill",
+  "description": "Example: spilling oversized tool output to a context-store blob referenced by URI",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/examples/agent-common/package.json
+++ b/examples/agent-common/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/example-agent-common",
+  "description": "Shared helpers for the agent-* example packages",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/examples/agent-gemini-image/package.json
+++ b/examples/agent-gemini-image/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/example-agent-gemini-image",
+  "description": "Example: end-to-end Gemini image generation writing returned image bytes to disk",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/examples/agent-multi-provider/package.json
+++ b/examples/agent-multi-provider/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/example-agent-multi-provider",
+  "description": "Example: model-per-task, failover, and routing policies over @intx/agent sources",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/examples/agent-quickstart/package.json
+++ b/examples/agent-quickstart/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/example-agent-quickstart",
+  "description": "Example: the smallest runnable @intx/agent program — construct, send, print, close",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/examples/agent-resume/package.json
+++ b/examples/agent-resume/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/example-agent-resume",
+  "description": "Example: an @intx/agent conversation surviving process death via its contextDir",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/examples/agent-rewind/package.json
+++ b/examples/agent-rewind/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/example-agent-rewind",
+  "description": "Example: rewinding an @intx/agent conversation to an older commit in a cloned contextDir",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/examples/agent-rich-tool/package.json
+++ b/examples/agent-rich-tool/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/example-agent-rich-tool",
+  "description": "Example: the pendingMarker ToolResult field that opens an approval or payment-pending gate",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/examples/agent-structured-payload/package.json
+++ b/examples/agent-structured-payload/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/example-agent-structured-payload",
+  "description": "Example: delivering a typed InterchangeType payload to an @intx/agent intact",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/examples/coding-agent/package.json
+++ b/examples/coding-agent/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/example-coding-agent",
+  "description": "Reference coding agent wiring @intx/agent to @intx/tools-posix and @intx/tools-lsp",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/examples/posix-demo/README.md
+++ b/examples/posix-demo/README.md
@@ -1,0 +1,95 @@
+# posix-demo
+
+Two agents holding a conversation over an in-process mailbox. Alpha
+relays a question from the user to Beta and reports Beta's answer back.
+It wires the POSIX and mail tool packages onto `@intx/agent` through the
+`@intx/harness` composition layer.
+
+Unlike the `agent-*` examples, this is a standalone script, not an
+importable module: `src/cli.ts` runs its setup at module scope and has
+no `main()` to call. Run it; don't import it.
+
+## What it shows
+
+- Two agents — **Alpha** (a relay) and **Beta** (a responder) — plus a
+  **user** identity, all registered on one in-process
+  `@intx/mail-memory` transport, each with its own Ed25519 key.
+- Each agent built with `createHarness` over an `@intx/agent`
+  definition, wired with mail tools (`@intx/tools-mail`) and POSIX tools
+  (`@intx/tools-posix`), an isogit context store, and a permissive
+  authorize.
+- Cross-agent messaging: Alpha's system prompt tells it to `mail_send`
+  the user's question to Beta and relay Beta's reply back to the user.
+- Per-agent provider config: Alpha and Beta read independent `ALPHA_*`
+  and `BETA_*` env vars, so they can run on different providers.
+- Draining each harness's event `stream()` to a per-agent console
+  logger, and a clean shutdown once Alpha's reply lands in the user's
+  INBOX.
+
+## Running
+
+Both agents default to an OpenAI-compatible provider at
+`http://localhost:4096/v1`. Point them at whatever you have:
+
+```bash
+cd examples/posix-demo
+
+export OPENAI_API_KEY=sk-...
+export OPENAI_MODEL=...
+bun run start
+```
+
+Each agent is configured independently through its own prefix; unset
+values fall back to the shared `OPENAI_*` / `OPENCODE_API_KEY` /
+`ANTHROPIC_API_KEY` variables:
+
+| Variable                           | Default                                                                                     |
+| ---------------------------------- | ------------------------------------------------------------------------------------------- |
+| `ALPHA_PROVIDER` / `BETA_PROVIDER` | `openai-compatible`                                                                         |
+| `ALPHA_BASE_URL` / `BETA_BASE_URL` | `OPENAI_BASE_URL`, else `http://localhost:4096/v1` (Anthropic: `https://api.anthropic.com`) |
+| `ALPHA_API_KEY` / `BETA_API_KEY`   | `OPENAI_API_KEY` / `OPENCODE_API_KEY` (Anthropic: `ANTHROPIC_API_KEY`)                      |
+| `ALPHA_MODEL` / `BETA_MODEL`       | `OPENAI_MODEL` (Anthropic: `claude-sonnet-4-6`)                                             |
+| `DEMO_SEED`                        | the built-in "ask Beta what it wants to be when it grows up" prompt                         |
+
+To run the two agents on different providers — say Beta on Anthropic:
+
+```bash
+export OPENAI_API_KEY=sk-...           # alpha
+export OPENAI_MODEL=...
+export BETA_PROVIDER=anthropic
+export ANTHROPIC_API_KEY=sk-ant-...
+bun run start
+```
+
+Agent context stores are written under `tmp/agent-alpha` and
+`tmp/agent-beta` inside the package, covered by the repo-wide `tmp/`
+gitignore. Delete them for a clean run.
+
+## What the script does
+
+`src/cli.ts` runs top to bottom:
+
+1. **Resolve two sources.** `readAgentSource("ALPHA")` and
+   `readAgentSource("BETA")` read the prefixed env vars; a missing API
+   key or model is fatal.
+2. **Build identities and transport.** One `createInMemoryTransport`
+   hosts three addresses — `alpha@`, `beta@`, and `user@local.interchange`
+   — each registered with its own Ed25519 crypto.
+3. **Construct two harnesses.** Each agent gets mail and POSIX tool
+   runners, an isogit store under `tmp/`, and a `MailEnv`. Alpha's
+   prompt makes it a relay; Beta's makes it a thoughtful responder.
+4. **Watch and log.** The user's INBOX is watched for Alpha's final
+   reply; each harness's event stream is drained to a labelled logger.
+5. **Seed the conversation.** The user sends `DEMO_SEED` to Alpha. Alpha
+   messages Beta, Beta answers, Alpha relays it to the user, and the
+   INBOX watcher triggers shutdown. A 120-second safety timer bounds the
+   run.
+
+## Next
+
+- [`agent-quickstart`](../agent-quickstart/README.md) — the single-agent
+  minimum, with no tools or mail.
+- [`ring-demo`](../ring-demo/README.md) — the same in-process-mail
+  pattern scaled to a five-agent ring.
+- [`coding-agent`](../coding-agent/README.md) — a single agent wired to
+  the POSIX and LSP tool packages for real file work.

--- a/examples/posix-demo/package.json
+++ b/examples/posix-demo/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/example-posix-demo",
+  "description": "Example: two agents relaying over in-process mail with POSIX and mail tools",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/examples/ring-demo/README.md
+++ b/examples/ring-demo/README.md
@@ -1,0 +1,86 @@
+# ring-demo
+
+A "braintrust" of five agents that pass a question around a ring over an
+in-process mailbox, each adding its perspective, until the discussion
+returns to the start and the first agent synthesizes a recommendation.
+
+Like `posix-demo`, this is a standalone script — `src/cli.ts` runs at
+module scope with no `main()` to import.
+
+## What it shows
+
+- A five-agent ring — **alpha** (Facilitator), **bravo** (Devil's
+  Advocate), **charlie** (Technical Architect), **delta** (UX Lead), and
+  **echo** (Synthesizer) — plus a **user**, all on one
+  `@intx/mail-memory` transport with per-agent Ed25519 identities.
+- Ring routing built entirely from system prompts: each agent's prompt
+  names the next address and tells it to `mail_send` the running
+  discussion onward. Alpha frames the question, sends it to bravo, and
+  uses `mail_wait` to block until echo closes the ring.
+- Two director modes side by side: agents past the first use
+  `buildDefaultDirectorRef({ mode: "reactive" })` — one tool call per
+  inbound message, no follow-up inference — while alpha uses the default
+  conversational director so it can compose the final reply.
+- Each agent carries mail and POSIX tools, an isogit store, and a
+  permissive authorize, constructed in a loop over the ring.
+
+## Running
+
+Defaults to an OpenAI-compatible provider at `http://localhost:4096/v1`;
+all five agents share one source.
+
+```bash
+cd examples/ring-demo
+
+export OPENAI_API_KEY=sk-...
+export OPENAI_MODEL=...
+bun run start
+```
+
+| Variable        | Default                                                                                     |
+| --------------- | ------------------------------------------------------------------------------------------- |
+| `RING_PROVIDER` | `openai-compatible`                                                                         |
+| `RING_BASE_URL` | `OPENAI_BASE_URL`, else `http://localhost:4096/v1` (Anthropic: `https://api.anthropic.com`) |
+| `RING_API_KEY`  | `OPENAI_API_KEY` / `OPENCODE_API_KEY` (Anthropic: `ANTHROPIC_API_KEY`)                      |
+| `RING_MODEL`    | `OPENAI_MODEL` (Anthropic: `claude-sonnet-4-6`)                                             |
+| `RING_PROMPT`   | "Should we build our own authentication system or use a third-party provider?"              |
+
+To run against Anthropic:
+
+```bash
+export RING_PROVIDER=anthropic
+export ANTHROPIC_API_KEY=sk-ant-...
+bun run start
+```
+
+Per-agent context stores are written under `tmp/ring/<name>` inside the
+package, covered by the repo-wide `tmp/` gitignore.
+
+## What the script does
+
+`src/cli.ts` runs top to bottom:
+
+1. **Resolve one source** from `RING_*` (fatal on a missing key or
+   model).
+2. **Build the ring.** Five names, each mapped to a role with a title
+   and perspective, plus a `user` identity — all registered on one
+   in-process transport with their own crypto.
+3. **Construct one harness per agent** in a loop: mail and POSIX tools,
+   an isogit store under `tmp/ring/<name>`, and a system prompt built by
+   `buildRingPrompt` that hard-codes the next hop. Agents past index 0
+   run in reactive director mode; alpha runs conversational.
+4. **Watch and log.** The user's INBOX is watched for alpha's final
+   braintrust recommendation; each harness's stream is drained to a
+   labelled logger.
+5. **Seed the ring.** The user sends `RING_PROMPT` to alpha. The message
+   circulates alpha → bravo → charlie → delta → echo, echo hands back to
+   alpha (unblocking its `mail_wait`), and alpha writes the synthesized
+   recommendation to the user's INBOX, which triggers shutdown. A
+   300-second safety timer bounds the run.
+
+## Next
+
+- [`posix-demo`](../posix-demo/README.md) — the two-agent version of the
+  same in-process-mail wiring.
+- [`agent-multi-provider`](../agent-multi-provider/README.md) — routing
+  policies (model-per-task, failover) on a single agent.

--- a/examples/ring-demo/package.json
+++ b/examples/ring-demo/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/example-ring-demo",
+  "description": "Example: a braintrust ring of agents circulating a question over in-process mail",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/agent",
+  "description": "In-process agent runtime: construct an agent, send it a message, get a reply",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/authz/package.json
+++ b/packages/authz/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/authz",
+  "description": "Grant evaluation engine that authorizes a principal against a resource and action",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/crypto",
+  "description": "Ed25519 cryptographic provider with SSH and PGP detached signatures and ASCII armoring",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/db",
+  "description": "Client, schema, migrations, and row parsers for the hub's PostgreSQL database",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/harness",
+  "description": "Mail-transport composition layer over @intx/agent adding INBOX watch and connector routing",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/hub-agent/package.json
+++ b/packages/hub-agent/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/hub-agent",
+  "description": "Sidecar-side orchestrator linking per-agent stores and sessions to the hub over WebSocket",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/hub-api/package.json
+++ b/packages/hub-api/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/hub-api",
+  "description": "The hub's HTTP API: routes, middleware, authentication, and served OpenAPI spec",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/hub-client/package.json
+++ b/packages/hub-client/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/hub-client",
+  "description": "Browser-side client for the Interchange hub REST API and SSE instance sessions",
   "version": "0.2.2",
   "private": true,
   "type": "module",

--- a/packages/hub-common/package.json
+++ b/packages/hub-common/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/hub-common",
+  "description": "Shared utilities for the Interchange hub packages",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/hub-sessions/package.json
+++ b/packages/hub-sessions/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/hub-sessions",
+  "description": "Session-orchestration substrate for the hub: sidecar router, session, and asset services",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/inference-discovery-anthropic/package.json
+++ b/packages/inference-discovery-anthropic/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/inference-discovery-anthropic",
+  "description": "Anthropic provider plug-in for the inference discovery rig",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/inference-discovery-google-genai/package.json
+++ b/packages/inference-discovery-google-genai/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/inference-discovery-google-genai",
+  "description": "Google GenAI provider plug-in for the inference discovery rig",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/inference-discovery-openai/package.json
+++ b/packages/inference-discovery-openai/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/inference-discovery-openai",
+  "description": "OpenAI-protocol provider plug-in for the inference discovery rig",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/inference-discovery/package.json
+++ b/packages/inference-discovery/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/inference-discovery",
+  "description": "Runtime for the inference discovery rig: plug-in contract, capture runs, and capability catalog",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/inference-testing/package.json
+++ b/packages/inference-testing/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/inference-testing",
+  "description": "Deterministic test harness for the @intx/inference streaming pipeline",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/inference",
+  "description": "Provider-agnostic inference runtime with Anthropic, OpenAI, and Google GenAI adapters",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/log",
+  "description": "Structured logging with per-package loggers and pluggable development and production sinks",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/mail-memory/package.json
+++ b/packages/mail-memory/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/mail-memory",
+  "description": "In-memory MessageTransport for single-process and test environments",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/mime/package.json
+++ b/packages/mime/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/mime",
+  "description": "RFC 2822 message assembly and parsing with PGP detached signatures",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/pack-transport/package.json
+++ b/packages/pack-transport/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/pack-transport",
+  "description": "Git pack chunking and reassembly for the hub-sidecar WebSocket wire",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/storage-isogit/package.json
+++ b/packages/storage-isogit/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/storage-isogit",
+  "description": "Git-backed ContextStore and AuditStore with pack send/receive for moving repositories over the wire",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/tool-packaging/package.json
+++ b/packages/tool-packaging/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/tool-packaging",
+  "description": "Resolver and loader for the npm-distributed Interchange tool-package format",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/tools-lsp/package.json
+++ b/packages/tools-lsp/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/tools-lsp",
+  "description": "LSP-backed tool plugin exposing language servers to the agent harness",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/tools-mail/package.json
+++ b/packages/tools-mail/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/tools-mail",
+  "description": "Mail tool runner giving agents mail_send, mail_reply, mail_search, mail_read, and mail_wait",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/tools-posix/package.json
+++ b/packages/tools-posix/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/tools-posix",
+  "description": "POSIX tool runner giving agents read_file, write_file, edit_file, run_shell, search_files, and grep",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/types",
+  "description": "Runtime validators, API contract types, runtime interfaces, and sidecar wire frames for Interchange",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/workflow-deploy/package.json
+++ b/packages/workflow-deploy/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/workflow-deploy",
+  "description": "Deploy-time validation, capability walk, and operator-approval gating for workflows",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/workflow-host/package.json
+++ b/packages/workflow-host/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/workflow-host",
+  "description": "Production-host implementations of the abstract WorkflowRuntimeEnv from @intx/workflow",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/workflow",
+  "description": "Definition surface, state machine, and abstract runtime for multi-step agent workflows",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "type": "module",

--- a/tests/lib/package.json
+++ b/tests/lib/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intx/test-harness",
+  "description": "Database and environment test-harness primitives shared across the tests tree",
   "version": "0.2.2",
   "license": "LGPL-2.1-only",
   "private": true,


### PR DESCRIPTION
## Summary

- Every workspace `package.json` carries a `description`; npm shows it in
  search results and on the package page. The publish-metadata lint gate
  requires a non-empty description on every member (private included) and
  never fabricates wording — `--fix` sets the mechanical fields and fails
  loudly on any member still missing one.
- `examples/posix-demo` and `examples/ring-demo` gain READMEs matching the
  sibling example docs.
- `bin/check-deps.ts` enumerates workspace members from the root
  `workspaces` globs via a shared helper instead of its own hardcoded
  directory list, bringing `tests/lib` under coverage.

## Verification

- `make all` passes (lint, type-check, admin-ui bundle, tests).
- `bin/publish-metadata.ts` reports ok: 28 non-private packages, 46
  manifests with a description.
- `bin/check-deps.ts` reports ok: 46 workspace members.

Closes INTR-307
Closes INTR-309