### PR TITLE
Paginate the admin approvals list with auto-load on scroll

### DIFF
--- a/apps/admin-ui/src/lib/queries/tenants.test.ts
+++ b/apps/admin-ui/src/lib/queries/tenants.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from "bun:test";
+
+import { approvalsRequestPath } from "./tenants";
+
+describe("approvalsRequestPath", () => {
+  test("omits the query string on the first page", () => {
+    expect(approvalsRequestPath("tnt_1", undefined)).toBe(
+      "/api/tenants/tnt_1/approvals",
+    );
+  });
+
+  test("appends the cursor as a query parameter", () => {
+    expect(approvalsRequestPath("tnt_1", "abc123")).toBe(
+      "/api/tenants/tnt_1/approvals?cursor=abc123",
+    );
+  });
+
+  test("url-encodes a cursor containing reserved characters", () => {
+    expect(approvalsRequestPath("tnt_1", "a b/c+d=")).toBe(
+      "/api/tenants/tnt_1/approvals?cursor=a+b%2Fc%2Bd%3D",
+    );
+  });
+});

--- a/apps/admin-ui/src/lib/queries/tenants.ts
+++ b/apps/admin-ui/src/lib/queries/tenants.ts
@@ -1,5 +1,9 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { queryOptions } from "@tanstack/react-query";
+import {
+  infiniteQueryOptions,
+  queryOptions,
+  type InfiniteData,
+} from "@tanstack/react-query";
 import {
   createBrowserTransport,
   deliverWorkflowSignal,
@@ -325,19 +329,43 @@ export type ApprovalResponse = {
   updatedAt: string;
 };
 
-export function tenantApprovalsQuery(tenantId: string) {
-  return queryOptions({
+// One keyset-paginated page of the approvals list, mirroring the wire envelope
+// the endpoint returns. `nextCursor` is null once the tail is reached.
+export type ApprovalPage = {
+  data: ApprovalResponse[];
+  nextCursor: string | null;
+};
+
+// Builds the request path for one page. The first page carries no cursor; a
+// cursor is opaque and may contain URL-reserved characters, so it is encoded
+// through URLSearchParams rather than interpolated directly.
+export function approvalsRequestPath(
+  tenantId: string,
+  cursor: string | undefined,
+): string {
+  const base = `/api/tenants/${tenantId}/approvals`;
+  if (cursor === undefined) return base;
+  return `${base}?${new URLSearchParams({ cursor }).toString()}`;
+}
+
+export function tenantApprovalsInfiniteQuery(tenantId: string) {
+  // The page param is the cursor, `undefined` on the first page. It is spelled
+  // out as an explicit type argument so `initialPageParam: undefined` and the
+  // `string` cursor from `getNextPageParam` unify to `string | undefined`;
+  // inference alone narrows the seed to `undefined` and rejects the cursor.
+  return infiniteQueryOptions<
+    ApprovalPage,
+    Error,
+    InfiniteData<ApprovalPage>,
+    string[],
+    string | undefined
+  >({
     queryKey: ["tenants", tenantId, "approvals"],
-    queryFn: async () => {
-      // The endpoint is keyset-paginated; the panel renders the first page and
-      // deliberately drops `nextCursor`, matching the other admin list views.
-      // The type mirrors the wire envelope so the discarded field is explicit.
-      const res = await api<{
-        data: ApprovalResponse[];
-        nextCursor: string | null;
-      }>("GET", `/api/tenants/${tenantId}/approvals`);
-      return res.data;
-    },
+    queryFn: ({ pageParam }) =>
+      api<ApprovalPage>("GET", approvalsRequestPath(tenantId, pageParam)),
+    initialPageParam: undefined,
+    // TanStack signals "no more pages" with `undefined`; the wire uses `null`.
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });
 }
 

--- a/apps/admin-ui/src/pages/tenant-approvals.tsx
+++ b/apps/admin-ui/src/pages/tenant-approvals.tsx
@@ -1,9 +1,10 @@
+import { useEffect, useRef } from "react";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 import { TenantNav } from "@/components/tenant-nav";
 import {
-  tenantApprovalsQuery,
+  tenantApprovalsInfiniteQuery,
   type ApprovalResponse,
 } from "@/lib/queries/tenants";
 import { parseApprovalSnapshot } from "@/lib/approval-snapshot";
@@ -61,9 +62,28 @@ export function TenantApprovalsPage() {
   const { tenantId } = useParams({
     from: "/authed/tenants/$tenantId/approvals",
   });
-  const { data: approvals, isLoading } = useQuery(
-    tenantApprovalsQuery(tenantId),
-  );
+  const { data, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useInfiniteQuery(tenantApprovalsInfiniteQuery(tenantId));
+
+  const approvals = data?.pages.flatMap((page) => page.data) ?? [];
+
+  // Auto-load the next page when the sentinel below the table scrolls into
+  // view. The guard keeps a single fetch in flight; the observer re-attaches
+  // whenever `hasNextPage`/`fetchNextPage` change and disconnects on cleanup,
+  // so the callback never closes over a stale `isFetchingNextPage`.
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel || !hasNextPage) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0]?.isIntersecting && !isFetchingNextPage) {
+        void fetchNextPage();
+      }
+    });
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return (
     <div>
@@ -74,7 +94,7 @@ export function TenantApprovalsPage() {
       </p>
       {isLoading ? (
         <p className="mt-4 text-sm text-muted-foreground">Loading...</p>
-      ) : !approvals || approvals.length === 0 ? (
+      ) : approvals.length === 0 ? (
         <p className="mt-4 text-sm text-muted-foreground">
           No pending approvals.
         </p>
@@ -95,6 +115,10 @@ export function TenantApprovalsPage() {
               ))}
             </TableBody>
           </Table>
+          <div ref={sentinelRef} />
+          {isFetchingNextPage ? (
+            <p className="p-3 text-sm text-muted-foreground">Loading more...</p>
+          ) : null}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- The tenant approvals panel reads the endpoint's keyset cursor through an
  infinite query and auto-loads the next page as the operator scrolls to the
  bottom, so every pending approval is reachable rather than only the first
  page (default 50).
- `approvalsRequestPath` builds each page's request path — no cursor on the
  first page, the opaque cursor URL-encoded on subsequent pages.

## Verification

- `make all` passes: lint, `tsc -b`, the admin-ui `vite build`, and the test
  suites (exit 0).
- `approvalsRequestPath` is unit-tested for the first-page, cursor, and
  URL-reserved-character cases.
- Driven in a browser against a seeded tenant: 50 rows render on first load
  and auto-load to all 55 on scroll; a 5-row tenant stays a single page with
  no extra fetch; a 0-row tenant shows "No pending approvals."

Closes INTR-337