### PR TITLE
Enforce credential-use authorization at agent launch and rotation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -279,6 +279,7 @@
       "name": "@intx/db",
       "version": "0.2.2",
       "dependencies": {
+        "@intx/authz": "workspace:*",
         "@intx/log": "workspace:*",
         "@intx/types": "workspace:*",
         "arktype": "catalog:",

--- a/docs/CREDENTIALS.md
+++ b/docs/CREDENTIALS.md
@@ -93,6 +93,12 @@ The grant validation ensures that a definition creator cannot grant an agent acc
 
 At launch time, if the agent requires invoker-sourced credentials, the invoker's grants are additionally validated. The effective credential set is the union of tenant, creator, and invoker credentials, subject to each party's authorization.
 
+### Model-Source Credential Authorization (Interim)
+
+Model-source (tenant-catalog) credentials carry an additional gate: the secret behind a catalog offering only enters a launchable inference source when the agent's creator holds a `credential:{id}` / `use` grant for the referenced credential. This is enforced fail-closed — anything other than an `allow` effect (including `ask`, `deny`, or no matching grant) withholds the secret — at agent launch and again on credential rotation, so a rotated secret is never pushed to a running instance whose creator lacks the grant.
+
+This is a deliberate interim tightening. Catalog credentials are tenant-owned (tenant-source), and under the source-based authority model (tenant/creator/invoker) a tenant-source credential would be authorized by tenant/role policy rather than by a per-principal `use` grant. Gating catalog-credential use on the creator's explicit grant is stricter than that model requires. Unifying catalog-credential authorization with the source-based model is planned; until then the creator `use` grant is the authoritative check on this path.
+
 ## Walk-up Resolution
 
 All three concepts (providers, OAuth clients, credentials) use the same walk-up resolution pattern through the tenant hierarchy. Starting from the current tenant, the system checks for a match, then moves to the parent tenant, and continues until it finds a match or reaches the root.

--- a/docs/CREDENTIALS.md
+++ b/docs/CREDENTIALS.md
@@ -85,7 +85,7 @@ When the control plane launches an agent into a harness, it processes each crede
 2. Find credentials matching the provider, source (principal filter), and scopes
 3. If a name is specified, narrow to that name
 4. If multiple credentials still match, the launch fails -- the administrator must resolve the ambiguity
-5. Validate that the agent's principal has appropriate grants for the resolved credential
+5. Validate that the creator has appropriate grants for the resolved credential, using the creator's context (via `creatorPrincipalId` on the definition)
 6. If zero matches, the launch fails (missing required credential)
 7. If all checks pass, the resolved credential is included in the harness's launch payload
 

--- a/packages/authz/src/credential-use-invariants.test.ts
+++ b/packages/authz/src/credential-use-invariants.test.ts
@@ -1,0 +1,120 @@
+import { describe, test, expect } from "bun:test";
+
+import { evaluateGrants } from "./evaluate";
+import { matchPattern } from "./patterns";
+import type { GrantRule } from "./types";
+
+const CRED = "credential:crd_abc123";
+const USE = "use";
+
+function grant(
+  overrides: Partial<GrantRule> &
+    Pick<GrantRule, "resource" | "action" | "effect">,
+): GrantRule {
+  return {
+    id: `grt_${Math.random().toString(36).slice(2, 10)}`,
+    origin: "system",
+    conditions: null,
+    expiresAt: null,
+    roleId: null,
+    principalId: null,
+    ...overrides,
+  };
+}
+
+describe("wildcard matcher reaches credential:{id}/use", () => {
+  test("matchPattern('*', ...) matches both resource and action", () => {
+    expect(matchPattern("*", CRED)).toBe(true);
+    expect(matchPattern("*", USE)).toBe(true);
+  });
+
+  test("owner */* grant resolves to allow for credential:{id}/use", async () => {
+    const result = await evaluateGrants(
+      [grant({ resource: "*", action: "*", effect: "allow" })],
+      CRED,
+      USE,
+    );
+    expect(result.effect).toBe("allow");
+  });
+
+  test("credential:* / use also resolves to allow", async () => {
+    const result = await evaluateGrants(
+      [grant({ resource: "credential:*", action: "use", effect: "allow" })],
+      CRED,
+      USE,
+    );
+    expect(result.effect).toBe("allow");
+  });
+});
+
+describe("admin/member default grants lack use on credentials", () => {
+  test("admin read/create/manage do NOT satisfy use", async () => {
+    const adminGrants = [
+      grant({ resource: "*", action: "read", effect: "allow" }),
+      grant({ resource: "*", action: "create", effect: "allow" }),
+      grant({ resource: "*", action: "manage", effect: "allow" }),
+    ];
+    const result = await evaluateGrants(adminGrants, CRED, USE);
+    expect(result.effect).toBe(null);
+    expect(result.effect === "allow").toBe(false);
+  });
+
+  test("member read does NOT satisfy use", async () => {
+    const result = await evaluateGrants(
+      [grant({ resource: "*", action: "read", effect: "allow" })],
+      CRED,
+      USE,
+    );
+    expect(result.effect).toBe(null);
+  });
+});
+
+describe("fail-closed: anything other than allow is denial", () => {
+  test("no matching grant resolves to effect null", async () => {
+    const result = await evaluateGrants([], CRED, USE);
+    expect(result.effect).toBe(null);
+    expect(result.effect !== "allow").toBe(true);
+  });
+
+  test("ask effect is not allow", async () => {
+    const result = await evaluateGrants(
+      [grant({ resource: "credential:*", action: "use", effect: "ask" })],
+      CRED,
+      USE,
+    );
+    expect(result.effect).toBe("ask");
+    expect(result.effect !== "allow").toBe(true);
+  });
+
+  test("deny at equal specificity beats allow", async () => {
+    const allow = grant({
+      resource: "credential:*",
+      action: "use",
+      effect: "allow",
+    });
+    const deny = grant({
+      resource: "credential:*",
+      action: "use",
+      effect: "deny",
+    });
+    const result = await evaluateGrants([allow, deny], CRED, USE);
+    expect(result.effect).toBe("deny");
+    expect(result.effect !== "allow").toBe(true);
+  });
+
+  test("conditioned grant with no registry is skipped (fail closed)", async () => {
+    const result = await evaluateGrants(
+      [
+        grant({
+          resource: "credential:*",
+          action: "use",
+          effect: "allow",
+          conditions: { some_condition: true },
+        }),
+      ],
+      CRED,
+      USE,
+    );
+    expect(result.effect).toBe(null);
+  });
+});

--- a/packages/authz/src/evaluate.test.ts
+++ b/packages/authz/src/evaluate.test.ts
@@ -664,6 +664,9 @@ function memoryStore(grants: GrantRule[]): GrantStore {
     async collectGrants() {
       return grants;
     },
+    async collectGrantsInChain() {
+      return grants;
+    },
   };
 }
 
@@ -725,6 +728,9 @@ describe("authorize with in-memory store", () => {
       async collectGrants(principalId, tenantId) {
         receivedPrincipalId = principalId;
         receivedTenantId = tenantId;
+        return [grant({ resource: "*", action: "*", effect: "allow" })];
+      },
+      async collectGrantsInChain() {
         return [grant({ resource: "*", action: "*", effect: "allow" })];
       },
     };

--- a/packages/authz/src/memory-store.ts
+++ b/packages/authz/src/memory-store.ts
@@ -15,14 +15,25 @@
 import type { GrantRule, GrantStore } from "./types";
 
 export function createInMemoryGrantStore(grants: GrantRule[]): GrantStore {
+  function collect(principalId: string): GrantRule[] {
+    const now = new Date();
+    return grants.filter((g) => {
+      if (g.principalId !== principalId) return false;
+      if (g.expiresAt !== null && g.expiresAt <= now) return false;
+      return true;
+    });
+  }
+
+  // tenantId (and thus the ancestor chain) is a no-op here: the caller
+  // pre-scopes the grant array, so chain collection returns the same set as
+  // single-tenant collection. The DB-backed store is where the chain walk
+  // actually happens.
   return {
     async collectGrants(principalId: string): Promise<GrantRule[]> {
-      const now = new Date();
-      return grants.filter((g) => {
-        if (g.principalId !== principalId) return false;
-        if (g.expiresAt !== null && g.expiresAt <= now) return false;
-        return true;
-      });
+      return collect(principalId);
+    },
+    async collectGrantsInChain(principalId: string): Promise<GrantRule[]> {
+      return collect(principalId);
     },
   };
 }

--- a/packages/db/migrations/0037_credential_use_backfill.sql
+++ b/packages/db/migrations/0037_credential_use_backfill.sql
@@ -1,0 +1,39 @@
+-- Backfill `credential:{id}` / `use` grants for the owner of every existing
+-- personal credential (rows where `principal_id` is set) that does not already
+-- have one. This keeps existing personal-credential owners working once
+-- launch enforcement fails closed. Organizational credentials
+-- (`principal_id` IS NULL) are intentionally excluded: they remain gated
+-- behind tenant-owner role inheritance and explicit administrative grants.
+--
+-- Idempotent: the `WHERE NOT EXISTS` guard skips any credential whose owner
+-- already holds a matching grant, so re-application inserts nothing and does
+-- not fail. Grant ids reproduce the app convention (`grt_` prefix followed by
+-- 32 hex characters) via `gen_random_uuid()`.
+INSERT INTO "grant" (
+  "id",
+  "tenant_id",
+  "principal_id",
+  "resource",
+  "action",
+  "effect",
+  "origin",
+  "expires_at"
+)
+SELECT
+  'grt_' || replace(gen_random_uuid()::text, '-', ''),
+  c."tenant_id",
+  c."principal_id",
+  'credential:' || c."id",
+  'use',
+  'allow',
+  'creator',
+  NULL
+FROM "credential" c
+WHERE c."principal_id" IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "grant" g
+    WHERE g."principal_id" = c."principal_id"
+      AND g."resource" = 'credential:' || c."id"
+      AND g."action" = 'use'
+  );

