### PR TITLE
Recover scheduler timers from the committed object store

### DIFF
--- a/apps/sidecar/src/workflow-run-pack-client.ts
+++ b/apps/sidecar/src/workflow-run-pack-client.ts
@@ -685,6 +685,8 @@ export function createWorkflowRunPackPushingRepoStore(
     resolveHead: underlying.resolveHead.bind(underlying),
     getRepoDir: underlying.getRepoDir.bind(underlying),
     openCommittedReads: underlying.openCommittedReads.bind(underlying),
+    openCommittedReadsAtCommit:
+      underlying.openCommittedReadsAtCommit.bind(underlying),
     subscribe: underlying.subscribe.bind(underlying),
     flushWorkflowRunPushes,
     notifyAddressRoutable,

--- a/apps/sidecar/src/workflow-run-pack-client.ts
+++ b/apps/sidecar/src/workflow-run-pack-client.ts
@@ -684,6 +684,7 @@ export function createWorkflowRunPackPushingRepoStore(
     listRefs: underlying.listRefs.bind(underlying),
     resolveHead: underlying.resolveHead.bind(underlying),
     getRepoDir: underlying.getRepoDir.bind(underlying),
+    openCommittedReads: underlying.openCommittedReads.bind(underlying),
     subscribe: underlying.subscribe.bind(underlying),
     flushWorkflowRunPushes,
     notifyAddressRoutable,

--- a/packages/hub-api/src/git-http/receive-pack.test.ts
+++ b/packages/hub-api/src/git-http/receive-pack.test.ts
@@ -121,6 +121,9 @@ function createStubStore(stub: ReceivePackStub): {
     openCommittedReads: async () => {
       throw new Error("openCommittedReads: not used in this test");
     },
+    openCommittedReadsAtCommit: async () => {
+      throw new Error("openCommittedReadsAtCommit: not used in this test");
+    },
     receivePack: async (
       _principal: Principal,
       _repoId: RepoId,

--- a/packages/hub-api/src/git-http/receive-pack.test.ts
+++ b/packages/hub-api/src/git-http/receive-pack.test.ts
@@ -118,6 +118,9 @@ function createStubStore(stub: ReceivePackStub): {
     getRepoDir: () => {
       throw new Error("getRepoDir: not used in this test");
     },
+    openCommittedReads: async () => {
+      throw new Error("openCommittedReads: not used in this test");
+    },
     receivePack: async (
       _principal: Principal,
       _repoId: RepoId,

--- a/packages/hub-api/src/routes/workflows.test.ts
+++ b/packages/hub-api/src/routes/workflows.test.ts
@@ -288,6 +288,7 @@ function createStubRepoStore(repoDirById?: Map<string, string>): RepoStore {
       return dir;
     },
     openCommittedReads: unused,
+    openCommittedReadsAtCommit: unused,
     subscribe: () => {
       throw new Error("stub repoStore is not wired in workflow tests");
     },

--- a/packages/hub-api/src/routes/workflows.test.ts
+++ b/packages/hub-api/src/routes/workflows.test.ts
@@ -287,6 +287,7 @@ function createStubRepoStore(repoDirById?: Map<string, string>): RepoStore {
       }
       return dir;
     },
+    openCommittedReads: unused,
     subscribe: () => {
       throw new Error("stub repoStore is not wired in workflow tests");
     },

--- a/packages/hub-sessions/src/hub-session-orchestrator.test.ts
+++ b/packages/hub-sessions/src/hub-session-orchestrator.test.ts
@@ -244,6 +244,7 @@ function unusedRepoStore(): RepoStore {
       throw new Error("mock AgentRepoStore.repoStore is not wired");
     },
     openCommittedReads: unused,
+    openCommittedReadsAtCommit: unused,
     subscribe: () => {
       throw new Error("mock AgentRepoStore.repoStore is not wired");
     },

--- a/packages/hub-sessions/src/hub-session-orchestrator.test.ts
+++ b/packages/hub-sessions/src/hub-session-orchestrator.test.ts
@@ -243,6 +243,7 @@ function unusedRepoStore(): RepoStore {
     getRepoDir: () => {
       throw new Error("mock AgentRepoStore.repoStore is not wired");
     },
+    openCommittedReads: unused,
     subscribe: () => {
       throw new Error("mock AgentRepoStore.repoStore is not wired");
     },

--- a/packages/hub-sessions/src/index.ts
+++ b/packages/hub-sessions/src/index.ts
@@ -146,6 +146,8 @@ export {
 } from "./workflow-run-event-log";
 export type {
   AuthorizeFn,
+  CommittedReads,
+  CommittedTreeEntry,
   CreateRepoStoreConfig,
   InitRepoOpts,
   KindHandler,

--- a/packages/hub-sessions/src/repo-store/index.ts
+++ b/packages/hub-sessions/src/repo-store/index.ts
@@ -1,5 +1,7 @@
 export type {
   AuthorizeFn,
+  CommittedReads,
+  CommittedTreeEntry,
   InitRepoOpts,
   KindHandler,
   NewlyTerminalRun,

--- a/packages/hub-sessions/src/repo-store/store.test.ts
+++ b/packages/hub-sessions/src/repo-store/store.test.ts
@@ -2140,4 +2140,159 @@ describe("RepoStore", () => {
       thirdSha,
     );
   });
+
+  test("openCommittedReads lists committed entries and reads blobs by oid", async () => {
+    const dataDir = await makeTempDir("repo-store-committed-reads-");
+    const handler = createTestHandler();
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: allowAll,
+    });
+
+    await store.writeTree(principal, repoId, REF, {
+      files: {
+        "runs/r1/events/0.json": "zero",
+        "runs/r1/events/1.json": "one",
+      },
+      message: "seed events",
+    });
+
+    const reads = await store.openCommittedReads(principal, repoId, REF);
+    if (reads === null) throw new Error("expected committed reads");
+
+    const runs = await reads.listDir("runs");
+    expect(runs.map((e) => e.name)).toEqual(["r1"]);
+    expect(runs[0]?.type).toBe("tree");
+
+    const events = await reads.listDir("runs/r1/events");
+    expect(events.map((e) => e.name).sort()).toEqual(["0.json", "1.json"]);
+    for (const e of events) expect(e.type).toBe("blob");
+
+    const zero = events.find((e) => e.name === "0.json");
+    if (zero === undefined) throw new Error("unreachable");
+    const bytes = await reads.readBlobByOid(zero.oid);
+    expect(new TextDecoder().decode(bytes)).toBe("zero");
+  });
+
+  test("openCommittedReads reads committed state after the working tree is wiped", async () => {
+    const dataDir = await makeTempDir("repo-store-committed-vs-worktree-");
+    const handler = createTestHandler();
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: allowAll,
+    });
+
+    await store.writeTree(principal, repoId, REF, {
+      files: { "runs/r1/events/0.json": "committed" },
+      message: "seed",
+    });
+
+    // Diverge the working tree from the object store: delete the
+    // materialized checkout while leaving `.git` intact. A working-tree
+    // read would now miss the event; a committed read must not.
+    const dir = path.join(dataDir, handler.directoryPrefix, repoId.id);
+    await fs.promises.rm(path.join(dir, "runs"), {
+      recursive: true,
+      force: true,
+    });
+
+    const reads = await store.openCommittedReads(principal, repoId, REF);
+    if (reads === null) throw new Error("expected committed reads");
+    const events = await reads.listDir("runs/r1/events");
+    expect(events.map((e) => e.name)).toEqual(["0.json"]);
+    const only = events[0];
+    if (only === undefined) throw new Error("unreachable");
+    const bytes = await reads.readBlobByOid(only.oid);
+    expect(new TextDecoder().decode(bytes)).toBe("committed");
+  });
+
+  test("openCommittedReads returns null for a missing repo or unresolved ref", async () => {
+    const dataDir = await makeTempDir("repo-store-committed-null-");
+    const handler = createTestHandler();
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: allowAll,
+    });
+
+    expect(await store.openCommittedReads(principal, repoId, REF)).toBeNull();
+
+    await store.writeTree(principal, repoId, REF, {
+      files: { "runs/r1/events/0.json": "zero" },
+      message: "seed",
+    });
+    expect(
+      await store.openCommittedReads(principal, repoId, "refs/heads/absent"),
+    ).toBeNull();
+  });
+
+  test("openCommittedReads listing an absent directory returns the empty array", async () => {
+    const dataDir = await makeTempDir("repo-store-committed-empty-");
+    const handler = createTestHandler();
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: allowAll,
+    });
+
+    await store.writeTree(principal, repoId, REF, {
+      files: { "runs/r1/events/0.json": "zero" },
+      message: "seed",
+    });
+
+    const reads = await store.openCommittedReads(principal, repoId, REF);
+    if (reads === null) throw new Error("expected committed reads");
+    expect(await reads.listDir("runs/absent/events")).toEqual([]);
+  });
+
+  test("openCommittedReads lists the repository root with the empty path", async () => {
+    const dataDir = await makeTempDir("repo-store-committed-root-");
+    const handler = createTestHandler();
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: allowAll,
+    });
+
+    await store.writeTree(principal, repoId, REF, {
+      files: { "a.json": "x", "runs/r1/events/0.json": "y" },
+      message: "seed",
+    });
+
+    const reads = await store.openCommittedReads(principal, repoId, REF);
+    if (reads === null) throw new Error("expected committed reads");
+    const root = await reads.listDir("");
+    expect(root.map((e) => e.name).sort()).toEqual(["a.json", "runs"]);
+  });
+
+  test("openCommittedReads is gated on the resolveRef authorize action", async () => {
+    const dataDir = await makeTempDir("repo-store-committed-gate-");
+    const handler = createTestHandler();
+    const denyResolveRef: AuthorizeFn = (_p, _r, _ref, action) =>
+      action === "resolveRef"
+        ? { allowed: false, reason: "no committed reads" }
+        : { allowed: true };
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: denyResolveRef,
+    });
+
+    await store.writeTree(principal, repoId, REF, {
+      files: { "runs/r1/events/0.json": "zero" },
+      message: "seed",
+    });
+
+    await expect(
+      store.openCommittedReads(principal, repoId, REF),
+    ).rejects.toThrow("authorize_denied: no committed reads");
+  });
 });

