### PR TITLE
Add a per-source quirks parameter to provider adapter factories

### DIFF
--- a/packages/inference/src/adapter.test.ts
+++ b/packages/inference/src/adapter.test.ts
@@ -40,6 +40,38 @@ describe("createAdapterRegistry", () => {
     expect(seen).toEqual([source]);
   });
 
+  test("forwards the quirks bag to the factory untouched", () => {
+    const seen: unknown[] = [];
+    const registry = createAdapterRegistry({
+      test: (_source, quirks) => {
+        seen.push(quirks);
+        return createStubAdapter();
+      },
+    });
+
+    const quirks = { some: "bag" };
+    registry.resolve(createSource("test"), quirks);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBe(quirks);
+  });
+
+  test("passes undefined to the factory when the quirks bag is omitted", () => {
+    const seen = { called: false, quirks: "sentinel" as unknown };
+    const registry = createAdapterRegistry({
+      test: (_source, quirks) => {
+        seen.called = true;
+        seen.quirks = quirks;
+        return createStubAdapter();
+      },
+    });
+
+    registry.resolve(createSource("test"));
+
+    expect(seen.called).toBe(true);
+    expect(seen.quirks).toBeUndefined();
+  });
+
   test("invokes the factory fresh on every resolve", () => {
     let calls = 0;
     const registry = createAdapterRegistry({

--- a/packages/inference/src/adapter.ts
+++ b/packages/inference/src/adapter.ts
@@ -59,14 +59,25 @@ export type ProviderAdapter = {
 
 // Builds a fresh adapter for one inference call. Invoked per call so the
 // returned adapter's per-request parser state never leaks across calls.
-export type AdapterFactory = (source: LastCycleSource) => ProviderAdapter;
+//
+// `quirks` is an opaque per-source bag of provider-specific accommodations,
+// passed as a sibling of `source` rather than a field on it: `source` is the
+// slim `LastCycleSource` descriptor that rides on every usage event, whereas
+// quirks are deployment configuration supplied at instantiation. The bag is
+// opaque to everything above the factory; interpreting and validating it is
+// the factory's own responsibility. It is optional: an absent bag means the
+// adapter's default behavior, so callers that have no quirks omit it.
+export type AdapterFactory = (
+  source: LastCycleSource,
+  quirks?: unknown,
+) => ProviderAdapter;
 
 // Resolves an inference source to a provider adapter. Membership is keyed by
 // the source's `provider` identifier; resolution mints a fresh adapter so the
 // per-instance stateful parser is isolated per call and per failover attempt.
 export type AdapterRegistry = {
   has(provider: string): boolean;
-  resolve(source: LastCycleSource): ProviderAdapter;
+  resolve(source: LastCycleSource, quirks?: unknown): ProviderAdapter;
 };
 
 /**
@@ -94,12 +105,12 @@ export function createAdapterRegistry(
     has(provider: string): boolean {
       return byProvider.has(provider);
     },
-    resolve(source: LastCycleSource): ProviderAdapter {
+    resolve(source: LastCycleSource, quirks?: unknown): ProviderAdapter {
       const factory = byProvider.get(source.provider);
       if (factory === undefined) {
         throw new Error(`Unknown inference provider: ${source.provider}`);
       }
-      return factory(source);
+      return factory(source, quirks);
     },
   };
 }

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -808,9 +808,25 @@ function extractPacingDelayMs(headers: Headers): number | undefined {
   return delays.length > 0 ? Math.max(...delays) : undefined;
 }
 
+// The anthropic adapter carries no per-source accommodations today, so its
+// quirks shape is empty. A quirks bag is deployment configuration crossing
+// into the system at this boundary; rejecting unknown keys makes a
+// misconfigured bag — for example an openai quirk pasted onto an anthropic
+// source — fail loudly here rather than run silently ignored.
+export const AnthropicQuirks = type({ "+": "reject" });
+export type AnthropicQuirks = typeof AnthropicQuirks.infer;
+
 export function createAnthropicAdapter(
   source: LastCycleSource,
+  quirks?: unknown,
 ): ProviderAdapter {
+  const parsedQuirks = AnthropicQuirks(quirks ?? {});
+  if (parsedQuirks instanceof type.errors) {
+    throw new Error(
+      `anthropic adapter: invalid quirks: ${parsedQuirks.summary}`,
+    );
+  }
+
   const blockIndexToCallId = new Map<number, string>();
 
   return {

--- a/packages/inference/src/providers/google-genai.ts
+++ b/packages/inference/src/providers/google-genai.ts
@@ -1525,9 +1525,24 @@ function parseResponse(
   return out;
 }
 
+// The google-genai adapter carries no per-source accommodations today, so its
+// quirks shape is empty. A quirks bag is deployment configuration crossing
+// into the system at this boundary; rejecting unknown keys makes a
+// misconfigured bag fail loudly here rather than run silently ignored.
+export const GoogleGenAIQuirks = type({ "+": "reject" });
+export type GoogleGenAIQuirks = typeof GoogleGenAIQuirks.infer;
+
 export function createGoogleGenAIAdapter(
   source: LastCycleSource,
+  quirks?: unknown,
 ): ProviderAdapter {
+  const parsedQuirks = GoogleGenAIQuirks(quirks ?? {});
+  if (parsedQuirks instanceof type.errors) {
+    throw new Error(
+      `google-genai adapter: invalid quirks: ${parsedQuirks.summary}`,
+    );
+  }
+
   // Per-request state lives in the closure: block-index allocation
   // and signature-anchor pairing both need to span SSE events.
   // `buildRequest` does not touch state; only `parseResponse` does.

--- a/packages/inference/src/providers/index.ts
+++ b/packages/inference/src/providers/index.ts
@@ -9,7 +9,7 @@ import { createOpenAIAdapter } from "./openai";
 
 export { createAnthropicAdapter } from "./anthropic";
 export { createGoogleGenAIAdapter } from "./google-genai";
-export { createOpenAIAdapter } from "./openai";
+export { createOpenAIAdapter, OpenAIQuirks } from "./openai";
 
 function builtinFactories(): Record<string, AdapterFactory> {
   return {

--- a/packages/inference/src/providers/index.ts
+++ b/packages/inference/src/providers/index.ts
@@ -7,8 +7,8 @@ import { createAnthropicAdapter } from "./anthropic";
 import { createGoogleGenAIAdapter } from "./google-genai";
 import { createOpenAIAdapter } from "./openai";
 
-export { createAnthropicAdapter } from "./anthropic";
-export { createGoogleGenAIAdapter } from "./google-genai";
+export { createAnthropicAdapter, AnthropicQuirks } from "./anthropic";
+export { createGoogleGenAIAdapter, GoogleGenAIQuirks } from "./google-genai";
 export { createOpenAIAdapter, OpenAIQuirks } from "./openai";
 
 function builtinFactories(): Record<string, AdapterFactory> {

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -26,6 +26,38 @@ const OPENAI_TOOL_NAME_LIMIT: ToolNameLimit = {
   maxLength: 64,
 };
 
+// Per-source accommodations for the OpenAI-compatible backends this adapter
+// serves. Every field is optional; an absent field resolves to today's
+// universal behavior, so a source that supplies no quirks is unchanged.
+export const OpenAIQuirks = type({
+  // Emit `reasoning_content` on every assistant message even when the turn
+  // carried no thinking (kimi requires it whenever thinking is enabled). When
+  // false, the field is emitted only on turns that actually have thinking.
+  "forceAssistantReasoningContent?": "boolean",
+  // Which delta fields to read reasoning tokens from, in precedence order.
+  // Constrained to the fields the chunk schema declares so the type cannot
+  // promise a field the parser would drop before reading.
+  "reasoningFieldNames?": "('reasoning_content' | 'reasoning')[]",
+  // Reject unknown keys so a mistyped quirk name fails loudly at construction
+  // rather than being silently ignored and running with default behavior.
+  "+": "reject",
+});
+export type OpenAIQuirks = typeof OpenAIQuirks.infer;
+
+type ReasoningField = "reasoning_content" | "reasoning";
+
+const DEFAULT_REASONING_FIELDS: readonly ReasoningField[] = [
+  "reasoning_content",
+  "reasoning",
+];
+
+// Quirks resolved to concrete values at the factory edge, so interior code
+// never re-decides a default.
+type ResolvedOpenAIQuirks = {
+  forceAssistantReasoningContent: boolean;
+  reasoningFieldNames: readonly ReasoningField[];
+};
+
 // ---------------------------------------------------------------------------
 // Request building
 // ---------------------------------------------------------------------------
@@ -34,8 +66,11 @@ function buildRequest(
   messages: ConversationTurn[],
   model: string,
   options: InferenceOptions,
+  quirks: ResolvedOpenAIQuirks,
 ): BuiltRequest {
-  const convertedMessages: unknown[] = messages.flatMap(toOpenAIMessage);
+  const convertedMessages: unknown[] = messages.flatMap((msg) =>
+    toOpenAIMessage(msg, quirks.forceAssistantReasoningContent),
+  );
 
   const body: Record<string, unknown> = {
     model,
@@ -108,7 +143,10 @@ function toOpenAIResponseFormat(
   }
 }
 
-function toOpenAIMessage(msg: ConversationTurn): unknown[] {
+function toOpenAIMessage(
+  msg: ConversationTurn,
+  forceAssistantReasoningContent: boolean,
+): unknown[] {
   if (msg.role === "system") {
     const text = msg.content
       .filter((b): b is { type: "text"; text: string } => b.type === "text")
@@ -188,14 +226,23 @@ function toOpenAIMessage(msg: ConversationTurn): unknown[] {
       result["content"] = null;
     }
 
-    // Some providers (e.g. kimi) require reasoning_content on ALL assistant
-    // messages when thinking is enabled. If thinking blocks exist anywhere in
-    // the conversation, every assistant message must carry reasoning_content —
-    // even if empty for that particular turn.
-    result["reasoning_content"] =
-      thinkingBlocks.length > 0
-        ? thinkingBlocks.map((b) => b.thinking).join("")
-        : "";
+    // kimi requires reasoning_content on every assistant message once thinking
+    // is enabled anywhere in the conversation, even on turns that carried no
+    // thinking of their own. forceAssistantReasoningContent (the universal
+    // default, true) satisfies that: the field is always present, empty on a
+    // turn with no thinking. A source whose backend does not share that
+    // requirement sets the quirk false, and the field is emitted only on turns
+    // that actually have thinking.
+    if (forceAssistantReasoningContent) {
+      result["reasoning_content"] =
+        thinkingBlocks.length > 0
+          ? thinkingBlocks.map((b) => b.thinking).join("")
+          : "";
+    } else if (thinkingBlocks.length > 0) {
+      result["reasoning_content"] = thinkingBlocks
+        .map((b) => b.thinking)
+        .join("");
+    }
 
     if (toolCalls.length > 0) {
       result["tool_calls"] = toolCalls.map((tc) => ({
@@ -442,6 +489,7 @@ function parseResponse(
   sseData: string,
   indexer: OpenAIBlockIndexer,
   source: LastCycleSource,
+  reasoningFieldNames: readonly ReasoningField[],
 ): InferenceEvent[] {
   // parseSSE strips the `[DONE]` sentinel before yielding payloads, so
   // anything that reaches us here is supposed to be a JSON chunk. A
@@ -500,19 +548,30 @@ function parseResponse(
   const events: InferenceEvent[] = [];
 
   // Providers stream reasoning tokens under different field names:
-  //   - kimi (via OpenRouter): delta.reasoning
-  //   - kimi (direct): delta.reasoning_content
-  //   - DeepSeek / others: delta.reasoning_content
+  // reasoning_content (kimi direct, DeepSeek) or reasoning (kimi via
+  // OpenRouter). `reasoningFieldNames` gives the fields to read and their
+  // precedence; the first field carrying a non-null value wins. An
+  // empty-string value still claims its slot (matching the prior
+  // `reasoning_content ?? reasoning` short-circuit) and is filtered by the
+  // length gate below.
   //
-  // OpenAI's Chat Completions ships reasoning_content and content as
-  // separate logical content blocks without a wire-level block index.
-  // The parser assigns indices on first observation in arrival order
-  // via the per-request `indexer`: whichever kind streams first lands
-  // at 0, the other (if it appears) at 1. This satisfies the harness's
-  // per-index routing contract — distinct kinds get distinct indices
-  // and the harness's collision detection between block kinds at the
-  // same index never fires from a normal OpenAI response.
-  const reasoning = delta.reasoning_content ?? delta.reasoning;
+  // OpenAI's Chat Completions ships reasoning and content as separate
+  // logical content blocks without a wire-level block index. The parser
+  // assigns indices on first observation in arrival order via the
+  // per-request `indexer`: whichever kind streams first lands at 0, the
+  // other (if it appears) at 1. This satisfies the harness's per-index
+  // routing contract — distinct kinds get distinct indices and the
+  // harness's collision detection between block kinds at the same index
+  // never fires from a normal OpenAI response.
+  let reasoning: string | null | undefined;
+  for (const field of reasoningFieldNames) {
+    const value =
+      field === "reasoning_content" ? delta.reasoning_content : delta.reasoning;
+    if (value !== undefined && value !== null) {
+      reasoning = value;
+      break;
+    }
+  }
   if (typeof reasoning === "string" && reasoning.length > 0) {
     events.push({
       type: "inference.thinking.delta",
@@ -713,7 +772,21 @@ function parseDuration(value: string): number | undefined {
   return total > 0 ? Math.ceil(total) : undefined;
 }
 
-export function createOpenAIAdapter(source: LastCycleSource): ProviderAdapter {
+export function createOpenAIAdapter(
+  source: LastCycleSource,
+  quirks?: unknown,
+): ProviderAdapter {
+  const parsedQuirks = OpenAIQuirks(quirks ?? {});
+  if (parsedQuirks instanceof type.errors) {
+    throw new Error(`openai adapter: invalid quirks: ${parsedQuirks.summary}`);
+  }
+  const resolvedQuirks: ResolvedOpenAIQuirks = {
+    forceAssistantReasoningContent:
+      parsedQuirks.forceAssistantReasoningContent ?? true,
+    reasoningFieldNames:
+      parsedQuirks.reasoningFieldNames ?? DEFAULT_REASONING_FIELDS,
+  };
+
   // Per-request indexer state. Adapter instances are created per
   // request (see `adapter.ts`), so each call to `createOpenAIAdapter`
   // gets a fresh counter for assigning block indices to reasoning vs.
@@ -726,8 +799,15 @@ export function createOpenAIAdapter(source: LastCycleSource): ProviderAdapter {
     toolCallBlockIndex: new Map<number, number>(),
   };
   return {
-    buildRequest,
-    parseResponse: (sseData) => parseResponse(sseData, indexer, source),
+    buildRequest: (messages, model, options) =>
+      buildRequest(messages, model, options, resolvedQuirks),
+    parseResponse: (sseData) =>
+      parseResponse(
+        sseData,
+        indexer,
+        source,
+        resolvedQuirks.reasoningFieldNames,
+      ),
     extractRetryAfterMs,
     extractPacingDelayMs,
   };

--- a/tests/inference/providers/anthropic.test.ts
+++ b/tests/inference/providers/anthropic.test.ts
@@ -1056,3 +1056,23 @@ describe("Anthropic adapter: parseResponse", () => {
     }
   });
 });
+
+describe("Anthropic adapter: quirks", () => {
+  test("constructs with an absent quirks bag", () => {
+    expect(() => createAnthropicAdapter(TEST_SOURCE)).not.toThrow();
+  });
+
+  test("constructs with an explicit undefined quirks bag", () => {
+    expect(() => createAnthropicAdapter(TEST_SOURCE, undefined)).not.toThrow();
+  });
+
+  test("constructs with an empty quirks bag", () => {
+    expect(() => createAnthropicAdapter(TEST_SOURCE, {})).not.toThrow();
+  });
+
+  test("rejects a populated quirks bag since it declares no quirks", () => {
+    expect(() =>
+      createAnthropicAdapter(TEST_SOURCE, { anything: true }),
+    ).toThrow(/invalid quirks/);
+  });
+});

--- a/tests/inference/providers/builtin-registry.test.ts
+++ b/tests/inference/providers/builtin-registry.test.ts
@@ -1,0 +1,56 @@
+import { type } from "arktype";
+import { describe, test, expect } from "bun:test";
+import { createBuiltinRegistry } from "@intx/inference/providers";
+import type { ConversationTurn, LastCycleSource } from "@intx/types/runtime";
+
+const OPENAI_SOURCE: LastCycleSource = {
+  sourceId: "test-openai",
+  provider: "openai",
+  model: "test-openai-model",
+};
+
+// A focused view of the built request: the only field these tests assert on
+// is `reasoning_content` on the first assistant message. Validating through
+// arktype keeps the parsed body typed without an unsafe access; arktype
+// retains the message's other keys, so `"reasoning_content" in message`
+// reflects the wire shape faithfully.
+const AssistantMessageView = type({
+  messages: type({ role: "string", "reasoning_content?": "string" }).array(),
+});
+
+const ASSISTANT_TURN: ConversationTurn[] = [
+  { role: "assistant", content: [{ type: "text", text: "hi" }], timestamp: 1 },
+];
+
+function firstMessageThroughResolve(quirks?: unknown) {
+  const adapter = createBuiltinRegistry().resolve(OPENAI_SOURCE, quirks);
+  const body = AssistantMessageView.assert(
+    JSON.parse(
+      adapter.buildRequest(ASSISTANT_TURN, "test-openai-model", {}).body,
+    ),
+  );
+  const message = body.messages[0];
+  if (message === undefined) throw new Error("expected an assistant message");
+  return message;
+}
+
+describe("createBuiltinRegistry resolves quirks into the real provider factory", () => {
+  test("applies an openai quirk passed through resolve", () => {
+    // forceAssistantReasoningContent:false omits reasoning_content on a turn
+    // with no thinking. Observing that omission on the adapter produced by
+    // resolve proves the quirk bag reaches the real factory through the
+    // registry — the production path the harness takes.
+    const message = firstMessageThroughResolve({
+      forceAssistantReasoningContent: false,
+    });
+    expect("reasoning_content" in message).toBe(false);
+  });
+
+  test("surfaces a factory quirks rejection through resolve", () => {
+    expect(() =>
+      createBuiltinRegistry().resolve(OPENAI_SOURCE, {
+        forceAssistantReasoningContnt: false,
+      }),
+    ).toThrow(/invalid quirks/);
+  });
+});

--- a/tests/inference/providers/google-genai.test.ts
+++ b/tests/inference/providers/google-genai.test.ts
@@ -4203,3 +4203,25 @@ describe("Google GenAI adapter: tool-name codec round-trip", () => {
     expect(start.data.name).toBe(PREFIXED);
   });
 });
+
+describe("Google GenAI adapter: quirks", () => {
+  test("constructs with an absent quirks bag", () => {
+    expect(() => createGoogleGenAIAdapter(TEST_SOURCE)).not.toThrow();
+  });
+
+  test("constructs with an explicit undefined quirks bag", () => {
+    expect(() =>
+      createGoogleGenAIAdapter(TEST_SOURCE, undefined),
+    ).not.toThrow();
+  });
+
+  test("constructs with an empty quirks bag", () => {
+    expect(() => createGoogleGenAIAdapter(TEST_SOURCE, {})).not.toThrow();
+  });
+
+  test("rejects a populated quirks bag since it declares no quirks", () => {
+    expect(() =>
+      createGoogleGenAIAdapter(TEST_SOURCE, { anything: true }),
+    ).toThrow(/invalid quirks/);
+  });
+});

--- a/tests/inference/providers/openai.test.ts
+++ b/tests/inference/providers/openai.test.ts
@@ -1011,3 +1011,191 @@ describe("OpenAI adapter: responseFormat translation", () => {
     });
   });
 });
+
+describe("OpenAI adapter: quirks", () => {
+  const ReasoningContentView = type({ "reasoning_content?": "string" });
+
+  const assistantWithText: ConversationTurn[] = [
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: 1000,
+    },
+  ];
+  const assistantWithThinking: ConversationTurn[] = [
+    {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "pondering" },
+        { type: "text", text: "hello" },
+      ],
+      timestamp: 1000,
+    },
+  ];
+
+  function assistantMessage(
+    adapterInstance: ProviderAdapter,
+    turns: ConversationTurn[],
+  ) {
+    const req = adapterInstance.buildRequest(turns, "gpt-4o", {});
+    const body = OpenAIRequestBody.assert(JSON.parse(req.body));
+    const message = body.messages[0];
+    if (message === undefined) throw new Error("expected an assistant message");
+    return message;
+  }
+
+  test("absent quirks emit reasoning_content on assistant turns without thinking", () => {
+    const message = assistantMessage(
+      createOpenAIAdapter(TEST_SOURCE),
+      assistantWithText,
+    );
+    expect(ReasoningContentView.assert(message).reasoning_content).toBe("");
+  });
+
+  test("forceAssistantReasoningContent false omits reasoning_content on turns without thinking", () => {
+    const message = assistantMessage(
+      createOpenAIAdapter(TEST_SOURCE, {
+        forceAssistantReasoningContent: false,
+      }),
+      assistantWithText,
+    );
+    expect("reasoning_content" in message).toBe(false);
+  });
+
+  test("forceAssistantReasoningContent false still emits reasoning_content on turns with thinking", () => {
+    const message = assistantMessage(
+      createOpenAIAdapter(TEST_SOURCE, {
+        forceAssistantReasoningContent: false,
+      }),
+      assistantWithThinking,
+    );
+    expect(ReasoningContentView.assert(message).reasoning_content).toBe(
+      "pondering",
+    );
+  });
+
+  test("absent quirks read reasoning from reasoning_content, then reasoning", async () => {
+    const fromContent = await parseWire(createOpenAIAdapter(TEST_SOURCE), [
+      wire.openai.chunk({ reasoningContent: "abc" }),
+    ]);
+    expect(fromContent).toHaveLength(1);
+    expect(fromContent[0]?.type).toBe("inference.thinking.delta");
+    if (fromContent[0]?.type === "inference.thinking.delta") {
+      expect(fromContent[0].data.token).toBe("abc");
+    }
+
+    const fromReasoning = await parseWire(createOpenAIAdapter(TEST_SOURCE), [
+      wire.openai.chunk({ reasoning: "xyz" }),
+    ]);
+    expect(fromReasoning).toHaveLength(1);
+    if (fromReasoning[0]?.type === "inference.thinking.delta") {
+      expect(fromReasoning[0].data.token).toBe("xyz");
+    }
+  });
+
+  test("reasoningFieldNames [reasoning] reads only delta.reasoning", async () => {
+    const ignored = await parseWire(
+      createOpenAIAdapter(TEST_SOURCE, { reasoningFieldNames: ["reasoning"] }),
+      [wire.openai.chunk({ reasoningContent: "abc" })],
+    );
+    expect(ignored).toEqual([]);
+
+    const read = await parseWire(
+      createOpenAIAdapter(TEST_SOURCE, { reasoningFieldNames: ["reasoning"] }),
+      [wire.openai.chunk({ reasoning: "xyz" })],
+    );
+    expect(read).toHaveLength(1);
+    if (read[0]?.type === "inference.thinking.delta") {
+      expect(read[0].data.token).toBe("xyz");
+    }
+  });
+
+  test("reasoningFieldNames [] reads no reasoning", async () => {
+    const events = await parseWire(
+      createOpenAIAdapter(TEST_SOURCE, { reasoningFieldNames: [] }),
+      [wire.openai.chunk({ reasoningContent: "abc" })],
+    );
+    expect(events).toEqual([]);
+  });
+
+  test("reasoning precedence follows configured order, not wire order", async () => {
+    const reasoningFirst = await parseWire(
+      createOpenAIAdapter(TEST_SOURCE, {
+        reasoningFieldNames: ["reasoning", "reasoning_content"],
+      }),
+      [wire.openai.chunk({ reasoningContent: "cc", reasoning: "rr" })],
+    );
+    expect(reasoningFirst).toHaveLength(1);
+    if (reasoningFirst[0]?.type === "inference.thinking.delta") {
+      expect(reasoningFirst[0].data.token).toBe("rr");
+    }
+
+    const contentFirst = await parseWire(createOpenAIAdapter(TEST_SOURCE), [
+      wire.openai.chunk({ reasoningContent: "cc", reasoning: "rr" }),
+    ]);
+    expect(contentFirst).toHaveLength(1);
+    if (contentFirst[0]?.type === "inference.thinking.delta") {
+      expect(contentFirst[0].data.token).toBe("cc");
+    }
+  });
+
+  test("rejects a quirks bag with a wrong field type at construction", () => {
+    expect(() =>
+      createOpenAIAdapter(TEST_SOURCE, {
+        forceAssistantReasoningContent: "yes",
+      }),
+    ).toThrow(/invalid quirks/);
+  });
+
+  test("rejects a reasoning field name the adapter cannot read", () => {
+    expect(() =>
+      createOpenAIAdapter(TEST_SOURCE, { reasoningFieldNames: ["thinking"] }),
+    ).toThrow(/invalid quirks/);
+  });
+
+  test("rejects an unknown quirk key so a typo fails loudly", () => {
+    expect(() =>
+      createOpenAIAdapter(TEST_SOURCE, {
+        forceAssistantReasoningContnt: false,
+      }),
+    ).toThrow(/invalid quirks/);
+  });
+
+  test("an empty-string reasoning field claims its slot and suppresses lower precedence", async () => {
+    // Matches the prior `reasoning_content ?? reasoning` short-circuit: an
+    // empty string is a present value, so it wins its precedence slot and the
+    // length gate then drops it — the lower-precedence `reasoning` is never
+    // read. "First non-empty wins" would instead surface "xyz"; it must not.
+    const events = await parseWire(createOpenAIAdapter(TEST_SOURCE), [
+      wire.openai.chunk({ reasoningContent: "", reasoning: "xyz" }),
+    ]);
+    expect(events).toEqual([]);
+  });
+
+  test("a null reasoning field is skipped so a lower-precedence field is read", async () => {
+    // `reasoning_content` is declared `string | null` on the wire; a null
+    // value falls through to the next configured field, matching the prior
+    // `??` null-skip. The wire DSL cannot emit an explicit null, so this drives
+    // a raw chunk.
+    const events = await parseWire(createOpenAIAdapter(TEST_SOURCE), [
+      wire.openai.raw(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-test",
+          object: "chat.completion.chunk",
+          choices: [
+            {
+              index: 0,
+              delta: { reasoning_content: null, reasoning: "xyz" },
+              finish_reason: null,
+            },
+          ],
+        })}\n\n`,
+      ),
+    ]);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe("inference.thinking.delta");
+    if (events[0]?.type === "inference.thinking.delta") {
+      expect(events[0].data.token).toBe("xyz");
+    }
+  });
+});

--- a/tests/inference/providers/quirks-exports.test.ts
+++ b/tests/inference/providers/quirks-exports.test.ts
@@ -1,0 +1,52 @@
+import { type } from "arktype";
+import { describe, test, expect } from "bun:test";
+import {
+  AnthropicQuirks,
+  GoogleGenAIQuirks,
+  OpenAIQuirks,
+} from "@intx/inference/providers";
+
+// These import the quirk validators from the package boundary rather than a
+// relative path on purpose: the point is to prove the re-exports in the
+// providers barrel are wired up. A dropped or renamed re-export would pass
+// tsc and every other suite, because nothing else imports these symbols; only
+// exercising them from `@intx/inference/providers` catches it. The catalog
+// resolver builds typed quirk values against exactly these exports.
+describe("provider quirk validators are exported and usable", () => {
+  test("OpenAIQuirks validates a well-formed bag and returns the value", () => {
+    const parsed = OpenAIQuirks({
+      forceAssistantReasoningContent: false,
+      reasoningFieldNames: ["reasoning"],
+    });
+    expect(parsed instanceof type.errors).toBe(false);
+    if (!(parsed instanceof type.errors)) {
+      expect(parsed.reasoningFieldNames).toEqual(["reasoning"]);
+      expect(parsed.forceAssistantReasoningContent).toBe(false);
+    }
+  });
+
+  test("OpenAIQuirks rejects a reasoning field name it cannot read", () => {
+    expect(
+      OpenAIQuirks({ reasoningFieldNames: ["thinking"] }) instanceof
+        type.errors,
+    ).toBe(true);
+  });
+
+  test("OpenAIQuirks rejects an unknown key", () => {
+    expect(OpenAIQuirks({ nope: true }) instanceof type.errors).toBe(true);
+  });
+
+  test("AnthropicQuirks and GoogleGenAIQuirks accept an empty bag", () => {
+    expect(AnthropicQuirks({}) instanceof type.errors).toBe(false);
+    expect(GoogleGenAIQuirks({}) instanceof type.errors).toBe(false);
+  });
+
+  test("AnthropicQuirks and GoogleGenAIQuirks reject a populated bag", () => {
+    expect(AnthropicQuirks({ anything: true }) instanceof type.errors).toBe(
+      true,
+    );
+    expect(GoogleGenAIQuirks({ anything: true }) instanceof type.errors).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Provider adapter factories and the registry's `resolve` accept an optional
  opaque `quirks` bag, which each factory validates into its own typed arktype
  shape; an absent bag reproduces each adapter's prior universal behavior.
- The openai adapter (which also serves `openai-compatible`) exposes two
  per-source quirks — `forceAssistantReasoningContent` and `reasoningFieldNames`
  — with unknown keys and unreadable field names rejected loudly at construction.
- The anthropic and google-genai adapters declare empty quirk shapes that reject
  any populated bag, so a bag meant for another provider fails at the boundary.

## Verification

The build passes (`make all` exits 0; 4269 + 391 tests). No in-tree caller
behavior changes: the sole production caller resolves adapters with no quirks
and is unchanged. Tests cover both quirks' default and non-default paths, the
exported validators from the package boundary, and quirk resolution through the
builtin registry into a real factory.

Closes INTR-139