### PR TITLE
Re-register parked approval correlations after a hub or child reconnect

### DIFF
--- a/apps/sidecar/src/conversation-state.ts
+++ b/apps/sidecar/src/conversation-state.ts
@@ -946,7 +946,7 @@ function parseJsonOrThrow(raw: string, label: string): unknown {
   }
 }
 
-function isErrnoNotFound(cause: unknown): boolean {
+export function isErrnoNotFound(cause: unknown): boolean {
   if (cause === null || typeof cause !== "object") return false;
   const code = (cause as { code?: unknown }).code;
   return code === "ENOENT";

--- a/apps/sidecar/src/index.ts
+++ b/apps/sidecar/src/index.ts
@@ -391,8 +391,37 @@ const orchestrator = createSidecarOrchestrator({
   // pack was interrupted mid-transfer never re-ships, because it has no later
   // local write to re-arm the coalescing loop.
   onWorkflowAddressesRoutable: (addresses) => {
+    // The deploy router is captured synchronously during orchestrator
+    // construction, before the link ever connects, so a routable callback can
+    // only fire once it exists; assert (like `getWorkflowAddresses`) rather
+    // than optional-chain so a wiring regression fails loud.
+    if (sidecarDeployRouter === undefined) {
+      throw new Error(
+        "sidecar boot: deploy router was not constructed before a reconnect made workflow addresses routable",
+      );
+    }
     for (const address of addresses) {
       wrappedRepoStore.notifyAddressRoutable(address);
+      // Trigger B: re-register the deployment's parked correlations. A long hub
+      // outage can evict a `signal.correlation.register` frame from the link's
+      // bounded send queue; re-driving it on reconnect recovers the parked
+      // run's approvability. Two independent facts make this safe:
+      //   - The hub-side co-write's `registerSignalCorrelation` throws only when
+      //     the deployment has no `status = "deployed"` row. That row is written
+      //     at DEPLOY time and persists across the outage -- the reconnect
+      //     challenge re-routes the address in the hub's in-memory index but
+      //     writes no DB status, so the lookup already resolves. (The frame
+      //     also lands after the address is wire-routable: the link fires this
+      //     after `challenge.response`, and both frames queue on the hub's
+      //     per-connection chain -- see the pack re-ship note above.)
+      //   - A sidecar restart re-emits the parked set twice (child
+      //     re-establishment fires Trigger A too), but the co-write dedups on
+      //     the `correlationId` PK/unique constraints via `onConflictDoNothing`,
+      //     so the duplicate is a no-op. The pre-existing non-transactional
+      //     status-check window in `registerSignalCorrelation` that this
+      //     widened concurrency exercises is tracked in INTR-338, out of scope
+      //     here.
+      sidecarDeployRouter.reEmitParkedCorrelations(address);
     }
   },
   // On disconnect, block the deployment addresses' workflow-run pushes until

--- a/apps/sidecar/src/workflow-host-wiring.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import { type } from "arktype";
+
 import { createEd25519Crypto, generateKeyPair } from "@intx/crypto";
 import { hexEncode } from "@intx/types";
 import { createInMemoryTransport } from "@intx/mail-memory";
@@ -312,6 +314,35 @@ function createMemoryFrameStream() {
 
 function createTempBaseDir(prefix: string): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+// The supervisor's `parked-correlations.request` control-frame discriminator.
+// The re-emit-parked-correlations tests assert this reaches the downstream
+// (supervisor -> child) stream when Trigger B fires.
+const PARKED_REQUEST_TYPE = "parked-correlations.request";
+
+// One downstream control line is the JSON serialization of a signed envelope:
+// `{ envelope: { seq, channelId, payload }, sig }`. The re-emit tests inspect
+// `envelope.payload.type` to detect a `parked-correlations.request` without
+// verifying the signature (the supervisor's IPC public key is not exposed to
+// the test). Structurally validate the envelope-carrying shape and return the
+// payload discriminator, or `undefined` when the line is not a typed frame.
+const DownstreamFrameShape = type({
+  envelope: {
+    payload: {
+      "type?": "string",
+      "+": "ignore",
+    },
+    "+": "ignore",
+  },
+  "+": "ignore",
+});
+
+function downstreamPayloadType(line: string): string | undefined {
+  const parsed: unknown = JSON.parse(line);
+  const validated = DownstreamFrameShape(parsed);
+  if (validated instanceof type.errors) return undefined;
+  return validated.envelope.payload.type;
 }
 
 /**
@@ -2522,5 +2553,219 @@ describe("createSidecarDeployRouter multi-step branch", () => {
       router.deploy(singleStepFrame("ins_col-a@example.com", "wf-collide")),
     ).rejects.toThrow(/deriveDeploymentId collision/);
     expect(spawner.spawnCount()).toBe(1);
+  });
+
+  test("reEmitParkedCorrelations reaches the live supervisor and sends a parked-correlations.request downstream", async () => {
+    // Trigger B: the hub-reconnect fan-out. After a deploy populates
+    // `activeSupervisors` for the deployment address, the router's
+    // address-dispatch wrapper must reach the live supervisor's own no-arg
+    // `reEmitParkedCorrelations`, which the supervisor implements by sending a
+    // `parked-correlations.request` control frame down to the child. The mock
+    // child never answers, so the supervisor's watchdog eventually fires; the
+    // router's fire-and-forget contract means the request frame lands on the
+    // downstream stream regardless, which is the observable evidence here.
+    const childIpcKeyPair = await generateKeyPair();
+    const supervisorToChild = createMemoryNdjsonStream();
+    const childToSupervisor = createMemoryNdjsonStream();
+    const eventChildToSupervisor = createMemoryFrameStream();
+    let resolveExit: ((code: number) => void) | undefined;
+    const exited = new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    });
+    let observedEnv: Record<string, string> | undefined;
+    const spawner: SubprocessSpawner = ({ env }) => {
+      observedEnv = env;
+      const handle: SubprocessHandle = {
+        pid: 10500,
+        controlWriter: supervisorToChild.writer,
+        controlReader: childToSupervisor.reader,
+        eventReader: eventChildToSupervisor.reader,
+        kill: () => {
+          childToSupervisor.close();
+          eventChildToSupervisor.close();
+          resolveExit?.(0);
+        },
+        exited,
+      };
+      return handle;
+    };
+
+    const dataDir = await createTempBaseDir("sidecar-reemit-data-");
+    const { router } = await buildMultistepFixture({
+      spawner,
+      multistepSubstrateEnv: { SIDECAR_DATA_DIR: dataDir },
+    });
+
+    const sources = defaultMultistepSources();
+    const definition = {
+      id: "wf-reemit",
+      triggers: [{ type: "manual" }],
+      stepOrder: ["step-1", "step-2"],
+      steps: { "step-1": { kind: "step" }, "step-2": { kind: "step" } },
+    };
+    const frame = makeMultistepFrame({ definition, sources });
+
+    const deployPromise = router.deploy(frame);
+    while (observedEnv === undefined) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    const channelId = observedEnv.IPC_CHANNEL_ID;
+    if (channelId === undefined) {
+      throw new Error("IPC_CHANNEL_ID not set in spawn-time env");
+    }
+    const childSender = createControlChannelSender({
+      privateKeySeed: childIpcKeyPair.privateKey,
+      channelId,
+      writer: {
+        write(line: string) {
+          childToSupervisor.inject(line);
+          return Promise.resolve();
+        },
+      },
+    });
+    await childSender.send({
+      type: "ready",
+      data: {
+        childPid: 10500,
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
+      },
+    });
+    await deployPromise;
+
+    // `activeSupervisors` is keyed by the frame's agent address; the router
+    // routes the re-emit through that same key.
+    expect(router.activeAddresses()).toEqual([frame.agentAddress]);
+
+    // Each downstream line is a signed envelope `{ envelope: { seq, channelId,
+    // payload }, sig }`; read `envelope.payload.type` without verifying the
+    // signature (the supervisor's IPC public key is not exposed to the test).
+    // The supervisor emits its own `parked-correlations.request` on spawn (a
+    // fresh child becoming addressable), so the trigger is observed as an
+    // increase in the downstream request count, not its first appearance.
+    function parkedRequestCount(): number {
+      return supervisorToChild
+        .flushed()
+        .filter((line) => downstreamPayloadType(line) === PARKED_REQUEST_TYPE)
+        .length;
+    }
+
+    // Let the spawn-time Trigger A re-emit settle so the baseline captures it;
+    // the assertion below then proves the Trigger B call adds a request on top.
+    await new Promise((r) => setTimeout(r, 50));
+    const baseline = parkedRequestCount();
+
+    router.reEmitParkedCorrelations(frame.agentAddress);
+
+    // Fire-and-forget: poll the downstream stream until the router's request
+    // frame lands on top of the spawn-time baseline, bounded so a wiring break
+    // fails the test instead of hanging.
+    const deadline = Date.now() + 2000;
+    while (parkedRequestCount() <= baseline) {
+      if (Date.now() > deadline) {
+        throw new Error(
+          "reEmitParkedCorrelations did not add a parked-correlations.request to the downstream control stream",
+        );
+      }
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    expect(parkedRequestCount()).toBeGreaterThan(baseline);
+  });
+
+  test("reEmitParkedCorrelations for an address with no active supervisor is a no-op", async () => {
+    // The edge boundary: the hub reports an address routable, but no live
+    // supervisor owns it (a torn-down or not-yet-respawned deployment). The
+    // router must skip it -- neither throw nor drive any downstream frame.
+    const childIpcKeyPair = await generateKeyPair();
+    const supervisorToChild = createMemoryNdjsonStream();
+    const childToSupervisor = createMemoryNdjsonStream();
+    const eventChildToSupervisor = createMemoryFrameStream();
+    let resolveExit: ((code: number) => void) | undefined;
+    const exited = new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    });
+    let observedEnv: Record<string, string> | undefined;
+    const spawner: SubprocessSpawner = ({ env }) => {
+      observedEnv = env;
+      const handle: SubprocessHandle = {
+        pid: 10600,
+        controlWriter: supervisorToChild.writer,
+        controlReader: childToSupervisor.reader,
+        eventReader: eventChildToSupervisor.reader,
+        kill: () => {
+          childToSupervisor.close();
+          eventChildToSupervisor.close();
+          resolveExit?.(0);
+        },
+        exited,
+      };
+      return handle;
+    };
+
+    const dataDir = await createTempBaseDir("sidecar-reemit-miss-data-");
+    const { router } = await buildMultistepFixture({
+      spawner,
+      multistepSubstrateEnv: { SIDECAR_DATA_DIR: dataDir },
+    });
+
+    const sources = defaultMultistepSources();
+    const definition = {
+      id: "wf-reemit-miss",
+      triggers: [{ type: "manual" }],
+      stepOrder: ["step-1", "step-2"],
+      steps: { "step-1": { kind: "step" }, "step-2": { kind: "step" } },
+    };
+    const frame = makeMultistepFrame({ definition, sources });
+
+    const deployPromise = router.deploy(frame);
+    while (observedEnv === undefined) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    const channelId = observedEnv.IPC_CHANNEL_ID;
+    if (channelId === undefined) {
+      throw new Error("IPC_CHANNEL_ID not set in spawn-time env");
+    }
+    const childSender = createControlChannelSender({
+      privateKeySeed: childIpcKeyPair.privateKey,
+      channelId,
+      writer: {
+        write(line: string) {
+          childToSupervisor.inject(line);
+          return Promise.resolve();
+        },
+      },
+    });
+    await childSender.send({
+      type: "ready",
+      data: {
+        childPid: 10600,
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
+      },
+    });
+    await deployPromise;
+
+    const missAddress = "ins_dep_nonexistent@wf.example";
+    expect(router.activeAddresses()).not.toContain(missAddress);
+
+    // The deployed supervisor emits its own `parked-correlations.request` on
+    // spawn; the miss-address re-emit must add nothing on top of that
+    // baseline. Count downstream requests before and after the no-op call.
+    function parkedRequestCount(): number {
+      return supervisorToChild
+        .flushed()
+        .filter((line) => downstreamPayloadType(line) === PARKED_REQUEST_TYPE)
+        .length;
+    }
+    // Settle the spawn-time Trigger A re-emit so it is folded into the baseline
+    // rather than racing the post-call window below.
+    await new Promise((r) => setTimeout(r, 50));
+    const baseline = parkedRequestCount();
+
+    // The no-op skip must not throw for an address with no live supervisor.
+    expect(() => router.reEmitParkedCorrelations(missAddress)).not.toThrow();
+
+    // Give any errant fire-and-forget a chance to land, then confirm the miss
+    // added no downstream request for the missing address.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(parkedRequestCount()).toBe(baseline);
   });
 });

--- a/apps/sidecar/src/workflow-host-wiring.ts
+++ b/apps/sidecar/src/workflow-host-wiring.ts
@@ -689,6 +689,17 @@ export interface SidecarDeployRouter extends DeployRouter {
    * and boot-time restore live, so a caller re-reads it per connect.
    */
   activeAddresses(): string[];
+  /**
+   * Trigger B: re-register every correlation the deployment at `address` is
+   * currently parked on, by asking its live supervisor to re-emit them to the
+   * hub. The boot edge calls this per address the hub link re-routes on a
+   * reconnect challenge (`onWorkflowAddressesRoutable`), so a register frame
+   * the hub dropped from its bounded send queue during the outage is recovered.
+   * The address-dispatch wrapper around the supervisor's own no-arg
+   * `reEmitParkedCorrelations`; fire-and-forget (the driver is best-effort and
+   * watchdog-bounded inside the supervisor).
+   */
+  reEmitParkedCorrelations(address: string): void;
 }
 
 export function createSidecarDeployRouter(deps: {
@@ -1927,6 +1938,27 @@ export function createSidecarDeployRouter(deps: {
       // add; undeploy and spawn-unwind remove), so its keys are the addresses
       // this sidecar can currently route mail to.
       return [...activeSupervisors.keys()];
+    },
+    reEmitParkedCorrelations(address: string): void {
+      const wired = activeSupervisors.get(address);
+      if (wired === undefined) {
+        // Edge boundary: the hub reports this address routable but no live
+        // supervisor owns it -- a deployment torn down, or not yet respawned.
+        // Re-registering a torn-down deployment would be wrong, so skipping is
+        // correct. Logged at debug (not warn) so a supervisor unexpectedly
+        // missing for a live deployment is still traceable without crying wolf
+        // on the ordinary torn-down case.
+        logger.debug`re-emit on reconnect: no active supervisor for ${address}; skipping`;
+        return;
+      }
+      // Fire-and-forget: the driver is best-effort and watchdog-bounded inside
+      // the supervisor, so the reconnect fan-out never awaits it. The promise
+      // is dropped deliberately; the `.catch` is defense-in-depth since the
+      // driver already swallows its own query failures.
+      void wired.supervisor.reEmitParkedCorrelations().catch((cause) => {
+        const message = cause instanceof Error ? cause.message : String(cause);
+        logger.warn`re-emit of parked correlations on hub reconnect failed for ${address}: ${message}`;
+      });
     },
   };
 }

--- a/apps/sidecar/src/workflow-substrate-factory-parked-approval.test.ts
+++ b/apps/sidecar/src/workflow-substrate-factory-parked-approval.test.ts
@@ -1,0 +1,304 @@
+// `loadParkedApproval` durable reads: the sidecar binding recovers a parked
+// correlation's approval snapshot for the child's re-registration enumeration.
+//
+// Two layouts, verified against the production read helpers:
+//   - COLD (multi-step): the snapshot lives in the per-attempt isogit step
+//     store on disk; the read loads it, and returns undefined (without
+//     manufacturing a repo) when the store dir is absent.
+//   - WARM (single-step): the snapshot lives in the durable conversation
+//     store, mirrored to the workflow-run substrate under `agent-state/<stepId>/`.
+//     The read reconstructs it from the substrate WITHOUT going through the live
+//     registry -- proving a respawned child (whose live store is unbuilt) still
+//     recovers the snapshot.
+
+import { describe, test, expect } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { ApprovalSnapshot, PendingOperation } from "@intx/types/runtime";
+import type {
+  Principal,
+  RepoId,
+  RepoStore,
+} from "@intx/hub-sessions/substrate";
+import { createIsogitStore } from "@intx/storage-isogit";
+
+import {
+  readColdParkedApprovalSnapshot,
+  readWarmParkedApprovalSnapshot,
+  stepStorageRoot,
+} from "./workflow-substrate-factory";
+import { createDurableConversationStore } from "./conversation-state";
+
+const WORKFLOW_RUN_REPO_ID: RepoId = {
+  kind: "workflow-run",
+  id: "parked-approval",
+};
+const WORKFLOW_RUN_REF = "refs/heads/main";
+const PRINCIPAL: Principal = { kind: "workflow-process" };
+const EMPTY_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  thinking: 0,
+};
+
+const snapshot: ApprovalSnapshot = {
+  name: "charge_card",
+  description: "Charge the customer's card",
+  inputSchema: { type: "object" },
+  arguments: { amount: 100 },
+};
+
+function pendingApproval(
+  correlationId: string,
+  approvalSnapshot?: ApprovalSnapshot,
+): PendingOperation {
+  return {
+    correlationId,
+    kind: "approval",
+    registeredAt: 0,
+    gateId: `gate-${correlationId}`,
+    ...(approvalSnapshot !== undefined ? { approvalSnapshot } : {}),
+  };
+}
+
+async function makeTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "parked-approval-"));
+}
+
+const testSigner = (payload: string): Promise<string> =>
+  Promise.resolve(`sig:${payload.length}`);
+
+describe("readColdParkedApprovalSnapshot", () => {
+  test("loads the snapshot from a parked step's on-disk store", async () => {
+    const dataDir = await makeTempDir();
+    const coordinate = {
+      dataDir,
+      workflowRunRepoId: WORKFLOW_RUN_REPO_ID,
+      runId: "run-1",
+      stepId: "s",
+      attempt: 1,
+    };
+    const store = await createIsogitStore(
+      stepStorageRoot(coordinate),
+      testSigner,
+    );
+    await store.writeMetadata({
+      pendingOperations: [pendingApproval("corr-1", snapshot)],
+      tokenUsage: EMPTY_USAGE,
+    });
+
+    const got = await readColdParkedApprovalSnapshot({
+      ...coordinate,
+      correlationId: "corr-1",
+    });
+    expect(got).toEqual(snapshot);
+  });
+
+  test("returns undefined without creating a repo when the store is absent", async () => {
+    const dataDir = await makeTempDir();
+    const coordinate = {
+      dataDir,
+      workflowRunRepoId: WORKFLOW_RUN_REPO_ID,
+      runId: "missing",
+      stepId: "s",
+      attempt: 1,
+    };
+
+    const got = await readColdParkedApprovalSnapshot({
+      ...coordinate,
+      correlationId: "corr-x",
+    });
+    expect(got).toBeUndefined();
+    // The read is a read: a missing store is never manufactured on disk.
+    await expect(fs.stat(stepStorageRoot(coordinate))).rejects.toThrow();
+  });
+
+  test("returns undefined for a correlation with no matching pending op", async () => {
+    const dataDir = await makeTempDir();
+    const coordinate = {
+      dataDir,
+      workflowRunRepoId: WORKFLOW_RUN_REPO_ID,
+      runId: "run-2",
+      stepId: "s",
+      attempt: 1,
+    };
+    const store = await createIsogitStore(
+      stepStorageRoot(coordinate),
+      testSigner,
+    );
+    await store.writeMetadata({
+      pendingOperations: [pendingApproval("corr-a", snapshot)],
+      tokenUsage: EMPTY_USAGE,
+    });
+
+    const got = await readColdParkedApprovalSnapshot({
+      ...coordinate,
+      correlationId: "corr-other",
+    });
+    expect(got).toBeUndefined();
+  });
+
+  test("returns undefined for a matching op that carries no snapshot", async () => {
+    const dataDir = await makeTempDir();
+    const coordinate = {
+      dataDir,
+      workflowRunRepoId: WORKFLOW_RUN_REPO_ID,
+      runId: "run-3",
+      stepId: "s",
+      attempt: 1,
+    };
+    const store = await createIsogitStore(
+      stepStorageRoot(coordinate),
+      testSigner,
+    );
+    await store.writeMetadata({
+      pendingOperations: [pendingApproval("corr-1")],
+      tokenUsage: EMPTY_USAGE,
+    });
+
+    const got = await readColdParkedApprovalSnapshot({
+      ...coordinate,
+      correlationId: "corr-1",
+    });
+    expect(got).toBeUndefined();
+  });
+});
+
+/**
+ * Read every file under `<repoDir>/<prefix>` into a path->bytes map, keyed by
+ * the repo-relative path, so a `writeTreePreservingPrefix` merge callback sees
+ * the prior subtree the way the real substrate presents it.
+ */
+async function readPrefixEntries(
+  repoDir: string,
+  prefix: string,
+): Promise<Map<string, Uint8Array>> {
+  const entries = new Map<string, Uint8Array>();
+  const prefixDir = path.join(repoDir, prefix);
+  let names: string[];
+  try {
+    names = await fs.readdir(prefixDir, { recursive: true });
+  } catch {
+    return entries;
+  }
+  for (const name of names) {
+    const full = path.join(prefixDir, name);
+    if (!(await fs.stat(full)).isFile()) continue;
+    entries.set(`${prefix}${name}`, await fs.readFile(full));
+  }
+  return entries;
+}
+
+/**
+ * A substrate stub that persists `writeTreePreservingPrefix` to disk under
+ * `getRepoDir`, so a durable-conversation mirror round-trips through the real
+ * checkpoint/WAL layout the read reconstructs from. Any other method surfaces
+ * as a precise failure.
+ */
+function createStubSubstrate(baseDir: string): RepoStore {
+  const repoDirFor = (repoId: RepoId): string =>
+    path.join(baseDir, repoId.kind, repoId.id);
+  const stub: Partial<RepoStore> = {
+    getRepoDir: repoDirFor,
+    async writeTreePreservingPrefix(_principal, repoId, _ref, args) {
+      const repoDir = repoDirFor(repoId);
+      const existing = await readPrefixEntries(repoDir, args.preservePrefix);
+      const merged = await args.merge(existing);
+      await fs.rm(path.join(repoDir, args.preservePrefix), {
+        recursive: true,
+        force: true,
+      });
+      for (const [relPath, content] of Object.entries(merged)) {
+        const full = path.join(repoDir, relPath);
+        await fs.mkdir(path.dirname(full), { recursive: true });
+        await fs.writeFile(full, content);
+      }
+      return { commitSha: "deadbeefcafef00d", newlyTerminalRuns: [] };
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub; missing methods surface as a precise failure via the proxy
+  return new Proxy(stub as RepoStore, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (value !== undefined) return value;
+      return () => {
+        throw new Error(
+          `stub substrate: ${String(prop)} not implemented for this test`,
+        );
+      };
+    },
+  });
+}
+
+describe("readWarmParkedApprovalSnapshot", () => {
+  test("reconstructs the snapshot from the durable substrate mirror", async () => {
+    const substrate = createStubSubstrate(await makeTempDir());
+    const store = await createDurableConversationStore({
+      localStoreDir: await makeTempDir(),
+      signer: testSigner,
+      substrate,
+      workflowRunRepoId: WORKFLOW_RUN_REPO_ID,
+      workflowRunRef: WORKFLOW_RUN_REF,
+      principal: PRINCIPAL,
+      agentKey: "s",
+    });
+    // Suspend-time state: the parked approval's pending op, then mirrored to
+    // the substrate at the run boundary. No live registry is involved on the
+    // read side, mirroring a respawned child whose warm store is unbuilt.
+    await store.storage.writeMetadata({
+      pendingOperations: [pendingApproval("corr-1", snapshot)],
+      tokenUsage: EMPTY_USAGE,
+    });
+    await store.mirrorToSubstrate();
+
+    const got = await readWarmParkedApprovalSnapshot({
+      substrate,
+      workflowRunRepoId: WORKFLOW_RUN_REPO_ID,
+      stepId: "s",
+      correlationId: "corr-1",
+    });
+    expect(got).toEqual(snapshot);
+  });
+
+  test("returns undefined when no durable state exists for the agent", async () => {
+    const substrate = createStubSubstrate(await makeTempDir());
+
+    const got = await readWarmParkedApprovalSnapshot({
+      substrate,
+      workflowRunRepoId: WORKFLOW_RUN_REPO_ID,
+      stepId: "never-ran",
+      correlationId: "corr-x",
+    });
+    expect(got).toBeUndefined();
+  });
+
+  test("returns undefined for a matching op that carries no snapshot", async () => {
+    const substrate = createStubSubstrate(await makeTempDir());
+    const store = await createDurableConversationStore({
+      localStoreDir: await makeTempDir(),
+      signer: testSigner,
+      substrate,
+      workflowRunRepoId: WORKFLOW_RUN_REPO_ID,
+      workflowRunRef: WORKFLOW_RUN_REF,
+      principal: PRINCIPAL,
+      agentKey: "s",
+    });
+    await store.storage.writeMetadata({
+      pendingOperations: [pendingApproval("corr-1")],
+      tokenUsage: EMPTY_USAGE,
+    });
+    await store.mirrorToSubstrate();
+
+    const got = await readWarmParkedApprovalSnapshot({
+      substrate,
+      workflowRunRepoId: WORKFLOW_RUN_REPO_ID,
+      stepId: "s",
+      correlationId: "corr-1",
+    });
+    expect(got).toBeUndefined();
+  });
+});

--- a/apps/sidecar/src/workflow-substrate-factory.ts
+++ b/apps/sidecar/src/workflow-substrate-factory.ts
@@ -29,9 +29,11 @@ import { type } from "arktype";
 
 import { InferenceSource } from "@intx/types/runtime";
 import type {
+  ApprovalSnapshot,
   AuditStore,
   ContextStore,
   MessageTransport,
+  PendingOperation,
 } from "@intx/types/runtime";
 import { evaluateGrants } from "@intx/authz";
 import type { GrantRule } from "@intx/authz";
@@ -46,6 +48,7 @@ import { createDefaultDirectorRegistry } from "@intx/agent";
 import { createSSHSignature } from "@intx/crypto";
 import {
   createAgentRepoStore,
+  WORKFLOW_RUN_AGENT_STATE_PREFIX,
   type Principal,
   type RepoId,
   type RepoStore,
@@ -64,6 +67,7 @@ import {
   createWorkflowStepInvoker,
   type ChildOutboundMailBridge,
   type GrantEvaluator,
+  type LoadParkedApproval,
   type RunChildWorkflow,
   type RunWorkflowChildBindings,
   type SourcesSnapshotRef,
@@ -91,6 +95,8 @@ import {
 } from "./step-agent-tools";
 import {
   createDurableConversationRegistry,
+  isErrnoNotFound,
+  reconstructDurableConversation,
   type DurableConversationRegistry,
 } from "./conversation-state";
 
@@ -412,7 +418,7 @@ function createStepStorageSigner(signingKey: {
  * this invariant loudly on the cold path (a resume opening a store that
  * lacks the resumed correlationId's pending-op throws).
  */
-function stepStorageRoot(args: {
+export function stepStorageRoot(args: {
   dataDir: string;
   workflowRunRepoId: RepoId;
   runId: string;
@@ -480,6 +486,94 @@ function warmStepStorageRoot(args: {
     args.workflowRunRepoId.id,
     "warm",
     encodeURIComponent(args.stepId),
+  );
+}
+
+async function directoryExists(dir: string): Promise<boolean> {
+  try {
+    return (await fs.promises.stat(dir)).isDirectory();
+  } catch (cause) {
+    if (isErrnoNotFound(cause)) return false;
+    throw cause;
+  }
+}
+
+function findApprovalSnapshot(
+  pendingOperations: readonly PendingOperation[],
+  correlationId: string,
+): ApprovalSnapshot | undefined {
+  return pendingOperations.find((op) => op.correlationId === correlationId)
+    ?.approvalSnapshot;
+}
+
+/**
+ * Read a cold (multi-step) parked step's approval snapshot from its on-disk
+ * per-attempt isogit store. The store is written at suspend and survives while
+ * the run is non-terminal -- a parked step keeps the run in-flight, so the
+ * run-completion reclamation (`cleanupRunStorage`) never fires against it.
+ *
+ * Returns undefined when the store directory is absent, surfacing a missing
+ * store as the absence the caller treats as an inconsistency rather than
+ * manufacturing an empty repo on the read path: `createIsogitStore` calls
+ * `initAgentRepo`, which would `mkdir` and init a fresh repo for a
+ * non-existent dir. The `directoryExists` guard keeps the read a read -- on an
+ * existing store `initAgentRepo` finds a repo and commits nothing, so no
+ * signer is needed (`load()` never signs).
+ */
+export async function readColdParkedApprovalSnapshot(args: {
+  dataDir: string;
+  workflowRunRepoId: RepoId;
+  runId: string;
+  stepId: string;
+  attempt: number;
+  correlationId: string;
+}): Promise<ApprovalSnapshot | undefined> {
+  const storeDir = stepStorageRoot({
+    dataDir: args.dataDir,
+    workflowRunRepoId: args.workflowRunRepoId,
+    runId: args.runId,
+    stepId: args.stepId,
+    attempt: args.attempt,
+  });
+  if (!(await directoryExists(storeDir))) return undefined;
+  const store = await createIsogitStore(storeDir);
+  const { pendingOperations } = await store.load();
+  return findApprovalSnapshot(pendingOperations, args.correlationId);
+}
+
+/**
+ * Read a warm (single-step) parked agent's approval snapshot from durable
+ * substrate state. A warm agent's pending operations live in its durable
+ * conversation store, mirrored to the workflow-run substrate under
+ * `agent-state/<stepId>/`.
+ *
+ * Reconstructs that state read-only -- deliberately NOT through
+ * `DurableConversationRegistry.acquire`, whose first acquire writes and
+ * commits a substrate restore into the live store and would front-run the warm
+ * agent's own restore ordering. A respawned child has not rebuilt the live
+ * store when re-registration runs (resume re-parks without re-invoking the
+ * step), so the substrate is the only place the snapshot lives at that moment.
+ * Returns undefined when no durable state exists for the agent.
+ */
+export async function readWarmParkedApprovalSnapshot(args: {
+  substrate: RepoStore;
+  workflowRunRepoId: RepoId;
+  stepId: string;
+  correlationId: string;
+}): Promise<ApprovalSnapshot | undefined> {
+  const agentStateDir = path.join(
+    args.substrate.getRepoDir(args.workflowRunRepoId),
+    WORKFLOW_RUN_AGENT_STATE_PREFIX,
+    encodeURIComponent(args.stepId),
+  );
+  const reconstructed = await reconstructDurableConversation(
+    agentStateDir,
+    args.stepId,
+  );
+  if (reconstructed === null) return undefined;
+  return findApprovalSnapshot(
+    reconstructed.pendingOperations,
+    args.correlationId,
   );
 }
 
@@ -1312,6 +1406,34 @@ export function createSidecarSubstrateFactory(
               { recursive: true, force: true },
             );
 
+    // Recover a parked correlation's approval snapshot for the child's
+    // re-registration enumeration. Wired unconditionally (unlike
+    // `cleanupRunStorage`, which is cold-only): a warm agent parks on approval
+    // just as a cold one does, and the branch on `warmKeep` selects the durable
+    // read -- cold reads the per-attempt isogit store, warm reconstructs the
+    // agent's durable conversation state from the substrate.
+    const loadParkedApproval: LoadParkedApproval = ({
+      runId,
+      stepId,
+      attempt,
+      correlationId,
+    }) =>
+      env.spawn.warmKeep
+        ? readWarmParkedApprovalSnapshot({
+            substrate,
+            workflowRunRepoId,
+            stepId,
+            correlationId,
+          })
+        : readColdParkedApprovalSnapshot({
+            dataDir: validated.SIDECAR_DATA_DIR,
+            workflowRunRepoId,
+            runId,
+            stepId,
+            attempt,
+            correlationId,
+          });
+
     const bindings: RunWorkflowChildBindings = {
       substrate,
       workflowRunRepoId,
@@ -1324,6 +1446,7 @@ export function createSidecarSubstrateFactory(
       spawnChild,
       scheduler,
       evaluateGrants: evaluateGrantsAdapter,
+      loadParkedApproval,
       ...(cleanupRunStorage !== undefined ? { cleanupRunStorage } : {}),
     };
     return bindings;

--- a/packages/inference/src/reactor.test.ts
+++ b/packages/inference/src/reactor.test.ts
@@ -1060,6 +1060,115 @@ describe("createReactor — gate lifecycle", () => {
     expect(cleared.data.reason).toBe("shutdown");
   });
 
+  test("does not emit reactor.gate.blocked until the suspend is durably committed", async () => {
+    // Persist-before-settle. The `reactor.gate.blocked` event resolves the
+    // `send()` awaiter as "suspended", and a downstream consumer (the warm
+    // agent's run-boundary durability mirror) reads the pending operation back
+    // out of the context store the instant `send()` settles. So the durable
+    // commit must land BEFORE the event is emitted -- otherwise the mirror
+    // reads an uncommitted store and durably loses the approval snapshot. This
+    // test gates the commit's `writeMetadata`: `blocked` must not appear while
+    // the commit is pending, and must appear once it is released. A regression
+    // that emits before committing would fire `blocked` while the gate is held.
+    let releaseCommit: (() => void) | undefined;
+    const commitGate = new Promise<void>((resolve) => {
+      releaseCommit = resolve;
+    });
+    const base = makeContextStore();
+    const contextStore: ContextStore = {
+      ...base,
+      async writeMetadata(metadata, signal) {
+        await commitGate;
+        return base.writeMetadata(metadata, signal);
+      },
+    };
+    const { reactor, events, waitFor } = createTestReactor({
+      contextStore,
+      director: directorFromTable({
+        "message.received": (_e, _s, caps) =>
+          caps.suspend({
+            type: "approval",
+            gateId: "commit-order-gate",
+            timeoutMs: 5000,
+          }),
+        "reactor.gate.cleared": (_e, _s, caps) => caps.done(),
+      }),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+
+    // The commit is held, so a correctly-ordered reactor has not emitted
+    // `blocked` yet; a reactor that emits before committing would have.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(events.some((e) => e.type === "reactor.gate.blocked")).toBe(false);
+
+    // Release the durable commit; only now may `blocked` be emitted.
+    releaseCommit?.();
+    await waitFor("reactor.gate.blocked");
+
+    reactor.abort("admin_kill");
+    await waitFor("reactor.done");
+  });
+
+  test("defers a gate clear racing the commit until after blocked", async () => {
+    // blocked-before-cleared. A gate whose timeout timer elapses while the
+    // suspend's durable commit is still in flight must not have its clear take
+    // effect before `reactor.gate.blocked` is emitted: downstream status
+    // derivation and the send-awaiter assume a gate's `blocked` precedes any
+    // effect of its clearing. This holds the commit's `writeMetadata` open long
+    // enough for a short gate timeout to fire inside the window, then asserts
+    // `blocked` is emitted before the `reactor.gate.cleared` it belongs to.
+    let releaseCommit: (() => void) | undefined;
+    const commitGate = new Promise<void>((resolve) => {
+      releaseCommit = resolve;
+    });
+    const base = makeContextStore();
+    const contextStore: ContextStore = {
+      ...base,
+      async writeMetadata(metadata, signal) {
+        await commitGate;
+        return base.writeMetadata(metadata, signal);
+      },
+    };
+    const { reactor, events, waitFor } = createTestReactor({
+      contextStore,
+      director: directorFromTable({
+        "message.received": (_e, _s, caps) =>
+          caps.suspend({
+            type: "approval",
+            gateId: "race-gate",
+            timeoutMs: 30,
+          }),
+        "reactor.gate.cleared": (_e, _s, caps) => caps.done(),
+      }),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+
+    // Let the gate's timeout elapse while the commit is still held. Neither the
+    // block nor the clear may surface until the commit is released.
+    await new Promise((r) => setTimeout(r, 80));
+    expect(events.some((e) => e.type === "reactor.gate.blocked")).toBe(false);
+    expect(events.some((e) => e.type === "reactor.gate.cleared")).toBe(false);
+
+    releaseCommit?.();
+    await waitFor("reactor.done");
+
+    const blockedIndex = events.findIndex(
+      (e) => e.type === "reactor.gate.blocked",
+    );
+    const clearedIndex = events.findIndex(
+      (e) => e.type === "reactor.gate.cleared",
+    );
+    expect(blockedIndex).toBeGreaterThanOrEqual(0);
+    expect(clearedIndex).toBeGreaterThan(blockedIndex);
+    expect(getEvent(events, "reactor.gate.cleared").data.reason).toBe(
+      "timeout",
+    );
+  });
+
   test("gate timeout fires reactor.gate.cleared with reason=timeout", async () => {
     const { reactor, events, waitFor } = createTestReactor({
       shutdownTimeoutMs: 500,

--- a/packages/inference/src/reactor.ts
+++ b/packages/inference/src/reactor.ts
@@ -1029,6 +1029,22 @@ export function createReactor(config: ReactorConfig): Reactor {
   // Gate suspension critical section
   // -------------------------------------------------------------------------
 
+  // While a suspend is committing (the `await commitCycle()` in
+  // `suspendOnGate`), its gate is already armed but `reactor.gate.blocked` has
+  // not been emitted yet. If the gate's timeout timer elapses inside that
+  // window, `onGateCleared` would take effect ahead of the `blocked` it belongs
+  // to — emitting `reactor.gate.cleared` on the plain path, or enqueuing the
+  // synthetic `resume.tool_result` and removing the pending operation on the
+  // ask rail — before the suspension has been announced. `deriveStatus` and the
+  // send-awaiter both assume a gate's `blocked` precedes any effect of its
+  // clearing, so the in-flight suspend is tracked here and such a clear is
+  // deferred until `blocked` has fired.
+  type InFlightSuspend = {
+    gateId: string;
+    deferredClear: { reason: "resolved" | "timeout" | "shutdown" } | null;
+  };
+  let suspendingGate: InFlightSuspend | null = null;
+
   // Callback the gate manager invokes when a gate resolves, times out, or is
   // shut down. Refreshes the snapshot and drives the loop's next step.
   //
@@ -1049,6 +1065,18 @@ export function createReactor(config: ReactorConfig): Reactor {
     gateId: string,
     reason: "resolved" | "timeout" | "shutdown",
   ): void {
+    // A clear that fires while this gate's suspend is still committing must not
+    // take effect before `reactor.gate.blocked` is emitted. Record it and let
+    // suspendOnGate replay the full handler once the block is announced.
+    if (
+      suspendingGate !== null &&
+      suspendingGate.gateId === gateId &&
+      suspendingGate.deferredClear === null
+    ) {
+      suspendingGate.deferredClear = { reason };
+      return;
+    }
+
     if (stateManager !== null) {
       stateManager.setGatesSnapshot(gates.snapshot());
     }
@@ -1103,18 +1131,10 @@ export function createReactor(config: ReactorConfig): Reactor {
       }
     }
 
-    emit({
-      type: "reactor.gate.blocked",
-      seq: nextSeq(),
-      data: {
-        reason: gateType,
-        gateId,
-        ...(correlationId !== undefined ? { correlationId } : {}),
-        ...(pendingOp?.approvalSnapshot !== undefined
-          ? { approvalSnapshot: pendingOp.approvalSnapshot }
-          : {}),
-      },
-    });
+    // Track this suspend as in flight so a clear racing the commit below is
+    // deferred until `reactor.gate.blocked` has been emitted.
+    const inFlightSuspend: InFlightSuspend = { gateId, deferredClear: null };
+    suspendingGate = inFlightSuspend;
 
     // Register the gate. onGateCleared enqueues the cleared event so the loop
     // processes it normally without blocking here.
@@ -1137,6 +1157,38 @@ export function createReactor(config: ReactorConfig): Reactor {
     // Commit before the loop continues so the suspended state is durable
     // across restart.
     await commitCycle();
+
+    // Emit `reactor.gate.blocked` only AFTER the commit. This event resolves
+    // the `send()` awaiter as "suspended", and a downstream consumer (the warm
+    // agent's run-boundary durability mirror) reads the pending operation back
+    // out of the just-committed context store the instant `send()` settles.
+    // Emitting before the commit would resolve `send()` first, letting that
+    // mirror read a store that has not yet persisted the pending op -- it would
+    // durably mirror an empty pending-operation set and lose the approval
+    // snapshot, so a parked correlation could not be re-registered after a hub
+    // reconnect. This upholds persist-before-settle: the durable commit the
+    // header promises before returning to the loop lands before the suspension
+    // settles.
+    emit({
+      type: "reactor.gate.blocked",
+      seq: nextSeq(),
+      data: {
+        reason: gateType,
+        gateId,
+        ...(correlationId !== undefined ? { correlationId } : {}),
+        ...(pendingOp?.approvalSnapshot !== undefined
+          ? { approvalSnapshot: pendingOp.approvalSnapshot }
+          : {}),
+      },
+    });
+
+    // The suspension is announced. If the gate cleared while the commit was in
+    // flight, its handler was deferred to keep it after `blocked`; replay it
+    // now, in order.
+    suspendingGate = null;
+    if (inFlightSuspend.deferredClear !== null) {
+      onGateCleared(gateId, inFlightSuspend.deferredClear.reason);
+    }
   }
 
   // Re-registers a live gate and correlation for each pending operation loaded

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -561,10 +561,11 @@ export const APPROVAL_SNAPSHOT_MAX_BYTES = 131072;
 /**
  * {@link ApprovalSnapshot} bounded to {@link APPROVAL_SNAPSHOT_MAX_BYTES}.
  * Parse the snapshot through this validator where it crosses a trust boundary
- * (the `park.notify` IPC frame and the sidecar→hub register frame); internal
- * hops use the unbounded {@link ApprovalSnapshot}. `.narrow` bounds the runtime
- * check only — its inferred type is identical to {@link ApprovalSnapshot} — so
- * the cap holds only where a frame is actually parsed, not merely typed.
+ * (the `park.notify` IPC frame, the `parked-correlations.response` IPC frame,
+ * and the sidecar→hub register frame); internal hops use the unbounded
+ * {@link ApprovalSnapshot}. `.narrow` bounds the runtime check only — its
+ * inferred type is identical to {@link ApprovalSnapshot} — so the cap holds only
+ * where a frame is actually parsed, not merely typed.
  */
 export const BoundedApprovalSnapshot = ApprovalSnapshot.narrow(
   (snapshot, ctx) => {

--- a/packages/workflow-host/src/child/index.ts
+++ b/packages/workflow-host/src/child/index.ts
@@ -41,6 +41,8 @@ export {
   type DiscoveredRun,
 } from "./self-discovery";
 
+export type { LoadParkedApproval } from "./parked-correlations";
+
 export {
   createWarmAgentCache,
   type WarmAgentCache,

--- a/packages/workflow-host/src/child/parked-correlations.test.ts
+++ b/packages/workflow-host/src/child/parked-correlations.test.ts
@@ -1,0 +1,259 @@
+import { describe, test, expect } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { signalName } from "@intx/types";
+import type { ApprovalSnapshot } from "@intx/types/runtime";
+import type {
+  RepoId,
+  RepoStore as SubstrateRepoStore,
+} from "@intx/hub-sessions/substrate";
+import {
+  createInMemoryRepoStore,
+  type RepoStore as RuntimeRepoStore,
+  type WorkflowEvent,
+} from "@intx/workflow";
+
+import {
+  collectParkedApprovalCorrelations,
+  type LoadParkedApproval,
+} from "./parked-correlations";
+
+const at = new Date().toISOString();
+const repoId: RepoId = { kind: "workflow-run", id: "dep-1" };
+
+const snapshot: ApprovalSnapshot = {
+  name: "charge_card",
+  description: "Charge the customer's card",
+  inputSchema: { type: "object" },
+  arguments: { amount: 100 },
+};
+
+/**
+ * A durable log that reduces to a single step parked on `signalName`. Mirrors
+ * the post-flush crash window a real park leaves behind: RunStarted, the
+ * step's StepStarted, then the SignalAwaited that reduces the step to
+ * `awaiting-signal`.
+ */
+function parkedSeed(
+  runId: string,
+  stepId: string,
+  name: string,
+): WorkflowEvent[] {
+  return parkedSeedSteps(runId, [{ stepId, name }]);
+}
+
+/**
+ * A durable log that reduces to several concurrently-parked steps in one run:
+ * RunStarted, a StepStarted per step, then a SignalAwaited per step.
+ */
+function parkedSeedSteps(
+  runId: string,
+  steps: { stepId: string; name: string }[],
+): WorkflowEvent[] {
+  const events: WorkflowEvent[] = [
+    {
+      kind: "RunStarted",
+      seq: 1,
+      at,
+      runId,
+      definitionHash: "x",
+      trigger: { type: "manual", payload: undefined },
+    },
+  ];
+  let seq = 2;
+  for (const step of steps) {
+    events.push({
+      kind: "StepStarted",
+      seq: seq++,
+      at,
+      stepId: step.stepId,
+      attempt: 1,
+      input: { ref: "inline:null" },
+    });
+  }
+  for (const step of steps) {
+    events.push({
+      kind: "SignalAwaited",
+      seq: seq++,
+      at,
+      stepId: step.stepId,
+      signalName: step.name,
+    });
+  }
+  return events;
+}
+
+/**
+ * A substrate stub that resolves `getRepoDir` the way the real substrate does
+ * -- `<baseDir>/<kind>/<id>` -- and surfaces any other method as a precise
+ * failure. `getRepoDir` is the only method the enumeration exercises.
+ */
+function createStubSubstrate(baseDir: string): SubstrateRepoStore {
+  const stub: Partial<SubstrateRepoStore> = {
+    getRepoDir(id: RepoId): string {
+      return path.join(baseDir, id.kind, id.id);
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub; missing methods surface as a precise failure via the proxy
+  return new Proxy(stub as SubstrateRepoStore, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (value !== undefined) return value;
+      return () => {
+        throw new Error(
+          `stub substrate: ${String(prop)} not implemented for this test`,
+        );
+      };
+    },
+  });
+}
+
+/**
+ * Build a substrate stub and a runtime repo store seeded with the given parked
+ * runs. `discoverInFlightRuns` reads run ids from the substrate repo dir's
+ * `runs/` listing and events from the runtime repo store, so both are seeded
+ * for the same run ids.
+ */
+async function setup(
+  runs: { runId: string; stepId: string; name: string }[],
+): Promise<{
+  substrate: SubstrateRepoStore;
+  runtimeRepoStore: RuntimeRepoStore;
+}> {
+  const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "parked-corr-"));
+  const runsDir = path.join(baseDir, repoId.kind, repoId.id, "runs");
+  const runtimeRepoStore = createInMemoryRepoStore();
+  for (const run of runs) {
+    await fs.mkdir(path.join(runsDir, run.runId), { recursive: true });
+    for (const event of parkedSeed(run.runId, run.stepId, run.name)) {
+      await runtimeRepoStore.append(run.runId, event);
+    }
+  }
+  return { substrate: createStubSubstrate(baseDir), runtimeRepoStore };
+}
+
+describe("collectParkedApprovalCorrelations", () => {
+  test("enumerates a parked control-plane correlation and loads its snapshot", async () => {
+    const { substrate, runtimeRepoStore } = await setup([
+      { runId: "run-1", stepId: "s", name: signalName("corr-1") },
+    ]);
+    const calls: unknown[] = [];
+    const loadParkedApproval: LoadParkedApproval = async (args) => {
+      calls.push(args);
+      return snapshot;
+    };
+
+    const result = await collectParkedApprovalCorrelations({
+      substrate,
+      repoId,
+      runtimeRepoStore,
+      loadParkedApproval,
+    });
+
+    expect(result).toEqual([
+      { runId: "run-1", correlationId: "corr-1", kind: "approval", snapshot },
+    ]);
+    expect(calls).toEqual([
+      { runId: "run-1", stepId: "s", attempt: 1, correlationId: "corr-1" },
+    ]);
+  });
+
+  test("enumerates parked correlations across multiple runs and steps", async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "parked-corr-"));
+    const runsDir = path.join(baseDir, repoId.kind, repoId.id, "runs");
+    const runtimeRepoStore = createInMemoryRepoStore();
+    // run-a parks two steps concurrently; run-b parks one. The enumeration
+    // must report every park across both the run loop and the step loop.
+    await fs.mkdir(path.join(runsDir, "run-a"), { recursive: true });
+    for (const event of parkedSeedSteps("run-a", [
+      { stepId: "s1", name: signalName("corr-a1") },
+      { stepId: "s2", name: signalName("corr-a2") },
+    ])) {
+      await runtimeRepoStore.append("run-a", event);
+    }
+    await fs.mkdir(path.join(runsDir, "run-b"), { recursive: true });
+    for (const event of parkedSeedSteps("run-b", [
+      { stepId: "s1", name: signalName("corr-b1") },
+    ])) {
+      await runtimeRepoStore.append("run-b", event);
+    }
+    const substrate = createStubSubstrate(baseDir);
+    const calls: string[] = [];
+    const loadParkedApproval: LoadParkedApproval = async (args) => {
+      calls.push(args.correlationId);
+      return snapshot;
+    };
+
+    const result = await collectParkedApprovalCorrelations({
+      substrate,
+      repoId,
+      runtimeRepoStore,
+      loadParkedApproval,
+    });
+
+    // Enumeration order follows directory and map iteration, so assert as a
+    // set: every parked correlation is reported exactly once, each with its
+    // snapshot.
+    expect(result.map((r) => r.correlationId).sort()).toEqual([
+      "corr-a1",
+      "corr-a2",
+      "corr-b1",
+    ]);
+    expect(result.every((r) => r.kind === "approval")).toBe(true);
+    expect(result.every((r) => r.snapshot === snapshot)).toBe(true);
+    expect(calls.sort()).toEqual(["corr-a1", "corr-a2", "corr-b1"]);
+  });
+
+  test("skips a step parked on an author-chosen signal name", async () => {
+    const { substrate, runtimeRepoStore } = await setup([
+      { runId: "run-2", stepId: "g", name: "human-approval" },
+    ]);
+    let called = false;
+    const loadParkedApproval: LoadParkedApproval = async () => {
+      called = true;
+      return snapshot;
+    };
+
+    const result = await collectParkedApprovalCorrelations({
+      substrate,
+      repoId,
+      runtimeRepoStore,
+      loadParkedApproval,
+    });
+
+    expect(result).toEqual([]);
+    expect(called).toBe(false);
+  });
+
+  test("throws when a control-plane park is found but no binding is wired", async () => {
+    const { substrate, runtimeRepoStore } = await setup([
+      { runId: "run-3", stepId: "s", name: signalName("corr-3") },
+    ]);
+
+    await expect(
+      collectParkedApprovalCorrelations({
+        substrate,
+        repoId,
+        runtimeRepoStore,
+      }),
+    ).rejects.toThrow(/no loadParkedApproval binding is wired/);
+  });
+
+  test("throws when the binding has no snapshot for an enumerated park", async () => {
+    const { substrate, runtimeRepoStore } = await setup([
+      { runId: "run-4", stepId: "s", name: signalName("corr-4") },
+    ]);
+    const loadParkedApproval: LoadParkedApproval = async () => undefined;
+
+    await expect(
+      collectParkedApprovalCorrelations({
+        substrate,
+        repoId,
+        runtimeRepoStore,
+        loadParkedApproval,
+      }),
+    ).rejects.toThrow(/the run log and the step store disagree/);
+  });
+});

--- a/packages/workflow-host/src/child/parked-correlations.ts
+++ b/packages/workflow-host/src/child/parked-correlations.ts
@@ -1,0 +1,111 @@
+// Enumerate a child's currently-parked approval correlations from durable
+// state, so the child can answer a supervisor `parked-correlations.request`.
+//
+// Enumeration keys on REDUCED step state, never on raw `SignalAwaited` log
+// events. `parkOnSignal` commits `SignalAwaited` to the durable log before it
+// checks for the approval snapshot, so a snapshot-less correlated suspend (a
+// director `caps.suspend`, an unwired authz gate) leaves a control-plane
+// `SignalAwaited` in the log yet reduces to `phase === "failed"` -- never
+// `awaiting-signal`, and never a hub row. Filtering on the reduced
+// `awaiting-signal` phase therefore surfaces only the parks that carry a
+// durable snapshot by construction; a snapshot-less enumerated step is a
+// disagreement between the log and the step store, which this module surfaces
+// loudly rather than dropping.
+
+import type {
+  RepoId,
+  RepoStore as SubstrateRepoStore,
+} from "@intx/hub-sessions/substrate";
+import type { RepoStore as RuntimeRepoStore } from "@intx/workflow";
+import type { SignalKind } from "@intx/types";
+import { correlationIdFromSignalName } from "@intx/types";
+import type { ApprovalSnapshot } from "@intx/types/runtime";
+
+import { discoverInFlightRuns } from "./self-discovery";
+
+/**
+ * Recover the durable approval snapshot for one parked control-plane
+ * correlation. The child owns enumeration; the host owns the per-step
+ * on-disk layout (cold vs warm), so the snapshot read is a host binding.
+ * Returns `undefined` when no pending operation for the correlation carries
+ * a snapshot.
+ */
+export type LoadParkedApproval = (args: {
+  runId: string;
+  stepId: string;
+  attempt: number;
+  correlationId: string;
+}) => Promise<ApprovalSnapshot | undefined>;
+
+/**
+ * One parked approval correlation: the child-supplied half of a suspension
+ * registration. `kind` is the literal `"approval"` -- the enumeration filter
+ * (a control-plane `signalName(correlationId)` channel) already establishes
+ * that this is an approval, and reading `kind` back from the durable record
+ * (a bare `"approval"` literal) would risk a future signal kind silently
+ * inheriting approval's snapshot policy instead of declaring its own.
+ */
+export interface ParkedApprovalCorrelation {
+  runId: string;
+  correlationId: string;
+  kind: SignalKind;
+  snapshot: ApprovalSnapshot;
+}
+
+export interface CollectParkedApprovalCorrelationsOpts {
+  substrate: SubstrateRepoStore;
+  repoId: RepoId;
+  runtimeRepoStore: RuntimeRepoStore;
+  loadParkedApproval?: LoadParkedApproval;
+}
+
+/**
+ * Enumerate every in-flight run's reduced state and return one entry per step
+ * parked on a control-plane approval channel. Throws when a park is found but
+ * no `loadParkedApproval` binding is wired to recover its snapshot, or when
+ * the binding returns no snapshot for an enumerated park -- both are
+ * disagreements between the reduced state and the durable store that must not
+ * silently drop a correlation the hub is waiting to register.
+ */
+export async function collectParkedApprovalCorrelations(
+  opts: CollectParkedApprovalCorrelationsOpts,
+): Promise<ParkedApprovalCorrelation[]> {
+  const discovered = await discoverInFlightRuns({
+    substrate: opts.substrate,
+    repoId: opts.repoId,
+    runtimeRepoStore: opts.runtimeRepoStore,
+  });
+  const out: ParkedApprovalCorrelation[] = [];
+  for (const run of discovered) {
+    for (const step of run.resumedState.steps.values()) {
+      if (step.phase !== "awaiting-signal") continue;
+      const name = step.awaitingSignal?.name;
+      if (name === undefined) continue;
+      const correlationId = correlationIdFromSignalName(name);
+      if (correlationId === undefined) continue;
+      if (opts.loadParkedApproval === undefined) {
+        throw new Error(
+          `workflow-child parked-correlations: run ${run.runId} step ${step.stepId} is parked on control-plane correlation ${correlationId}, but no loadParkedApproval binding is wired to recover its snapshot`,
+        );
+      }
+      const snapshot = await opts.loadParkedApproval({
+        runId: run.runId,
+        stepId: step.stepId,
+        attempt: step.currentAttempt,
+        correlationId,
+      });
+      if (snapshot === undefined) {
+        throw new Error(
+          `workflow-child parked-correlations: reduced state shows run ${run.runId} step ${step.stepId} awaiting control-plane correlation ${correlationId} (attempt ${String(step.currentAttempt)}), but durable storage carries no approval snapshot for it; the run log and the step store disagree`,
+        );
+      }
+      out.push({
+        runId: run.runId,
+        correlationId,
+        kind: "approval",
+        snapshot,
+      });
+    }
+  }
+  return out;
+}

--- a/packages/workflow-host/src/child/run-child.ts
+++ b/packages/workflow-host/src/child/run-child.ts
@@ -113,6 +113,10 @@ import { hashGrants } from "../supervisor/credentials";
 
 import type { SpawnTimeEnv } from "./env-bootstrap";
 import { discoverInFlightRuns } from "./self-discovery";
+import {
+  collectParkedApprovalCorrelations,
+  type LoadParkedApproval,
+} from "./parked-correlations";
 import type { ChildOutboundMailBridge } from "./outbound-mail-bridge";
 import { createWarmAgentCache, type WarmAgentCache } from "./warm-agent-cache";
 
@@ -315,6 +319,21 @@ export interface RunWorkflowChildBindings {
    * adapter (which roots no per-run scratch of its own) can omit it.
    */
   cleanupRunStorage?: (runId: string) => Promise<void>;
+  /**
+   * Recover the durable approval snapshot for a parked control-plane
+   * correlation, so the child can answer a supervisor
+   * `parked-correlations.request` (the supervisor's re-registration path
+   * after a re-establishment). The child owns enumeration -- it walks its
+   * own reduced run state for `awaiting-signal` steps on control-plane
+   * channels -- but the snapshot lives in per-step durable storage whose
+   * on-disk layout (cold vs warm) the host owns, so the read is a host
+   * binding next to `cleanupRunStorage`. Optional so tests inject a stub and
+   * the recursive child-workflow adapter (which roots no per-step approval
+   * storage) can omit it; a production child that enumerates a parked
+   * control-plane step with no binding wired throws rather than silently
+   * dropping the correlation the hub is waiting to register.
+   */
+  loadParkedApproval?: LoadParkedApproval;
   /** Optional director registry; defaults to the canonical built-ins. */
   directors?: DirectorRegistry;
   /** Optional clock override; production wires `() => new Date()`. */
@@ -1048,6 +1067,38 @@ async function handleControlPayload(
       }
       ctx.substrateWriteBridge.handleWriteResponse(payload.data);
       return false;
+    }
+    case "parked-correlations.request": {
+      // Answer the supervisor's re-registration enumeration from durable
+      // state. Awaiting inline is safe -- unlike `signal.deliver`, this
+      // reads (self-discovery + the snapshot binding) and sends one upstream
+      // reply without awaiting any downstream frame, so it cannot deadlock
+      // the iterator against a response it is itself blocking. A store
+      // inconsistency (an enumerated park with no durable snapshot, or no
+      // binding to recover one) throws out of the loop like the other
+      // invariant-violation arms rather than dropping a correlation the hub
+      // is waiting to register.
+      const parked = await collectParkedApprovalCorrelations({
+        substrate: ctx.bindings.substrate,
+        repoId: ctx.bindings.workflowRunRepoId,
+        runtimeRepoStore: ctx.runtimeRepoStore,
+        ...(ctx.bindings.loadParkedApproval !== undefined
+          ? { loadParkedApproval: ctx.bindings.loadParkedApproval }
+          : {}),
+      });
+      await ctx.upstreamSender.send({
+        type: "parked-correlations.response",
+        data: { requestId: payload.data.requestId, parked },
+      });
+      return false;
+    }
+    case "parked-correlations.response": {
+      // `parked-correlations.response` is the child->supervisor reply frame;
+      // receiving one on the child's downstream side is a protocol violation
+      // in the same shape as a downstream `substrate.merge.response`.
+      throw new Error(
+        "workflow-child received a `parked-correlations.response` frame on its inbound control channel; this is a child-only upstream payload",
+      );
     }
   }
 }

--- a/packages/workflow-host/src/index.ts
+++ b/packages/workflow-host/src/index.ts
@@ -147,6 +147,7 @@ export {
   type DiscoveredRun,
   type DrainController,
   type GrantEvaluator,
+  type LoadParkedApproval,
   type RunWorkflowChildBindings,
   type RunWorkflowChildFromProcessEnvOpts,
   type RunWorkflowChildOpts,

--- a/packages/workflow-host/src/ipc/control-channel.ts
+++ b/packages/workflow-host/src/ipc/control-channel.ts
@@ -442,6 +442,44 @@ export const ControlPayload = type(
       // process boundary. Optional: only an ask-rail suspension carries one.
       "snapshot?": BoundedApprovalSnapshot,
     },
+  })
+  .or({
+    // Supervisor-initiated request: enumerate the child's currently-parked
+    // approval correlations. The supervisor fires this after a
+    // re-establishment (child respawn, or hub-link reconnect fanned out to
+    // this deployment) so it can re-register at the hub every correlation
+    // whose original `park.notify`-driven register may have been lost while
+    // the hub was down. Modeled on `substrate.merge.request`: a
+    // supervisor->child request the child answers on `parked-correlations.
+    // response`, correlated by `requestId`. Carries no filter -- one child
+    // owns one deployment, so the child enumerates everything parked and the
+    // supervisor re-emits all; the hub co-write is idempotent.
+    type: "'parked-correlations.request'",
+    data: {
+      requestId: "string > 0",
+    },
+  })
+  .or({
+    // Child's reply to `parked-correlations.request`. Each entry mirrors
+    // `park.notify`'s data -- the child-supplied half of a
+    // `SuspensionRegistration` the supervisor stamps its deployment identity
+    // onto -- so the supervisor's re-emit path shares one transform with the
+    // `park.notify` arm. Only reduced-state approval parks appear here: the
+    // child enumerates steps whose reduced phase is `awaiting-signal` on a
+    // control-plane `signalName(correlationId)` channel, each of which carries
+    // a durable snapshot by construction (a snapshot-less correlated suspend
+    // reduces to `failed`, not `awaiting-signal`). `snapshot` is therefore
+    // required, and size-capped at this process boundary like `park.notify`.
+    type: "'parked-correlations.response'",
+    data: {
+      requestId: "string > 0",
+      parked: type({
+        runId: "string > 0",
+        correlationId: "string > 0",
+        kind: SignalKind,
+        snapshot: BoundedApprovalSnapshot,
+      }).array(),
+    },
   });
 
 export type ControlPayload = typeof ControlPayload.infer;

--- a/packages/workflow-host/src/ipc/ipc.test.ts
+++ b/packages/workflow-host/src/ipc/ipc.test.ts
@@ -1443,6 +1443,145 @@ describe("park.notify snapshot validation", () => {
   });
 });
 
+describe("parked-correlations frames", () => {
+  const validSnapshot = {
+    name: "charge_card",
+    description: "Charge the customer's card",
+    inputSchema: { type: "object" },
+    arguments: { amount: 100 },
+  };
+
+  test("round-trips a request and a response through Ed25519", async () => {
+    const kp = await generateKeyPair();
+    const channelId = generateChannelId();
+    const stream = createMemoryNdjsonStream();
+    const sender = createControlChannelSender({
+      privateKeySeed: kp.privateKey,
+      channelId,
+      writer: stream.writer,
+    });
+    const crashes: string[] = [];
+    const received: ControlPayload[] = [];
+
+    const consumer = (async () => {
+      for await (const payload of receiveControlChannel({
+        publicKey: kp.publicKey,
+        channelId,
+        reader: stream.reader,
+        onCrash: (reason) => crashes.push(reason),
+      })) {
+        received.push(payload);
+        if (received.length === 2) return;
+      }
+    })();
+
+    await sender.send({
+      type: "parked-correlations.request",
+      data: { requestId: "pc-1" },
+    });
+    await sender.send({
+      type: "parked-correlations.response",
+      data: {
+        requestId: "pc-1",
+        parked: [
+          {
+            runId: "run-1",
+            correlationId: "corr-1",
+            kind: "approval",
+            snapshot: validSnapshot,
+          },
+        ],
+      },
+    });
+
+    await consumer;
+    stream.close();
+
+    expect(crashes).toEqual([]);
+    expect(received).toEqual([
+      { type: "parked-correlations.request", data: { requestId: "pc-1" } },
+      {
+        type: "parked-correlations.response",
+        data: {
+          requestId: "pc-1",
+          parked: [
+            {
+              runId: "run-1",
+              correlationId: "corr-1",
+              kind: "approval",
+              snapshot: validSnapshot,
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  test("accepts a well-formed request", () => {
+    const validated = ControlPayload({
+      type: "parked-correlations.request",
+      data: { requestId: "pc-1" },
+    });
+    expect(validated instanceof type.errors).toBe(false);
+  });
+
+  test("rejects a request missing requestId", () => {
+    const validated = ControlPayload({
+      type: "parked-correlations.request",
+      data: {},
+    });
+    expect(validated instanceof type.errors).toBe(true);
+  });
+
+  test("accepts a response with an empty parked list", () => {
+    const validated = ControlPayload({
+      type: "parked-correlations.response",
+      data: { requestId: "pc-1", parked: [] },
+    });
+    expect(validated instanceof type.errors).toBe(false);
+  });
+
+  test("rejects a response missing requestId", () => {
+    const validated = ControlPayload({
+      type: "parked-correlations.response",
+      data: { parked: [] },
+    });
+    expect(validated instanceof type.errors).toBe(true);
+  });
+
+  test("rejects a response entry with no snapshot", () => {
+    const validated = ControlPayload({
+      type: "parked-correlations.response",
+      data: {
+        requestId: "pc-1",
+        parked: [{ runId: "run-1", correlationId: "corr-1", kind: "approval" }],
+      },
+    });
+    expect(validated instanceof type.errors).toBe(true);
+  });
+
+  test("rejects a response entry whose snapshot exceeds the size cap", () => {
+    const validated = ControlPayload({
+      type: "parked-correlations.response",
+      data: {
+        requestId: "pc-1",
+        parked: [
+          {
+            runId: "run-1",
+            correlationId: "corr-1",
+            kind: "approval",
+            snapshot: {
+              ...validSnapshot,
+              inputSchema: { pad: "a".repeat(APPROVAL_SNAPSHOT_MAX_BYTES) },
+            },
+          },
+        ],
+      },
+    });
+    expect(validated instanceof type.errors).toBe(true);
+  });
+});
+
 describe("substrate.write.request payload validation", () => {
   test("accepts a well-formed substrate.write.request", () => {
     const payload = {

--- a/packages/workflow-host/src/supervisor/re-emit-parked-correlations.test.ts
+++ b/packages/workflow-host/src/supervisor/re-emit-parked-correlations.test.ts
@@ -1,11 +1,13 @@
-// Supervisor `reEmitParkedCorrelations` driver.
+// Supervisor `reEmitParkedCorrelations` driver and its Trigger A wiring.
 //
 // On a re-establishment the supervisor queries the child for its currently-
 // parked correlations (`parked-correlations.request`) and re-registers each
 // through `onSuspensionRegister` -- recovering a `park.notify` register the hub
-// may have missed while it was down at suspend. The driver is best-effort: it
-// no-ops when the child is not addressable, and a query that times out is
-// dropped for the next re-establishment to re-drive.
+// may have missed while it was down at suspend. The supervisor fires this
+// automatically whenever a fresh child becomes addressable: after a spawn and
+// after a recycle's `installNewChild`. The driver itself is best-effort: it
+// no-ops when the child is not addressable, and a query that times out or whose
+// send fails is dropped for the next re-establishment to re-drive.
 
 import { describe, test, expect } from "bun:test";
 import fs from "node:fs/promises";
@@ -21,6 +23,8 @@ import type { RepoId, RepoStore } from "@intx/hub-sessions";
 import {
   createWorkflowSupervisor,
   type InboxPrimitives,
+  type SubprocessHandle,
+  type SubprocessSpawner,
   type SuspensionRegistration,
   type WorkflowSupervisor,
 } from "./index";
@@ -50,6 +54,17 @@ type ParkedEntry = {
   kind: "approval";
   snapshot: ApprovalSnapshot;
 };
+
+function registrationFor(entry: ParkedEntry): SuspensionRegistration {
+  return {
+    runId: entry.runId,
+    correlationId: entry.correlationId,
+    kind: entry.kind,
+    deploymentId: DEPLOYMENT_ID,
+    agentAddress: AGENT_ADDRESS,
+    approvalSnapshot: entry.snapshot,
+  };
+}
 
 function createMemoryNdjsonStream() {
   const buffer: string[] = [];
@@ -174,21 +189,135 @@ function createNoopInboxPrimitives(): InboxPrimitives {
   };
 }
 
-interface Harness {
-  supervisor: WorkflowSupervisor;
-  registrations: SuspensionRegistration[];
-  cleanup: () => Promise<void>;
+type FakeChild = {
+  pid: number;
+  channelId: string | undefined;
+  s2c: ReturnType<typeof createMemoryNdjsonStream>;
+  c2s: ReturnType<typeof createMemoryNdjsonStream>;
+  events: ReturnType<typeof createMemoryFrameStream>;
+  // When true, the supervisor's downstream writes to this child throw,
+  // simulating a closing pipe so the driver's send-failure path is exercised.
+  failWrites: boolean;
+};
+
+/**
+ * A subprocess spawner that records one `FakeChild` per spawn, so the test can
+ * drive the initial cohort and every recycle's replacement cohort.
+ */
+function createSpawnTracker() {
+  const children: FakeChild[] = [];
+  const spawner: SubprocessSpawner = ({ env }) => {
+    const s2c = createMemoryNdjsonStream();
+    const c2s = createMemoryNdjsonStream();
+    const events = createMemoryFrameStream();
+    const child: FakeChild = {
+      pid: 9300 + children.length,
+      channelId: env.IPC_CHANNEL_ID,
+      s2c,
+      c2s,
+      events,
+      failWrites: false,
+    };
+    children.push(child);
+    const handle: SubprocessHandle = {
+      pid: child.pid,
+      controlWriter: {
+        write(line: string) {
+          if (child.failWrites) throw new Error("controlWriter send boom");
+          return s2c.writer.write(line);
+        },
+      },
+      controlReader: c2s.reader,
+      eventReader: events.reader,
+      kill: () => {
+        events.close();
+        c2s.close();
+      },
+      exited: Promise.resolve(0),
+    };
+    return handle;
+  };
+  return { spawner, children };
 }
 
 /**
- * Spawn a supervisor wired to a mock child. The child answers a
- * `parked-correlations.request` with `parked` when it is an array, or ignores
- * the request (to exercise the watchdog) when it is `null`.
+ * Drive a cohort's `ready` handshake and start a mock child loop that answers
+ * `parked-correlations.request` from the shared `nextReply` ref (a `null` ref
+ * means never reply, to exercise the watchdog). Calls `onReply` after each
+ * answer so a test can await the fire-and-forget Trigger A effect
+ * deterministically.
+ */
+async function driveReadyAndAnswer(
+  child: FakeChild,
+  ipcKp: { privateKey: Uint8Array; publicKey: Uint8Array },
+  nextReply: { current: ParkedEntry[] | null },
+  onReply: () => void,
+): Promise<void> {
+  if (child.channelId === undefined) throw new Error("no channelId");
+  const childSender = createControlChannelSender({
+    privateKeySeed: ipcKp.privateKey,
+    channelId: child.channelId,
+    writer: {
+      write(line: string) {
+        child.c2s.inject(line);
+      },
+    },
+  });
+  await childSender.send({
+    type: "ready",
+    data: { childPid: child.pid, childPublicKey: hexEncode(ipcKp.publicKey) },
+  });
+
+  const receiver = receiveControlChannel({
+    publicKey: ipcKp.publicKey,
+    channelId: child.channelId,
+    reader: child.s2c.reader,
+    onCrash: () => undefined,
+  });
+  void (async () => {
+    for await (const payload of receiver) {
+      if (payload.type !== "parked-correlations.request") continue;
+      const reply = nextReply.current;
+      if (reply === null) continue; // watchdog path: never answer
+      const response: ControlPayload = {
+        type: "parked-correlations.response",
+        data: { requestId: payload.data.requestId, parked: reply },
+      };
+      await childSender.send(response);
+      onReply();
+    }
+  })();
+}
+
+interface Harness {
+  supervisor: WorkflowSupervisor;
+  registrations: SuspensionRegistration[];
+  nextReply: { current: ParkedEntry[] | null };
+  children: FakeChild[];
+  ipcKp: { privateKey: Uint8Array; publicKey: Uint8Array };
+  waitForRegistrations: (n: number) => Promise<void>;
+  cleanup: () => Promise<void>;
+}
+
+async function poll(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 2));
+  }
+  throw new Error("condition not met in time");
+}
+
+/**
+ * Spawn a supervisor with the mock cohort tracker and drive the initial
+ * cohort's `ready`. `initialReply` is what the first cohort reports for the
+ * spawn-seam Trigger A query; `setup` awaits that first reply so the fire-and-
+ * forget auto-emit has settled before the test proceeds (no race with a later
+ * `nextReply` change).
  */
 async function setup(opts: {
-  parked: ParkedEntry[] | null;
+  initialReply: ParkedEntry[] | null;
   parkedQueryWatchdogMs?: number;
-  failSendAfterReady?: boolean;
 }): Promise<Harness> {
   const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "reemit-parked-"));
   const hostTransport = createInMemoryTransport();
@@ -196,30 +325,14 @@ async function setup(opts: {
   hostTransport.register(AGENT_ADDRESS, createEd25519Crypto(agentKeyPair));
   const mailBus = wrapHubTransportAsMailBus(hostTransport);
 
-  const supervisorIpcKeyPair = await generateKeyPair();
-  const childIpcKeyPair = await generateKeyPair();
-
-  const supervisorToChild = createMemoryNdjsonStream();
-  const childToSupervisor = createMemoryNdjsonStream();
-  const eventChildToSupervisor = createMemoryFrameStream();
-  let resolveExit: ((code: number) => void) | undefined;
-  const exited = new Promise<number>((resolve) => {
-    resolveExit = resolve;
-  });
+  const ipcKp = await generateKeyPair();
+  const tracker = createSpawnTracker();
 
   const registrations: SuspensionRegistration[] = [];
-  let observedEnv: Record<string, string> | undefined;
-
-  // A downstream writer that starts failing once armed, so the driver's
-  // `parked-correlations.request` send rejects. Left disarmed through spawn so
-  // the credentials push and `ready` handshake succeed first.
-  let failWrites = false;
-  const guardedWriter: NdjsonWriter = {
-    write(line: string) {
-      if (failWrites) throw new Error("controlWriter send boom");
-      return supervisorToChild.writer.write(line);
-    },
+  const nextReply: { current: ParkedEntry[] | null } = {
+    current: opts.initialReply,
   };
+  let replies = 0;
 
   const supervisor = createWorkflowSupervisor({
     repoStore: createStubRepoStore(baseDir),
@@ -231,21 +344,7 @@ async function setup(opts: {
     onSuspensionRegister: (registration) => {
       registrations.push(registration);
     },
-    subprocessSpawner: ({ env }) => {
-      observedEnv = env;
-      return {
-        pid: 9300,
-        controlWriter: guardedWriter,
-        controlReader: childToSupervisor.reader,
-        eventReader: eventChildToSupervisor.reader,
-        kill: () => {
-          childToSupervisor.close();
-          eventChildToSupervisor.close();
-          resolveExit?.(0);
-        },
-        exited,
-      };
-    },
+    subprocessSpawner: tracker.spawner,
     binaryPath: "/fake/bin/workflow-child",
     substrateEnv: {},
     dynamicSpawnEnv: () => ({}),
@@ -258,7 +357,8 @@ async function setup(opts: {
     deriveStepAddress: () => AGENT_ADDRESS,
     deriveStepRepoId: () => ({ kind: "agent-state", id: DEPLOYMENT_ID }),
     inboxPrimitives: createNoopInboxPrimitives(),
-    ipcKeyPairFactory: () => Promise.resolve(supervisorIpcKeyPair),
+    ipcKeyPairFactory: () => Promise.resolve(ipcKp),
+    drainTimeoutMs: 200,
     ...(opts.parkedQueryWatchdogMs !== undefined
       ? { parkedQueryWatchdogMs: opts.parkedQueryWatchdogMs }
       : {}),
@@ -271,115 +371,123 @@ async function setup(opts: {
     onInferenceEvent: () => undefined,
   });
 
-  while (observedEnv === undefined) {
-    await new Promise((r) => setTimeout(r, 1));
-  }
-  const channelId = observedEnv.IPC_CHANNEL_ID;
-  if (channelId === undefined) throw new Error("IPC_CHANNEL_ID missing");
-
-  const childSender = createControlChannelSender({
-    privateKeySeed: childIpcKeyPair.privateKey,
-    channelId,
-    writer: {
-      write(line: string) {
-        childToSupervisor.inject(line);
-      },
-    },
-  });
-
-  await childSender.send({
-    type: "ready",
-    data: {
-      childPid: 9300,
-      childPublicKey: hexEncode(childIpcKeyPair.publicKey),
-    },
+  await poll(() => tracker.children.length >= 1);
+  const childA = tracker.children[0];
+  if (childA === undefined) throw new Error("cohort A missing");
+  await driveReadyAndAnswer(childA, ipcKp, nextReply, () => {
+    replies += 1;
   });
   await spawnPromise;
-  // Arm the write failure only now that spawn's own downstream frames landed.
-  if (opts.failSendAfterReady === true) failWrites = true;
-
-  // The mock child: drain the supervisor's downstream frames and answer a
-  // parked-correlations query. Verifies the supervisor's real signed frames
-  // through the production receiver.
-  const childReceiver = receiveControlChannel({
-    publicKey: supervisorIpcKeyPair.publicKey,
-    channelId,
-    reader: supervisorToChild.reader,
-    onCrash: (reason) => {
-      throw new Error(`mock child control receiver crashed: ${reason}`);
-    },
-  });
-  const childLoop = (async () => {
-    for await (const payload of childReceiver) {
-      if (payload.type !== "parked-correlations.request") continue;
-      if (opts.parked === null) continue; // exercise the watchdog: never reply
-      const response: ControlPayload = {
-        type: "parked-correlations.response",
-        data: { requestId: payload.data.requestId, parked: opts.parked },
-      };
-      await childSender.send(response);
-    }
-  })();
+  // Await the spawn-seam Trigger A round-trip (unless the cohort withholds its
+  // reply) so a later `nextReply` change cannot race the auto-emit.
+  if (nextReply.current !== null) {
+    await poll(() => replies >= 1);
+  }
 
   return {
     supervisor,
     registrations,
+    nextReply,
+    children: tracker.children,
+    ipcKp,
+    waitForRegistrations: (n) => poll(() => registrations.length >= n),
     cleanup: async () => {
       await supervisor.shutdown();
-      supervisorToChild.close();
-      await childLoop.catch(() => undefined);
+      for (const child of tracker.children) {
+        child.s2c.close();
+        child.c2s.close();
+        child.events.close();
+      }
       await fs.rm(baseDir, { recursive: true, force: true });
     },
   };
 }
 
 describe("supervisor reEmitParkedCorrelations", () => {
-  test("re-registers every parked correlation the child reports", async () => {
-    const harness = await setup({
-      parked: [
-        {
-          runId: "run-a",
-          correlationId: "corr-a",
-          kind: "approval",
-          snapshot: SNAPSHOT,
-        },
-        {
-          runId: "run-b",
-          correlationId: "corr-b",
-          kind: "approval",
-          snapshot: SNAPSHOT,
-        },
-      ],
-    });
-
-    await harness.supervisor.reEmitParkedCorrelations();
-
-    // Each parked correlation is re-registered with the deployment identity
-    // stamped on and its snapshot forwarded.
-    expect(harness.registrations).toEqual([
+  test("re-registers the parked set on spawn (Trigger A)", async () => {
+    const parked: ParkedEntry[] = [
       {
         runId: "run-a",
         correlationId: "corr-a",
         kind: "approval",
-        deploymentId: DEPLOYMENT_ID,
-        agentAddress: AGENT_ADDRESS,
-        approvalSnapshot: SNAPSHOT,
+        snapshot: SNAPSHOT,
       },
       {
         runId: "run-b",
         correlationId: "corr-b",
         kind: "approval",
-        deploymentId: DEPLOYMENT_ID,
-        agentAddress: AGENT_ADDRESS,
-        approvalSnapshot: SNAPSHOT,
+        snapshot: SNAPSHOT,
       },
-    ]);
+    ];
+    const harness = await setup({ initialReply: parked });
+
+    // The spawn seam fired the driver automatically; each parked correlation is
+    // re-registered with the deployment identity stamped on.
+    await harness.waitForRegistrations(2);
+    expect(harness.registrations).toEqual(parked.map(registrationFor));
 
     await harness.cleanup();
   });
 
-  test("re-registers nothing when the child reports no parked correlations", async () => {
-    const harness = await setup({ parked: [] });
+  test("re-registers the parked set on recycle against the new cohort (Trigger A)", async () => {
+    // Cohort A reports nothing on spawn; the recycle's fresh cohort reports a
+    // parked correlation, and the supervisor must re-emit it -- proving the
+    // recycle seam fires the driver against the NEW cohort's controlSender.
+    const harness = await setup({ initialReply: [] });
+    expect(harness.registrations).toEqual([]);
+
+    const recycled: ParkedEntry = {
+      runId: "run-c",
+      correlationId: "corr-c",
+      kind: "approval",
+      snapshot: SNAPSHOT,
+    };
+    harness.nextReply.current = [recycled];
+
+    const recycleP = harness.supervisor.recycle({ reason: "test-recycle" });
+    await poll(() => harness.children.length >= 2);
+    const childB = harness.children[1];
+    if (childB === undefined) throw new Error("cohort B missing");
+    let cohortBReplies = 0;
+    await driveReadyAndAnswer(childB, harness.ipcKp, harness.nextReply, () => {
+      cohortBReplies += 1;
+    });
+    await recycleP;
+
+    // The recycle-seam re-emit registered the new cohort's parked correlation.
+    // Only cohort B could have reported `corr-c` (cohort A reported nothing), so
+    // this proves the re-emit queried the fresh cohort.
+    await harness.waitForRegistrations(1);
+    expect(harness.registrations).toEqual([registrationFor(recycled)]);
+    expect(cohortBReplies).toBeGreaterThanOrEqual(1);
+
+    await harness.cleanup();
+  });
+
+  test("re-registers what the child reports on an explicit call", async () => {
+    // The spawn auto-emit reported nothing; an explicit call then re-registers
+    // the freshly-reported set.
+    const harness = await setup({ initialReply: [] });
+    expect(harness.registrations).toEqual([]);
+
+    const parked: ParkedEntry = {
+      runId: "run-x",
+      correlationId: "corr-x",
+      kind: "approval",
+      snapshot: SNAPSHOT,
+    };
+    harness.nextReply.current = [parked];
+
+    await harness.supervisor.reEmitParkedCorrelations();
+
+    await harness.waitForRegistrations(1);
+    expect(harness.registrations).toEqual([registrationFor(parked)]);
+
+    await harness.cleanup();
+  });
+
+  test("registers nothing when the child reports no parked correlations", async () => {
+    const harness = await setup({ initialReply: [] });
 
     await harness.supervisor.reEmitParkedCorrelations();
 
@@ -390,7 +498,11 @@ describe("supervisor reEmitParkedCorrelations", () => {
 
   test("returns without a register when the query times out", async () => {
     // The child never answers; the watchdog fires and the driver returns.
-    const harness = await setup({ parked: null, parkedQueryWatchdogMs: 50 });
+    const harness = await setup({
+      initialReply: [],
+      parkedQueryWatchdogMs: 50,
+    });
+    harness.nextReply.current = null;
 
     await harness.supervisor.reEmitParkedCorrelations();
 
@@ -401,19 +513,19 @@ describe("supervisor reEmitParkedCorrelations", () => {
 
   test("returns without a register when the query send fails", async () => {
     // The downstream send throws (a closing pipe). The driver swallows it,
-    // registers nothing, and leaves no unhandled rejection; the next
-    // re-establishment re-drives.
-    const harness = await setup({
-      parked: [
-        {
-          runId: "run-a",
-          correlationId: "corr-a",
-          kind: "approval",
-          snapshot: SNAPSHOT,
-        },
-      ],
-      failSendAfterReady: true,
-    });
+    // registers nothing, and leaves no unhandled rejection.
+    const harness = await setup({ initialReply: [] });
+    const childA = harness.children[0];
+    if (childA === undefined) throw new Error("cohort A missing");
+    childA.failWrites = true;
+    harness.nextReply.current = [
+      {
+        runId: "run-x",
+        correlationId: "corr-x",
+        kind: "approval",
+        snapshot: SNAPSHOT,
+      },
+    ];
 
     await harness.supervisor.reEmitParkedCorrelations();
 
@@ -422,8 +534,54 @@ describe("supervisor reEmitParkedCorrelations", () => {
     await harness.cleanup();
   });
 
+  test("an in-flight query settles via sentinel when shutdown aborts it", async () => {
+    // Guards the reject->settle refactor: a teardown that aborts an in-flight
+    // query must settle it with the null sentinel, not reject it (which would
+    // surface as an unhandled rejection since the auto-emit fires concurrently
+    // with arbitrary shutdown/recycle).
+    const harness = await setup({ initialReply: [] });
+    harness.nextReply.current = null; // the child answers no further query
+
+    let settled = false;
+    let rejected = false;
+    const inflight = harness.supervisor
+      .reEmitParkedCorrelations()
+      .then(() => {
+        settled = true;
+      })
+      .catch(() => {
+        rejected = true;
+      });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(settled).toBe(false); // still pending: proves the query was in flight
+
+    await harness.supervisor.shutdown();
+
+    await Promise.race([
+      inflight,
+      new Promise((_r, reject) =>
+        setTimeout(
+          () => reject(new Error("in-flight query hung after shutdown")),
+          1000,
+        ),
+      ),
+    ]);
+
+    expect(settled).toBe(true);
+    expect(rejected).toBe(false);
+    expect(harness.registrations).toEqual([]);
+
+    for (const child of harness.children) {
+      child.s2c.close();
+      child.c2s.close();
+      child.events.close();
+    }
+  });
+
   test("no-ops without throwing when the child is not addressable", async () => {
-    // Before spawn the supervisor is idle; the driver must skip, not throw.
+    // Before spawn the supervisor is idle; the driver must skip, not throw, and
+    // the spawner must never be invoked.
     const registrations: SuspensionRegistration[] = [];
     const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "reemit-idle-"));
     const supervisor = createWorkflowSupervisor({

--- a/packages/workflow-host/src/supervisor/re-emit-parked-correlations.test.ts
+++ b/packages/workflow-host/src/supervisor/re-emit-parked-correlations.test.ts
@@ -1,0 +1,461 @@
+// Supervisor `reEmitParkedCorrelations` driver.
+//
+// On a re-establishment the supervisor queries the child for its currently-
+// parked correlations (`parked-correlations.request`) and re-registers each
+// through `onSuspensionRegister` -- recovering a `park.notify` register the hub
+// may have missed while it was down at suspend. The driver is best-effort: it
+// no-ops when the child is not addressable, and a query that times out is
+// dropped for the next re-establishment to re-drive.
+
+import { describe, test, expect } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { createEd25519Crypto, generateKeyPair } from "@intx/crypto";
+import { hexEncode } from "@intx/types";
+import type { ApprovalSnapshot } from "@intx/types/runtime";
+import { createInMemoryTransport } from "@intx/mail-memory";
+import type { RepoId, RepoStore } from "@intx/hub-sessions";
+
+import {
+  createWorkflowSupervisor,
+  type InboxPrimitives,
+  type SuspensionRegistration,
+  type WorkflowSupervisor,
+} from "./index";
+import { wrapHubTransportAsMailBus } from "../mail-bus/index";
+import {
+  createControlChannelSender,
+  receiveControlChannel,
+  type ControlPayload,
+  type NdjsonReader,
+  type NdjsonWriter,
+  type FrameReader,
+} from "../ipc/index";
+
+const AGENT_ADDRESS = "ins_reemit-agent@integration.example";
+const DEPLOYMENT_ID = "reemit-dep";
+
+const SNAPSHOT: ApprovalSnapshot = {
+  name: "charge_card",
+  description: "Charge the customer's card",
+  inputSchema: { type: "object" },
+  arguments: { amount: 100 },
+};
+
+type ParkedEntry = {
+  runId: string;
+  correlationId: string;
+  kind: "approval";
+  snapshot: ApprovalSnapshot;
+};
+
+function createMemoryNdjsonStream() {
+  const buffer: string[] = [];
+  let waiter: (() => void) | null = null;
+  let done = false;
+  function wake() {
+    const w = waiter;
+    waiter = null;
+    if (w) w();
+  }
+  const reader: NdjsonReader = {
+    read(): AsyncIterableIterator<string> {
+      return (async function* () {
+        while (true) {
+          if (buffer.length > 0) {
+            const next = buffer.shift();
+            if (next === undefined) throw new Error("buffer shift undefined");
+            yield next;
+            continue;
+          }
+          if (done) return;
+          await new Promise<void>((resolve) => {
+            waiter = resolve;
+          });
+        }
+      })();
+    },
+  };
+  const writer: NdjsonWriter = {
+    write(line: string) {
+      buffer.push(line.replace(/\n$/, ""));
+      wake();
+    },
+  };
+  return {
+    writer,
+    reader,
+    inject(line: string) {
+      buffer.push(line.replace(/\n$/, ""));
+      wake();
+    },
+    close() {
+      done = true;
+      wake();
+    },
+  };
+}
+
+function createMemoryFrameStream() {
+  const buffer: Uint8Array[] = [];
+  let waiter: (() => void) | null = null;
+  let done = false;
+  function wake() {
+    const w = waiter;
+    waiter = null;
+    if (w) w();
+  }
+  const reader: FrameReader = {
+    read(): AsyncIterableIterator<Uint8Array> {
+      return (async function* () {
+        while (true) {
+          if (buffer.length > 0) {
+            const next = buffer.shift();
+            if (next === undefined) throw new Error("frame shift undefined");
+            yield next;
+            continue;
+          }
+          if (done) return;
+          await new Promise<void>((resolve) => {
+            waiter = resolve;
+          });
+        }
+      })();
+    },
+  };
+  return {
+    reader,
+    close() {
+      done = true;
+      wake();
+    },
+  };
+}
+
+/**
+ * Minimal `RepoStore` stub: `spawn` consults `getRepoDir` for credentials
+ * assembly. No re-emit path touches the substrate, so every other method
+ * throws to surface an accidental untested code path.
+ */
+function createStubRepoStore(baseDir: string): RepoStore {
+  const stub: Partial<RepoStore> = {
+    getRepoDir(repoId: RepoId): string {
+      return path.join(baseDir, repoId.kind, repoId.id);
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub; only getRepoDir is exercised and any other method throws via the proxy
+  return new Proxy(stub as RepoStore, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (value !== undefined) return value;
+      return () => {
+        throw new Error(`stub RepoStore: ${String(prop)} not implemented`);
+      };
+    },
+  });
+}
+
+function createNoopInboxPrimitives(): InboxPrimitives {
+  return {
+    async enqueueInbox() {
+      throw new Error("enqueueInbox not exercised in the re-emit test");
+    },
+    async dequeueToProcessing() {
+      return null;
+    },
+    async markConsumed() {
+      throw new Error("markConsumed not exercised in the re-emit test");
+    },
+    async replayProcessingToInbox() {
+      return { commitSha: "noop", replayedKeys: [] };
+    },
+  };
+}
+
+interface Harness {
+  supervisor: WorkflowSupervisor;
+  registrations: SuspensionRegistration[];
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Spawn a supervisor wired to a mock child. The child answers a
+ * `parked-correlations.request` with `parked` when it is an array, or ignores
+ * the request (to exercise the watchdog) when it is `null`.
+ */
+async function setup(opts: {
+  parked: ParkedEntry[] | null;
+  parkedQueryWatchdogMs?: number;
+  failSendAfterReady?: boolean;
+}): Promise<Harness> {
+  const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "reemit-parked-"));
+  const hostTransport = createInMemoryTransport();
+  const agentKeyPair = await generateKeyPair();
+  hostTransport.register(AGENT_ADDRESS, createEd25519Crypto(agentKeyPair));
+  const mailBus = wrapHubTransportAsMailBus(hostTransport);
+
+  const supervisorIpcKeyPair = await generateKeyPair();
+  const childIpcKeyPair = await generateKeyPair();
+
+  const supervisorToChild = createMemoryNdjsonStream();
+  const childToSupervisor = createMemoryNdjsonStream();
+  const eventChildToSupervisor = createMemoryFrameStream();
+  let resolveExit: ((code: number) => void) | undefined;
+  const exited = new Promise<number>((resolve) => {
+    resolveExit = resolve;
+  });
+
+  const registrations: SuspensionRegistration[] = [];
+  let observedEnv: Record<string, string> | undefined;
+
+  // A downstream writer that starts failing once armed, so the driver's
+  // `parked-correlations.request` send rejects. Left disarmed through spawn so
+  // the credentials push and `ready` handshake succeed first.
+  let failWrites = false;
+  const guardedWriter: NdjsonWriter = {
+    write(line: string) {
+      if (failWrites) throw new Error("controlWriter send boom");
+      return supervisorToChild.writer.write(line);
+    },
+  };
+
+  const supervisor = createWorkflowSupervisor({
+    repoStore: createStubRepoStore(baseDir),
+    signAsPrincipal: async () => ({
+      sig: new Uint8Array(64),
+      principalKind: "supervisor",
+    }),
+    mailBus,
+    onSuspensionRegister: (registration) => {
+      registrations.push(registration);
+    },
+    subprocessSpawner: ({ env }) => {
+      observedEnv = env;
+      return {
+        pid: 9300,
+        controlWriter: guardedWriter,
+        controlReader: childToSupervisor.reader,
+        eventReader: eventChildToSupervisor.reader,
+        kill: () => {
+          childToSupervisor.close();
+          eventChildToSupervisor.close();
+          resolveExit?.(0);
+        },
+        exited,
+      };
+    },
+    binaryPath: "/fake/bin/workflow-child",
+    substrateEnv: {},
+    dynamicSpawnEnv: () => ({}),
+    workflowRunRepoId: { kind: "workflow-run", id: DEPLOYMENT_ID },
+    workflowRunRef: "refs/heads/main",
+    deploymentId: DEPLOYMENT_ID,
+    stepCount: 1,
+    deploymentMailAddress: AGENT_ADDRESS,
+    readPrincipal: { kind: "supervisor" },
+    deriveStepAddress: () => AGENT_ADDRESS,
+    deriveStepRepoId: () => ({ kind: "agent-state", id: DEPLOYMENT_ID }),
+    inboxPrimitives: createNoopInboxPrimitives(),
+    ipcKeyPairFactory: () => Promise.resolve(supervisorIpcKeyPair),
+    ...(opts.parkedQueryWatchdogMs !== undefined
+      ? { parkedQueryWatchdogMs: opts.parkedQueryWatchdogMs }
+      : {}),
+  });
+
+  const spawnPromise = supervisor.spawn({
+    stepOrder: ["step-1"],
+    definitionHash: "def-hash",
+    warmKeep: false,
+    onInferenceEvent: () => undefined,
+  });
+
+  while (observedEnv === undefined) {
+    await new Promise((r) => setTimeout(r, 1));
+  }
+  const channelId = observedEnv.IPC_CHANNEL_ID;
+  if (channelId === undefined) throw new Error("IPC_CHANNEL_ID missing");
+
+  const childSender = createControlChannelSender({
+    privateKeySeed: childIpcKeyPair.privateKey,
+    channelId,
+    writer: {
+      write(line: string) {
+        childToSupervisor.inject(line);
+      },
+    },
+  });
+
+  await childSender.send({
+    type: "ready",
+    data: {
+      childPid: 9300,
+      childPublicKey: hexEncode(childIpcKeyPair.publicKey),
+    },
+  });
+  await spawnPromise;
+  // Arm the write failure only now that spawn's own downstream frames landed.
+  if (opts.failSendAfterReady === true) failWrites = true;
+
+  // The mock child: drain the supervisor's downstream frames and answer a
+  // parked-correlations query. Verifies the supervisor's real signed frames
+  // through the production receiver.
+  const childReceiver = receiveControlChannel({
+    publicKey: supervisorIpcKeyPair.publicKey,
+    channelId,
+    reader: supervisorToChild.reader,
+    onCrash: (reason) => {
+      throw new Error(`mock child control receiver crashed: ${reason}`);
+    },
+  });
+  const childLoop = (async () => {
+    for await (const payload of childReceiver) {
+      if (payload.type !== "parked-correlations.request") continue;
+      if (opts.parked === null) continue; // exercise the watchdog: never reply
+      const response: ControlPayload = {
+        type: "parked-correlations.response",
+        data: { requestId: payload.data.requestId, parked: opts.parked },
+      };
+      await childSender.send(response);
+    }
+  })();
+
+  return {
+    supervisor,
+    registrations,
+    cleanup: async () => {
+      await supervisor.shutdown();
+      supervisorToChild.close();
+      await childLoop.catch(() => undefined);
+      await fs.rm(baseDir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("supervisor reEmitParkedCorrelations", () => {
+  test("re-registers every parked correlation the child reports", async () => {
+    const harness = await setup({
+      parked: [
+        {
+          runId: "run-a",
+          correlationId: "corr-a",
+          kind: "approval",
+          snapshot: SNAPSHOT,
+        },
+        {
+          runId: "run-b",
+          correlationId: "corr-b",
+          kind: "approval",
+          snapshot: SNAPSHOT,
+        },
+      ],
+    });
+
+    await harness.supervisor.reEmitParkedCorrelations();
+
+    // Each parked correlation is re-registered with the deployment identity
+    // stamped on and its snapshot forwarded.
+    expect(harness.registrations).toEqual([
+      {
+        runId: "run-a",
+        correlationId: "corr-a",
+        kind: "approval",
+        deploymentId: DEPLOYMENT_ID,
+        agentAddress: AGENT_ADDRESS,
+        approvalSnapshot: SNAPSHOT,
+      },
+      {
+        runId: "run-b",
+        correlationId: "corr-b",
+        kind: "approval",
+        deploymentId: DEPLOYMENT_ID,
+        agentAddress: AGENT_ADDRESS,
+        approvalSnapshot: SNAPSHOT,
+      },
+    ]);
+
+    await harness.cleanup();
+  });
+
+  test("re-registers nothing when the child reports no parked correlations", async () => {
+    const harness = await setup({ parked: [] });
+
+    await harness.supervisor.reEmitParkedCorrelations();
+
+    expect(harness.registrations).toEqual([]);
+
+    await harness.cleanup();
+  });
+
+  test("returns without a register when the query times out", async () => {
+    // The child never answers; the watchdog fires and the driver returns.
+    const harness = await setup({ parked: null, parkedQueryWatchdogMs: 50 });
+
+    await harness.supervisor.reEmitParkedCorrelations();
+
+    expect(harness.registrations).toEqual([]);
+
+    await harness.cleanup();
+  });
+
+  test("returns without a register when the query send fails", async () => {
+    // The downstream send throws (a closing pipe). The driver swallows it,
+    // registers nothing, and leaves no unhandled rejection; the next
+    // re-establishment re-drives.
+    const harness = await setup({
+      parked: [
+        {
+          runId: "run-a",
+          correlationId: "corr-a",
+          kind: "approval",
+          snapshot: SNAPSHOT,
+        },
+      ],
+      failSendAfterReady: true,
+    });
+
+    await harness.supervisor.reEmitParkedCorrelations();
+
+    expect(harness.registrations).toEqual([]);
+
+    await harness.cleanup();
+  });
+
+  test("no-ops without throwing when the child is not addressable", async () => {
+    // Before spawn the supervisor is idle; the driver must skip, not throw.
+    const registrations: SuspensionRegistration[] = [];
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "reemit-idle-"));
+    const supervisor = createWorkflowSupervisor({
+      repoStore: createStubRepoStore(baseDir),
+      signAsPrincipal: async () => ({
+        sig: new Uint8Array(64),
+        principalKind: "supervisor",
+      }),
+      mailBus: wrapHubTransportAsMailBus(createInMemoryTransport()),
+      onSuspensionRegister: (registration) => {
+        registrations.push(registration);
+      },
+      subprocessSpawner: () => {
+        throw new Error("spawner must not be called for the idle no-op path");
+      },
+      binaryPath: "/fake/bin/workflow-child",
+      substrateEnv: {},
+      dynamicSpawnEnv: () => ({}),
+      workflowRunRepoId: { kind: "workflow-run", id: DEPLOYMENT_ID },
+      workflowRunRef: "refs/heads/main",
+      deploymentId: DEPLOYMENT_ID,
+      stepCount: 1,
+      deploymentMailAddress: AGENT_ADDRESS,
+      readPrincipal: { kind: "supervisor" },
+      deriveStepAddress: () => AGENT_ADDRESS,
+      deriveStepRepoId: () => ({ kind: "agent-state", id: DEPLOYMENT_ID }),
+      inboxPrimitives: createNoopInboxPrimitives(),
+    });
+
+    await supervisor.reEmitParkedCorrelations();
+
+    expect(registrations).toEqual([]);
+    await fs.rm(baseDir, { recursive: true, force: true });
+  });
+});

--- a/packages/workflow-host/src/supervisor/supervisor.ts
+++ b/packages/workflow-host/src/supervisor/supervisor.ts
@@ -64,8 +64,13 @@ import {
   type WorkflowRunWorkflowProcessPrincipal,
 } from "@intx/hub-sessions/substrate";
 import { base64Decode, base64Encode, hexEncode } from "@intx/types";
+import type { SignalKind } from "@intx/types";
 import { RepoId } from "@intx/types/sidecar";
-import type { InferenceSource, OutboundMessage } from "@intx/types/runtime";
+import type {
+  ApprovalSnapshot,
+  InferenceSource,
+  OutboundMessage,
+} from "@intx/types/runtime";
 import type { CancelOrigin } from "@intx/workflow";
 
 import {
@@ -143,6 +148,15 @@ const logger = getLogger(["workflow-host", "supervisor"]);
 export const DEFAULT_TERMINAL_WRITE_WATCHDOG_MS = 30_000;
 
 /**
+ * Default watchdog for `reEmitParkedCorrelations`' wait on the child's
+ * `parked-correlations.response`. Shares the terminal-write watchdog's 30s
+ * budget: generous enough for a healthy child to enumerate its in-flight runs
+ * and load each parked snapshot, tight enough that a wedged-but-alive child
+ * does not hang the reconnect caller until some coarser timeout intervenes.
+ */
+export const DEFAULT_PARKED_QUERY_WATCHDOG_MS = 30_000;
+
+/**
  * Public surface returned by `createWorkflowSupervisor`. Each method
  * advances the supervisor through one lifecycle transition; the
  * supervisor's internal state is encapsulated.
@@ -212,6 +226,21 @@ export interface WorkflowSupervisor {
    * closing pipe. Throws otherwise.
    */
   deliverSources(opts: DeliverSourcesOpts): Promise<void>;
+  /**
+   * Re-register every correlation the child is currently parked on by
+   * querying it for its parked correlations and re-emitting each through
+   * `onSuspensionRegister`. Recovers a `park.notify` register the hub may have
+   * missed while it was down at suspend time.
+   *
+   * Best-effort and safe to call at any time, including concurrently. Unlike
+   * `deliverSignal`/`deliverSources`, which throw when the child is not
+   * addressable, this NO-OPS on a non-addressable phase (idle / stopping /
+   * stopped / recycling): a re-establishment landing mid-recycle must not
+   * crash, and the next spawn re-drives it. A query that fails or times out is
+   * logged and dropped; the hub co-write is idempotent, so the next
+   * re-establishment re-drives it. The caller need not guard the call site.
+   */
+  reEmitParkedCorrelations(): Promise<void>;
   /**
    * Current snapshot of the credentials pushed to the child. Surfaced
    * so the host can audit the per-step contentHash without
@@ -385,6 +414,8 @@ export function createWorkflowSupervisor(
   const drainTimeoutMs = bindings.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS;
   const terminalWriteWatchdogMs =
     bindings.terminalWriteWatchdogMs ?? DEFAULT_TERMINAL_WRITE_WATCHDOG_MS;
+  const parkedQueryWatchdogMs =
+    bindings.parkedQueryWatchdogMs ?? DEFAULT_PARKED_QUERY_WATCHDOG_MS;
 
   // Pure observability: invoke the dispatch-timing hook (when wired) at
   // the two per-message boundaries the 4.7 latency gate brackets. A
@@ -749,37 +780,26 @@ export function createWorkflowSupervisor(
         continue;
       }
       if (payload.type === "park.notify") {
-        // The workflow-process child reported a control-plane suspension:
-        // an agent step parked on a reserved `signalName(correlationId)`
-        // channel. Stamp the deployment identity the supervisor owns
-        // (`deploymentId` + the deployment's mail address) onto the
-        // child-supplied `runId`/`correlationId`/`kind` and hand it to the
-        // host's suspension-register sink, which (production: the sidecar)
-        // sends a `signal.correlation.register` frame to the hub so the run's
-        // routing + approval rows are co-written. Best-effort: a throwing
-        // sink is logged, not rethrown, so it cannot tear the pump down and
-        // stop draining every other upstream frame for the cohort. A host
-        // that wires no sink registers nothing.
-        if (bindings.onSuspensionRegister !== undefined) {
-          try {
-            bindings.onSuspensionRegister({
-              runId: payload.data.runId,
-              correlationId: payload.data.correlationId,
-              kind: payload.data.kind,
-              deploymentId: bindings.deploymentId,
-              agentAddress: bindings.deploymentMailAddress,
-              ...(payload.data.snapshot !== undefined
-                ? { approvalSnapshot: payload.data.snapshot }
-                : {}),
-            });
-          } catch (cause) {
-            const message =
-              cause instanceof Error ? cause.message : String(cause);
-            logger.error`onSuspensionRegister sink threw for runId=${payload.data.runId} correlationId=${payload.data.correlationId}: ${message}`;
-          }
-        } else {
-          logger.warn`park.notify received for runId=${payload.data.runId} but no onSuspensionRegister sink is wired; correlation ${payload.data.correlationId} not registered`;
-        }
+        // The workflow-process child reported a control-plane suspension: an
+        // agent step parked on a reserved `signalName(correlationId)` channel.
+        // Register it the same way the reconnect re-emit driver does, through
+        // the shared `registerSuspension` transform.
+        registerSuspension({
+          runId: payload.data.runId,
+          correlationId: payload.data.correlationId,
+          kind: payload.data.kind,
+          ...(payload.data.snapshot !== undefined
+            ? { snapshot: payload.data.snapshot }
+            : {}),
+        });
+        continue;
+      }
+      if (payload.type === "parked-correlations.response") {
+        // The child answered a `reEmitParkedCorrelations` query. Resolve the
+        // awaiting driver; a response with no pending entry (the query already
+        // timed out and dropped it) is logged and dropped, never thrown, so it
+        // cannot tear the pump down.
+        resolveParkedResponse(payload.data);
         continue;
       }
       logger.warn`workflow-process upstream control payload ignored: type=${payload.type}`;
@@ -816,6 +836,10 @@ export function createWorkflowSupervisor(
     for (const [requestId, entry] of pendingMerges) {
       pendingMerges.delete(requestId);
       entry.resolve({ ok: false, reason: `cohort aborted: ${reason}` });
+    }
+    for (const [requestId, entry] of pendingParkedQueries) {
+      pendingParkedQueries.delete(requestId);
+      entry.reject(new Error(`cohort aborted: ${reason}`));
     }
     for (const [runId, waiter] of markConsumedCompletionWaiters.entries()) {
       markConsumedCompletionWaiters.delete(runId);
@@ -859,6 +883,128 @@ export function createWorkflowSupervisor(
       return;
     }
     entry.resolve({ ok: false, reason: data.result.reason });
+  }
+
+  // Stamp the deployment identity the supervisor owns onto a child-supplied
+  // park and hand it to the host's suspension-register sink. Shared by the
+  // `park.notify` arm (the happy-path emit) and `reEmitParkedCorrelations`
+  // (the re-establishment re-emit). Best-effort: a throwing sink is logged,
+  // not rethrown, so it cannot tear the upstream pump down or abort a re-emit
+  // partway through the parked set. The sink (production: the sidecar) turns
+  // the stamped registration into a `signal.correlation.register` frame the
+  // hub co-writes the run's routing + approval rows from.
+  function registerSuspension(park: {
+    runId: string;
+    correlationId: string;
+    kind: SignalKind;
+    snapshot?: ApprovalSnapshot;
+  }): void {
+    if (bindings.onSuspensionRegister === undefined) {
+      logger.warn`suspension register for runId=${park.runId} but no onSuspensionRegister sink is wired; correlation ${park.correlationId} not registered`;
+      return;
+    }
+    try {
+      bindings.onSuspensionRegister({
+        runId: park.runId,
+        correlationId: park.correlationId,
+        kind: park.kind,
+        deploymentId: bindings.deploymentId,
+        agentAddress: bindings.deploymentMailAddress,
+        ...(park.snapshot !== undefined
+          ? { approvalSnapshot: park.snapshot }
+          : {}),
+      });
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      logger.error`onSuspensionRegister sink threw for runId=${park.runId} correlationId=${park.correlationId}: ${message}`;
+    }
+  }
+
+  // Pending `reEmitParkedCorrelations` queries keyed by the supervisor-minted
+  // `requestId`. The driver installs an entry, sends `parked-correlations.
+  // request`, and awaits; the matching `parked-correlations.response` resolves
+  // it. Supervisor-minted (not child-echoed like `pendingMerges`) because the
+  // supervisor originates this request; the counter lives in the factory
+  // closure so a recycle does not reset it and let a late old-child response
+  // resolve a new query.
+  type ParkedCorrelations = Extract<
+    ControlPayload,
+    { type: "parked-correlations.response" }
+  >["data"]["parked"];
+  type PendingParkedQuery = {
+    resolve: (parked: ParkedCorrelations) => void;
+    reject: (cause: Error) => void;
+  };
+  const pendingParkedQueries = new Map<string, PendingParkedQuery>();
+  let parkedQuerySeq = 0;
+
+  function resolveParkedResponse(
+    data: Extract<
+      ControlPayload,
+      { type: "parked-correlations.response" }
+    >["data"],
+  ): void {
+    const entry = pendingParkedQueries.get(data.requestId);
+    if (entry === undefined) {
+      logger.warn`parked-correlations.response landed with no pending entry; requestId=${data.requestId} dropped`;
+      return;
+    }
+    pendingParkedQueries.delete(data.requestId);
+    entry.resolve(data.parked);
+  }
+
+  async function reEmitParkedCorrelations(): Promise<void> {
+    // No-op (NOT throw) when the child is not addressable. `deliverSignal`
+    // throws on non-running/starting (including recycling) because it points a
+    // write at the dying child's closing pipe and wants the caller to retry;
+    // this driver's contract is the opposite -- the next re-establishment
+    // re-drives it -- so skipping recycling and letting the next spawn's
+    // re-emit cover it is correct here, not a missed guard.
+    if (state.phase !== "running" && state.phase !== "starting") {
+      logger.info`reEmitParkedCorrelations: child not addressable (phase=${state.phase}); skipping`;
+      return;
+    }
+    const controlSender = state.controlSender;
+    const requestId = `pc-${String((parkedQuerySeq += 1))}`;
+    const responded = new Promise<ParkedCorrelations>((resolve, reject) => {
+      pendingParkedQueries.set(requestId, { resolve, reject });
+    });
+    // Watchdog: a wedged-but-alive child never tears its cohort down, so
+    // `rejectCohortAwaiters` would never fire and this await would hang the
+    // re-establishment caller. On expiry, drop the pending entry and return;
+    // the next re-establishment re-drives (the hub co-write is idempotent).
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+    const watchdog = new Promise<"timeout">((resolve) => {
+      timeoutHandle = setTimeout(() => {
+        timeoutHandle = null;
+        if (pendingParkedQueries.delete(requestId)) {
+          logger.warn`reEmitParkedCorrelations: requestId=${requestId} did not respond within ${String(parkedQueryWatchdogMs)}ms; re-registration retries on the next re-establishment`;
+        }
+        resolve("timeout");
+      }, parkedQueryWatchdogMs);
+    });
+    let outcome: ParkedCorrelations | "timeout";
+    try {
+      await controlSender.send({
+        type: "parked-correlations.request",
+        data: { requestId },
+      });
+      outcome = await Promise.race([responded, watchdog]);
+    } catch (cause) {
+      // The send failed, or `rejectCohortAwaiters` rejected the pending query
+      // on cohort teardown. Best-effort: log and return; the next
+      // re-establishment re-drives.
+      pendingParkedQueries.delete(requestId);
+      if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+      const message = cause instanceof Error ? cause.message : String(cause);
+      logger.warn`reEmitParkedCorrelations query failed: ${message}; re-registration retries on the next re-establishment`;
+      return;
+    }
+    if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+    if (outcome === "timeout") return;
+    for (const parked of outcome) {
+      registerSuspension(parked);
+    }
   }
 
   /**
@@ -2579,6 +2725,7 @@ export function createWorkflowSupervisor(
     recycle,
     deliverSignal,
     deliverSources,
+    reEmitParkedCorrelations,
     getCredentialsSnapshot,
   };
 }

--- a/packages/workflow-host/src/supervisor/supervisor.ts
+++ b/packages/workflow-host/src/supervisor/supervisor.ts
@@ -839,7 +839,7 @@ export function createWorkflowSupervisor(
     }
     for (const [requestId, entry] of pendingParkedQueries) {
       pendingParkedQueries.delete(requestId);
-      entry.reject(new Error(`cohort aborted: ${reason}`));
+      entry.settle(null);
     }
     for (const [runId, waiter] of markConsumedCompletionWaiters.entries()) {
       markConsumedCompletionWaiters.delete(runId);
@@ -931,9 +931,14 @@ export function createWorkflowSupervisor(
     ControlPayload,
     { type: "parked-correlations.response" }
   >["data"]["parked"];
+  // Settle with the child's `parked` list, or `null` when the cohort is torn
+  // down before it answers. Mirrors `pendingMerges`: a settle-with-sentinel,
+  // never a reject, because a cohort abort is an ordinary outcome the driver
+  // handles -- and Trigger A fires the driver concurrently with arbitrary
+  // shutdown/recycle, so a rejection here would surface as an unhandled
+  // rejection the moment a teardown aborts an in-flight auto-emit.
   type PendingParkedQuery = {
-    resolve: (parked: ParkedCorrelations) => void;
-    reject: (cause: Error) => void;
+    settle: (parked: ParkedCorrelations | null) => void;
   };
   const pendingParkedQueries = new Map<string, PendingParkedQuery>();
   let parkedQuerySeq = 0;
@@ -950,7 +955,7 @@ export function createWorkflowSupervisor(
       return;
     }
     pendingParkedQueries.delete(data.requestId);
-    entry.resolve(data.parked);
+    entry.settle(data.parked);
   }
 
   async function reEmitParkedCorrelations(): Promise<void> {
@@ -966,11 +971,11 @@ export function createWorkflowSupervisor(
     }
     const controlSender = state.controlSender;
     const requestId = `pc-${String((parkedQuerySeq += 1))}`;
-    const responded = new Promise<ParkedCorrelations>((resolve, reject) => {
-      pendingParkedQueries.set(requestId, { resolve, reject });
+    const responded = new Promise<ParkedCorrelations | null>((resolve) => {
+      pendingParkedQueries.set(requestId, { settle: resolve });
     });
-    // Watchdog: a wedged-but-alive child never tears its cohort down, so
-    // `rejectCohortAwaiters` would never fire and this await would hang the
+    // Watchdog: a wedged-but-alive child never tears its cohort down, so the
+    // cohort-abort settle would never fire and this await would hang the
     // re-establishment caller. On expiry, drop the pending entry and return;
     // the next re-establishment re-drives (the hub co-write is idempotent).
     let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
@@ -983,7 +988,7 @@ export function createWorkflowSupervisor(
         resolve("timeout");
       }, parkedQueryWatchdogMs);
     });
-    let outcome: ParkedCorrelations | "timeout";
+    let outcome: ParkedCorrelations | null | "timeout";
     try {
       await controlSender.send({
         type: "parked-correlations.request",
@@ -991,9 +996,8 @@ export function createWorkflowSupervisor(
       });
       outcome = await Promise.race([responded, watchdog]);
     } catch (cause) {
-      // The send failed, or `rejectCohortAwaiters` rejected the pending query
-      // on cohort teardown. Best-effort: log and return; the next
-      // re-establishment re-drives.
+      // The downstream send failed (a closing pipe). Best-effort: drop the
+      // pending entry, log, and return; the next re-establishment re-drives.
       pendingParkedQueries.delete(requestId);
       if (timeoutHandle !== null) clearTimeout(timeoutHandle);
       const message = cause instanceof Error ? cause.message : String(cause);
@@ -1001,7 +1005,9 @@ export function createWorkflowSupervisor(
       return;
     }
     if (timeoutHandle !== null) clearTimeout(timeoutHandle);
-    if (outcome === "timeout") return;
+    // `timeout` (watchdog fired) or `null` (cohort torn down before the child
+    // answered): nothing to re-emit; the next re-establishment re-drives.
+    if (outcome === "timeout" || outcome === null) return;
     for (const parked of outcome) {
       registerSuspension(parked);
     }
@@ -1792,6 +1798,19 @@ export function createWorkflowSupervisor(
       ).catch((cause) => {
         const message = cause instanceof Error ? cause.message : String(cause);
         logger.error`upstream control pump failed: ${message}`;
+      });
+
+      // Trigger A: re-register every correlation the freshly-ready child is
+      // parked on. A `park.notify` register can be lost while the hub is down
+      // at the original suspend; a child that resumes such a parked run (a
+      // sidecar restart re-spawning this deployment, or a recycle -- see the
+      // matching call in `installNewChild`) re-parks without re-emitting, so
+      // the supervisor re-drives it from every re-establishment. Fire-and-
+      // forget after the pump is armed to route the response: best-effort,
+      // watchdog-bounded, and an empty round-trip when nothing is parked.
+      void reEmitParkedCorrelations().catch((cause) => {
+        const message = cause instanceof Error ? cause.message : String(cause);
+        logger.warn`re-emit of parked correlations on re-establishment failed: ${message}`;
       });
 
       // Arm the recycle policy. The policy is a no-op when all bounds
@@ -2610,6 +2629,18 @@ export function createWorkflowSupervisor(
             // entries the previous cohort's replayProcessingToInbox
             // just moved back.
             wakeDispatch();
+
+            // Trigger A on the recycle seam: the respawned child re-parks any
+            // surviving parked run without re-emitting, and a recycle leaves
+            // the hub link untouched so the reconnect trigger never fires --
+            // so re-drive the re-registration here too. Same fire-and-forget
+            // contract as the spawn seam; the fresh cohort's controlSender is
+            // in `state` now, and its pump (armed above) routes the response.
+            void reEmitParkedCorrelations().catch((cause) => {
+              const message =
+                cause instanceof Error ? cause.message : String(cause);
+              logger.warn`re-emit of parked correlations on re-establishment failed: ${message}`;
+            });
           },
           onCrash: onChildCrash,
           // Edge-resolved once at the supervisor factory; recycle bounds

--- a/packages/workflow-host/src/supervisor/types.ts
+++ b/packages/workflow-host/src/supervisor/types.ts
@@ -296,14 +296,17 @@ export interface WorkflowSupervisorBindings {
   /** Mail-bus surface for address registration and inbound subscription. */
   mailBus: MailBusBindings;
   /**
-   * Optional control-plane suspension sink. The supervisor invokes it from
-   * its upstream-control pump's `park.notify` arm, stamping `deploymentId`
-   * and `deploymentMailAddress` (as `agentAddress`) onto the child-supplied
-   * `runId`/`correlationId`/`kind`. Production wires this to the sidecar's
-   * hub link so a `signal.correlation.register` frame reaches the hub; a host
-   * that does not wire it does not register suspensions (tests, single-process
-   * deployments). Best-effort: the pump logs a throwing sink and keeps
-   * draining, so one bad register cannot wedge the control pump.
+   * Optional control-plane suspension sink. Two callers invoke it, both
+   * stamping `deploymentId` and `deploymentMailAddress` (as `agentAddress`)
+   * onto the child-supplied `runId`/`correlationId`/`kind`: the upstream-control
+   * pump's `park.notify` arm (the happy-path emit at suspend), and
+   * `reEmitParkedCorrelations` (the re-establishment re-emit that recovers a
+   * register the hub missed while it was down). Production wires this to the
+   * sidecar's hub link so a `signal.correlation.register` frame reaches the hub;
+   * a host that does not wire it does not register suspensions (tests,
+   * single-process deployments). Best-effort: a throwing sink is logged and
+   * both callers keep going, so one bad register cannot wedge the control pump
+   * or abort a re-emit partway through the parked set.
    */
   onSuspensionRegister?: (registration: SuspensionRegistration) => void;
   /** Subprocess spawner the supervisor invokes per spawn. */
@@ -526,6 +529,18 @@ export interface WorkflowSupervisorBindings {
    * for the production duration.
    */
   terminalWriteWatchdogMs?: number;
+  /**
+   * Watchdog timeout (ms) for `reEmitParkedCorrelations`' wait on the
+   * child's `parked-correlations.response`. Caps the wait so a
+   * wedged-but-alive child (whose cohort never tears down, so the
+   * cohort-abort rejection never fires) cannot hang the re-registration
+   * driver -- and therefore the reconnect/re-establishment caller that
+   * awaits it. On expiry the pending query is dropped and the driver
+   * returns; the next re-establishment re-drives it. Defaults to
+   * `DEFAULT_PARKED_QUERY_WATCHDOG_MS`. Tests inject a small value so the
+   * timeout path is observable.
+   */
+  parkedQueryWatchdogMs?: number;
   /**
    * Optional per-message dispatch-timing observer. When supplied, the
    * dispatch loop invokes it twice per dispatched inbox entry: once with

--- a/packages/workflow/src/runtime/park-notify.test.ts
+++ b/packages/workflow/src/runtime/park-notify.test.ts
@@ -11,7 +11,7 @@
 import { describe, test, expect } from "bun:test";
 
 import { createDefaultDirectorRegistry, defineAgent } from "@intx/agent";
-import { signalName } from "@intx/types";
+import { correlationIdFromSignalName, signalName } from "@intx/types";
 import type { ApprovalSnapshot, ConversationTurn } from "@intx/types/runtime";
 
 import {
@@ -22,6 +22,7 @@ import {
   createInMemorySignalChannel,
   createNoopDrainController,
   defineWorkflow,
+  resumeFromLog,
   runtimeRun,
   step,
   type SignalChannel,
@@ -118,6 +119,44 @@ describe("env.onPark at a control-plane suspension", () => {
       if (f.kind !== "StepFailed") throw new Error("unreachable");
       expect(f.error.message).toContain("carries no approval snapshot");
     }
+  });
+
+  test("a snapshot-less correlated suspend commits a durable control-plane SignalAwaited but reduces to failed", async () => {
+    // Pins the invariant re-registration enumeration rests on: `parkOnSignal`
+    // commits `SignalAwaited` to the durable log BEFORE it checks for the
+    // approval snapshot, so a snapshot-less correlated suspend leaves a
+    // control-plane `SignalAwaited` in the log -- yet the run fails and the
+    // step reduces to `failed`, not `awaiting-signal`. Enumeration keys on the
+    // reduced phase, so such a park never surfaces; a consumer that scanned
+    // raw `SignalAwaited` events instead would wrongly surface it.
+    const oneStep = defineWorkflow({
+      id: "park-suspend-durable",
+      trigger: { type: "manual" },
+      steps: { s: step({ agent }) },
+    });
+    const invokeStep: StepInvoker = async () => ({
+      suspend: { correlationId: "corr-durable" },
+    });
+    const env = buildEnv(oneStep, {
+      invokeStep,
+      signalChannel: createInMemorySignalChannel(),
+      onPark: () => undefined,
+    });
+    const runId = "run-durable-fail";
+
+    const result = await runtimeRun(oneStep, env, { runId }).complete;
+    expect(result.terminalStatus).toBe("failed");
+
+    const events = await env.repoStore.read(runId);
+    const controlPlaneAwaited = events.filter(
+      (e) =>
+        e.kind === "SignalAwaited" &&
+        correlationIdFromSignalName(e.signalName) !== undefined,
+    );
+    expect(controlPlaneAwaited.length).toBeGreaterThan(0);
+
+    const state = resumeFromLog(runId, events);
+    expect(state.steps.get("s")?.phase).toBe("failed");
   });
 
   test("a plain awaitSignal gate on an author-chosen name fires no onPark", async () => {

--- a/tests/workflow-deploy/reconnect-reemits-parked-correlation.test.ts
+++ b/tests/workflow-deploy/reconnect-reemits-parked-correlation.test.ts
@@ -1,0 +1,695 @@
+// Acceptance test for INTR-333: a hub reconnect re-emits a parked run's
+// correlation so the run becomes approvable again.
+//
+// The scenario the ticket names is "suspend with the hub down -> hub comes up
+// -> the correlation is registered and the run is approvable". The load-bearing
+// state is the ABSENCE of the parked run's `signal_correlation` + `approval`
+// rows at the hub (the `signal.correlation.register` frame the suspend emitted
+// never co-wrote them) followed by their APPEARANCE after the hub link
+// reconnects. The recovery is the sidecar's Trigger B: on the reconnect
+// ownership challenge the hub-link fires `onWorkflowAddressesRoutable`, which
+// calls `reEmitParkedCorrelations(address)`, which asks the deployment's live
+// supervisor to re-query its child's durably-parked approval correlations and
+// re-emit each through the suspension sink -> a fresh
+// `signal.correlation.register` frame reaches the hub -> the co-write lands the
+// rows -> the run is approvable.
+//
+// Making "the register did not co-write" deterministic
+// ----------------------------------------------------
+// Emitting the register while the hub link is genuinely down would require
+// holding the child in inference across a link drop -- a race with no harness
+// hook to gate it, and this file must not modify the shared harness. Two
+// hub-side facts let the scenario be forced deterministically instead:
+//
+//   1. On a mere WebSocket drop the sidecar subprocess and the deployment's
+//      supervisor stay alive; only the hub link reconnects. The parked run is
+//      never resumed, so the child keeps the approval park in durable state and
+//      still reports it to a `parked-correlations.request`. So dropping the link
+//      does NOT respawn the child: Trigger A (child re-establishment) never
+//      fires on this path, and the ONLY re-emit driver on reconnect is Trigger
+//      B (`onWorkflowAddressesRoutable`).
+//
+//   2. The parked run's `signal_correlation` + `approval` rows are hub-side DB
+//      state. Deleting them while the link is down reproduces exactly the state
+//      a hub that missed the suspend-time register would be in: a child parked
+//      on a correlation with no rows at the hub.
+//
+// So the test fires the trigger with the link up (the run parks and its initial
+// register co-writes the rows -- proving the run genuinely parked and the
+// co-write is wired), captures the correlationId, drops the link, DELETES both
+// rows while disconnected, asserts they are absent, then reconnects and asserts
+// they reappear. The reappearance can ONLY come from the reconnect re-emitting
+// the still-parked correlation's register: no other actor writes these rows,
+// the run is never resumed, and the child is never respawned. A regression that
+// removed the Trigger B re-emit would leave the rows deleted and the poll would
+// time out.
+//
+// Harness justification: SPAWN-REAL. A real hub server, a real sidecar
+// subprocess, a real workflow-process child, and a test inference provider. The
+// suspend/park half runs against the real sidecar through the shared
+// `deploy-flow-env` fixture; the co-write + row assertions run against a real
+// migrated Postgres schema (`@intx/test-harness`), bridged by wiring the fixture
+// hub's `registerSignalCorrelation` lookup to the real DB co-write. The drop is
+// a genuine server-side WebSocket close; the recovery is the sidecar's real
+// `hub-link` reconnect passing the hub's ownership challenge and the supervisor
+// re-emitting the parked correlation.
+//
+// Single-test file. The `deploy-flow-env` (real sidecar subprocess + its
+// on-disk warm step-state) is `beforeAll`-scoped, while the DB resets per test.
+// A second test would inherit the first run's warm workspace and live parked
+// run; a run-once guard below fails loud if a second test is ever added here
+// rather than letting that assumption rot.
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { and, eq } from "drizzle-orm";
+
+import { defineAgent, createDefaultDirectorRegistry } from "@intx/agent";
+import { createApprovalStore, createSignalCorrelationStore } from "@intx/db";
+import {
+  approval,
+  signalCorrelation,
+  workflowDeployment,
+} from "@intx/db/schema";
+import { generateId } from "@intx/hub-common";
+import { type RepoId, type WorkflowRunHubPrincipal } from "@intx/hub-sessions";
+import { signalName } from "@intx/types";
+import type { ApprovalSnapshot, HarnessConfig } from "@intx/types/runtime";
+import { WireGrantRule } from "@intx/types/grant-wire";
+import type { ToolPackagePin } from "@intx/types/tool-packages";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import {
+  seedAsset,
+  seedPrincipal,
+  seedTenants,
+  seedWorkflowDeployment,
+} from "@intx/test-harness/seed";
+import { defineWorkflow, step, type WorkflowDefinition } from "@intx/workflow";
+import {
+  createWorkflowDeployOrchestrator,
+  deriveDeploymentAddress,
+  isWorkflowDerivedAddress,
+  type ApprovalSet,
+  type DeploySingleStepFn,
+  type LaunchSessionFn,
+  type SendMultiStepDeployFn,
+  type WorkflowRepoWriter,
+} from "@intx/workflow-deploy";
+import { deriveDeploymentId } from "@intx/sidecar-app/src/workflow-host-wiring";
+
+import {
+  SESSION_ID,
+  dropHubLink,
+  fireMailTrigger,
+  readWorkflowRunEvents,
+  startDeployFlowEnv,
+  waitFor,
+  waitForFirstRunId,
+  waitForReconnect,
+  type DeployFlowEnv,
+} from "../hub-agent/lib/deploy-flow-env";
+import { toLaunchDeployContent } from "./launch-session-bridge";
+
+const DEPLOYMENT_DOMAIN = "integration.interchange";
+// A legacy `ins_<hex>` deployment identity (not a workflow-derived
+// `ins_dep_<...>` address), matching the reconnect-survival fixtures. The
+// reconnect ownership challenge re-routes it and fires
+// `onWorkflowAddressesRoutable`, which is what drives Trigger B.
+const INSTANCE_LOCAL = "dep0ec0ffee0ec0ffee0ec0ffee0ec0f";
+const DEPLOYMENT_ID = INSTANCE_LOCAL;
+const WORKFLOW_RUN_REF = "refs/heads/main";
+const STEP_ID = "step1";
+
+// The tool the model is told to call. Its grant is `ask`, so the call SUSPENDS
+// instead of running, parking the run on the reserved control-plane channel.
+const TOOL_NAME = "@intx/tools-mail/sidecar-bundle:mail_send";
+const ASK_RESOURCE = `tool:${TOOL_NAME}`;
+
+// The `mail_send` arguments the mock issues. The synthetic bundle writes its
+// `to` argument into the file named by `body`; the run parks before the tool
+// ever runs, so these only travel as far as the approval snapshot's arguments.
+const CALL_TO = "correlation-recovery";
+const CALL_BODY = "reconnect-tool-ran.txt";
+const RESUME_REPLY_PREFIX = "done: ";
+
+const TOOL_PINS: readonly ToolPackagePin[] = [
+  { name: "@intx/tools-mail", version: "0.1.2" },
+];
+
+// The operator-approved `ask` grant shipped in-band on the deploy frame. Effect
+// `ask` is the whole point: the tool call suspends awaiting an external
+// decision rather than running, so the run parks and mints a correlation.
+const ASK_GRANT: WireGrantRule = {
+  id: "grant-tool-ask",
+  resource: ASK_RESOURCE,
+  action: "invoke",
+  effect: "ask",
+  origin: "creator",
+  conditions: null,
+  expiresAt: null,
+  roleId: null,
+  principalId: null,
+};
+
+const TENANT_ID = "tnt_reconnect_reemit";
+const DEFINITION_ASSET_ID = "ast_reconnect_wf";
+const APPROVER_USER_ID = "usr_reconnect_approver";
+const APPROVER_PRINCIPAL_ID = "prn_reconnect_approver";
+
+let env: DeployFlowEnv;
+let h: TestDb;
+
+// The deployment mail address and the workflow-run repo slug the supervisor
+// stamps onto the register frame's `deploymentId`. The co-write resolves
+// tenancy by the address and cross-checks the slug, so the seeded
+// `workflow_deployment` row is keyed by the slug with this address.
+const deploymentMailAddress = deriveDeploymentAddress({
+  deploymentId: DEPLOYMENT_ID,
+  deploymentDomain: DEPLOYMENT_DOMAIN,
+});
+const deploymentSlug = deriveDeploymentId(deploymentMailAddress);
+
+/**
+ * The real hub co-write, mirroring `createHubSessionLookups`'s
+ * `registerSignalCorrelation`: resolve tenancy from the deployed
+ * `workflow_deployment` the address names, cross-check the frame's
+ * `deploymentId` against it, and co-write the `signal_correlation` + `approval`
+ * rows in one transaction through the real stores. Wired into the fixture hub's
+ * sidecar router so both the suspend-time register and the reconnect re-emit
+ * land durable rows on the same schema this test reads. Idempotent via
+ * `registerIfAbsent` / `createIfAbsent`, so a re-emit after a delete re-inserts.
+ */
+function createRegisterSignalCorrelation(db: TestDb["db"]) {
+  const signalCorrelationStore = createSignalCorrelationStore(db);
+  const approvalStore = createApprovalStore(db);
+  return async ({
+    correlationId,
+    runId,
+    deploymentId,
+    agentAddress,
+    kind,
+    approvalSnapshot,
+  }: {
+    correlationId: string;
+    runId: string;
+    deploymentId: string;
+    agentAddress: string;
+    kind: "approval";
+    approvalSnapshot: ApprovalSnapshot;
+  }): Promise<void> => {
+    const deployment = await db
+      .select({
+        id: workflowDeployment.id,
+        tenantId: workflowDeployment.tenantId,
+      })
+      .from(workflowDeployment)
+      .where(
+        and(
+          eq(workflowDeployment.address, agentAddress),
+          eq(workflowDeployment.status, "deployed"),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0]);
+    if (deployment === undefined) {
+      throw new Error(
+        `No deployed workflow deployment for address "${agentAddress}"; cannot register signal correlation ${correlationId}`,
+      );
+    }
+    if (deployment.id !== deploymentId) {
+      throw new Error(
+        `Deployment id mismatch registering signal correlation ${correlationId}: frame claims "${deploymentId}" but address "${agentAddress}" resolves to "${deployment.id}"`,
+      );
+    }
+    const tenantId = deployment.tenantId;
+    await db.transaction(async (tx) => {
+      await signalCorrelationStore.registerIfAbsent(
+        {
+          correlationId,
+          tenantId,
+          deploymentId,
+          agentAddress,
+          runId,
+          signalName: signalName(correlationId),
+          kind,
+        },
+        tx,
+      );
+      await approvalStore.createIfAbsent(
+        {
+          id: generateId("approval"),
+          tenantId,
+          deploymentId,
+          runId,
+          agentAddress,
+          correlationId,
+          status: "pending",
+          toolDefinition: {
+            name: approvalSnapshot.name,
+            description: approvalSnapshot.description,
+            inputSchema: approvalSnapshot.inputSchema,
+          },
+          toolArguments: approvalSnapshot.arguments,
+          scope: null,
+          timeoutAt: null,
+        },
+        tx,
+      );
+    });
+  };
+}
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "a hub reconnect re-emits a parked run's correlation so it is approvable",
+  () => {
+    // Run-once guard. The env (sidecar subprocess + on-disk warm step-state +
+    // the live parked run) is shared across the describe block, so a second
+    // test would inherit this run's parked correlation and the "absent then
+    // present" assertions would stop meaning what they claim. Fail loud if a
+    // second test is ever added rather than letting the assumption rot; a
+    // genuinely independent scenario belongs in its own file with its own env.
+    let hasRun = false;
+
+    beforeAll(async () => {
+      h = await createTestDb();
+      env = await startDeployFlowEnv({
+        // Persistent tool-call mock: re-issue the ask-granted call until its
+        // result is in history, then reply. The run parks on the first call and
+        // is never approved in this test, so it stays parked -- exactly the
+        // durable state Trigger B re-emits on reconnect.
+        inferenceApprovalToolCall: {
+          toolName: TOOL_NAME,
+          input: { to: CALL_TO, body: CALL_BODY },
+          resultPrefix: RESUME_REPLY_PREFIX,
+        },
+        // Wire the real DB co-write into the fixture hub so a register frame
+        // that reaches the hub writes real rows.
+        registerSignalCorrelation: createRegisterSignalCorrelation(h.db),
+      });
+    });
+
+    afterAll(async () => {
+      await env.teardown();
+      await h.close();
+    });
+
+    beforeEach(async () => {
+      await h.reset();
+    });
+
+    test("re-registers the parked correlation on reconnect", async () => {
+      if (hasRun) {
+        throw new Error(
+          "reconnect re-emit acceptance test assumes a single test per shared " +
+            "env: the live parked run and warm step-state carry across, so a " +
+            "second test would break the absent-then-present row assertions. " +
+            "Add a new scenario in its own file with its own env instead.",
+        );
+      }
+      hasRun = true;
+
+      // A legacy `ins_<hex>` deployment address routes through the challenged
+      // reconnect path (the source of Trigger B), not the keyless workflow set.
+      expect(isWorkflowDerivedAddress(deploymentMailAddress)).toBe(false);
+
+      // Seed the tenancy the co-write resolves against: a tenant, the workflow
+      // definition asset the deployment references, the deployment row itself
+      // (keyed by the run-repo slug, addressed by the deployment mail address),
+      // and an active approver principal.
+      await seedTenants(h.db, [{ id: TENANT_ID }]);
+      await seedAsset(h.db, {
+        id: DEFINITION_ASSET_ID,
+        tenantId: TENANT_ID,
+        kind: "workflow",
+        name: "reconnect-reemit-wf",
+      });
+      await seedWorkflowDeployment(h.db, {
+        id: deploymentSlug,
+        tenantId: TENANT_ID,
+        definitionAssetId: DEFINITION_ASSET_ID,
+        address: deploymentMailAddress,
+        publicKey: null,
+        status: "deployed",
+      });
+      await seedPrincipal(h.db, {
+        id: APPROVER_PRINCIPAL_ID,
+        tenantId: TENANT_ID,
+        kind: "user",
+        refId: APPROVER_USER_ID,
+        status: "active",
+      });
+
+      const agent = defineAgent({
+        id: "agent-reconnect-reemit",
+        systemPrompt: "You are the single-step agent under approval control.",
+        tools: [],
+        capabilities: [],
+        inference: {
+          sources: [{ provider: "anthropic", model: "mock-model" }],
+        },
+      });
+
+      const workflow: WorkflowDefinition = defineWorkflow({
+        id: `wf_${DEPLOYMENT_ID}`,
+        trigger: { type: "mail", to: deploymentMailAddress },
+        steps: {
+          [STEP_ID]: step({ agent }),
+        },
+      });
+
+      const config: HarnessConfig = {
+        sessionId: SESSION_ID,
+        agentId: `ins_${DEPLOYMENT_ID}`,
+        tenantId: "tenant-1",
+        principalId: "prin_reconnect-reemit-1",
+        agentAddress: deploymentMailAddress,
+        systemPrompt:
+          "Fallback prompt (overridden per step by the orchestrator)",
+        tools: [],
+        // The `ask`-effect grant makes the tool call suspend in the child
+        // instead of running, so the run parks and mints a correlation.
+        grants: [ASK_GRANT],
+        sources: [
+          {
+            id: "anthropic:mock-model",
+            provider: "anthropic",
+            baseURL: `http://localhost:${String(env.inference.server.port)}`,
+            apiKey: "sk-mock",
+            model: "mock-model",
+          },
+        ],
+        defaultSource: "anthropic:mock-model",
+      };
+
+      const operatorApprovals: ApprovalSet = new Set<string>([
+        "inference.source:anthropic:mock-model",
+        "director:@intx/agent/default",
+        `mail.address:${deploymentMailAddress}`,
+        `mail.send:${DEPLOYMENT_DOMAIN}`,
+      ]);
+
+      const launchSession: LaunchSessionFn = async (orchestratorParams) => {
+        await env.hub.sessionService.stageWorkflowStep({
+          agentAddress: orchestratorParams.agentAddress,
+          agentId: orchestratorParams.agentId,
+          instanceId: orchestratorParams.instanceId,
+          config: orchestratorParams.config,
+          deployContent: toLaunchDeployContent(
+            orchestratorParams.deployContent,
+          ),
+          ...(orchestratorParams.toolPackagePins !== undefined
+            ? { toolPackagePins: orchestratorParams.toolPackagePins }
+            : {}),
+        });
+      };
+
+      const sendMultiStepDeploy: SendMultiStepDeployFn = async (params) =>
+        env.hub.router.sendAgentDeploy(params.agentAddress, params.config, {
+          definition: {
+            id: params.definition.id,
+            triggers: [...params.definition.triggers],
+            stepOrder: [...params.definition.stepOrder],
+            steps: params.definition.steps as Record<string, unknown>,
+            ...(params.definition.state !== undefined
+              ? { state: params.definition.state }
+              : {}),
+          },
+          sources: params.sources,
+        });
+
+      const deploySingleStepAtHead: DeploySingleStepFn = (params) =>
+        env.hub.sessionService.deploySingleStepAtHead(params);
+
+      const workflowRepo: WorkflowRepoWriter = {
+        async writeWorkflowRepo(args) {
+          const repoId: RepoId = { kind: "workflow", id: args.workflowRepoId };
+          const principal: WorkflowRunHubPrincipal = { kind: "hub" };
+          const files: Record<string, string> = {};
+          for (const [k, v] of args.files) {
+            files[k] = v;
+          }
+          await env.hub.agentRepoStore.repoStore.writeTree(
+            principal,
+            repoId,
+            "refs/heads/main",
+            {
+              files,
+              message: `reconnect-reemit test: write workflow repo ${args.workflowRepoId}`,
+            },
+          );
+        },
+      };
+
+      const orchestrator = createWorkflowDeployOrchestrator({
+        directorRegistry: createDefaultDirectorRegistry(),
+        workflowRepo,
+        launchSession,
+        sendMultiStepDeploy,
+        deploySingleStepAtHead,
+      });
+
+      let result: Awaited<ReturnType<typeof orchestrator.deployWorkflow>>;
+      try {
+        result = await orchestrator.deployWorkflow({
+          workflow,
+          config,
+          deployContent: { systemPrompt: config.systemPrompt },
+          operatorApprovals,
+          deploymentId: DEPLOYMENT_ID,
+          deploymentDomain: DEPLOYMENT_DOMAIN,
+          hubPublicKey: "00".repeat(32),
+          toolPackagePins: TOOL_PINS,
+        });
+      } catch (cause) {
+        const message = cause instanceof Error ? cause.message : String(cause);
+        const diag = env.sidecarDiagnostics();
+        throw new Error(
+          `deployWorkflow failed: ${message}\n${diag.length > 0 ? diag : "<no sidecar diagnostics>"}`,
+          { cause },
+        );
+      }
+      expect(result.publicKey).toBeTruthy();
+
+      const workflowRunRepoId: RepoId = {
+        kind: "workflow-run",
+        id: deploymentSlug,
+      };
+      env.registerDeployment({
+        deploymentId: DEPLOYMENT_ID,
+        workflowDefinition: workflow,
+        workflowRunRepoId,
+        workflowRunRef: WORKFLOW_RUN_REF,
+        mailAddress: deploymentMailAddress,
+      });
+
+      // Wait for the deployment to ack its key so the sidecar's hub link is
+      // fully live and the address is routable before firing the trigger and
+      // before the drop below has a challenged address to re-route.
+      await waitFor(() => env.hub.deployAcks.has(deploymentMailAddress), {
+        timeoutMs: 20_000,
+        diagnostics: env.sidecarDiagnostics,
+      });
+      expect(env.hub.router.getRoutableAddresses()).toContain(
+        deploymentMailAddress,
+      );
+
+      // ---- park the run (link up) ----
+      //
+      // Fire the trigger. The model calls the tool; the call hits the ask grant
+      // and suspends, so the run parks and mints a correlation. Because the link
+      // is up, the suspend-time `signal.correlation.register` co-writes the rows
+      // -- which both proves the run genuinely parked and gives us the
+      // correlationId to track across the drop/reconnect.
+      await fireMailTrigger(env, deploymentMailAddress, {
+        messageId: "<reconnect-reemit-1@integration.interchange>",
+      });
+
+      const runId = await waitForFirstRunId(env, workflowRunRepoId, {
+        diagnostics: env.sidecarDiagnostics,
+        timeoutMs: 20_000,
+      });
+
+      // Wait for the co-written pending approval row -- proof the reactor
+      // suspended, the step parked, the register reached the hub, and the hub
+      // co-wrote both rows.
+      await waitFor(
+        async () => {
+          const rows = await h.db
+            .select()
+            .from(approval)
+            .where(eq(approval.deploymentId, deploymentSlug));
+          return rows.length === 1;
+        },
+        { timeoutMs: 20_000, diagnostics: env.sidecarDiagnostics },
+      );
+
+      const parkedApprovalRows = await h.db
+        .select()
+        .from(approval)
+        .where(eq(approval.deploymentId, deploymentSlug));
+      expect(parkedApprovalRows).toHaveLength(1);
+      const parkedApproval = parkedApprovalRows[0];
+      if (parkedApproval === undefined) throw new Error("unreachable");
+      expect(parkedApproval.status).toBe("pending");
+      expect(parkedApproval.runId).toBe(runId);
+      const correlationId = parkedApproval.correlationId;
+
+      // The run has parked, not completed: the workflow-run log carries the
+      // `SignalAwaited` marker for the reserved correlation channel. This is the
+      // durable park the child re-reports to Trigger B's `parked-correlations.
+      // request`, so wait for it to land before disturbing the rows.
+      await waitFor(
+        async () => {
+          const events = await readWorkflowRunEvents(env, DEPLOYMENT_ID, runId);
+          return events.some(
+            (e) =>
+              e.type === "SignalAwaited" &&
+              e.body["signalName"] === signalName(correlationId),
+          );
+        },
+        { timeoutMs: 20_000, diagnostics: env.sidecarDiagnostics },
+      );
+      const parkedTypes = (
+        await readWorkflowRunEvents(env, DEPLOYMENT_ID, runId)
+      ).map((e) => e.type);
+      expect(parkedTypes).not.toContain("RunCompleted");
+      expect(parkedTypes).not.toContain("RunFailed");
+
+      // ---- drop the hub link ----
+      //
+      // A raw drop, not a settle: the run is parked (no pack push is in flight
+      // to interrupt), and severing the link is the whole point. The sidecar
+      // subprocess and the deployment's supervisor stay alive; only the hub link
+      // reconnects, so the parked run is never resumed and the child is never
+      // respawned. The address leaves the hub's routing index on the drop.
+      dropHubLink(env);
+      await waitFor(
+        () =>
+          !env.hub.router
+            .getRoutableAddresses()
+            .includes(deploymentMailAddress),
+        { timeoutMs: 10_000, diagnostics: env.sidecarDiagnostics },
+      );
+
+      // ---- reproduce "the register did not co-write" ----
+      //
+      // Delete the parked run's rows while the link is down. This is exactly the
+      // hub-side state a suspend that emitted its register while the hub was
+      // down would leave: a child parked on a correlation with no rows at the
+      // hub. Deleting while disconnected guarantees no concurrent re-emit can
+      // race the delete (the address is unrouted, so any queued register frame
+      // is dropped by the hub's ownership gate until the challenge re-routes it).
+      await h.db
+        .delete(approval)
+        .where(eq(approval.deploymentId, deploymentSlug));
+      await h.db
+        .delete(signalCorrelation)
+        .where(eq(signalCorrelation.deploymentId, deploymentSlug));
+
+      const approvalsWhileDown = await h.db
+        .select()
+        .from(approval)
+        .where(eq(approval.deploymentId, deploymentSlug));
+      expect(approvalsWhileDown).toHaveLength(0);
+      const correlationsWhileDown = await h.db
+        .select()
+        .from(signalCorrelation)
+        .where(eq(signalCorrelation.deploymentId, deploymentSlug));
+      expect(correlationsWhileDown).toHaveLength(0);
+
+      // ---- reconnect: Trigger B re-emits the parked correlation ----
+      //
+      // The sidecar reconnects and re-proves ownership of the deployment
+      // address. Passing the challenge fires the hub-link's
+      // `onWorkflowAddressesRoutable`, which calls `reEmitParkedCorrelations`:
+      // the supervisor re-queries the child's still-parked approval correlation
+      // and re-emits its register, which now reaches the routed hub and
+      // co-writes the rows again.
+      const reconnectMs = await waitForReconnect(env, deploymentMailAddress, {
+        timeoutMs: 30_000,
+      });
+      // A lower bound guards against a false "already routable" pass that never
+      // actually dropped; the upper bound catches a hung link.
+      expect(reconnectMs).toBeGreaterThan(1_000);
+      expect(reconnectMs).toBeLessThan(30_000);
+      expect(env.hub.router.getRoutableAddresses()).toContain(
+        deploymentMailAddress,
+      );
+
+      // ---- the acceptance criterion: the run is approvable again ----
+      //
+      // The re-emit is fire-and-forget (the reconnect fan-out never awaits it),
+      // so poll with a bounded deadline for both rows to reappear. Their return
+      // can only come from the reconnect re-registering the still-parked
+      // correlation: no other actor writes these rows, the run is never resumed,
+      // and the child is never respawned across a mere link drop. A regression
+      // that dropped the Trigger B re-emit would leave the rows deleted and this
+      // wait would time out.
+      await waitFor(
+        async () => {
+          const correlations = await h.db
+            .select()
+            .from(signalCorrelation)
+            .where(eq(signalCorrelation.correlationId, correlationId));
+          const approvals = await h.db
+            .select()
+            .from(approval)
+            .where(eq(approval.correlationId, correlationId));
+          return correlations.length === 1 && approvals.length === 1;
+        },
+        { timeoutMs: 30_000, diagnostics: env.sidecarDiagnostics },
+      );
+
+      const reemittedCorrelations = await h.db
+        .select()
+        .from(signalCorrelation)
+        .where(eq(signalCorrelation.correlationId, correlationId));
+      expect(reemittedCorrelations).toHaveLength(1);
+      const reemittedCorrelation = reemittedCorrelations[0];
+      if (reemittedCorrelation === undefined) throw new Error("unreachable");
+      expect(reemittedCorrelation.runId).toBe(runId);
+      expect(reemittedCorrelation.agentAddress).toBe(deploymentMailAddress);
+      expect(reemittedCorrelation.signalName).toBe(signalName(correlationId));
+      expect(reemittedCorrelation.resolvedAt).toBeNull();
+
+      const reemittedApprovals = await h.db
+        .select()
+        .from(approval)
+        .where(eq(approval.correlationId, correlationId));
+      expect(reemittedApprovals).toHaveLength(1);
+      const reemittedApproval = reemittedApprovals[0];
+      if (reemittedApproval === undefined) throw new Error("unreachable");
+      // Pending + unresolved: the run is approvable, which is the whole point of
+      // the recovery.
+      expect(reemittedApproval.status).toBe("pending");
+      expect(reemittedApproval.runId).toBe(runId);
+      expect(reemittedApproval.agentAddress).toBe(deploymentMailAddress);
+      expect(reemittedApproval.resolvedAt).toBeNull();
+      // The re-emitted register carried the child's durable approval snapshot,
+      // so the approvable row exposes the same tool the model asked to invoke.
+      expect(reemittedApproval.toolDefinition).toEqual({
+        name: TOOL_NAME,
+        description: "Send a mail message",
+        inputSchema: {
+          type: "object",
+          properties: { to: { type: "string" }, body: { type: "string" } },
+          required: ["to", "body"],
+        },
+      });
+      expect(reemittedApproval.toolArguments).toEqual({
+        to: CALL_TO,
+        body: CALL_BODY,
+      });
+    }, 240_000);
+  },
+);


### PR DESCRIPTION
## Summary

- When an agent step parks on an approval gate, the sidecar re-registers its
  correlation with the hub whenever a fresh child becomes addressable or the hub
  reconnects, so a run parked while the hub was down at suspend time stays
  approvable.
- The workflow child enumerates its parked approval correlations from durable
  state (both warm single-step and cold per-attempt layouts) and answers the
  supervisor's query over the signed control channel.
- The reactor commits a suspended step's pending operation before signalling
  `reactor.gate.blocked`, and orders that signal after the commit and before any
  racing gate clear, so the approval snapshot is durably persisted and
  reconstructable after a restart.

## Verification

- `make all` passes (4752 tests, 0 failures).
- The reconnect flow works end-to-end against the real deploy harness: a warm
  agent parked on an approval, its hub link dropped and its correlation rows
  deleted, becomes approvable again after reconnect
  (`tests/workflow-deploy/reconnect-reemits-parked-correlation.test.ts`).

Closes INTR-333