--- a/packages/hub-sessions/src/repo-store/store.test.ts
+++ b/packages/hub-sessions/src/repo-store/store.test.ts
@@ -2295,4 +2295,99 @@ describe("RepoStore", () => {
       store.openCommittedReads(principal, repoId, REF),
     ).rejects.toThrow("authorize_denied: no committed reads");
   });
+
+  test("openCommittedReadsAtCommit reads the pinned commit, not the ref tip", async () => {
+    const dataDir = await makeTempDir("repo-store-committed-at-");
+    const handler = createTestHandler();
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: allowAll,
+    });
+
+    const first = await store.writeTree(principal, repoId, REF, {
+      files: { "runs/r1/events/0.json": "zero" },
+      message: "c1",
+    });
+    await store.writeTree(principal, repoId, REF, {
+      files: { "runs/r1/events/1.json": "one" },
+      message: "c2",
+    });
+
+    // Pinned to the first commit, the reads see only that commit's tree
+    // even though the ref tip has advanced to include 1.json.
+    const reads = await store.openCommittedReadsAtCommit(
+      principal,
+      repoId,
+      first.commitSha,
+    );
+    if (reads === null) throw new Error("expected committed reads");
+    const events = await reads.listDir("runs/r1/events");
+    expect(events.map((e) => e.name)).toEqual(["0.json"]);
+  });
+
+  test("openCommittedReadsAtCommit returns null for a missing repo or unknown commit", async () => {
+    const dataDir = await makeTempDir("repo-store-committed-at-null-");
+    const handler = createTestHandler();
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: allowAll,
+    });
+
+    const absent = "0".repeat(40);
+    expect(
+      await store.openCommittedReadsAtCommit(principal, repoId, absent),
+    ).toBeNull();
+
+    await store.writeTree(principal, repoId, REF, {
+      files: { "runs/r1/events/0.json": "zero" },
+      message: "seed",
+    });
+    // Well-formed SHA that names no commit in the object store.
+    expect(
+      await store.openCommittedReadsAtCommit(principal, repoId, absent),
+    ).toBeNull();
+  });
+
+  test("openCommittedReadsAtCommit rejects a malformed commit SHA", async () => {
+    const dataDir = await makeTempDir("repo-store-committed-at-bad-");
+    const handler = createTestHandler();
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: allowAll,
+    });
+
+    await expect(
+      store.openCommittedReadsAtCommit(principal, repoId, "not-a-sha"),
+    ).rejects.toThrow("commit_sha_invalid");
+  });
+
+  test("openCommittedReadsAtCommit is gated on the resolveRef authorize action", async () => {
+    const dataDir = await makeTempDir("repo-store-committed-at-gate-");
+    const handler = createTestHandler();
+    const denyResolveRef: AuthorizeFn = (_p, _r, _ref, action) =>
+      action === "resolveRef"
+        ? { allowed: false, reason: "no committed reads" }
+        : { allowed: true };
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": handler },
+      authorize: denyResolveRef,
+    });
+
+    const { commitSha } = await store.writeTree(principal, repoId, REF, {
+      files: { "runs/r1/events/0.json": "zero" },
+      message: "seed",
+    });
+
+    await expect(
+      store.openCommittedReadsAtCommit(principal, repoId, commitSha),
+    ).rejects.toThrow("authorize_denied: no committed reads");
+  });
 });

--- a/packages/hub-sessions/src/repo-store/store.ts
+++ b/packages/hub-sessions/src/repo-store/store.ts
@@ -15,6 +15,8 @@ import { hasCode } from "@intx/types";
 import { getLogger } from "@intx/log";
 import type {
   AuthorizeFn,
+  CommittedReads,
+  CommittedTreeEntry,
   InitRepoOpts,
   KindHandler,
   Principal,
@@ -1846,6 +1848,35 @@ export function createRepoStore(config: CreateRepoStoreConfig): RepoStore {
     return resolveRefSha(repoDir(repoId), ref);
   }
 
+  async function openCommittedReads(
+    principal: Principal,
+    repoId: RepoId,
+    ref: string,
+  ): Promise<CommittedReads | null> {
+    gateAccess(principal, repoId, ref, "resolveRef");
+    const dir = repoDir(repoId);
+    const repoExists = await fs.promises
+      .stat(path.join(dir, ".git"))
+      .then(() => true)
+      .catch(() => false);
+    if (!repoExists) return null;
+    const commitSha = await resolveRefSha(dir, ref);
+    if (commitSha === null) return null;
+    const { readBlobByOid } = buildPriorTreeClosures(dir, commitSha);
+    const listDir = async (relPath: string): Promise<CommittedTreeEntry[]> => {
+      const oid = await resolveTreeEntry(dir, commitSha, relPath, "tree");
+      if (oid === null) return [];
+      const { tree } = await git.readTree({
+        fs,
+        dir,
+        cache: cacheFor(dir),
+        oid,
+      });
+      return tree.map((e) => ({ name: e.path, oid: e.oid, type: e.type }));
+    };
+    return { listDir, readBlobByOid };
+  }
+
   function subscribe(
     principal: Principal,
     repoId: RepoId,
@@ -2020,6 +2051,7 @@ export function createRepoStore(config: CreateRepoStoreConfig): RepoStore {
     listRefs,
     resolveHead,
     getRepoDir,
+    openCommittedReads,
     subscribe,
   };
 }

--- a/packages/hub-sessions/src/repo-store/store.ts
+++ b/packages/hub-sessions/src/repo-store/store.ts
@@ -1848,20 +1848,11 @@ export function createRepoStore(config: CreateRepoStoreConfig): RepoStore {
     return resolveRefSha(repoDir(repoId), ref);
   }
 
-  async function openCommittedReads(
-    principal: Principal,
-    repoId: RepoId,
-    ref: string,
-  ): Promise<CommittedReads | null> {
-    gateAccess(principal, repoId, ref, "resolveRef");
-    const dir = repoDir(repoId);
-    const repoExists = await fs.promises
-      .stat(path.join(dir, ".git"))
-      .then(() => true)
-      .catch(() => false);
-    if (!repoExists) return null;
-    const commitSha = await resolveRefSha(dir, ref);
-    if (commitSha === null) return null;
+  // Build the committed-read closures pinned to a commit. Shared by the
+  // by-ref (`openCommittedReads`) and by-commit
+  // (`openCommittedReadsAtCommit`) entrypoints, which differ only in how
+  // they obtain and validate the commit SHA.
+  function committedReadsAt(dir: string, commitSha: string): CommittedReads {
     const { readBlobByOid } = buildPriorTreeClosures(dir, commitSha);
     const listDir = async (relPath: string): Promise<CommittedTreeEntry[]> => {
       const oid = await resolveTreeEntry(dir, commitSha, relPath, "tree");
@@ -1875,6 +1866,52 @@ export function createRepoStore(config: CreateRepoStoreConfig): RepoStore {
       return tree.map((e) => ({ name: e.path, oid: e.oid, type: e.type }));
     };
     return { listDir, readBlobByOid };
+  }
+
+  async function repoHasGitDir(dir: string): Promise<boolean> {
+    return fs.promises
+      .stat(path.join(dir, ".git"))
+      .then(() => true)
+      .catch(() => false);
+  }
+
+  async function openCommittedReads(
+    principal: Principal,
+    repoId: RepoId,
+    ref: string,
+  ): Promise<CommittedReads | null> {
+    gateAccess(principal, repoId, ref, "resolveRef");
+    const dir = repoDir(repoId);
+    if (!(await repoHasGitDir(dir))) return null;
+    const commitSha = await resolveRefSha(dir, ref);
+    if (commitSha === null) return null;
+    return committedReadsAt(dir, commitSha);
+  }
+
+  async function openCommittedReadsAtCommit(
+    principal: Principal,
+    repoId: RepoId,
+    commitSha: string,
+  ): Promise<CommittedReads | null> {
+    // No single ref to gate on; use the same `"*"`/`resolveRef` bulk-read
+    // gate that `listRefs` and `resolveHead` use.
+    gateAccess(principal, repoId, "*", "resolveRef");
+    if (!/^[0-9a-f]{40}$/.test(commitSha)) {
+      throw new Error(`commit_sha_invalid: ${commitSha}`);
+    }
+    const dir = repoDir(repoId);
+    if (!(await repoHasGitDir(dir))) return null;
+    // Confirm the commit object is present so a pruned commit reads as a
+    // clean `null` rather than a lazy throw on the first tree walk.
+    const present = await git
+      .readCommit({ fs, dir, cache: cacheFor(dir), oid: commitSha })
+      .then(() => true)
+      .catch((err: unknown) => {
+        if (hasCode(err) && err.code === "NotFoundError") return false;
+        throw err;
+      });
+    if (!present) return null;
+    return committedReadsAt(dir, commitSha);
   }
 
   function subscribe(
@@ -2052,6 +2089,7 @@ export function createRepoStore(config: CreateRepoStoreConfig): RepoStore {
     resolveHead,
     getRepoDir,
     openCommittedReads,
+    openCommittedReadsAtCommit,
     subscribe,
   };
 }

--- a/packages/hub-sessions/src/repo-store/subscribe-kind.test.ts
+++ b/packages/hub-sessions/src/repo-store/subscribe-kind.test.ts
@@ -208,3 +208,118 @@ describe("subscribeKind", () => {
     expect(collected.map((e) => e.timerId)).toEqual(["t0", "t1", "t2"]);
   });
 });
+
+describe("subscribeKind added-blob handling", () => {
+  test("sorts added blobs across runs by run then seq", async () => {
+    const dataDir = await makeTempDir("subscribe-kind-sort-");
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": createPermissiveHandler() },
+      authorize: allowAll,
+    });
+    // A single commit adds events across two runs out of natural order.
+    await store.writeTree(principal, repoId, REF, {
+      files: {
+        "runs/rB/events/1.json": JSON.stringify({
+          type: "TimerFired",
+          data: { timerId: "b1" },
+        }),
+        "runs/rA/events/2.json": JSON.stringify({
+          type: "TimerFired",
+          data: { timerId: "a2" },
+        }),
+        "runs/rA/events/0.json": JSON.stringify({
+          type: "TimerFired",
+          data: { timerId: "a0" },
+        }),
+      },
+      message: "mixed",
+    });
+    const ac = new AbortController();
+    const iter = subscribeKind(store, principal, repoId, REF, RunEvent, {
+      signal: ac.signal,
+      from: { seq: 0 },
+      kinds: ["TimerFired"],
+    });
+    const got: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      const n = await iter.next();
+      if (n.done) break;
+      got.push(`${n.value.runId}:${String(n.value.seq)}`);
+    }
+    ac.abort();
+    expect(got).toEqual(["rA:0", "rA:2", "rB:1"]);
+  });
+
+  test("throws on an illegal event filename", async () => {
+    const dataDir = await makeTempDir("subscribe-kind-badname-");
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": createPermissiveHandler() },
+      authorize: allowAll,
+    });
+    await store.writeTree(principal, repoId, REF, {
+      files: {
+        "runs/r1/events/not-a-seq.json": JSON.stringify({
+          type: "TimerFired",
+          data: { timerId: "x" },
+        }),
+      },
+      message: "bad filename",
+    });
+    const ac = new AbortController();
+    const iter = subscribeKind(store, principal, repoId, REF, RunEvent, {
+      signal: ac.signal,
+      from: { seq: 0 },
+      kinds: ["TimerFired"],
+    });
+    await expect(iter.next()).rejects.toThrow("event_filename_invalid");
+    ac.abort();
+  });
+
+  test("throws on an unparseable added blob", async () => {
+    const dataDir = await makeTempDir("subscribe-kind-badjson-");
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": createPermissiveHandler() },
+      authorize: allowAll,
+    });
+    await store.writeTree(principal, repoId, REF, {
+      files: { "runs/r1/events/0.json": "{ not json" },
+      message: "bad json",
+    });
+    const ac = new AbortController();
+    const iter = subscribeKind(store, principal, repoId, REF, RunEvent, {
+      signal: ac.signal,
+      from: { seq: 0 },
+      kinds: ["TimerFired"],
+    });
+    await expect(iter.next()).rejects.toThrow("subscribe_kind_invalid_json");
+    ac.abort();
+  });
+
+  test("throws on an added blob missing its type", async () => {
+    const dataDir = await makeTempDir("subscribe-kind-notype-");
+    const store = createRepoStore({
+      dataDir,
+      signingKey,
+      handlers: { "agent-state": createPermissiveHandler() },
+      authorize: allowAll,
+    });
+    await store.writeTree(principal, repoId, REF, {
+      files: { "runs/r1/events/0.json": JSON.stringify({ data: {} }) },
+      message: "no type",
+    });
+    const ac = new AbortController();
+    const iter = subscribeKind(store, principal, repoId, REF, RunEvent, {
+      signal: ac.signal,
+      from: { seq: 0 },
+      kinds: ["TimerFired"],
+    });
+    await expect(iter.next()).rejects.toThrow("subscribe_kind_missing_type");
+    ac.abort();
+  });
+});