--- a/packages/db/migrations/meta/0037_snapshot.json
+++ b/packages/db/migrations/meta/0037_snapshot.json
@@ -1,0 +1,3237 @@
+{
+  "id": "c7abb15a-7dd5-4e6b-8dab-268560e27f60",
+  "prevId": "b2763bf2-79d9-45bb-ba70-c15305f63dd5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": ["user_id"],
+          "tableTo": "user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": ["user_id"],
+          "tableTo": "user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": ["token"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": ["email"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.federation_trust": {
+      "name": "federation_trust",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_tenant_id": {
+          "name": "target_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "federation_trust_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "federation_trust_target_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_target_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "columnsFrom": ["target_tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federation_trust_tenant_id_target_tenant_id_unique": {
+          "name": "federation_trust_tenant_id_target_tenant_id_unique",
+          "columns": ["tenant_id", "target_tenant_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant": {
+      "name": "tenant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_parent_id_tenant_id_fk": {
+          "name": "tenant_parent_id_tenant_id_fk",
+          "tableFrom": "tenant",
+          "columnsFrom": ["parent_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_slug_unique": {
+          "name": "tenant_slug_unique",
+          "columns": ["slug"],
+          "nullsNotDistinct": false
+        },
+        "tenant_domain_unique": {
+          "name": "tenant_domain_unique",
+          "columns": ["domain"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal": {
+      "name": "principal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_tenant_id_tenant_id_fk": {
+          "name": "principal_tenant_id_tenant_id_fk",
+          "tableFrom": "principal",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "principal_tenant_id_kind_ref_id_unique": {
+          "name": "principal_tenant_id_kind_ref_id_unique",
+          "columns": ["tenant_id", "kind", "ref_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_role": {
+      "name": "agent_role",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_role_agent_id_agent_id_fk": {
+          "name": "agent_role_agent_id_agent_id_fk",
+          "tableFrom": "agent_role",
+          "columnsFrom": ["agent_id"],
+          "tableTo": "agent",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_role_role_id_role_id_fk": {
+          "name": "agent_role_role_id_role_id_fk",
+          "tableFrom": "agent_role",
+          "columnsFrom": ["role_id"],
+          "tableTo": "role",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_role_agent_id_role_id_pk": {
+          "name": "agent_role_agent_id_role_id_pk",
+          "columns": ["agent_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal_role": {
+      "name": "principal_role",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_role_principal_id_principal_id_fk": {
+          "name": "principal_role_principal_id_principal_id_fk",
+          "tableFrom": "principal_role",
+          "columnsFrom": ["principal_id"],
+          "tableTo": "principal",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "principal_role_role_id_role_id_fk": {
+          "name": "principal_role_role_id_role_id_fk",
+          "tableFrom": "principal_role",
+          "columnsFrom": ["role_id"],
+          "tableTo": "role",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "principal_role_principal_id_role_id_pk": {
+          "name": "principal_role_principal_id_role_id_pk",
+          "columns": ["principal_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_tenant_id_tenant_id_fk": {
+          "name": "role_tenant_id_tenant_id_fk",
+          "tableFrom": "role",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grant": {
+      "name": "grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grant_tenant_id_tenant_id_fk": {
+          "name": "grant_tenant_id_tenant_id_fk",
+          "tableFrom": "grant",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "grant_role_id_role_id_fk": {
+          "name": "grant_role_id_role_id_fk",
+          "tableFrom": "grant",
+          "columnsFrom": ["role_id"],
+          "tableTo": "role",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "grant_principal_id_principal_id_fk": {
+          "name": "grant_principal_id_principal_id_fk",
+          "tableFrom": "grant",
+          "columnsFrom": ["principal_id"],
+          "tableTo": "principal",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_config": {
+          "name": "context_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_state": {
+          "name": "initial_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_config": {
+          "name": "model_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_requirements": {
+          "name": "credential_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_requirements": {
+          "name": "model_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_packages": {
+          "name": "tool_packages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "grant_requirements": {
+          "name": "grant_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_tenant_id_tenant_id_fk": {
+          "name": "agent_tenant_id_tenant_id_fk",
+          "tableFrom": "agent",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_creator_principal_id_principal_id_fk": {
+          "name": "agent_creator_principal_id_principal_id_fk",
+          "tableFrom": "agent",
+          "columnsFrom": ["creator_principal_id"],
+          "tableTo": "principal",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version": {
+      "name": "agent_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_agent_id_agent_id_fk": {
+          "name": "agent_version_agent_id_agent_id_fk",
+          "tableFrom": "agent_version",
+          "columnsFrom": ["agent_id"],
+          "tableTo": "agent",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_info_url": {
+          "name": "user_info_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_tenant_id_tenant_id_fk": {
+          "name": "provider_tenant_id_tenant_id_fk",
+          "tableFrom": "provider",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_tenant_name": {
+          "name": "provider_tenant_name",
+          "columns": ["tenant_id", "name"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_scopes": {
+          "name": "default_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_tenant_id_tenant_id_fk": {
+          "name": "oauth_client_tenant_id_tenant_id_fk",
+          "tableFrom": "oauth_client",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "oauth_client_provider_id_provider_id_fk": {
+          "name": "oauth_client_provider_id_provider_id_fk",
+          "tableFrom": "oauth_client",
+          "columnsFrom": ["provider_id"],
+          "tableTo": "provider",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_tenant_provider": {
+          "name": "oauth_client_tenant_provider",
+          "columns": ["tenant_id", "provider_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credential": {
+      "name": "credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_secret": {
+          "name": "refresh_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credential_tenant_id_tenant_id_fk": {
+          "name": "credential_tenant_id_tenant_id_fk",
+          "tableFrom": "credential",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "credential_principal_id_principal_id_fk": {
+          "name": "credential_principal_id_principal_id_fk",
+          "tableFrom": "credential",
+          "columnsFrom": ["principal_id"],
+          "tableTo": "principal",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "credential_provider_id_provider_id_fk": {
+          "name": "credential_provider_id_provider_id_fk",
+          "tableFrom": "credential",
+          "columnsFrom": ["provider_id"],
+          "tableTo": "provider",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "credential_oauth_client_id_oauth_client_id_fk": {
+          "name": "credential_oauth_client_id_oauth_client_id_fk",
+          "tableFrom": "credential",
+          "columnsFrom": ["oauth_client_id"],
+          "tableTo": "oauth_client",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "credential_tenant_name": {
+          "name": "credential_tenant_name",
+          "columns": ["tenant_id", "name"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset": {
+      "name": "asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_tenant_id_tenant_id_fk": {
+          "name": "asset_tenant_id_tenant_id_fk",
+          "tableFrom": "asset",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "asset_creator_principal_id_principal_id_fk": {
+          "name": "asset_creator_principal_id_principal_id_fk",
+          "tableFrom": "asset",
+          "columnsFrom": ["creator_principal_id"],
+          "tableTo": "principal",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_tenant_kind_name": {
+          "name": "asset_tenant_kind_name",
+          "columns": ["tenant_id", "kind", "name"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_asset": {
+      "name": "agent_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_mode": {
+          "name": "access_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read-only'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_asset_agent_id_agent_id_fk": {
+          "name": "agent_asset_agent_id_agent_id_fk",
+          "tableFrom": "agent_asset",
+          "columnsFrom": ["agent_id"],
+          "tableTo": "agent",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_asset_asset_id_asset_id_fk": {
+          "name": "agent_asset_asset_id_asset_id_fk",
+          "tableFrom": "agent_asset",
+          "columnsFrom": ["asset_id"],
+          "tableTo": "asset",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_asset_agent_asset": {
+          "name": "agent_asset_agent_asset",
+          "columns": ["agent_id", "asset_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_wallet_id_wallet_id_fk": {
+          "name": "transaction_wallet_id_wallet_id_fk",
+          "tableFrom": "transaction",
+          "columnsFrom": ["wallet_id"],
+          "tableTo": "wallet",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "transaction_agent_id_agent_id_fk": {
+          "name": "transaction_agent_id_agent_id_fk",
+          "tableFrom": "transaction",
+          "columnsFrom": ["agent_id"],
+          "tableTo": "agent",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet": {
+      "name": "wallet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend_type": {
+          "name": "backend_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallet_tenant_id_tenant_id_fk": {
+          "name": "wallet_tenant_id_tenant_id_fk",
+          "tableFrom": "wallet",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offering": {
+      "name": "offering",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "offering_agent_id_agent_id_fk": {
+          "name": "offering_agent_id_agent_id_fk",
+          "tableFrom": "offering",
+          "columnsFrom": ["agent_id"],
+          "tableTo": "agent",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "offering_tenant_id_tenant_id_fk": {
+          "name": "offering_tenant_id_tenant_id_fk",
+          "tableFrom": "offering",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model": {
+      "name": "model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_tenant_id_tenant_id_fk": {
+          "name": "model_tenant_id_tenant_id_fk",
+          "tableFrom": "model",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_tenant_canonical_name": {
+          "name": "model_tenant_canonical_name",
+          "columns": ["tenant_id", "canonical_name"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_offering": {
+      "name": "model_offering",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_tags": {
+          "name": "deployment_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_offering_tenant_id_tenant_id_fk": {
+          "name": "model_offering_tenant_id_tenant_id_fk",
+          "tableFrom": "model_offering",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "model_offering_model_id_model_id_fk": {
+          "name": "model_offering_model_id_model_id_fk",
+          "tableFrom": "model_offering",
+          "columnsFrom": ["model_id"],
+          "tableTo": "model",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "model_offering_provider_id_model_provider_id_fk": {
+          "name": "model_offering_provider_id_model_provider_id_fk",
+          "tableFrom": "model_offering",
+          "columnsFrom": ["provider_id"],
+          "tableTo": "model_provider",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_offering_tenant_model_provider": {
+          "name": "model_offering_tenant_model_provider",
+          "columns": ["tenant_id", "model_id", "provider_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_pricing": {
+      "name": "model_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offering_id": {
+          "name": "offering_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_token_price": {
+          "name": "input_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_token_price": {
+          "name": "output_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_token_price": {
+          "name": "cache_read_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_write_token_price": {
+          "name": "cache_write_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thinking_token_price": {
+          "name": "thinking_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_request_fee": {
+          "name": "per_request_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_image_fee": {
+          "name": "per_image_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_audio_fee": {
+          "name": "per_audio_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_pricing_tenant_id_tenant_id_fk": {
+          "name": "model_pricing_tenant_id_tenant_id_fk",
+          "tableFrom": "model_pricing",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "model_pricing_offering_id_model_offering_id_fk": {
+          "name": "model_pricing_offering_id_model_offering_id_fk",
+          "tableFrom": "model_pricing",
+          "columnsFrom": ["offering_id"],
+          "tableTo": "model_offering",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_pricing_offering_currency_effective_from": {
+          "name": "model_pricing_offering_currency_effective_from",
+          "columns": ["offering_id", "currency", "effective_from"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider": {
+      "name": "model_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_provider_tenant_id_tenant_id_fk": {
+          "name": "model_provider_tenant_id_tenant_id_fk",
+          "tableFrom": "model_provider",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "model_provider_credential_id_credential_id_fk": {
+          "name": "model_provider_credential_id_credential_id_fk",
+          "tableFrom": "model_provider",
+          "columnsFrom": ["credential_id"],
+          "tableTo": "credential",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "model_provider_wallet_id_wallet_id_fk": {
+          "name": "model_provider_wallet_id_wallet_id_fk",
+          "tableFrom": "model_provider",
+          "columnsFrom": ["wallet_id"],
+          "tableTo": "wallet",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_provider_tenant_name": {
+          "name": "model_provider_tenant_name",
+          "columns": ["tenant_id", "name"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "model_provider_auth_xor": {
+          "name": "model_provider_auth_xor",
+          "value": "(\"model_provider\".\"credential_id\" is not null) <> (\"model_provider\".\"wallet_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sidecar": {
+      "name": "sidecar",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash_sha256": {
+          "name": "token_hash_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sidecar_token_hash_sha256_unique": {
+          "name": "sidecar_token_hash_sha256_unique",
+          "columns": ["token_hash_sha256"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_session": {
+      "name": "agent_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_session_tenant_id_tenant_id_fk": {
+          "name": "agent_session_tenant_id_tenant_id_fk",
+          "tableFrom": "agent_session",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_session_agent_id_agent_id_fk": {
+          "name": "agent_session_agent_id_agent_id_fk",
+          "tableFrom": "agent_session",
+          "columnsFrom": ["agent_id"],
+          "tableTo": "agent",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_session_principal_id_principal_id_fk": {
+          "name": "agent_session_principal_id_principal_id_fk",
+          "tableFrom": "agent_session",
+          "columnsFrom": ["principal_id"],
+          "tableTo": "principal",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_instance": {
+      "name": "agent_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployed'"
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kernel_id": {
+          "name": "kernel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_preferences": {
+          "name": "model_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_instance_agent_id_agent_id_fk": {
+          "name": "agent_instance_agent_id_agent_id_fk",
+          "tableFrom": "agent_instance",
+          "columnsFrom": ["agent_id"],
+          "tableTo": "agent",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_instance_tenant_id_tenant_id_fk": {
+          "name": "agent_instance_tenant_id_tenant_id_fk",
+          "tableFrom": "agent_instance",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_instance_principal_id_principal_id_fk": {
+          "name": "agent_instance_principal_id_principal_id_fk",
+          "tableFrom": "agent_instance",
+          "columnsFrom": ["principal_id"],
+          "tableTo": "principal",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "agent_instance_version_id_agent_version_id_fk": {
+          "name": "agent_instance_version_id_agent_version_id_fk",
+          "tableFrom": "agent_instance",
+          "columnsFrom": ["version_id"],
+          "tableTo": "agent_version",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "agent_instance_session_id_agent_session_id_fk": {
+          "name": "agent_instance_session_id_agent_session_id_fk",
+          "tableFrom": "agent_instance",
+          "columnsFrom": ["session_id"],
+          "tableTo": "agent_session",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "agent_instance_sidecar_id_sidecar_id_fk": {
+          "name": "agent_instance_sidecar_id_sidecar_id_fk",
+          "tableFrom": "agent_instance",
+          "columnsFrom": ["sidecar_id"],
+          "tableTo": "sidecar",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_instance_address_unique": {
+          "name": "agent_instance_address_unique",
+          "columns": ["address"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_asset": {
+      "name": "session_asset",
+      "schema": "",
+      "columns": {
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_asset_id": {
+          "name": "agent_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mount_path": {
+          "name": "mount_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_pack_sha": {
+          "name": "asset_pack_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "materialized_at": {
+          "name": "materialized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_asset_pack_sha_idx": {
+          "name": "session_asset_pack_sha_idx",
+          "columns": [
+            {
+              "expression": "asset_pack_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "session_asset_instance_id_agent_instance_id_fk": {
+          "name": "session_asset_instance_id_agent_instance_id_fk",
+          "tableFrom": "session_asset",
+          "columnsFrom": ["instance_id"],
+          "tableTo": "agent_instance",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "session_asset_agent_asset_id_agent_asset_id_fk": {
+          "name": "session_asset_agent_asset_id_agent_asset_id_fk",
+          "tableFrom": "session_asset",
+          "columnsFrom": ["agent_asset_id"],
+          "tableTo": "agent_asset",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_asset_instance_id_mount_path_pk": {
+          "name": "session_asset_instance_id_mount_path_pk",
+          "columns": ["instance_id", "mount_path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inference_turn": {
+      "name": "inference_turn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "inference_turn_instance_id_started_at_idx": {
+          "name": "inference_turn_instance_id_started_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "inference_turn_session_id_agent_session_id_fk": {
+          "name": "inference_turn_session_id_agent_session_id_fk",
+          "tableFrom": "inference_turn",
+          "columnsFrom": ["session_id"],
+          "tableTo": "agent_session",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "inference_turn_instance_id_agent_instance_id_fk": {
+          "name": "inference_turn_instance_id_agent_instance_id_fk",
+          "tableFrom": "inference_turn",
+          "columnsFrom": ["instance_id"],
+          "tableTo": "agent_instance",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "inference_turn_tenant_id_tenant_id_fk": {
+          "name": "inference_turn_tenant_id_tenant_id_fk",
+          "tableFrom": "inference_turn",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_mail": {
+      "name": "session_mail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "raw": {
+          "name": "raw",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_mail_instance_id_created_at_idx": {
+          "name": "session_mail_instance_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "session_mail_session_id_agent_session_id_fk": {
+          "name": "session_mail_session_id_agent_session_id_fk",
+          "tableFrom": "session_mail",
+          "columnsFrom": ["session_id"],
+          "tableTo": "agent_session",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "session_mail_instance_id_agent_instance_id_fk": {
+          "name": "session_mail_instance_id_agent_instance_id_fk",
+          "tableFrom": "session_mail",
+          "columnsFrom": ["instance_id"],
+          "tableTo": "agent_instance",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "session_mail_tenant_id_tenant_id_fk": {
+          "name": "session_mail_tenant_id_tenant_id_fk",
+          "tableFrom": "session_mail",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turn_part": {
+      "name": "turn_part",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "turn_part_turn_id_inference_turn_id_fk": {
+          "name": "turn_part_turn_id_inference_turn_id_fk",
+          "tableFrom": "turn_part",
+          "columnsFrom": ["turn_id"],
+          "tableTo": "inference_turn",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "turn_part_session_id_agent_session_id_fk": {
+          "name": "turn_part_session_id_agent_session_id_fk",
+          "tableFrom": "turn_part",
+          "columnsFrom": ["session_id"],
+          "tableTo": "agent_session",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_token": {
+      "name": "git_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash_sha256": {
+          "name": "token_hash_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_pattern": {
+          "name": "ref_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "git_token_user_id_name_active_idx": {
+          "name": "git_token_user_id_name_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"git_token\".\"revoked_at\" is null",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "git_token_tenant_id_tenant_id_fk": {
+          "name": "git_token_tenant_id_tenant_id_fk",
+          "tableFrom": "git_token",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "git_token_user_id_user_id_fk": {
+          "name": "git_token_user_id_user_id_fk",
+          "tableFrom": "git_token",
+          "columnsFrom": ["user_id"],
+          "tableTo": "user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "git_token_principal_id_principal_id_fk": {
+          "name": "git_token_principal_id_principal_id_fk",
+          "tableFrom": "git_token",
+          "columnsFrom": ["principal_id"],
+          "tableTo": "principal",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "git_token_token_hash_sha256_unique": {
+          "name": "git_token_token_hash_sha256_unique",
+          "columns": ["token_hash_sha256"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_deployment": {
+      "name": "workflow_deployment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_asset_id": {
+          "name": "definition_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_deployment_tenant_idx": {
+          "name": "workflow_deployment_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "workflow_deployment_address_idx": {
+          "name": "workflow_deployment_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "workflow_deployment_tenant_id_tenant_id_fk": {
+          "name": "workflow_deployment_tenant_id_tenant_id_fk",
+          "tableFrom": "workflow_deployment",
+          "columnsFrom": ["tenant_id"],
+          "tableTo": "tenant",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "workflow_deployment_definition_asset_id_asset_id_fk": {
+          "name": "workflow_deployment_definition_asset_id_asset_id_fk",
+          "tableFrom": "workflow_deployment",
+          "columnsFrom": ["definition_asset_id"],
+          "tableTo": "asset",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1783998502613,
       "tag": "0036_sharp_the_executioner",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1784193583232,
+      "tag": "0037_credential_use_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -16,6 +16,7 @@
     }
   },
   "dependencies": {
+    "@intx/authz": "workspace:*",
     "@intx/log": "workspace:*",
     "@intx/types": "workspace:*",
     "arktype": "catalog:",

--- a/packages/db/src/grant-store.ts
+++ b/packages/db/src/grant-store.ts
@@ -1,4 +1,4 @@
-import { eq, and, or, isNull, gt, inArray } from "drizzle-orm";
+import { eq, and, or, isNull, gt, inArray, type SQL } from "drizzle-orm";
 
 import type { GrantRule, GrantStore } from "@intx/types/authz";
 
@@ -6,6 +6,7 @@ import type { DB } from "./client";
 import { grant } from "./schema/grants";
 import { principalRole } from "./schema/roles";
 import { parseGrantRow } from "./parse-row";
+import { getAncestorChain } from "./tenant-hierarchy";
 
 function toGrantRule(row: typeof grant.$inferSelect): GrantRule {
   const parsed = parseGrantRow(row);
@@ -22,30 +23,61 @@ function toGrantRule(row: typeof grant.$inferSelect): GrantRule {
   };
 }
 
+/**
+ * Collects a principal's live (non-expired) grants — the ones the principal
+ * owns directly plus the ones granted to any role it holds — restricted to
+ * the tenants matched by `tenantScope`. The scope is the sole knob that
+ * decides single-tenant versus chain-aware collection.
+ */
+async function collectGrantsScoped(
+  db: DB["db"],
+  principalId: string,
+  tenantScope: SQL,
+): Promise<GrantRule[]> {
+  const roleAssignments = await db.query.principalRole.findMany({
+    where: eq(principalRole.principalId, principalId),
+  });
+  const roleIds = roleAssignments.map((a) => a.roleId);
+
+  const now = new Date();
+
+  const ownership = [eq(grant.principalId, principalId)];
+  if (roleIds.length > 0) {
+    ownership.push(inArray(grant.roleId, roleIds));
+  }
+
+  const rows = await db.query.grant.findMany({
+    where: and(
+      tenantScope,
+      or(...ownership),
+      or(isNull(grant.expiresAt), gt(grant.expiresAt, now)),
+    ),
+  });
+
+  return rows.map(toGrantRule);
+}
+
 export function createGrantStore(db: DB["db"]): GrantStore {
   return {
     async collectGrants(principalId, tenantId) {
-      const roleAssignments = await db.query.principalRole.findMany({
-        where: eq(principalRole.principalId, principalId),
-      });
-      const roleIds = roleAssignments.map((a) => a.roleId);
+      return collectGrantsScoped(db, principalId, eq(grant.tenantId, tenantId));
+    },
 
-      const now = new Date();
-
-      const ownership = [eq(grant.principalId, principalId)];
-      if (roleIds.length > 0) {
-        ownership.push(inArray(grant.roleId, roleIds));
-      }
-
-      const rows = await db.query.grant.findMany({
-        where: and(
-          eq(grant.tenantId, tenantId),
-          or(...ownership),
-          or(isNull(grant.expiresAt), gt(grant.expiresAt, now)),
-        ),
-      });
-
-      return rows.map(toGrantRule);
+    // Union the principal's grants across the tenant ancestor chain — the
+    // acting tenant plus every ancestor up to the root. Mirrors the
+    // ancestor-chain resolution credential lookup already performs, so a
+    // `credential:{id}` / `use` grant stamped with an ancestor tenant (as the
+    // mint path and 0037 backfill do) still authorizes use of a credential
+    // inherited down the chain. Kept distinct from the single-tenant
+    // `collectGrants` so only the source-resolution credential-use check
+    // widens to the chain; the general RBAC path stays single-tenant.
+    async collectGrantsInChain(principalId, tenantId) {
+      const chain = await getAncestorChain(db, tenantId);
+      return collectGrantsScoped(
+        db,
+        principalId,
+        inArray(grant.tenantId, chain),
+      );
     },
   };
 }

--- a/packages/db/src/model-source-resolution.ts
+++ b/packages/db/src/model-source-resolution.ts
@@ -1,11 +1,13 @@
 import { and, eq } from "drizzle-orm";
 
+import { evaluateGrants } from "@intx/authz";
 import {
   InvokerModelPreferences,
   ModelRequirements,
   type ModelRequirement,
   type ProviderPreference,
 } from "@intx/types";
+import type { GrantRule } from "@intx/types/authz";
 import type { InferenceSource } from "@intx/types/runtime";
 
 import {
@@ -14,6 +16,7 @@ import {
 } from "./catalog-resolution";
 import type { DB } from "./client";
 import { resolveCredentialById } from "./credential-resolution";
+import { createGrantStore } from "./grant-store";
 import { agent } from "./schema/agents";
 
 /**
@@ -24,6 +27,7 @@ import { agent } from "./schema/agents";
 export type SourceSkip =
   | { reason: "wallet_backed"; provider: string }
   | { reason: "credential_unresolved"; provider: string }
+  | { reason: "credential_unauthorized"; provider: string }
   | { reason: "provider_misconfigured"; provider: string };
 
 /**
@@ -96,6 +100,7 @@ async function buildSource(
   db: DB["db"],
   tenantId: string,
   resolved: ResolvedOffering,
+  creatorGrants: GrantRule[],
 ): Promise<
   { ok: true; source: InferenceSource } | { ok: false; skip: SourceSkip }
 > {
@@ -119,7 +124,7 @@ async function buildSource(
 
   // Resolve the secret through the tenant-scoped credential resolver so a
   // provider row referencing a credential outside the tenant's ancestor
-  // chain cannot leak that secret (INTR-203: the chain is the authority).
+  // chain cannot leak that secret (the chain is the authority).
   const credential = await resolveCredentialById(
     db,
     tenantId,
@@ -129,6 +134,23 @@ async function buildSource(
     return {
       ok: false,
       skip: { reason: "credential_unresolved", provider: provider.name },
+    };
+  }
+
+  // The tenant chain proves the credential is reachable; it does not prove the
+  // agent's creator is authorized to spend it. Gate the secret on the creator
+  // holding a `credential:{id}` / `use` grant. Fail closed: anything other than
+  // an `allow` effect (including `ask`, `deny`, and no matching grant at all)
+  // withholds the secret so it never enters a launchable source.
+  const authorization = await evaluateGrants(
+    creatorGrants,
+    `credential:${credential.id}`,
+    "use",
+  );
+  if (authorization.effect !== "allow") {
+    return {
+      ok: false,
+      skip: { reason: "credential_unauthorized", provider: provider.name },
     };
   }
 
@@ -156,11 +178,17 @@ async function buildSource(
  * offering is resolved to a credential-backed source; offerings that cannot
  * produce one are skipped. A required model that yields no source makes the
  * agent unlaunchable.
+ *
+ * `creatorGrants` are the agent creator's collected grants. A credential-backed
+ * source is only emitted when the creator holds `credential:{id}` / `use` for
+ * the referenced credential; otherwise the offering is skipped
+ * (`credential_unauthorized`) and its secret is withheld.
  */
 export async function resolveModelSources(
   db: DB["db"],
   tenantId: string,
   requirements: ModelRequirement[],
+  creatorGrants: GrantRule[],
   opts?: { invokerPreferences?: Record<string, ProviderPreference> },
 ): Promise<CatalogSourceResolution> {
   if (requirements.length === 0) {
@@ -191,7 +219,7 @@ export async function resolveModelSources(
     const skips: SourceSkip[] = [];
     const modelSources: InferenceSource[] = [];
     for (const candidate of candidates) {
-      const built = await buildSource(db, tenantId, candidate);
+      const built = await buildSource(db, tenantId, candidate, creatorGrants);
       if (built.ok) {
         modelSources.push(built.source);
       } else {
@@ -250,7 +278,17 @@ export async function resolveInstanceModelSources(
     invokerPreferences[preference.model] = preference.providers;
   }
 
-  return resolveModelSources(db, tenantId, requirements, {
+  // The authorizing party for a credential-backed source is the agent's
+  // creator, recorded on the definition. Re-resolution (rotation, reconnect)
+  // must re-check the creator's `credential:{id}` / `use` grant, so collect
+  // the creator's grants here rather than threading them through the push
+  // callers.
+  const creatorGrants = await createGrantStore(db).collectGrants(
+    agentRow.creatorPrincipalId,
+    tenantId,
+  );
+
+  return resolveModelSources(db, tenantId, requirements, creatorGrants, {
     invokerPreferences,
   });
 }

--- a/packages/db/src/model-source-resolution.ts
+++ b/packages/db/src/model-source-resolution.ts
@@ -143,6 +143,13 @@ async function buildSource(
   // an `allow` effect (including `ask`, `deny`, and no matching grant at all)
   // withholds the secret so it never enters a launchable source.
   //
+  // Gating on the creator's `use` grant is a deliberate interim tightening over
+  // the tenant-source default: catalog credentials are tenant-owned, and the
+  // broader source-based credential-authority model (tenant/creator/invoker)
+  // would authorize a tenant-source credential via tenant/role policy rather
+  // than a per-principal grant. That model is where this check should ultimately
+  // live; until it subsumes catalog credentials, this stays as-is by design.
+  //
   // No condition registry is passed: credential-use grants are minted and
   // backfilled unconditionally (conditions: null), so conditional grants are
   // intentionally not evaluated on this path.

--- a/packages/db/src/model-source-resolution.ts
+++ b/packages/db/src/model-source-resolution.ts
@@ -142,6 +142,10 @@ async function buildSource(
   // holding a `credential:{id}` / `use` grant. Fail closed: anything other than
   // an `allow` effect (including `ask`, `deny`, and no matching grant at all)
   // withholds the secret so it never enters a launchable source.
+  //
+  // No condition registry is passed: credential-use grants are minted and
+  // backfilled unconditionally (conditions: null), so conditional grants are
+  // intentionally not evaluated on this path.
   const authorization = await evaluateGrants(
     creatorGrants,
     `credential:${credential.id}`,
@@ -282,8 +286,12 @@ export async function resolveInstanceModelSources(
   // creator, recorded on the definition. Re-resolution (rotation, reconnect)
   // must re-check the creator's `credential:{id}` / `use` grant, so collect
   // the creator's grants here rather than threading them through the push
-  // callers.
-  const creatorGrants = await createGrantStore(db).collectGrants(
+  // callers. Collect across the tenant ancestor chain: credential resolution
+  // already reaches inherited credentials up the chain, and the authorizing
+  // `use` grant is stamped with the credential's own (ancestor) tenant, so a
+  // single-tenant collection would fail closed on a legitimately inherited
+  // credential.
+  const creatorGrants = await createGrantStore(db).collectGrantsInChain(
     agentRow.creatorPrincipalId,
     tenantId,
   );

--- a/packages/hub-api/src/routes/credentials.ts
+++ b/packages/hub-api/src/routes/credentials.ts
@@ -2,7 +2,7 @@ import { eq, and, isNull } from "drizzle-orm";
 import { Hono } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
 
-import { credential, provider } from "@intx/db/schema";
+import { credential, grant as grantTable, provider } from "@intx/db/schema";
 import {
   getAncestorChain,
   resolveCredentialByName,
@@ -201,28 +201,56 @@ export function createCredentialRoutes({
       }
 
       const now = new Date();
-      const row = first(
-        await db
-          .insert(credential)
-          .values({
-            id: generateId("credential"),
+      const credentialId = generateId("credential");
+      const ownerPrincipalId = body.principalId ?? null;
+
+      const row = await db.transaction(async (tx) => {
+        const inserted = first(
+          await tx
+            .insert(credential)
+            .values({
+              id: credentialId,
+              tenantId: tenantCtx.id,
+              providerId: body.providerId,
+              principalId: ownerPrincipalId,
+              oauthClientId: body.oauthClientId ?? null,
+              name: body.name,
+              type: body.type,
+              description: body.description ?? null,
+              secret: body.secret,
+              refreshSecret: body.refreshSecret ?? null,
+              scopes: body.scopes ?? null,
+              expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
+              metadata: body.metadata ?? null,
+              createdAt: now,
+              updatedAt: now,
+            })
+            .returning(),
+        );
+
+        // A personal credential (principalId set) grants its owner durable
+        // `use` authority on creation so the owner can launch agents with
+        // their own credential without a separate manual grant. Org
+        // credentials (principalId null) are covered by tenant-owner role
+        // inheritance and explicit administrative role grants, so they get
+        // no auto-grant here.
+        if (ownerPrincipalId !== null) {
+          await tx.insert(grantTable).values({
+            id: generateId("grant"),
             tenantId: tenantCtx.id,
-            providerId: body.providerId,
-            principalId: body.principalId ?? null,
-            oauthClientId: body.oauthClientId ?? null,
-            name: body.name,
-            type: body.type,
-            description: body.description ?? null,
-            secret: body.secret,
-            refreshSecret: body.refreshSecret ?? null,
-            scopes: body.scopes ?? null,
-            expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
-            metadata: body.metadata ?? null,
+            principalId: ownerPrincipalId,
+            resource: `credential:${credentialId}`,
+            action: "use",
+            effect: "allow",
+            origin: "creator",
+            expiresAt: null,
             createdAt: now,
             updatedAt: now,
-          })
-          .returning(),
-      );
+          });
+        }
+
+        return inserted;
+      });
 
       return c.json(formatCredential(row), 201);
     },

--- a/packages/hub-api/src/routes/instances.test.ts
+++ b/packages/hub-api/src/routes/instances.test.ts
@@ -1164,6 +1164,16 @@ describe("POST /agents/instances seeds creator agent-state grant", () => {
         resource: "instance:*",
         action: "create",
       }),
+      // The definition's creator holds `credential:{id}` / `use` for the
+      // catalog credential, so model-source resolution authorizes the secret
+      // and the agent is launchable.
+      makeGrant({
+        id: "g-creator-cred-use",
+        resource: `credential:${CREDENTIAL_ID}`,
+        action: "use",
+        origin: "creator",
+        principalId: CREATOR_ID,
+      }),
     ]);
   }
 

--- a/packages/hub-api/src/routes/instances.ts
+++ b/packages/hub-api/src/routes/instances.ts
@@ -206,10 +206,20 @@ export function createInstanceRoutes({
         invokerPreferences[preference.model] = preference.providers;
       }
 
+      // A model source only carries a credential secret when the definition's
+      // creator holds `credential:{id}` / `use` for it. Resolution authorizes
+      // the creator against these grants and withholds the secret otherwise,
+      // surfacing an unauthorized credential as a not-launchable skip below.
+      const creatorSourceGrants = await grantStore.collectGrants(
+        creatorPrincipalId,
+        tenant.id,
+      );
+
       const resolution = await resolveModelSources(
         db,
         tenant.id,
         modelRequirements,
+        creatorSourceGrants,
         { invokerPreferences },
       );
       if (!resolution.ok) {

--- a/packages/hub-api/src/routes/instances.ts
+++ b/packages/hub-api/src/routes/instances.ts
@@ -210,7 +210,11 @@ export function createInstanceRoutes({
       // creator holds `credential:{id}` / `use` for it. Resolution authorizes
       // the creator against these grants and withholds the secret otherwise,
       // surfacing an unauthorized credential as a not-launchable skip below.
-      const creatorSourceGrants = await grantStore.collectGrants(
+      // Collect across the tenant ancestor chain: credential resolution reaches
+      // inherited credentials up the chain, and the authorizing `use` grant is
+      // stamped with the credential's own (ancestor) tenant, so single-tenant
+      // collection would withhold a legitimately inherited credential.
+      const creatorSourceGrants = await grantStore.collectGrantsInChain(
         creatorPrincipalId,
         tenant.id,
       );

--- a/packages/types/src/authz.ts
+++ b/packages/types/src/authz.ts
@@ -14,6 +14,19 @@ export type GrantRule = {
 
 export type GrantStore = {
   collectGrants(principalId: string, tenantId: string): Promise<GrantRule[]>;
+  /**
+   * Like `collectGrants`, but unions the principal's grants across the tenant
+   * ancestor chain (the acting tenant plus every ancestor up to the root)
+   * rather than a single tenant. Only the source-resolution credential-use
+   * check uses this: it mirrors the ancestor-chain reach of credential
+   * resolution so a `credential:{id}` / `use` grant stamped with an inherited
+   * credential's own (ancestor) tenant still authorizes use. The general RBAC
+   * path stays on the single-tenant `collectGrants`.
+   */
+  collectGrantsInChain(
+    principalId: string,
+    tenantId: string,
+  ): Promise<GrantRule[]>;
 };
 
 export type ConditionContext = {

--- a/tests/db/credential-use-backfill.test.ts
+++ b/tests/db/credential-use-backfill.test.ts
@@ -1,0 +1,202 @@
+// Verifies the `credential:{id}` / `use` grant backfill migration against a
+// real, schema-isolated database.
+//
+// The migration runs once during `createTestDb` when the tables are empty, so
+// its effect on seeded data is exercised by re-executing the exact SQL the
+// migration ships. Re-running the same statement is also the idempotency
+// scenario: a second and third application must insert nothing and must not
+// error.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { and, eq, sql } from "drizzle-orm";
+
+import { grant } from "@intx/db/schema";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import { REPO_ROOT } from "@intx/test-harness/env";
+import {
+  seedCredential,
+  seedPrincipal,
+  seedProvider,
+  seedTenants,
+} from "@intx/test-harness/seed";
+
+const BACKFILL_SQL = readFileSync(
+  path.join(
+    REPO_ROOT,
+    "packages/db/migrations/0037_credential_use_backfill.sql",
+  ),
+  "utf-8",
+);
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "credential-use backfill migration (real DB)",
+  () => {
+    let h: TestDb;
+
+    beforeAll(async () => {
+      h = await createTestDb();
+    });
+
+    afterAll(async () => {
+      await h.close();
+    });
+
+    beforeEach(async () => {
+      await h.reset();
+    });
+
+    async function runBackfill(): Promise<void> {
+      await h.db.execute(sql.raw(BACKFILL_SQL));
+    }
+
+    async function useGrantsFor(
+      principalId: string,
+      resource: string,
+    ): Promise<(typeof grant.$inferSelect)[]> {
+      return h.db
+        .select()
+        .from(grant)
+        .where(
+          and(
+            eq(grant.principalId, principalId),
+            eq(grant.resource, resource),
+            eq(grant.action, "use"),
+          ),
+        );
+    }
+
+    test("grants credential use to each personal credential owner", async () => {
+      await seedTenants(h.db, [{ id: "tnt_leaf" }]);
+      await seedProvider(h.db, {
+        id: "prv_1",
+        tenantId: "tnt_leaf",
+        name: "github",
+      });
+      await seedPrincipal(h.db, { id: "prn_owner", tenantId: "tnt_leaf" });
+      await seedCredential(h.db, {
+        id: "crd_personal",
+        tenantId: "tnt_leaf",
+        providerId: "prv_1",
+        name: "personal-cred",
+        principalId: "prn_owner",
+      });
+
+      await runBackfill();
+
+      const grants = await useGrantsFor("prn_owner", "credential:crd_personal");
+      expect(grants).toHaveLength(1);
+      const [g] = grants;
+      expect(g?.tenantId).toBe("tnt_leaf");
+      expect(g?.effect).toBe("allow");
+      expect(g?.origin).toBe("creator");
+      expect(g?.expiresAt).toBeNull();
+      expect(g?.roleId).toBeNull();
+      expect(g?.id).toMatch(/^grt_[0-9a-f]{32}$/);
+    });
+
+    test("does not grant use for organizational credentials", async () => {
+      await seedTenants(h.db, [{ id: "tnt_leaf" }]);
+      await seedProvider(h.db, {
+        id: "prv_1",
+        tenantId: "tnt_leaf",
+        name: "github",
+      });
+      await seedCredential(h.db, {
+        id: "crd_org",
+        tenantId: "tnt_leaf",
+        providerId: "prv_1",
+        name: "org-cred",
+        principalId: null,
+      });
+
+      await runBackfill();
+
+      const orgResourceGrants = await h.db
+        .select()
+        .from(grant)
+        .where(
+          and(
+            eq(grant.resource, "credential:crd_org"),
+            eq(grant.action, "use"),
+          ),
+        );
+      expect(orgResourceGrants).toHaveLength(0);
+    });
+
+    test("re-applying the backfill is a no-op", async () => {
+      await seedTenants(h.db, [{ id: "tnt_leaf" }]);
+      await seedProvider(h.db, {
+        id: "prv_1",
+        tenantId: "tnt_leaf",
+        name: "github",
+      });
+      await seedPrincipal(h.db, { id: "prn_owner", tenantId: "tnt_leaf" });
+      await seedCredential(h.db, {
+        id: "crd_personal",
+        tenantId: "tnt_leaf",
+        providerId: "prv_1",
+        name: "personal-cred",
+        principalId: "prn_owner",
+      });
+
+      await runBackfill();
+      const first = await useGrantsFor("prn_owner", "credential:crd_personal");
+      expect(first).toHaveLength(1);
+      const originalId = first[0]?.id;
+
+      await runBackfill();
+      await runBackfill();
+
+      const after = await useGrantsFor("prn_owner", "credential:crd_personal");
+      expect(after).toHaveLength(1);
+      expect(after[0]?.id).toBe(originalId);
+    });
+
+    test("preserves a pre-existing use grant and adds none", async () => {
+      await seedTenants(h.db, [{ id: "tnt_leaf" }]);
+      await seedProvider(h.db, {
+        id: "prv_1",
+        tenantId: "tnt_leaf",
+        name: "github",
+      });
+      await seedPrincipal(h.db, { id: "prn_owner", tenantId: "tnt_leaf" });
+      await seedCredential(h.db, {
+        id: "crd_personal",
+        tenantId: "tnt_leaf",
+        providerId: "prv_1",
+        name: "personal-cred",
+        principalId: "prn_owner",
+      });
+      await h.db.insert(grant).values({
+        id: "grt_preexisting",
+        tenantId: "tnt_leaf",
+        principalId: "prn_owner",
+        resource: "credential:crd_personal",
+        action: "use",
+        effect: "allow",
+        origin: "creator",
+      });
+
+      await runBackfill();
+
+      const grants = await useGrantsFor("prn_owner", "credential:crd_personal");
+      expect(grants).toHaveLength(1);
+      expect(grants[0]?.id).toBe("grt_preexisting");
+    });
+  },
+);

--- a/tests/db/credential-use-cross-tenant.test.ts
+++ b/tests/db/credential-use-cross-tenant.test.ts
@@ -1,0 +1,285 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import {
+  createGrantStore,
+  resolveInstanceModelSources,
+  resolveModelSources,
+} from "@intx/db";
+import type { ModelRequirement } from "@intx/types";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import {
+  seedAgent,
+  seedCredential,
+  seedGrant,
+  seedModel,
+  seedModelOffering,
+  seedModelProvider,
+  seedPrincipal,
+  seedProvider,
+  seedTenants,
+} from "@intx/test-harness/seed";
+
+// Credential resolution walks the tenant ancestor chain: a child tenant
+// reaches a credential owned by a parent through inheritance. The
+// credential-use grant check must widen to the same chain, because the owner's
+// authorizing `credential:{id}` / `use` grant is stamped with the credential's
+// own (parent) tenant, exactly as the mint path and the 0037 backfill produce
+// it. These tests pin the multi-tenant contract on both secret-injecting
+// paths — launch (resolveModelSources) and rotation/reconnect re-resolution
+// (resolveInstanceModelSources) — against a parent tenant `tnt_root` and a
+// child tenant `tnt_child` that inherits from it. The single-tenant suite in
+// credential-use-enforcement.test.ts does not exercise inheritance, which is
+// the gap that let the fail-closed asymmetry through.
+
+const SECRET = "sk-parent-personal-credential";
+const REQ_OPUS: ModelRequirement[] = [{ model: "opus" }];
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "credential-use enforcement across the tenant chain (real DB)",
+  () => {
+    let h: TestDb;
+
+    beforeAll(async () => {
+      h = await createTestDb();
+    });
+
+    afterAll(async () => {
+      await h.close();
+    });
+
+    beforeEach(async () => {
+      await h.reset();
+    });
+
+    // Parent tenant `tnt_root` owns a personal credential (principalId set),
+    // the credential-backed offering for model "opus", and the model catalog.
+    // Child tenant `tnt_child` inherits all of it through the ancestor chain
+    // and hosts an agent whose creator is the given principal. The credential's
+    // owner is always `prn_owner` in the parent; the creator principal (which
+    // may differ) and its tenant are supplied per case. The owner's
+    // `credential:{id}` / `use` grant, when a case seeds one, is stamped with
+    // the credential's tenant (tnt_root) — the mint/backfill behavior.
+    async function seedInheritedCredential(opts: {
+      creatorPrincipalId: string;
+      creatorTenantId: string;
+    }): Promise<void> {
+      await seedTenants(h.db, [
+        { id: "tnt_root" },
+        { id: "tnt_child", parentId: "tnt_root" },
+      ]);
+      await seedPrincipal(h.db, { id: "prn_owner", tenantId: "tnt_root" });
+      if (opts.creatorPrincipalId !== "prn_owner") {
+        await seedPrincipal(h.db, {
+          id: opts.creatorPrincipalId,
+          tenantId: opts.creatorTenantId,
+        });
+      }
+      await seedProvider(h.db, {
+        id: "prv_x",
+        tenantId: "tnt_root",
+        name: "prv-x",
+      });
+      await seedCredential(h.db, {
+        id: "cred_a",
+        tenantId: "tnt_root",
+        providerId: "prv_x",
+        principalId: "prn_owner",
+        name: "cred-a",
+        secret: SECRET,
+      });
+      await seedModel(h.db, {
+        id: "mdl_opus",
+        tenantId: "tnt_root",
+        canonicalName: "opus",
+      });
+      await seedModelProvider(h.db, {
+        id: "mpv_anthropic",
+        tenantId: "tnt_root",
+        name: "anthropic",
+        credentialId: "cred_a",
+      });
+      await seedModelOffering(h.db, {
+        id: "mof_a",
+        tenantId: "tnt_root",
+        modelId: "mdl_opus",
+        providerId: "mpv_anthropic",
+      });
+      await seedAgent(h.db, {
+        id: "agt_1",
+        tenantId: "tnt_child",
+        creatorPrincipalId: opts.creatorPrincipalId,
+        modelRequirements: [{ model: "opus" }],
+      });
+    }
+
+    // POSITIVE (the fix): the credential owner holds a specifically-scoped
+    // `credential:cred_a` / `use` grant in the PARENT tenant, and drives a
+    // child-tenant agent. The child inherits the credential; the owner's grant
+    // lives up the chain. Chain-aware collection must find it and emit the
+    // secret. This case fails before the fix.
+    describe("owner grant in the parent tenant (inherited credential)", () => {
+      async function seedOwnerWithParentGrant(): Promise<void> {
+        await seedInheritedCredential({
+          creatorPrincipalId: "prn_owner",
+          creatorTenantId: "tnt_root",
+        });
+        await seedGrant(h.db, {
+          id: "grt_owner_use",
+          tenantId: "tnt_root",
+          principalId: "prn_owner",
+          resource: "credential:cred_a",
+          action: "use",
+        });
+      }
+
+      test("launch resolution emits the inherited secret", async () => {
+        await seedOwnerWithParentGrant();
+
+        const creatorGrants = await createGrantStore(h.db).collectGrantsInChain(
+          "prn_owner",
+          "tnt_child",
+        );
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_child",
+          REQ_OPUS,
+          creatorGrants,
+        );
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.sources.map((s) => s.apiKey)).toEqual([SECRET]);
+      });
+
+      test("rotation re-resolution emits the inherited secret", async () => {
+        await seedOwnerWithParentGrant();
+
+        const result = await resolveInstanceModelSources(h.db, "tnt_child", {
+          agentId: "agt_1",
+          modelPreferences: null,
+        });
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.sources.map((s) => s.apiKey)).toEqual([SECRET]);
+      });
+    });
+
+    // REGRESSION GUARD: a child-tenant owner holding `*` / `*` in the CHILD
+    // tenant uses the inherited credential. This works today (the grant lives
+    // in the resolving tenant) and must keep working: chain-aware collection
+    // still includes the acting tenant, so it must find the child's `*` / `*`.
+    describe("child-tenant owner with wildcard grant in the child", () => {
+      async function seedChildOwnerWithWildcard(): Promise<void> {
+        await seedInheritedCredential({
+          creatorPrincipalId: "prn_child_owner",
+          creatorTenantId: "tnt_child",
+        });
+        await seedGrant(h.db, {
+          id: "grt_child_wildcard",
+          tenantId: "tnt_child",
+          principalId: "prn_child_owner",
+          resource: "*",
+          action: "*",
+        });
+      }
+
+      test("launch resolution emits the inherited secret", async () => {
+        await seedChildOwnerWithWildcard();
+
+        const creatorGrants = await createGrantStore(h.db).collectGrantsInChain(
+          "prn_child_owner",
+          "tnt_child",
+        );
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_child",
+          REQ_OPUS,
+          creatorGrants,
+        );
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.sources.map((s) => s.apiKey)).toEqual([SECRET]);
+      });
+
+      test("rotation re-resolution emits the inherited secret", async () => {
+        await seedChildOwnerWithWildcard();
+
+        const result = await resolveInstanceModelSources(h.db, "tnt_child", {
+          agentId: "agt_1",
+          modelPreferences: null,
+        });
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.sources.map((s) => s.apiKey)).toEqual([SECRET]);
+      });
+    });
+
+    // NEGATIVE (no over-broadening): a child-tenant creator holding NO
+    // `credential:cred_a` / `use` grant anywhere in the chain must be denied.
+    // Widening collection to the chain must not turn into "everyone up the
+    // chain can spend it" — a creator with no authorizing grant still fails
+    // closed and never sees the secret.
+    describe("child-tenant creator with no credential-use grant", () => {
+      async function seedUnauthorizedCreator(): Promise<void> {
+        await seedInheritedCredential({
+          creatorPrincipalId: "prn_stranger",
+          creatorTenantId: "tnt_child",
+        });
+      }
+
+      test("launch resolution withholds the secret", async () => {
+        await seedUnauthorizedCreator();
+
+        const creatorGrants = await createGrantStore(h.db).collectGrantsInChain(
+          "prn_stranger",
+          "tnt_child",
+        );
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_child",
+          REQ_OPUS,
+          creatorGrants,
+        );
+
+        expect(JSON.stringify(result)).not.toContain(SECRET);
+        expect(result).toMatchObject({
+          ok: false,
+          reason: "model_unavailable",
+          model: "opus",
+          skips: [{ reason: "credential_unauthorized", provider: "anthropic" }],
+        });
+      });
+
+      test("rotation re-resolution withholds the secret", async () => {
+        await seedUnauthorizedCreator();
+
+        const result = await resolveInstanceModelSources(h.db, "tnt_child", {
+          agentId: "agt_1",
+          modelPreferences: null,
+        });
+
+        expect(JSON.stringify(result)).not.toContain(SECRET);
+        expect(result).toMatchObject({
+          ok: false,
+          reason: "model_unavailable",
+          model: "opus",
+          skips: [{ reason: "credential_unauthorized", provider: "anthropic" }],
+        });
+      });
+    });
+  },
+);

--- a/tests/db/credential-use-enforcement.test.ts
+++ b/tests/db/credential-use-enforcement.test.ts
@@ -1,0 +1,223 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { resolveInstanceModelSources, resolveModelSources } from "@intx/db";
+import type { ModelRequirement } from "@intx/types";
+import type { GrantRule } from "@intx/types/authz";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import {
+  seedAgent,
+  seedCredential,
+  seedGrant,
+  seedModel,
+  seedModelOffering,
+  seedModelProvider,
+  seedPrincipal,
+  seedProvider,
+  seedTenants,
+} from "@intx/test-harness/seed";
+
+// The catalog resolver dereferences a provider's credential reference to the
+// secret and places it on a launchable source. That secret may only enter the
+// source when the agent's creator holds `credential:{id}` / `use` for it. These
+// tests pin the fail-closed contract on both paths that inject secrets: agent
+// launch (resolveModelSources) and rotation/reconnect re-resolution
+// (resolveInstanceModelSources). A non-owner creator lacking the grant must
+// never see the secret in the resolved sources.
+
+const REQ_OPUS: ModelRequirement[] = [{ model: "opus" }];
+const SECRET = "sk-tenant-credential";
+
+// A non-owner creator with no `credential:{id}` / `use` grant. The empty grant
+// list is the vulnerable case: nothing authorizes credential use, so the
+// resolver must withhold the secret.
+const UNAUTHORIZED_CREATOR_GRANTS: GrantRule[] = [];
+
+// A creator holding an explicit `credential:{id}` / `use` allow grant for the
+// tenant credential — the authorized case.
+const AUTHORIZED_CREATOR_GRANTS: GrantRule[] = [
+  {
+    id: "grt_use_cred_a",
+    resource: "credential:cred_a",
+    action: "use",
+    effect: "allow",
+    origin: "creator",
+    conditions: null,
+    expiresAt: null,
+    roleId: null,
+    principalId: "prn_creator",
+  },
+];
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "credential-use enforcement (real DB)",
+  () => {
+    let h: TestDb;
+
+    beforeAll(async () => {
+      h = await createTestDb();
+    });
+
+    afterAll(async () => {
+      await h.close();
+    });
+
+    beforeEach(async () => {
+      await h.reset();
+    });
+
+    // A single credential-backed offering for model "opus" through provider
+    // "anthropic", carrying an organizational credential (principalId null) on
+    // the resolving tenant. The credential's secret is what a built source
+    // carries as its apiKey.
+    async function seedTenantCredentialOffering(): Promise<void> {
+      await seedTenants(h.db, [{ id: "tnt_root" }]);
+      await seedProvider(h.db, {
+        id: "prv_x",
+        tenantId: "tnt_root",
+        name: "prv-x",
+      });
+      await seedCredential(h.db, {
+        id: "cred_a",
+        tenantId: "tnt_root",
+        providerId: "prv_x",
+        name: "cred-a",
+        secret: SECRET,
+      });
+      await seedModel(h.db, {
+        id: "mdl_opus",
+        tenantId: "tnt_root",
+        canonicalName: "opus",
+      });
+      await seedModelProvider(h.db, {
+        id: "mpv_anthropic",
+        tenantId: "tnt_root",
+        name: "anthropic",
+        credentialId: "cred_a",
+      });
+      await seedModelOffering(h.db, {
+        id: "mof_a",
+        tenantId: "tnt_root",
+        modelId: "mdl_opus",
+        providerId: "mpv_anthropic",
+      });
+    }
+
+    // Seed an agent whose creator's credential-use authorization the caller
+    // controls via `authorized`. The credential-using offering is the same
+    // organizational credential as the launch fixture.
+    async function seedAgentWithCreator(authorized: boolean): Promise<void> {
+      await seedTenantCredentialOffering();
+      await seedPrincipal(h.db, {
+        id: "prn_creator",
+        tenantId: "tnt_root",
+      });
+      if (authorized) {
+        await seedGrant(h.db, {
+          id: "grt_creator_use",
+          tenantId: "tnt_root",
+          principalId: "prn_creator",
+          resource: "credential:cred_a",
+          action: "use",
+        });
+      }
+      await seedAgent(h.db, {
+        id: "agt_1",
+        tenantId: "tnt_root",
+        creatorPrincipalId: "prn_creator",
+        modelRequirements: [{ model: "opus" }],
+      });
+    }
+
+    describe("launch path (resolveModelSources)", () => {
+      test("withholds the secret from a creator lacking credential/use", async () => {
+        await seedTenantCredentialOffering();
+
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_root",
+          REQ_OPUS,
+          UNAUTHORIZED_CREATOR_GRANTS,
+        );
+
+        // The secret must not reach any launchable source, and the whole
+        // resolution must not carry it anywhere.
+        expect(JSON.stringify(result)).not.toContain(SECRET);
+        expect(result).toMatchObject({
+          ok: false,
+          reason: "model_unavailable",
+          model: "opus",
+          skips: [{ reason: "credential_unauthorized", provider: "anthropic" }],
+        });
+      });
+
+      test("emits the secret to a creator holding credential/use", async () => {
+        await seedTenantCredentialOffering();
+
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_root",
+          REQ_OPUS,
+          AUTHORIZED_CREATOR_GRANTS,
+        );
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.sources).toEqual([
+          {
+            id: "mof_a",
+            provider: "anthropic",
+            baseURL: "https://api.anthropic.com",
+            apiKey: SECRET,
+            model: "opus",
+            capabilities: [],
+          },
+        ]);
+      });
+    });
+
+    describe("rotation path (resolveInstanceModelSources)", () => {
+      test("withholds the secret when the instance creator lacks credential/use", async () => {
+        await seedAgentWithCreator(false);
+
+        const result = await resolveInstanceModelSources(h.db, "tnt_root", {
+          agentId: "agt_1",
+          modelPreferences: null,
+        });
+
+        // The rotation push ships resolution.sources to the running sidecar.
+        // An unauthorized creator must never have the rotated secret pushed.
+        expect(JSON.stringify(result)).not.toContain(SECRET);
+        expect(result).toMatchObject({
+          ok: false,
+          reason: "model_unavailable",
+          model: "opus",
+          skips: [{ reason: "credential_unauthorized", provider: "anthropic" }],
+        });
+      });
+
+      test("pushes the secret when the instance creator holds credential/use", async () => {
+        await seedAgentWithCreator(true);
+
+        const result = await resolveInstanceModelSources(h.db, "tnt_root", {
+          agentId: "agt_1",
+          modelPreferences: null,
+        });
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.sources.map((s) => s.apiKey)).toEqual([SECRET]);
+      });
+    });
+  },
+);

--- a/tests/db/credential-use-invoker-override.test.ts
+++ b/tests/db/credential-use-invoker-override.test.ts
@@ -1,0 +1,187 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { resolveModelSources } from "@intx/db";
+import type { ModelRequirement, ProviderPreference } from "@intx/types";
+import type { GrantRule } from "@intx/types/authz";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import {
+  seedCredential,
+  seedModel,
+  seedModelOffering,
+  seedModelProvider,
+  seedPrincipal,
+  seedProvider,
+  seedTenants,
+} from "@intx/test-harness/seed";
+
+// The invoker's launch-time provider preference reorders and restricts the
+// tenant catalog, but it must not become a way to spend a credential the
+// agent's creator is not authorized for. The credential-use gate keys on the
+// creator's `credential:{id}` / `use` grant, and it sits below preference
+// application in buildSource — so an invoker `pin` onto an offering the creator
+// cannot use skips as `credential_unauthorized` rather than emitting the
+// secret. This test pins that boundary: same model, two providers backed by
+// distinct credentials, creator authorized for one credential only.
+
+const REQ_OPUS: ModelRequirement[] = [{ model: "opus" }];
+const SECRET_A = "sk-provider-a-credential";
+const SECRET_B = "sk-provider-b-credential";
+
+// The creator holds `credential:{id}` / `use` for provider A's credential
+// only. Provider B's credential is deliberately absent from this grant list.
+const CREATOR_GRANTS_A_ONLY: GrantRule[] = [
+  {
+    id: "grt_use_cred_a",
+    resource: "credential:cred_a",
+    action: "use",
+    effect: "allow",
+    origin: "creator",
+    conditions: null,
+    expiresAt: null,
+    roleId: null,
+    principalId: "prn_creator",
+  },
+];
+
+function pin(provider: string): Record<string, ProviderPreference> {
+  return { opus: { mode: "pin", order: [provider] } };
+}
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "credential-use enforcement under invoker override (real DB)",
+  () => {
+    let h: TestDb;
+
+    beforeAll(async () => {
+      h = await createTestDb();
+    });
+
+    afterAll(async () => {
+      await h.close();
+    });
+
+    beforeEach(async () => {
+      await h.reset();
+    });
+
+    // Two catalog offerings for model "opus" from providers "provider-a" and
+    // "provider-b", each backed by its own tenant credential. The creator is
+    // authorized for provider A's credential (cred_a) only.
+    async function seedTwoProviderCatalog(): Promise<void> {
+      await seedTenants(h.db, [{ id: "tnt_root" }]);
+      await seedPrincipal(h.db, { id: "prn_creator", tenantId: "tnt_root" });
+      await seedProvider(h.db, {
+        id: "prv_x",
+        tenantId: "tnt_root",
+        name: "prv-x",
+      });
+      await seedCredential(h.db, {
+        id: "cred_a",
+        tenantId: "tnt_root",
+        providerId: "prv_x",
+        name: "cred-a",
+        secret: SECRET_A,
+      });
+      await seedCredential(h.db, {
+        id: "cred_b",
+        tenantId: "tnt_root",
+        providerId: "prv_x",
+        name: "cred-b",
+        secret: SECRET_B,
+      });
+      await seedModel(h.db, {
+        id: "mdl_opus",
+        tenantId: "tnt_root",
+        canonicalName: "opus",
+      });
+      await seedModelProvider(h.db, {
+        id: "mpv_a",
+        tenantId: "tnt_root",
+        name: "provider-a",
+        credentialId: "cred_a",
+      });
+      await seedModelProvider(h.db, {
+        id: "mpv_b",
+        tenantId: "tnt_root",
+        name: "provider-b",
+        credentialId: "cred_b",
+      });
+      await seedModelOffering(h.db, {
+        id: "mof_a",
+        tenantId: "tnt_root",
+        modelId: "mdl_opus",
+        providerId: "mpv_a",
+      });
+      await seedModelOffering(h.db, {
+        id: "mof_b",
+        tenantId: "tnt_root",
+        modelId: "mdl_opus",
+        providerId: "mpv_b",
+      });
+    }
+
+    test("invoker pinning the authorized provider emits its secret", async () => {
+      await seedTwoProviderCatalog();
+
+      const result = await resolveModelSources(
+        h.db,
+        "tnt_root",
+        REQ_OPUS,
+        CREATOR_GRANTS_A_ONLY,
+        { invokerPreferences: pin("provider-a") },
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // The emitted source's `provider` is the offering's plugin (the runtime
+      // adapter), not the catalog provider name the invoker pinned on; both
+      // seeded providers default to the "anthropic" plugin. The load-bearing
+      // assertion is that provider A's secret is what reaches the source.
+      expect(result.sources).toEqual([
+        {
+          id: "mof_a",
+          provider: "anthropic",
+          baseURL: "https://api.anthropic.com",
+          apiKey: SECRET_A,
+          model: "opus",
+          capabilities: [],
+        },
+      ]);
+    });
+
+    test("invoker cannot pin a creator-unauthorized provider to spend its credential", async () => {
+      await seedTwoProviderCatalog();
+
+      const result = await resolveModelSources(
+        h.db,
+        "tnt_root",
+        REQ_OPUS,
+        CREATOR_GRANTS_A_ONLY,
+        { invokerPreferences: pin("provider-b") },
+      );
+
+      // The invoker restricted resolution to provider B, which the creator is
+      // not authorized to spend. The offering is skipped as
+      // credential_unauthorized rather than falling back to provider A, and
+      // provider B's secret never reaches the resolution.
+      expect(JSON.stringify(result)).not.toContain(SECRET_B);
+      expect(result).toMatchObject({
+        ok: false,
+        reason: "model_unavailable",
+        model: "opus",
+        skips: [{ reason: "credential_unauthorized", provider: "provider-b" }],
+      });
+    });
+  },
+);

--- a/tests/db/model-source-resolution.test.ts
+++ b/tests/db/model-source-resolution.test.ts
@@ -9,6 +9,7 @@ import {
 
 import { resolveInstanceModelSources, resolveModelSources } from "@intx/db";
 import type { ModelRequirement } from "@intx/types";
+import type { GrantRule } from "@intx/types/authz";
 import {
   createTestDb,
   harnessDbEnvAvailable,
@@ -17,6 +18,7 @@ import {
 import {
   seedAgent,
   seedCredential,
+  seedGrant,
   seedModel,
   seedModelOffering,
   seedModelProvider,
@@ -27,6 +29,24 @@ import {
 } from "@intx/test-harness/seed";
 
 const REQ_OPUS: ModelRequirement[] = [{ model: "opus" }];
+
+// A creator grant list that authorizes use of every credential, mirroring a
+// tenant owner's `*` / `*`. These direct-call tests exercise catalog ordering
+// and credential resolution, not credential-use authorization, so they pass an
+// authorized creator; the authorization gate has its own dedicated suite.
+const AUTHORIZED_CREATOR_GRANTS: GrantRule[] = [
+  {
+    id: "grt_test_owner",
+    resource: "*",
+    action: "*",
+    effect: "allow",
+    origin: "role",
+    conditions: null,
+    expiresAt: null,
+    roleId: null,
+    principalId: "prn_owner",
+  },
+];
 
 describe.skipIf(!harnessDbEnvAvailable())(
   "model-source-resolution (real DB)",
@@ -113,13 +133,23 @@ describe.skipIf(!harnessDbEnvAvailable())(
     describe("resolveModelSources", () => {
       test("returns no_requirements for an empty requirement list", async () => {
         await seedBase();
-        const result = await resolveModelSources(h.db, "tnt_root", []);
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_root",
+          [],
+          AUTHORIZED_CREATOR_GRANTS,
+        );
         expect(result).toEqual({ ok: false, reason: "no_requirements" });
       });
 
       test("builds a credential-backed source from the catalog", async () => {
         await seedBase();
-        const result = await resolveModelSources(h.db, "tnt_root", REQ_OPUS);
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_root",
+          REQ_OPUS,
+          AUTHORIZED_CREATOR_GRANTS,
+        );
         expect(result.ok).toBe(true);
         if (!result.ok) return;
         expect(result.sources).toEqual([
@@ -137,7 +167,12 @@ describe.skipIf(!harnessDbEnvAvailable())(
       test("orders sources by ascending priority", async () => {
         await seedBase();
         await addRelay(5);
-        const result = await resolveModelSources(h.db, "tnt_root", REQ_OPUS);
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_root",
+          REQ_OPUS,
+          AUTHORIZED_CREATOR_GRANTS,
+        );
         expect(result.ok).toBe(true);
         if (!result.ok) return;
         expect(result.sources.map((s) => s.id)).toEqual(["mof_a", "mof_relay"]);
@@ -145,17 +180,23 @@ describe.skipIf(!harnessDbEnvAvailable())(
 
       test("matches when an offering carries the required capability", async () => {
         await seedBase({ offeringCapabilities: ["vision"] });
-        const result = await resolveModelSources(h.db, "tnt_root", [
-          { model: "opus", capabilities: ["vision"] },
-        ]);
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_root",
+          [{ model: "opus", capabilities: ["vision"] }],
+          AUTHORIZED_CREATOR_GRANTS,
+        );
         expect(result.ok).toBe(true);
       });
 
       test("is unavailable when no offering carries the required capability", async () => {
         await seedBase();
-        const result = await resolveModelSources(h.db, "tnt_root", [
-          { model: "opus", capabilities: ["vision"] },
-        ]);
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_root",
+          [{ model: "opus", capabilities: ["vision"] }],
+          AUTHORIZED_CREATOR_GRANTS,
+        );
         expect(result).toMatchObject({
           ok: false,
           reason: "model_unavailable",
@@ -165,9 +206,12 @@ describe.skipIf(!harnessDbEnvAvailable())(
       test("hard-pin restricts to the named providers in order", async () => {
         await seedBase();
         await addRelay(0);
-        const result = await resolveModelSources(h.db, "tnt_root", [
-          { model: "opus", providers: { mode: "pin", order: ["relay"] } },
-        ]);
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_root",
+          [{ model: "opus", providers: { mode: "pin", order: ["relay"] } }],
+          AUTHORIZED_CREATOR_GRANTS,
+        );
         expect(result.ok).toBe(true);
         if (!result.ok) return;
         expect(result.sources.map((s) => s.id)).toEqual(["mof_relay"]);
@@ -178,12 +222,17 @@ describe.skipIf(!harnessDbEnvAvailable())(
         await addRelay(0);
         // relay has the better catalog priority, but the creator prefers
         // anthropic.
-        const result = await resolveModelSources(h.db, "tnt_root", [
-          {
-            model: "opus",
-            providers: { mode: "prefer", order: ["anthropic"] },
-          },
-        ]);
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_root",
+          [
+            {
+              model: "opus",
+              providers: { mode: "prefer", order: ["anthropic"] },
+            },
+          ],
+          AUTHORIZED_CREATOR_GRANTS,
+        );
         expect(result.ok).toBe(true);
         if (!result.ok) return;
         expect(result.sources.map((s) => s.id)).toEqual(["mof_a", "mof_relay"]);
@@ -209,7 +258,12 @@ describe.skipIf(!harnessDbEnvAvailable())(
           modelId: "mdl_opus",
           providerId: "mpv_anthropic",
         });
-        const result = await resolveModelSources(h.db, "tnt_root", REQ_OPUS);
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_root",
+          REQ_OPUS,
+          AUTHORIZED_CREATOR_GRANTS,
+        );
         expect(result).toMatchObject({
           ok: false,
           reason: "model_unavailable",
@@ -255,7 +309,12 @@ describe.skipIf(!harnessDbEnvAvailable())(
           modelId: "mdl_opus",
           providerId: "mpv_anthropic",
         });
-        const result = await resolveModelSources(h.db, "tnt_root", REQ_OPUS);
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_root",
+          REQ_OPUS,
+          AUTHORIZED_CREATOR_GRANTS,
+        );
         expect(result).toMatchObject({
           ok: false,
           reason: "model_unavailable",
@@ -276,6 +335,7 @@ describe.skipIf(!harnessDbEnvAvailable())(
               providers: { mode: "prefer", order: ["anthropic"] },
             },
           ],
+          AUTHORIZED_CREATOR_GRANTS,
           { invokerPreferences: { opus: { mode: "pin", order: ["relay"] } } },
         );
         expect(result.ok).toBe(true);
@@ -295,6 +355,16 @@ describe.skipIf(!harnessDbEnvAvailable())(
         await seedPrincipal(h.db, {
           id: "prn_creator",
           tenantId: "tnt_root",
+        });
+        // The creator is authorized to use every catalog credential, so
+        // rotation-time re-resolution keeps emitting the secret. The
+        // authorization gate itself is exercised by a dedicated suite.
+        await seedGrant(h.db, {
+          id: "grt_creator_use",
+          tenantId: "tnt_root",
+          principalId: "prn_creator",
+          resource: "credential:*",
+          action: "use",
         });
         await seedAgent(h.db, {
           id: "agt_1",

--- a/tests/hub-api/credential-routes.test.ts
+++ b/tests/hub-api/credential-routes.test.ts
@@ -1,0 +1,265 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { and, eq } from "drizzle-orm";
+
+import { createInMemoryGrantStore } from "@intx/authz";
+import { createApp, type GetSession } from "@intx/hub-api";
+import {
+  createSidecarEmitter,
+  type EventCollectorRegistry,
+  type SessionService,
+  type SidecarRouter,
+} from "@intx/hub-sessions";
+import { grant as grantTable } from "@intx/db/schema";
+import type { GrantRule } from "@intx/types/authz";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import {
+  seedPrincipal,
+  seedProvider,
+  seedTenants,
+} from "@intx/test-harness/seed";
+
+// These route tests exercise credential creation against a real migrated
+// schema so the auto-grant insert runs inside the same transaction as the
+// credential insert and is asserted directly against the grant table.
+
+const TENANT_ID = "tnt_cred";
+const ACTOR_PRINCIPAL_ID = "prn_actor";
+const OWNER_PRINCIPAL_ID = "prn_owner";
+const ACTOR_USER_ID = "usr_actor";
+const PROVIDER_ID = "prv_test";
+
+function createMockGetSession(userId: string): GetSession {
+  const now = new Date("2025-01-01");
+  return async () => ({
+    user: {
+      id: userId,
+      email: "test@example.com",
+      emailVerified: true,
+      name: "Test User",
+      createdAt: now,
+      updatedAt: now,
+    },
+    session: {
+      id: "session_test",
+      userId,
+      token: "tok_test",
+      expiresAt: new Date("2999-01-01"),
+      createdAt: now,
+      updatedAt: now,
+    },
+  });
+}
+
+function notImpl(name: string): never {
+  throw new Error(`mock: ${name} not implemented`);
+}
+
+function createMockSidecarRouter(): SidecarRouter {
+  return {
+    handleOpen: () => notImpl("handleOpen"),
+    handleMessage: () => notImpl("handleMessage"),
+    handleClose: () => notImpl("handleClose"),
+    routeMail: () => notImpl("routeMail"),
+    sendAgentDeploy: () => notImpl("sendAgentDeploy"),
+    sendAgentUndeploy: () => notImpl("sendAgentUndeploy"),
+    sendSourcesUpdate: () => notImpl("sendSourcesUpdate"),
+    sendPack: () => notImpl("sendPack"),
+    sendProvisionStep: () => notImpl("sendProvisionStep"),
+    bindStepRoute: () => notImpl("bindStepRoute"),
+    unbindStepRoute: () => notImpl("unbindStepRoute"),
+    sendSyncRequest: () => notImpl("sendSyncRequest"),
+    sendSignalDeliver: () => notImpl("sendSignalDeliver"),
+    sendDrain: () => notImpl("sendDrain"),
+    subscribeAgent: () => notImpl("subscribeAgent"),
+    dispatchAgentEvent: () => undefined,
+    getConnectedSidecars: () => [],
+    getRoutableAddresses: () => [],
+    getConnectorState: () => null,
+    events: createSidecarEmitter(),
+  };
+}
+
+function createMockSessionService(): SessionService {
+  return {
+    stageWorkflowStep: () => notImpl("stageWorkflowStep"),
+    deployInstanceAtHead: () => notImpl("deployInstanceAtHead"),
+    deployWorkflowDefinition: () => notImpl("deployWorkflowDefinition"),
+    deploySingleStepAtHead: () => notImpl("deploySingleStepAtHead"),
+    sendUserMessage: () => notImpl("sendUserMessage"),
+    endSession: () => notImpl("endSession"),
+  };
+}
+
+function createMockEventCollectors(): EventCollectorRegistry {
+  return {
+    create: () => notImpl("create"),
+    dispatch: () => notImpl("dispatch"),
+    abandon: () => notImpl("abandon"),
+    has: () => false,
+    getStatus: () => undefined,
+    getAccumulatedText: () => undefined,
+    getCurrentTurnId: () => undefined,
+    getLastTurnId: () => undefined,
+  };
+}
+
+function createGrant(action: string): GrantRule {
+  return {
+    id: `grant-actor-${action}`,
+    resource: "credential:*",
+    action,
+    effect: "allow",
+    origin: "system",
+    conditions: null,
+    expiresAt: null,
+    roleId: null,
+    principalId: ACTOR_PRINCIPAL_ID,
+  };
+}
+
+let h: TestDb;
+
+beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
+  h = await createTestDb();
+});
+
+afterAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
+  await h.close();
+});
+
+beforeEach(async () => {
+  if (!harnessDbEnvAvailable()) return;
+  await h.reset();
+});
+
+async function setup() {
+  await seedTenants(h.db, [{ id: TENANT_ID }]);
+  await seedPrincipal(h.db, {
+    id: ACTOR_PRINCIPAL_ID,
+    tenantId: TENANT_ID,
+    refId: ACTOR_USER_ID,
+  });
+  await seedPrincipal(h.db, {
+    id: OWNER_PRINCIPAL_ID,
+    tenantId: TENANT_ID,
+    refId: "usr_owner",
+  });
+  await seedProvider(h.db, {
+    id: PROVIDER_ID,
+    tenantId: TENANT_ID,
+    name: "openai",
+  });
+
+  const app = createApp({
+    getSession: createMockGetSession(ACTOR_USER_ID),
+    authHandler: () => new Response("", { status: 404 }),
+    db: h.db,
+    grantStore: createInMemoryGrantStore([createGrant("create")]),
+    sidecarRouter: createMockSidecarRouter(),
+    sessionService: createMockSessionService(),
+    eventCollectors: createMockEventCollectors(),
+    assetService: null,
+    repoStore: null,
+    maxTarballBytes: 10_000_000,
+  });
+  return app;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+async function useGrantsFor(credentialId: string, principalId: string) {
+  return h.db
+    .select()
+    .from(grantTable)
+    .where(
+      and(
+        eq(grantTable.principalId, principalId),
+        eq(grantTable.resource, `credential:${credentialId}`),
+        eq(grantTable.action, "use"),
+      ),
+    );
+}
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "POST /api/tenants/:tenantId/credentials",
+  () => {
+    test("mints a durable use-grant for the owner of a personal credential", async () => {
+      const app = await setup();
+      const res = await app.request(`/api/tenants/${TENANT_ID}/credentials`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          providerId: PROVIDER_ID,
+          name: "my-key",
+          type: "api_key",
+          secret: "sk-personal",
+          principalId: OWNER_PRINCIPAL_ID,
+        }),
+      });
+      expect(res.status).toBe(201);
+      const body: unknown = await res.json();
+      if (!isObject(body)) throw new Error("expected object body");
+      const credentialId = body["id"];
+      if (typeof credentialId !== "string") {
+        throw new Error("expected credential id");
+      }
+
+      const grants = await useGrantsFor(credentialId, OWNER_PRINCIPAL_ID);
+      expect(grants).toHaveLength(1);
+      const g = grants[0];
+      if (g === undefined) throw new Error("expected grant row");
+      expect(g.effect).toBe("allow");
+      expect(g.origin).toBe("creator");
+      expect(g.expiresAt).toBeNull();
+      expect(g.tenantId).toBe(TENANT_ID);
+    });
+
+    test("mints no use-grant for an organizational credential", async () => {
+      const app = await setup();
+      const res = await app.request(`/api/tenants/${TENANT_ID}/credentials`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          providerId: PROVIDER_ID,
+          name: "org-key",
+          type: "api_key",
+          secret: "sk-org",
+        }),
+      });
+      expect(res.status).toBe(201);
+      const body: unknown = await res.json();
+      if (!isObject(body)) throw new Error("expected object body");
+      const credentialId = body["id"];
+      if (typeof credentialId !== "string") {
+        throw new Error("expected credential id");
+      }
+      expect(body["principalId"]).toBeNull();
+
+      const allUseGrants = await h.db
+        .select()
+        .from(grantTable)
+        .where(
+          and(
+            eq(grantTable.resource, `credential:${credentialId}`),
+            eq(grantTable.action, "use"),
+          ),
+        );
+      expect(allUseGrants).toHaveLength(0);
+    });
+  },
+);

--- a/tests/lib/seed.ts
+++ b/tests/lib/seed.ts
@@ -12,6 +12,7 @@ import {
   agent,
   asset,
   credential,
+  grant,
   model,
   modelOffering,
   modelProvider,
@@ -282,5 +283,33 @@ export async function seedAgent(db: Db, a: SeedAgent): Promise<void> {
     creatorPrincipalId: a.creatorPrincipalId,
     name: a.name ?? a.id,
     modelRequirements: a.modelRequirements ?? null,
+  });
+}
+
+export type SeedGrant = {
+  id: string;
+  tenantId: string;
+  resource: string;
+  action: string;
+  principalId?: string | null;
+  roleId?: string | null;
+  effect?: "allow" | "deny" | "ask";
+  origin?: "system" | "role" | "creator" | "invoker";
+  conditions?: Record<string, unknown> | null;
+  expiresAt?: Date | null;
+};
+
+export async function seedGrant(db: Db, g: SeedGrant): Promise<void> {
+  await db.insert(grant).values({
+    id: g.id,
+    tenantId: g.tenantId,
+    resource: g.resource,
+    action: g.action,
+    principalId: g.principalId ?? null,
+    roleId: g.roleId ?? null,
+    effect: g.effect ?? "allow",
+    origin: g.origin ?? "creator",
+    conditions: g.conditions ?? null,
+    expiresAt: g.expiresAt ?? null,
   });
 }


### PR DESCRIPTION
## Summary

Agent launch and credential rotation resolve provider credentials into an
agent's model `sources[]`. Before this branch, that path shipped the credential
secret into the agent without checking that the agent's creator was authorized
to use the credential: the launch handler ran credential resolution and grant
evaluation as two independent loops that shared no data, and the rotation push
re-resolved secrets the same way. Any principal able to author or deploy an
agent definition could cause a tenant-sourced provider secret to be shipped
into an agent regardless of authorization — a confused-deputy / privilege
escalation. `docs/CREDENTIALS.md` already described this check as enforced; it
was not.

This branch enforces the invariant in the layer that owns it. A provider secret
enters an agent's model sources only if the agent's **creator** holds a
`credential:{id}` / `use` grant for that credential. The check lives in the
model-source resolution layer (`buildSource` / `resolveModelSources`), so both
the launch path (`hub-api` instances route) and the rotation/reconnect push
(`resolveInstanceModelSources`) are gated by one fail-closed check — any grant
effect other than `allow` withholds the secret and surfaces a
`credential_unauthorized` skip (a `not_launchable` 409 on launch; a silent,
never-rejecting no-op on rotation).

## What the branch does

- **Provisioning.** Creating a personal credential mints a durable
  `credential:{id}` / `use` grant (origin `creator`) for the owner in the same
  transaction. Organizational credentials mint none and remain governed by
  role-based access.
- **Backfill.** An idempotent data migration grants existing personal
  credentials' owners the same `use` grant, so fail-closed enforcement does not
  lock out credentials that predate provisioning.
- **Enforcement.** The resolution layer authorizes the creator against
  `credential:{id}` / `use` before a secret joins `sources[]`, fail closed, on
  both the launch and rotation paths.
- **Tenant inheritance.** Because credential resolution reaches a credential
  through the tenant ancestor chain, the credential-use check collects the
  creator's grants across that same chain (via a dedicated chain-aware
  collector), so an inherited credential authorizes correctly. The single-tenant
  grant collection used by general RBAC is unchanged.
- **Docs.** `docs/CREDENTIALS.md` now names the creator (not the freshly minted
  instance principal) as the authorizing subject, matching the enforcement.

## Verification

- `make all` is green on the tip: type-check, lint (Prettier, ESLint, API-docs
  freshness, dependency/launcher/exports checks), and the full test suite —
  4069 fast-suite and 518 integration tests pass, 0 fail, against a real
  Postgres.
- The enforcement is proven by mutation testing: reverting only the enforcement
  source (keeping the tests) makes the reproduction tests fail — the secret
  flows through for a non-owner creator on both launch and rotation — and
  restoring the fix makes them pass. The regression tests use a **non-owner**
  creator, since a tenant owner's wildcard grant would mask the vulnerability.
- New tests pin the authorization invariants (owner and `credential:*`/`use`
  satisfy the check; admin/member defaults do not; `ask`/`deny`/no-match fail
  closed) and cover the multi-tenant inheritance cases (inherited credential
  authorizes; child-tenant owner still authorizes; a creator with no grant
  anywhere in the chain is withheld).

Closes INTR-197.