--- a/packages/hub-sessions/src/repo-store/subscribe-kind.ts
+++ b/packages/hub-sessions/src/repo-store/subscribe-kind.ts
@@ -2,18 +2,12 @@ import fs from "node:fs";
 import git from "isomorphic-git";
 import { type, type Type } from "arktype";
 import { hasCode } from "@intx/types";
+import {
+  parseEventSeq,
+  WORKFLOW_RUN_EVENTS_DIR,
+  WORKFLOW_RUN_RUNS_PREFIX,
+} from "../workflow-run-kind";
 import type { Principal, RepoId, RepoStore } from "./types";
-
-/**
- * Path-layout constants for the workflow-run repo's event log. The
- * workflow-run kind handler commits one JSON blob per event under
- * `runs/<runId>/events/<seq>.json` (the layout decided in the
- * pre-build interface decisions for the workflow-run repo). The
- * `subscribeKind` helper owns this layout so the substrate `subscribe`
- * stays generic and free of workflow-event vocabulary.
- */
-const RUNS_PREFIX = "runs";
-const EVENTS_DIR = "events";
 
 /**
  * Substrate envelope shape. Imported textually rather than from
@@ -27,12 +21,6 @@ const SubstrateEvent = type({
   "oldSha?": "string | null",
   newSha: "string",
 });
-
-/**
- * Per-event filename shape. Filenames are `<seq>.json` under
- * `runs/<runId>/events/`. `<seq>` is a non-negative decimal integer.
- */
-const EVENT_FILENAME_RE = /^(0|[1-9][0-9]*)\.json$/;
 
 type EventCandidate = {
   /** Workflow-event seq parsed from the filename. */
@@ -87,9 +75,12 @@ export type SubscribeKindEntry<T> = {
  * kinds filter against the inner `type` discriminator, and yields one
  * `{ seq, event }` entry per matching blob.
  *
- * The path layout is owned here, not in the substrate: the substrate
- * `subscribe` is a generic ref-tail primitive and knows nothing about
- * workflow-runs.
+ * The path-layout vocabulary (the `runs/`/`events/` prefixes and the
+ * `<seq>.json` filename shape) lives in the workflow-run kind handler,
+ * which is the authority for what may land under this prefix; this
+ * helper imports it rather than re-encoding it. The substrate
+ * `subscribe` it wraps is a generic ref-tail primitive and knows
+ * nothing about workflow-runs.
  *
  * Diff scope: the helper enumerates event blobs present in the new
  * commit but absent from the old commit. A commit that does not add
@@ -208,27 +199,32 @@ async function enumerateEventBlobs(
     if (hasCode(err) && err.code === "NotFoundError") return out;
     throw err;
   }
-  const runsOid = await lookupSubtree(dir, commit.commit.tree, RUNS_PREFIX);
+  const runsOid = await lookupSubtree(
+    dir,
+    commit.commit.tree,
+    WORKFLOW_RUN_RUNS_PREFIX,
+  );
   if (runsOid === null) return out;
   const { tree: runs } = await git.readTree({ fs, dir, oid: runsOid });
   for (const runEntry of runs) {
     if (runEntry.type !== "tree") continue;
     const runId = runEntry.path;
-    const eventsOid = await lookupSubtree(dir, runEntry.oid, EVENTS_DIR);
+    const eventsOid = await lookupSubtree(
+      dir,
+      runEntry.oid,
+      WORKFLOW_RUN_EVENTS_DIR,
+    );
     if (eventsOid === null) continue;
     const { tree: events } = await git.readTree({ fs, dir, oid: eventsOid });
     for (const blob of events) {
       if (blob.type !== "blob") continue;
-      const match = EVENT_FILENAME_RE.exec(blob.path);
-      if (match === null) {
+      const blobPath = `${WORKFLOW_RUN_RUNS_PREFIX}/${runId}/${WORKFLOW_RUN_EVENTS_DIR}/${blob.path}`;
+      const seq = parseEventSeq(blob.path);
+      if (seq === null) {
         throw new Error(
-          `subscribe_kind_unexpected_event_filename: ${RUNS_PREFIX}/${runId}/${EVENTS_DIR}/${blob.path}`,
+          `subscribe_kind_unexpected_event_filename: ${blobPath}`,
         );
       }
-      const seqStr = match[1];
-      if (seqStr === undefined) throw new Error("unreachable");
-      const seq = Number.parseInt(seqStr, 10);
-      const blobPath = `${RUNS_PREFIX}/${runId}/${EVENTS_DIR}/${blob.path}`;
       out.set(`${runId}/${blob.path}`, { seq, runId, blobPath });
     }
   }

--- a/packages/hub-sessions/src/repo-store/subscribe-kind.ts
+++ b/packages/hub-sessions/src/repo-store/subscribe-kind.ts
@@ -1,6 +1,6 @@
 import { type, type Type } from "arktype";
 import {
-  parseEventSeq,
+  requireEventSeq,
   WORKFLOW_RUN_EVENTS_DIR,
   WORKFLOW_RUN_RUNS_PREFIX,
 } from "../workflow-run-kind";
@@ -208,12 +208,7 @@ async function enumerateEventBlobs(
     for (const blob of events) {
       if (blob.type !== "blob") continue;
       const blobPath = `${WORKFLOW_RUN_RUNS_PREFIX}/${runId}/${WORKFLOW_RUN_EVENTS_DIR}/${blob.name}`;
-      const seq = parseEventSeq(blob.name);
-      if (seq === null) {
-        throw new Error(
-          `subscribe_kind_unexpected_event_filename: ${blobPath}`,
-        );
-      }
+      const seq = requireEventSeq(blob.name, blobPath);
       out.set(`${runId}/${blob.name}`, {
         seq,
         runId,

--- a/packages/hub-sessions/src/repo-store/subscribe-kind.ts
+++ b/packages/hub-sessions/src/repo-store/subscribe-kind.ts
@@ -1,13 +1,10 @@
-import fs from "node:fs";
-import git from "isomorphic-git";
 import { type, type Type } from "arktype";
-import { hasCode } from "@intx/types";
 import {
   parseEventSeq,
   WORKFLOW_RUN_EVENTS_DIR,
   WORKFLOW_RUN_RUNS_PREFIX,
 } from "../workflow-run-kind";
-import type { Principal, RepoId, RepoStore } from "./types";
+import type { CommittedReads, Principal, RepoId, RepoStore } from "./types";
 
 /**
  * Substrate envelope shape. Imported textually rather than from
@@ -29,6 +26,8 @@ type EventCandidate = {
   runId: string;
   /** Repo-root-relative blob path. */
   blobPath: string;
+  /** Git object id of the event blob, for a direct cache-backed read. */
+  oid: string;
 };
 
 const KindEnvelope = type({
@@ -97,7 +96,6 @@ export async function* subscribeKind<V extends Type>(
   opts: SubscribeKindOpts,
 ): AsyncGenerator<SubscribeKindEntry<V["infer"]>, void, void> {
   const kindsAllowed = new Set<string>(opts.kinds);
-  const dir = store.getRepoDir(repoId);
   const subscribeOpts: {
     signal: AbortSignal;
     from: "head" | { seq: number };
@@ -116,17 +114,25 @@ export async function* subscribeKind<V extends Type>(
     if (envelope instanceof type.errors) {
       throw new Error(`subscribe_kind_envelope_invalid: ${envelope.summary}`);
     }
-    const candidates = await collectAddedEventBlobs(
-      dir,
-      envelope.oldSha ?? null,
+    const newReads = await store.openCommittedReadsAtCommit(
+      principal,
+      repoId,
       envelope.newSha,
     );
+    // A commit a concurrent GC pruned between the ref-update event and
+    // this read yields nothing; the substrate surfaces that as `null`.
+    if (newReads === null) continue;
+    const oldReads =
+      envelope.oldSha === undefined || envelope.oldSha === null
+        ? null
+        : await store.openCommittedReadsAtCommit(
+            principal,
+            repoId,
+            envelope.oldSha,
+          );
+    const candidates = await collectAddedEventBlobs(newReads, oldReads);
     for (const candidate of candidates) {
-      const raw = await readBlobAtCommit(
-        dir,
-        envelope.newSha,
-        candidate.blobPath,
-      );
+      const raw = await newReads.readBlobByOid(candidate.oid);
       let parsedJson: unknown;
       try {
         parsedJson = JSON.parse(new TextDecoder().decode(raw));
@@ -154,24 +160,25 @@ export async function* subscribeKind<V extends Type>(
 }
 
 /**
- * Walk the `runs/<runId>/events/` subtree at `newSha` and at `oldSha`
- * (when present) and return the set of event candidates present in
- * the new commit but not in the old. Filenames that fail the
- * `<seq>.json` shape are surfaced as errors rather than silently
- * skipped — the workflow-run kind handler's validatePush is the
- * authority for what may land under this prefix, so an unexpected
- * shape here is a substrate-side invariant violation.
+ * Diff the `runs/<runId>/events/` subtree between the new and old commit
+ * reads and return the event candidates present in the new commit but
+ * not the old. `oldReads` is `null` for the ref's first commit (no prior
+ * tip) or when the prior commit is no longer in the object store, in
+ * which case every event in the new commit is treated as added.
+ * Filenames that fail the `<seq>.json` shape are surfaced as errors
+ * rather than silently skipped — the workflow-run kind handler's
+ * validatePush is the authority for what may land under this prefix, so
+ * an unexpected shape here is a substrate-side invariant violation.
  */
 async function collectAddedEventBlobs(
-  dir: string,
-  oldSha: string | null,
-  newSha: string,
+  newReads: CommittedReads,
+  oldReads: CommittedReads | null,
 ): Promise<EventCandidate[]> {
-  const newSet = await enumerateEventBlobs(dir, newSha);
-  if (oldSha === null) {
+  const newSet = await enumerateEventBlobs(newReads);
+  if (oldReads === null) {
     return [...newSet.values()].sort(byRunThenSeq);
   }
-  const oldSet = await enumerateEventBlobs(dir, oldSha);
+  const oldSet = await enumerateEventBlobs(oldReads);
   const out: EventCandidate[] = [];
   for (const [key, candidate] of newSet) {
     if (oldSet.has(key)) continue;
@@ -188,66 +195,32 @@ function byRunThenSeq(a: EventCandidate, b: EventCandidate): number {
 }
 
 async function enumerateEventBlobs(
-  dir: string,
-  commitOid: string,
+  reads: CommittedReads,
 ): Promise<Map<string, EventCandidate>> {
   const out = new Map<string, EventCandidate>();
-  let commit: Awaited<ReturnType<typeof git.readCommit>>;
-  try {
-    commit = await git.readCommit({ fs, dir, oid: commitOid });
-  } catch (err) {
-    if (hasCode(err) && err.code === "NotFoundError") return out;
-    throw err;
-  }
-  const runsOid = await lookupSubtree(
-    dir,
-    commit.commit.tree,
-    WORKFLOW_RUN_RUNS_PREFIX,
-  );
-  if (runsOid === null) return out;
-  const { tree: runs } = await git.readTree({ fs, dir, oid: runsOid });
+  const runs = await reads.listDir(WORKFLOW_RUN_RUNS_PREFIX);
   for (const runEntry of runs) {
     if (runEntry.type !== "tree") continue;
-    const runId = runEntry.path;
-    const eventsOid = await lookupSubtree(
-      dir,
-      runEntry.oid,
-      WORKFLOW_RUN_EVENTS_DIR,
+    const runId = runEntry.name;
+    const events = await reads.listDir(
+      `${WORKFLOW_RUN_RUNS_PREFIX}/${runId}/${WORKFLOW_RUN_EVENTS_DIR}`,
     );
-    if (eventsOid === null) continue;
-    const { tree: events } = await git.readTree({ fs, dir, oid: eventsOid });
     for (const blob of events) {
       if (blob.type !== "blob") continue;
-      const blobPath = `${WORKFLOW_RUN_RUNS_PREFIX}/${runId}/${WORKFLOW_RUN_EVENTS_DIR}/${blob.path}`;
-      const seq = parseEventSeq(blob.path);
+      const blobPath = `${WORKFLOW_RUN_RUNS_PREFIX}/${runId}/${WORKFLOW_RUN_EVENTS_DIR}/${blob.name}`;
+      const seq = parseEventSeq(blob.name);
       if (seq === null) {
         throw new Error(
           `subscribe_kind_unexpected_event_filename: ${blobPath}`,
         );
       }
-      out.set(`${runId}/${blob.path}`, { seq, runId, blobPath });
+      out.set(`${runId}/${blob.name}`, {
+        seq,
+        runId,
+        blobPath,
+        oid: blob.oid,
+      });
     }
   }
   return out;
-}
-
-async function lookupSubtree(
-  dir: string,
-  parentTreeOid: string,
-  name: string,
-): Promise<string | null> {
-  const { tree } = await git.readTree({ fs, dir, oid: parentTreeOid });
-  const entry = tree.find((e) => e.path === name);
-  if (entry === undefined) return null;
-  if (entry.type !== "tree") return null;
-  return entry.oid;
-}
-
-async function readBlobAtCommit(
-  dir: string,
-  commitOid: string,
-  filepath: string,
-): Promise<Uint8Array> {
-  const { blob } = await git.readBlob({ fs, dir, oid: commitOid, filepath });
-  return blob;
 }

--- a/packages/hub-sessions/src/repo-store/types.ts
+++ b/packages/hub-sessions/src/repo-store/types.ts
@@ -517,6 +517,27 @@ export interface RepoStore {
     ref: string,
   ): Promise<CommittedReads | null>;
   /**
+   * Open cache-backed reads of the committed tree at an explicit commit,
+   * the by-SHA counterpart of `openCommittedReads`. A consumer that
+   * already holds a commit id — e.g. the `newSha`/`oldSha` of a
+   * ref-update event it is diffing — reads that exact commit through
+   * this, even after the ref has advanced past it. Every read the handle
+   * serves resolves through the git object store, pinned to `commitSha`.
+   *
+   * Gated under the same `resolveRef` action as `openCommittedReads`.
+   * `commitSha` is validated at the boundary: a malformed SHA throws
+   * `commit_sha_invalid`. Returns `null` when the repo does not yet exist
+   * or when `commitSha` names no commit in the object store (a commit a
+   * concurrent GC pruned between the caller learning of it and reading
+   * it), so a caller diffing a possibly-vanished commit gets an empty
+   * view rather than a mid-walk throw.
+   */
+  openCommittedReadsAtCommit(
+    principal: Principal,
+    repoId: RepoId,
+    commitSha: string,
+  ): Promise<CommittedReads | null>;
+  /**
    * Tail a ref's commit log. Returns an async iterator that emits
    * `{ seq, event }` entries: one per commit on the ref. `seq` is
    * zero-indexed at the ref's root commit and counts ancestors

--- a/packages/hub-sessions/src/repo-store/types.ts
+++ b/packages/hub-sessions/src/repo-store/types.ts
@@ -323,6 +323,42 @@ export interface KindHandler {
   }) => Promise<void> | void;
 }
 
+/**
+ * A single child entry returned by `CommittedReads.listDir`. `name` is
+ * the entry's own path segment (no parent prefix); `oid` is its git
+ * object id; `type` is the git tree-entry kind. `oid` lets a consumer
+ * read a blob's bytes via `readBlobByOid` without re-resolving the path,
+ * and lets it prove a subtree byte-unchanged by OID equality.
+ */
+export type CommittedTreeEntry = {
+  readonly name: string;
+  readonly oid: string;
+  readonly type: "blob" | "tree" | "commit";
+};
+
+/**
+ * Cache-backed reads pinned to the commit a ref resolved to at the
+ * moment `openCommittedReads` was called. Every read resolves against
+ * the git object store, never the materialized working tree, so a
+ * consumer observes committed state even when the on-disk checkout lags
+ * the committed tree. The pin is fixed at open time: a concurrent commit
+ * that advances the ref afterwards does not shift the reads, so an
+ * enumerate-then-read sequence sees a single coherent snapshot.
+ *
+ * `listDir` returns the direct children of a repo-root-relative POSIX
+ * directory path (no leading or trailing slash; the empty string lists
+ * the root). A path that is absent, or resolves to a non-tree, lists as
+ * the empty array — mirroring the prior-tree closures the substrate
+ * hands a kind handler. `readBlobByOid` reads a blob's bytes by its
+ * object id; a read fault surfaces as a thrown error rather than an
+ * empty result so a consumer cannot silently degrade a missing object
+ * into an absent event.
+ */
+export type CommittedReads = {
+  listDir(relPath: string): Promise<CommittedTreeEntry[]>;
+  readBlobByOid(oid: string): Promise<Uint8Array>;
+};
+
 export interface RepoStore {
   /**
    * Bookkeeping primitive. Idempotent. Creates the repo directory
@@ -459,6 +495,27 @@ export interface RepoStore {
    * they reach into for ref-listing and pack negotiation.
    */
   getRepoDir(repoId: RepoId): string;
+  /**
+   * Open cache-backed reads of the committed tree at `ref`'s tip. The
+   * ref is resolved once, at call time, and every read the returned
+   * handle serves is pinned to that commit and resolves through the git
+   * object store — not the materialized working tree `getRepoDir` points
+   * at. A consumer that must observe committed state (e.g. start-time
+   * recovery reconstructing a ledger from the persisted log) reads
+   * through this rather than the working tree, which a non-atomic
+   * post-commit materialization can leave lagging on a contended
+   * filesystem.
+   *
+   * Gated under the same `resolveRef` action as `resolveRef` / `listRefs`
+   * / `subscribe`. Returns `null` when the repo does not yet exist
+   * (mirrors `listRefs`'s empty-list contract for uninitialised repos)
+   * or when `ref` does not resolve to a commit.
+   */
+  openCommittedReads(
+    principal: Principal,
+    repoId: RepoId,
+    ref: string,
+  ): Promise<CommittedReads | null>;
   /**
    * Tail a ref's commit log. Returns an async iterator that emits
    * `{ seq, event }` entries: one per commit on the ref. `seq` is

--- a/packages/hub-sessions/src/session-service.test.ts
+++ b/packages/hub-sessions/src/session-service.test.ts
@@ -179,6 +179,7 @@ function unusedRepoStore(): RepoStore {
     getRepoDir: () => {
       throw new Error("mock AgentRepoStore.repoStore is not wired");
     },
+    openCommittedReads: unused,
     subscribe: () => {
       throw new Error("mock AgentRepoStore.repoStore is not wired");
     },
@@ -215,6 +216,7 @@ function createFakeRepoStore(
     getRepoDir: () => {
       throw new Error("repoStore method not wired in fake");
     },
+    openCommittedReads: unused,
     subscribe: () => {
       throw new Error("repoStore method not wired in fake");
     },

--- a/packages/hub-sessions/src/session-service.test.ts
+++ b/packages/hub-sessions/src/session-service.test.ts
@@ -180,6 +180,7 @@ function unusedRepoStore(): RepoStore {
       throw new Error("mock AgentRepoStore.repoStore is not wired");
     },
     openCommittedReads: unused,
+    openCommittedReadsAtCommit: unused,
     subscribe: () => {
       throw new Error("mock AgentRepoStore.repoStore is not wired");
     },
@@ -217,6 +218,7 @@ function createFakeRepoStore(
       throw new Error("repoStore method not wired in fake");
     },
     openCommittedReads: unused,
+    openCommittedReadsAtCommit: unused,
     subscribe: () => {
       throw new Error("repoStore method not wired in fake");
     },

--- a/packages/hub-sessions/src/substrate.ts
+++ b/packages/hub-sessions/src/substrate.ts
@@ -51,6 +51,8 @@ export type { SubscribeKindEntry } from "./repo-store/subscribe-kind";
 export { createAgentRepoStore } from "./agent-repo";
 
 export type {
+  CommittedReads,
+  CommittedTreeEntry,
   Principal,
   RepoId,
   RepoStore,

--- a/packages/hub-sessions/src/substrate.ts
+++ b/packages/hub-sessions/src/substrate.ts
@@ -20,10 +20,13 @@ export {
   dequeueToProcessing,
   enqueueInbox,
   markConsumed,
+  parseEventSeq,
   readOwnedMessageIds,
   readProcessingEntry,
   replayProcessingToInbox,
   WORKFLOW_RUN_AGENT_STATE_PREFIX,
+  WORKFLOW_RUN_EVENTS_DIR,
+  WORKFLOW_RUN_RUNS_PREFIX,
 } from "./workflow-run-kind";
 export type {
   WorkflowRunSupervisorPrincipal,

--- a/packages/hub-sessions/src/substrate.ts
+++ b/packages/hub-sessions/src/substrate.ts
@@ -24,6 +24,7 @@ export {
   readOwnedMessageIds,
   readProcessingEntry,
   replayProcessingToInbox,
+  requireEventSeq,
   WORKFLOW_RUN_AGENT_STATE_PREFIX,
   WORKFLOW_RUN_EVENTS_DIR,
   WORKFLOW_RUN_RUNS_PREFIX,

--- a/packages/hub-sessions/src/workflow-run-kind.test.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.test.ts
@@ -12,6 +12,7 @@ import {
   enqueueInbox,
   dequeueToProcessing,
   markConsumed,
+  parseEventSeq,
   readOwnedMessageIds,
   replayProcessingToInbox,
   WORKFLOW_RUN_GITIGNORE_PATH,
@@ -3820,5 +3821,40 @@ describe("claim-check API — retention watermark exactly-once + bounded", () =>
         mailAuditRef: { store: "audit", path: "mail/inflight" },
       }),
     ).rejects.toThrow(/claim_check_already_consumed/);
+  });
+});
+
+describe("parseEventSeq", () => {
+  test("accepts canonical <seq>.json names", () => {
+    expect(parseEventSeq("0.json")).toBe(0);
+    expect(parseEventSeq("1.json")).toBe(1);
+    expect(parseEventSeq("42.json")).toBe(42);
+    expect(parseEventSeq("1000000.json")).toBe(1_000_000);
+  });
+
+  test("rejects leading zeros, wrong case, whitespace, and near-misses", () => {
+    // Every reader of the event log narrows filenames through this one
+    // function; these are the boundaries a naive `\d+` rewrite would
+    // silently break, so they are pinned by example.
+    for (const bad of [
+      "00.json",
+      "01.json",
+      "1.JSON",
+      " 1.json",
+      "1.json\n",
+      "-1.json",
+      "+1.json",
+      "1.5.json",
+      "1e3.json",
+      "0x1.json",
+      "1..json",
+      "1.json.bak",
+      "events.jsonl",
+      "1",
+      ".json",
+      "",
+    ]) {
+      expect(parseEventSeq(bad)).toBeNull();
+    }
   });
 });

--- a/packages/hub-sessions/src/workflow-run-kind.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.ts
@@ -287,6 +287,24 @@ const CLAIM_CHECK_SUBDIRS = new Set<string>([
 const EVENT_FILENAME_RE = /^(0|[1-9][0-9]*)\.json$/;
 
 /**
+ * Parse the seq from a per-event log filename `<seq>.json` under
+ * `runs/<runId>/events/`. Returns the non-negative integer seq, or
+ * `null` when the name is not a legal per-event filename. This is the
+ * one place the filename shape is defined; every reader of the event log
+ * narrows names through it rather than re-encoding the regex. Callers
+ * decide what an illegal name means -- a foreign entry to skip, or a
+ * substrate-invariant violation to surface -- since `validatePush` is
+ * the authority that keeps illegal names from landing in the first place.
+ */
+export function parseEventSeq(filename: string): number | null {
+  const match = EVENT_FILENAME_RE.exec(filename);
+  if (match === null) return null;
+  const seqStr = match[1];
+  if (seqStr === undefined) return null;
+  return Number.parseInt(seqStr, 10);
+}
+
+/**
  * Per-blob filename shape for the `runs/<runId>/blobs/` subtree: a
  * lowercase 64-character sha256 hex string. Pins the regex to the key
  * the production `BlobSubstrate` adapter computes via `sha256Hex` so a

--- a/packages/hub-sessions/src/workflow-run-kind.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.ts
@@ -305,6 +305,24 @@ export function parseEventSeq(filename: string): number | null {
 }
 
 /**
+ * Narrow a per-event filename to its seq, throwing when it is illegal.
+ * A reader that enumerates the committed event log to act on its entries
+ * uses this rather than `parseEventSeq`: `validatePush` is the authority
+ * that keeps an illegal name from ever landing under
+ * `runs/<runId>/events/`, so a name that reaches a reader is corruption,
+ * and silently skipping it would drop an event from processing. `context`
+ * is the repo-root-relative blob path, surfaced in the error so the
+ * offending entry is identifiable.
+ */
+export function requireEventSeq(filename: string, context: string): number {
+  const seq = parseEventSeq(filename);
+  if (seq === null) {
+    throw new Error(`event_filename_invalid: ${context}`);
+  }
+  return seq;
+}
+
+/**
  * Per-blob filename shape for the `runs/<runId>/blobs/` subtree: a
  * lowercase 64-character sha256 hex string. Pins the regex to the key
  * the production `BlobSubstrate` adapter computes via `sha256Hex` so a

--- a/packages/hub-sessions/src/workflow-run-reader.test.ts
+++ b/packages/hub-sessions/src/workflow-run-reader.test.ts
@@ -140,16 +140,18 @@ describe("WorkflowRunReader", () => {
     ]);
   });
 
-  test("ignores non-event blobs in the events dir", async () => {
+  test("rejects an illegal event filename in the events dir", async () => {
+    // Only `<seq>.json` may land under `events/`; validatePush enforces
+    // that, so a foreign name here is corruption the reader surfaces
+    // rather than silently dropping.
     await commitFiles(dir, {
       "runs/run-1/events/0.json": JSON.stringify({ type: "RunStarted" }),
-      "runs/run-1/events/notanumber.json": JSON.stringify({ type: "Junk" }),
       "runs/run-1/events/1.txt": "not json",
     });
 
-    const events = await reader.readRunEvents(REPO_ID, REF, "run-1");
-    expect(events).toHaveLength(1);
-    expect(events[0]?.type).toBe("RunStarted");
+    await expect(reader.readRunEvents(REPO_ID, REF, "run-1")).rejects.toThrow(
+      "event_filename_invalid",
+    );
   });
 
   test("lists run ids present under runs/", async () => {

--- a/packages/hub-sessions/src/workflow-run-reader.test.ts
+++ b/packages/hub-sessions/src/workflow-run-reader.test.ts
@@ -36,6 +36,7 @@ function repoStoreFor(dirById: Map<string, string>): RepoStore {
       }
       return dir;
     },
+    openCommittedReads: unused,
     subscribe: () => {
       throw new Error("workflow-run reader test: subscribe not wired");
     },

--- a/packages/hub-sessions/src/workflow-run-reader.test.ts
+++ b/packages/hub-sessions/src/workflow-run-reader.test.ts
@@ -37,6 +37,7 @@ function repoStoreFor(dirById: Map<string, string>): RepoStore {
       return dir;
     },
     openCommittedReads: unused,
+    openCommittedReadsAtCommit: unused,
     subscribe: () => {
       throw new Error("workflow-run reader test: subscribe not wired");
     },

--- a/packages/hub-sessions/src/workflow-run-reader.ts
+++ b/packages/hub-sessions/src/workflow-run-reader.ts
@@ -4,7 +4,7 @@ import git from "isomorphic-git";
 import type { RepoId } from "./repo-store/types";
 import type { RepoStore } from "./repo-store/types";
 import {
-  parseEventSeq,
+  requireEventSeq,
   WORKFLOW_RUN_EVENTS_DIR,
   WORKFLOW_RUN_RUNS_PREFIX,
 } from "./workflow-run-kind";
@@ -175,10 +175,9 @@ export function createWorkflowRunReader(
     const events: WorkflowRunEvent[] = [];
     for (const entry of tree.tree) {
       if (entry.type !== "blob") continue;
-      const seq = parseEventSeq(entry.path);
-      if (seq === null) continue;
-      const blob = await git.readBlob({ fs, dir, oid: entry.oid });
       const path = `${eventsDir}/${entry.path}`;
+      const seq = requireEventSeq(entry.path, path);
+      const blob = await git.readBlob({ fs, dir, oid: entry.oid });
       const parsed = parseEventObject(
         new TextDecoder().decode(blob.blob),
         path,

--- a/packages/hub-sessions/src/workflow-run-reader.ts
+++ b/packages/hub-sessions/src/workflow-run-reader.ts
@@ -4,6 +4,7 @@ import git from "isomorphic-git";
 import type { RepoId } from "./repo-store/types";
 import type { RepoStore } from "./repo-store/types";
 import {
+  parseEventSeq,
   WORKFLOW_RUN_EVENTS_DIR,
   WORKFLOW_RUN_RUNS_PREFIX,
 } from "./workflow-run-kind";
@@ -23,8 +24,6 @@ export type WorkflowRunEvent = {
   type: string;
   body: Record<string, unknown>;
 };
-
-const EVENT_FILENAME_RE = /^(0|[1-9][0-9]*)\.json$/;
 
 /**
  * Reader for a workflow-run repo's committed event log. Projects the
@@ -176,9 +175,8 @@ export function createWorkflowRunReader(
     const events: WorkflowRunEvent[] = [];
     for (const entry of tree.tree) {
       if (entry.type !== "blob") continue;
-      const m = EVENT_FILENAME_RE.exec(entry.path);
-      if (m === null || m[1] === undefined) continue;
-      const seq = Number.parseInt(m[1], 10);
+      const seq = parseEventSeq(entry.path);
+      if (seq === null) continue;
       const blob = await git.readBlob({ fs, dir, oid: entry.oid });
       const path = `${eventsDir}/${entry.path}`;
       const parsed = parseEventObject(

--- a/packages/workflow-host/src/child/proxy-repo-store.ts
+++ b/packages/workflow-host/src/child/proxy-repo-store.ts
@@ -51,7 +51,8 @@ export interface CreateProxyWorkflowRunRepoStoreOpts {
    * data dir. Used for the read-only methods that consult the
    * substrate's local state -- `getRepoDir` (path computation, no
    * I/O), `resolveRef`, `listRefs`, `resolveHead`, `openCommittedReads`,
-   * `createPack`. The bare store is never used as a writer here; its
+   * `openCommittedReadsAtCommit`, `createPack`. The bare store is never
+   * used as a writer here; its
    * `writeTreePreservingPrefix` / `writeTree` / `receivePack` are not
    * reachable through this proxy.
    */
@@ -216,6 +217,8 @@ export function createProxyWorkflowRunRepoStore(
     resolveHead: bareStore.resolveHead.bind(bareStore),
     getRepoDir: bareStore.getRepoDir.bind(bareStore),
     openCommittedReads: bareStore.openCommittedReads.bind(bareStore),
+    openCommittedReadsAtCommit:
+      bareStore.openCommittedReadsAtCommit.bind(bareStore),
     subscribe(
       _principal: Principal,
       repoId: RepoId,

--- a/packages/workflow-host/src/child/proxy-repo-store.ts
+++ b/packages/workflow-host/src/child/proxy-repo-store.ts
@@ -50,8 +50,8 @@ export interface CreateProxyWorkflowRunRepoStoreOpts {
    * Bare substrate handle the child opens against the shared on-disk
    * data dir. Used for the read-only methods that consult the
    * substrate's local state -- `getRepoDir` (path computation, no
-   * I/O), `resolveRef`, `listRefs`, `resolveHead`, `createPack`. The
-   * bare store is never used as a writer here; its
+   * I/O), `resolveRef`, `listRefs`, `resolveHead`, `openCommittedReads`,
+   * `createPack`. The bare store is never used as a writer here; its
    * `writeTreePreservingPrefix` / `writeTree` / `receivePack` are not
    * reachable through this proxy.
    */
@@ -215,6 +215,7 @@ export function createProxyWorkflowRunRepoStore(
     listRefs: bareStore.listRefs.bind(bareStore),
     resolveHead: bareStore.resolveHead.bind(bareStore),
     getRepoDir: bareStore.getRepoDir.bind(bareStore),
+    openCommittedReads: bareStore.openCommittedReads.bind(bareStore),
     subscribe(
       _principal: Principal,
       repoId: RepoId,

--- a/packages/workflow-host/src/seams/scheduler.test.ts
+++ b/packages/workflow-host/src/seams/scheduler.test.ts
@@ -376,6 +376,50 @@ describe("workflow-host scheduler", () => {
   );
 
   test(
+    "recovery throws on an illegal event filename",
+    async () => {
+      const dataDir = await makeTempDir("scheduler-recovery-badname-");
+      const store = createRepoStore({
+        dataDir,
+        signingKey,
+        handlers: {
+          "agent-state": permissiveHandler("workflow-runs-badname"),
+        },
+        authorize: allowAll,
+      });
+      const repoId: RepoId = { kind: "agent-state", id: "deployment-g" };
+
+      // A foreign name under events/ is corruption; recovery surfaces it
+      // rather than silently dropping the blob.
+      await store.writeTree(principal, repoId, REF, {
+        files: {
+          "runs/r1/events/not-a-seq.json": JSON.stringify({
+            type: "TimerSet",
+            data: { timerId: "x", fireAt: new Date().toISOString() },
+          }),
+        },
+        message: "bad filename",
+      });
+
+      const scheduler = createWorkflowHostScheduler({
+        repoStore: store,
+        principal,
+        listActiveDeployments: () => [repoId],
+        ref: REF,
+        clock: () => new Date(),
+      });
+      try {
+        await expect(scheduler.start()).rejects.toThrow(
+          /event_filename_invalid/,
+        );
+      } finally {
+        await scheduler.stop();
+      }
+    },
+    { timeout: 5000 },
+  );
+
+  test(
     "cron-style TimerSet whose fireAt is in the past is skipped on recovery",
     async () => {
       const dataDir = await makeTempDir("scheduler-cron-skip-");

--- a/packages/workflow-host/src/seams/scheduler.test.ts
+++ b/packages/workflow-host/src/seams/scheduler.test.ts
@@ -222,6 +222,160 @@ describe("workflow-host scheduler", () => {
   );
 
   test(
+    "recovery reads committed state, not the working tree",
+    async () => {
+      // The invariant: recovery reconstructs its ledger from the git
+      // object store, so a committed TimerFired excludes its timer even
+      // when the materialized working tree does not reflect it. We force
+      // the hardest form of that divergence -- the working tree is gone
+      // entirely while the object store is intact -- so a working-tree
+      // read would recover nothing, and a committed read must recover the
+      // full ledger.
+      const dataDir = await makeTempDir("scheduler-recovery-committed-");
+      const store = createRepoStore({
+        dataDir,
+        signingKey,
+        handlers: {
+          "agent-state": permissiveHandler("workflow-runs-committed"),
+        },
+        authorize: allowAll,
+      });
+      const repoId: RepoId = { kind: "agent-state", id: "deployment-d" };
+      const runId = "r1";
+
+      const farFuture = Date.now() + 60_000;
+      await seedTimerSet(store, repoId, runId, 0, "t-unfired", farFuture);
+      await seedTimerSet(store, repoId, runId, 1, "t-fired", farFuture);
+      await store.writeTree(principal, repoId, REF, {
+        files: {
+          [`runs/${runId}/events/2.json`]: JSON.stringify({
+            seq: 2,
+            type: "TimerFired",
+            data: { timerId: "t-fired" },
+          }),
+        },
+        message: "TimerFired t-fired",
+      });
+
+      // Diverge the working tree from the committed object store: remove
+      // the materialized checkout while leaving `.git` intact. Only a
+      // committed read survives this.
+      await fs.promises.rm(path.join(store.getRepoDir(repoId), "runs"), {
+        recursive: true,
+        force: true,
+      });
+
+      const scheduler = createWorkflowHostScheduler({
+        repoStore: store,
+        principal,
+        listActiveDeployments: () => [repoId],
+        ref: REF,
+        clock: () => new Date(),
+      });
+      try {
+        await scheduler.start();
+        const queued = scheduler.queuedTimers();
+        const ids = queued.map((q) => q.timerId);
+        // The fired timer's committed TimerFired excludes it...
+        expect(ids).not.toContain("t-fired");
+        // ...and the unfired timer is still recovered from committed
+        // state, proving the read walked real events rather than the
+        // wiped working tree.
+        expect(ids).toEqual(["t-unfired"]);
+      } finally {
+        await scheduler.stop();
+      }
+    },
+    { timeout: 5000 },
+  );
+
+  test(
+    "recovery skips a compacted run with no events subtree",
+    async () => {
+      const dataDir = await makeTempDir("scheduler-recovery-compacted-");
+      const store = createRepoStore({
+        dataDir,
+        signingKey,
+        handlers: {
+          "agent-state": permissiveHandler("workflow-runs-compacted"),
+        },
+        authorize: allowAll,
+      });
+      const repoId: RepoId = { kind: "agent-state", id: "deployment-e" };
+
+      const farFuture = Date.now() + 60_000;
+      await seedTimerSet(store, repoId, "r1", 0, "t-live", farFuture);
+      // A terminated run is sealed into a combined `events.jsonl` with no
+      // `events/` subtree. Recovery walks per-event blobs only, so it must
+      // skip such a run rather than choke on the missing subtree.
+      await store.writeTree(principal, repoId, REF, {
+        files: {
+          "runs/r2/events.jsonl": JSON.stringify({
+            seq: 0,
+            type: "TimerSet",
+            data: {
+              timerId: "t-sealed",
+              fireAt: new Date(farFuture).toISOString(),
+            },
+          }),
+        },
+        message: "seal r2",
+      });
+
+      const scheduler = createWorkflowHostScheduler({
+        repoStore: store,
+        principal,
+        listActiveDeployments: () => [repoId],
+        ref: REF,
+        clock: () => new Date(),
+      });
+      try {
+        await scheduler.start();
+        const ids = scheduler.queuedTimers().map((q) => q.timerId);
+        expect(ids).toEqual(["t-live"]);
+      } finally {
+        await scheduler.stop();
+      }
+    },
+    { timeout: 5000 },
+  );
+
+  test(
+    "recovery throws on an unparseable event blob",
+    async () => {
+      const dataDir = await makeTempDir("scheduler-recovery-badjson-");
+      const store = createRepoStore({
+        dataDir,
+        signingKey,
+        handlers: {
+          "agent-state": permissiveHandler("workflow-runs-badjson"),
+        },
+        authorize: allowAll,
+      });
+      const repoId: RepoId = { kind: "agent-state", id: "deployment-f" };
+
+      await store.writeTree(principal, repoId, REF, {
+        files: { "runs/r1/events/0.json": "{ not json" },
+        message: "corrupt blob",
+      });
+
+      const scheduler = createWorkflowHostScheduler({
+        repoStore: store,
+        principal,
+        listActiveDeployments: () => [repoId],
+        ref: REF,
+        clock: () => new Date(),
+      });
+      try {
+        await expect(scheduler.start()).rejects.toThrow(/cannot parse/);
+      } finally {
+        await scheduler.stop();
+      }
+    },
+    { timeout: 5000 },
+  );
+
+  test(
     "cron-style TimerSet whose fireAt is in the past is skipped on recovery",
     async () => {
       const dataDir = await makeTempDir("scheduler-cron-skip-");

--- a/packages/workflow-host/src/seams/scheduler.ts
+++ b/packages/workflow-host/src/seams/scheduler.ts
@@ -350,14 +350,15 @@ type EventReadEntry = {
 
 /**
  * Read every timer-event blob across every run under the given
- * workflow-run repo. The recovery walk reads blobs from the
- * substrate's on-disk working tree directly via `enumerateEventBlobs`:
- * `subscribeKind` is a diff-shaped iterator over new commits, not a
- * "list everything at HEAD" primitive, so the startup ledger needs a
- * path-aware enumeration of the current ref tip rather than a tail
- * subscription. The substrate writes commit-then-checkout for every
- * ref-update, so the working tree is a coherent snapshot of the
- * current ref tip.
+ * workflow-run repo. Recovery reconstructs its ledger from committed
+ * state, so `enumerateEventBlobs` reads the git object store at the
+ * events ref tip via `openCommittedReads` rather than the materialized
+ * working tree, whose non-atomic post-commit checkout can lag the
+ * committed tree on a contended filesystem and hide an already-committed
+ * `TimerFired`. `subscribeKind` is a diff-shaped iterator over new
+ * commits, not a "list everything at HEAD" primitive, so the startup
+ * ledger needs this path-aware enumeration of the current ref tip rather
+ * than a tail subscription.
  */
 async function readAllEvents(
   opts: SchedulerOpts,
@@ -399,48 +400,34 @@ async function enumerateEventBlobs(
   opts: SchedulerOpts,
   repoId: RepoId,
 ): Promise<readonly RawEventRecord[]> {
-  const dir = opts.repoStore.getRepoDir(repoId);
-  const fs = await import("node:fs/promises");
-  const path = await import("node:path");
-  const runsDir = path.join(dir, "runs");
+  const reads = await opts.repoStore.openCommittedReads(
+    opts.principal,
+    repoId,
+    opts.ref,
+  );
+  if (reads === null) return [];
   const out: RawEventRecord[] = [];
-  let runEntries: string[];
-  try {
-    runEntries = await fs.readdir(runsDir);
-  } catch (cause) {
-    if (isErrnoNotFound(cause)) return out;
-    throw cause;
-  }
-  for (const runId of runEntries) {
-    const eventsDir = path.join(runsDir, runId, "events");
-    let blobs: string[];
-    try {
-      blobs = await fs.readdir(eventsDir);
-    } catch (cause) {
-      if (isErrnoNotFound(cause)) continue;
-      throw cause;
-    }
+  const runEntries = await reads.listDir("runs");
+  for (const runEntry of runEntries) {
+    if (runEntry.type !== "tree") continue;
+    const runId = runEntry.name;
+    const blobs = await reads.listDir(`runs/${runId}/events`);
     for (const blob of blobs) {
-      if (!/^(0|[1-9][0-9]*)\.json$/.test(blob)) continue;
-      const raw = await fs.readFile(path.join(eventsDir, blob), "utf8");
+      if (blob.type !== "blob") continue;
+      if (!/^(0|[1-9][0-9]*)\.json$/.test(blob.name)) continue;
+      const raw = await reads.readBlobByOid(blob.oid);
       let parsed: unknown;
       try {
-        parsed = JSON.parse(raw);
+        parsed = JSON.parse(new TextDecoder().decode(raw));
       } catch (cause) {
         throw new Error(
-          `scheduler recovery: cannot parse ${String(repoId.id)}/${runId}/events/${blob}: ${String(cause)}`,
+          `scheduler recovery: cannot parse ${String(repoId.id)}/${runId}/events/${blob.name}: ${String(cause)}`,
         );
       }
       out.push({ runId, payload: parsed });
     }
   }
   return out;
-}
-
-function isErrnoNotFound(cause: unknown): boolean {
-  if (cause === null || typeof cause !== "object") return false;
-  const code = (cause as { code?: unknown }).code;
-  return code === "ENOENT";
 }
 
 /**
@@ -524,17 +511,20 @@ async function findOwningDeployment(
   runId: string,
 ): Promise<RepoId | undefined> {
   const repoIds = await opts.listActiveDeployments();
-  const fs = await import("node:fs/promises");
-  const path = await import("node:path");
   for (const repoId of repoIds) {
-    const dir = opts.repoStore.getRepoDir(repoId);
-    try {
-      await fs.access(path.join(dir, "runs", runId, "events"));
-      return repoId;
-    } catch (cause) {
-      if (isErrnoNotFound(cause)) continue;
-      throw cause;
-    }
+    const reads = await opts.repoStore.openCommittedReads(
+      opts.principal,
+      repoId,
+      opts.ref,
+    );
+    if (reads === null) continue;
+    // The committed events subtree exists only when it holds at least
+    // one blob (git does not track empty trees), so a non-empty listing
+    // is exactly "this deployment owns the run". Reading committed state
+    // rather than the working tree keeps attribution correct when the
+    // checkout lags the object store.
+    const events = await reads.listDir(`runs/${runId}/events`);
+    if (events.length > 0) return repoId;
   }
   return undefined;
 }

--- a/packages/workflow-host/src/seams/scheduler.ts
+++ b/packages/workflow-host/src/seams/scheduler.ts
@@ -43,7 +43,12 @@ import type {
   RepoId,
   RepoStore,
 } from "@intx/hub-sessions/substrate";
-import { subscribeKind } from "@intx/hub-sessions/substrate";
+import {
+  parseEventSeq,
+  subscribeKind,
+  WORKFLOW_RUN_EVENTS_DIR,
+  WORKFLOW_RUN_RUNS_PREFIX,
+} from "@intx/hub-sessions/substrate";
 
 /**
  * Substrate-shape envelope for the workflow-event blob committed to
@@ -407,21 +412,22 @@ async function enumerateEventBlobs(
   );
   if (reads === null) return [];
   const out: RawEventRecord[] = [];
-  const runEntries = await reads.listDir("runs");
+  const runEntries = await reads.listDir(WORKFLOW_RUN_RUNS_PREFIX);
   for (const runEntry of runEntries) {
     if (runEntry.type !== "tree") continue;
     const runId = runEntry.name;
-    const blobs = await reads.listDir(`runs/${runId}/events`);
+    const eventsDir = `${WORKFLOW_RUN_RUNS_PREFIX}/${runId}/${WORKFLOW_RUN_EVENTS_DIR}`;
+    const blobs = await reads.listDir(eventsDir);
     for (const blob of blobs) {
       if (blob.type !== "blob") continue;
-      if (!/^(0|[1-9][0-9]*)\.json$/.test(blob.name)) continue;
+      if (parseEventSeq(blob.name) === null) continue;
       const raw = await reads.readBlobByOid(blob.oid);
       let parsed: unknown;
       try {
         parsed = JSON.parse(new TextDecoder().decode(raw));
       } catch (cause) {
         throw new Error(
-          `scheduler recovery: cannot parse ${String(repoId.id)}/${runId}/events/${blob.name}: ${String(cause)}`,
+          `scheduler recovery: cannot parse ${String(repoId.id)}/${runId}/${WORKFLOW_RUN_EVENTS_DIR}/${blob.name}: ${String(cause)}`,
         );
       }
       out.push({ runId, payload: parsed });
@@ -449,7 +455,7 @@ async function commitTimerFired(
       `scheduler commit: cannot find deployment owning run ${runId}`,
     );
   }
-  const prefix = `runs/${runId}/events/`;
+  const prefix = `${WORKFLOW_RUN_RUNS_PREFIX}/${runId}/${WORKFLOW_RUN_EVENTS_DIR}/`;
   await opts.repoStore.writeTreePreservingPrefix(
     opts.principal,
     owningRepoId,
@@ -461,11 +467,8 @@ async function commitTimerFired(
         let alreadyFired = false;
         for (const [filepath, contents] of existing) {
           const name = filepath.slice(prefix.length);
-          const match = /^(0|[1-9][0-9]*)\.json$/.exec(name);
-          if (match === null) continue;
-          const seqStr = match[1];
-          if (seqStr === undefined) continue;
-          const seq = Number.parseInt(seqStr, 10);
+          const seq = parseEventSeq(name);
+          if (seq === null) continue;
           if (seq > maxSeq) maxSeq = seq;
           try {
             const parsed: unknown = JSON.parse(
@@ -523,7 +526,9 @@ async function findOwningDeployment(
     // is exactly "this deployment owns the run". Reading committed state
     // rather than the working tree keeps attribution correct when the
     // checkout lags the object store.
-    const events = await reads.listDir(`runs/${runId}/events`);
+    const events = await reads.listDir(
+      `${WORKFLOW_RUN_RUNS_PREFIX}/${runId}/${WORKFLOW_RUN_EVENTS_DIR}`,
+    );
     if (events.length > 0) return repoId;
   }
   return undefined;

--- a/packages/workflow-host/src/seams/scheduler.ts
+++ b/packages/workflow-host/src/seams/scheduler.ts
@@ -44,7 +44,7 @@ import type {
   RepoStore,
 } from "@intx/hub-sessions/substrate";
 import {
-  parseEventSeq,
+  requireEventSeq,
   subscribeKind,
   WORKFLOW_RUN_EVENTS_DIR,
   WORKFLOW_RUN_RUNS_PREFIX,
@@ -420,7 +420,9 @@ async function enumerateEventBlobs(
     const blobs = await reads.listDir(eventsDir);
     for (const blob of blobs) {
       if (blob.type !== "blob") continue;
-      if (parseEventSeq(blob.name) === null) continue;
+      // Assert a legal <seq>.json name; an illegal one under the events
+      // prefix is corruption the recovery walk must not silently drop.
+      requireEventSeq(blob.name, `${eventsDir}/${blob.name}`);
       const raw = await reads.readBlobByOid(blob.oid);
       let parsed: unknown;
       try {
@@ -467,8 +469,7 @@ async function commitTimerFired(
         let alreadyFired = false;
         for (const [filepath, contents] of existing) {
           const name = filepath.slice(prefix.length);
-          const seq = parseEventSeq(name);
-          if (seq === null) continue;
+          const seq = requireEventSeq(name, `${prefix}${name}`);
           if (seq > maxSeq) maxSeq = seq;
           try {
             const parsed: unknown = JSON.parse(


### PR DESCRIPTION
## Summary

- The workflow-host scheduler's start-time recovery and fire-time deployment attribution read committed git state through the repo store rather than the materialized working tree, so a filesystem that lags the committed object store can no longer make recovery miss a committed `TimerFired` and re-queue an already-fired one-shot timer.
- The repo store exposes `openCommittedReads` (by ref) and `openCommittedReadsAtCommit` (by commit): cache-backed, authorize-gated reads of the committed tree. The workflow-event subscription reads through the by-commit primitive instead of walking the tree with its own git calls.
- The workflow-run event-log filename shape and `runs/`/`events/` prefixes live in one place (the kind handler), and every event-log reader rejects an illegal `<seq>.json` name rather than silently dropping the blob.

## Verification

`make all` exits 0: build, lint, 4080 unit tests, and 361 integration tests all pass. A regression test wipes the materialized `runs/` working tree while leaving the object store intact and asserts recovery still excludes the committed `TimerFired` and still queues the co-resident unfired timer — the lag scenario, which fails on the pre-fix working-tree read.

Closes INTR-308