### PR TITLE
Carry per-deployment adapter quirks through the inference catalog

### DIFF
--- a/bin/lib/catalog-seed-data.test.ts
+++ b/bin/lib/catalog-seed-data.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "bun:test";
+import { type, type Type } from "arktype";
+
+import {
+  AnthropicQuirks,
+  GoogleGenAIQuirks,
+  OpenAIQuirks,
+} from "@intx/inference/providers";
+
+import { catalogProviders, type CatalogPlugin } from "./catalog-seed-data";
+
+// Each catalog plugin maps to the adapter quirk validator that governs the
+// shape its offerings may carry. `openai` and `openai-compatible` share the
+// OpenAI adapter, so they share its validator.
+const quirkValidatorByPlugin: Record<CatalogPlugin, Type> = {
+  anthropic: AnthropicQuirks,
+  openai: OpenAIQuirks,
+  "openai-compatible": OpenAIQuirks,
+  "google-genai": GoogleGenAIQuirks,
+};
+
+function isPlainObject(value: unknown): boolean {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+describe("catalog seed offering quirks", () => {
+  for (const provider of catalogProviders) {
+    for (const offering of provider.offerings) {
+      const label = `${provider.name} / ${offering.model}`;
+
+      test(`${label} carries an explicit plain-object quirks bag`, () => {
+        expect(isPlainObject(offering.quirks)).toBe(true);
+      });
+
+      test(`${label} quirks validate against the ${provider.plugin} adapter`, () => {
+        const validator = quirkValidatorByPlugin[provider.plugin];
+        expect(validator(offering.quirks) instanceof type.errors).toBe(false);
+      });
+    }
+  }
+});

--- a/bin/lib/catalog-seed-data.ts
+++ b/bin/lib/catalog-seed-data.ts
@@ -1,0 +1,211 @@
+// Declarative catalog seed data for the local development database.
+//
+// bin/seed.ts drives these specs through the catalog HTTP API. The colocated
+// catalog-seed-data.test.ts is the CI guard: it asserts every offering's
+// quirks bag is a plain object that validates against its adapter's quirk
+// schema, so a seeded deployment can never ship an accommodation the adapter
+// would reject.
+//
+// This module is pure data and types — no HTTP, no side effects — so the
+// guard test can import it without pulling in the seed's network machinery.
+
+export type CatalogPlugin =
+  | "anthropic"
+  | "openai"
+  | "openai-compatible"
+  | "google-genai";
+
+export type CatalogModelSpec = {
+  canonicalName: string;
+  displayName: string;
+};
+
+export type CatalogOfferingSpec = {
+  // References a CatalogModelSpec.canonicalName.
+  model: string;
+  // Lower is preferred first when several deployments serve one model.
+  priority: number;
+  capabilities: string[];
+  // Per-deployment adapter accommodations, explicit on every offering (the
+  // guard enforces it) even when empty. See OPENAI_REASONING_QUIRKS for why
+  // the openai-plugin deployments spell out today's universal defaults.
+  quirks: Record<string, unknown>;
+  // Dev pricing as decimal strings, matching the API's string money fields.
+  price: { input: string; output: string };
+};
+
+export type CatalogProviderSpec = {
+  // Names both the catalog provider and the backing old-system provider row
+  // that owns its credential.
+  name: string;
+  plugin: CatalogPlugin;
+  baseURL: string;
+  credentialName: string;
+  // Fake dev secret; never a real key.
+  credentialSecret: string;
+  offerings: CatalogOfferingSpec[];
+};
+
+// The OpenAI adapter today forces reasoning_content on every assistant turn
+// and reads reasoning tokens from these fields, applying this to every
+// openai/openai-compatible source by default. kimi-serving backends depend on
+// that behavior. Spelling it out per deployment matches what these sources
+// implicitly rely on now, so the universal default can later be removed
+// without regressing them. The value equals the current default on purpose:
+// it is the accommodation being made explicit, not a deviation from it.
+const OPENAI_REASONING_QUIRKS: Record<string, unknown> = {
+  forceAssistantReasoningContent: true,
+  reasoningFieldNames: ["reasoning_content", "reasoning"],
+};
+
+export const catalogModels: CatalogModelSpec[] = [
+  { canonicalName: "claude-sonnet-4", displayName: "Claude Sonnet 4" },
+  { canonicalName: "claude-haiku-4", displayName: "Claude Haiku 4" },
+  { canonicalName: "gpt-4o", displayName: "GPT-4o" },
+  { canonicalName: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro" },
+  { canonicalName: "kimi-k2", displayName: "Kimi K2" },
+  { canonicalName: "kimi-k2.6", displayName: "Kimi K2.6" },
+];
+
+// The Fireworks / Moonshot / OpenRouter providers all offer the one `kimi-k2`
+// model, and the two OpenCode Zen providers both offer `kimi-k2.6`. Distinct
+// priorities give source resolution a deterministic order across the
+// deployments of a shared model. anthropic and google-genai adapters carry no
+// accommodations, so their offerings' quirks bag is empty.
+export const catalogProviders: CatalogProviderSpec[] = [
+  {
+    name: "Anthropic Direct",
+    plugin: "anthropic",
+    baseURL: "https://api.anthropic.com",
+    credentialName: "Anthropic Direct Key",
+    credentialSecret: "sk-ant-fake-key-for-seed-data",
+    offerings: [
+      {
+        model: "claude-sonnet-4",
+        priority: 0,
+        capabilities: ["tool-use", "long-context"],
+        quirks: {},
+        price: { input: "0.000003", output: "0.000015" },
+      },
+      {
+        model: "claude-haiku-4",
+        priority: 10,
+        capabilities: ["tool-use"],
+        quirks: {},
+        price: { input: "0.0000008", output: "0.000004" },
+      },
+    ],
+  },
+  {
+    name: "OpenAI Direct",
+    plugin: "openai",
+    baseURL: "https://api.openai.com/v1",
+    credentialName: "OpenAI Direct Key",
+    credentialSecret: "sk-openai-fake-key-for-seed-data",
+    offerings: [
+      {
+        model: "gpt-4o",
+        priority: 0,
+        capabilities: ["tool-use", "structured-output"],
+        quirks: OPENAI_REASONING_QUIRKS,
+        price: { input: "0.0000025", output: "0.00001" },
+      },
+    ],
+  },
+  {
+    name: "Gemini Direct",
+    plugin: "google-genai",
+    baseURL: "https://generativelanguage.googleapis.com",
+    credentialName: "Gemini Direct Key",
+    credentialSecret: "AIza-fake-key-for-seed-data",
+    offerings: [
+      {
+        model: "gemini-2.5-pro",
+        priority: 0,
+        capabilities: ["tool-use", "long-context"],
+        quirks: {},
+        price: { input: "0.00000125", output: "0.00001" },
+      },
+    ],
+  },
+  {
+    name: "Fireworks Kimi",
+    plugin: "openai-compatible",
+    baseURL: "https://api.fireworks.ai/inference/v1",
+    credentialName: "Fireworks Kimi Key",
+    credentialSecret: "fw-fake-key-for-seed-data",
+    offerings: [
+      {
+        model: "kimi-k2",
+        priority: 0,
+        capabilities: ["tool-use"],
+        quirks: OPENAI_REASONING_QUIRKS,
+        price: { input: "0.0000006", output: "0.0000025" },
+      },
+    ],
+  },
+  {
+    name: "Moonshot Kimi",
+    plugin: "openai-compatible",
+    baseURL: "https://api.moonshot.ai/v1",
+    credentialName: "Moonshot Kimi Key",
+    credentialSecret: "sk-moonshot-fake-key-for-seed-data",
+    offerings: [
+      {
+        model: "kimi-k2",
+        priority: 10,
+        capabilities: ["tool-use"],
+        quirks: OPENAI_REASONING_QUIRKS,
+        price: { input: "0.0000006", output: "0.0000025" },
+      },
+    ],
+  },
+  {
+    name: "OpenRouter Kimi",
+    plugin: "openai-compatible",
+    baseURL: "https://openrouter.ai/api/v1",
+    credentialName: "OpenRouter Kimi Key",
+    credentialSecret: "sk-or-fake-key-for-seed-data",
+    offerings: [
+      {
+        model: "kimi-k2",
+        priority: 20,
+        capabilities: ["tool-use"],
+        quirks: OPENAI_REASONING_QUIRKS,
+        price: { input: "0.0000006", output: "0.0000025" },
+      },
+    ],
+  },
+  {
+    name: "OpenCode Zen v1",
+    plugin: "openai-compatible",
+    baseURL: "https://opencode.ai/zen/v1",
+    credentialName: "OpenCode Zen v1 Key",
+    credentialSecret: "ocz-fake-key-for-seed-data",
+    offerings: [
+      {
+        model: "kimi-k2.6",
+        priority: 0,
+        capabilities: ["tool-use"],
+        quirks: OPENAI_REASONING_QUIRKS,
+        price: { input: "0.0000006", output: "0.0000025" },
+      },
+    ],
+  },
+  {
+    name: "OpenCode Zen Go v1",
+    plugin: "openai-compatible",
+    baseURL: "https://opencode.ai/zen/go/v1",
+    credentialName: "OpenCode Zen Go v1 Key",
+    credentialSecret: "ocz-go-fake-key-for-seed-data",
+    offerings: [
+      {
+        model: "kimi-k2.6",
+        priority: 10,
+        capabilities: ["tool-use"],
+        quirks: OPENAI_REASONING_QUIRKS,
+        price: { input: "0.0000006", output: "0.0000025" },
+      },
+    ],
+  },
+];

--- a/bin/seed.ts
+++ b/bin/seed.ts
@@ -43,6 +43,7 @@ import {
   WORKFLOW_RUN_GRANT_ACTION,
   WORKFLOW_RUN_GRANT_RESOURCE,
 } from "./workflow-fixture";
+import { catalogModels, catalogProviders } from "./lib/catalog-seed-data";
 
 const AuthResponse = type({ "user?": { id: "string" } });
 
@@ -197,6 +198,15 @@ function checkOrSkip(
     `[seed] FAIL ${label}: expected ${expected}, got ${status}\n`,
   );
   process.stderr.write(`[seed]   ${JSON.stringify(data)}\n`);
+  process.exit(1);
+}
+
+// A row that a create returned 201 or 409 for must appear in the subsequent
+// list. When it does not, the seed is in an inconsistent state (a create that
+// did not persist, a list that truncated), so fail loudly rather than skip
+// and leave dangling rows behind.
+function fatalMissing(label: string): never {
+  process.stderr.write(`[seed] FAIL ${label}: not found after create\n`);
   process.exit(1);
 }
 
@@ -1106,146 +1116,186 @@ if (supportBot) {
 }
 
 // -- Create model catalog --
+//
+// The declarative deployment set lives in ./lib/catalog-seed-data; this driver
+// walks it. Each catalog provider gets a dedicated old-system provider (so its
+// credential has a provider FK) and a credential, then the catalog provider,
+// its offerings (carrying explicit quirks), and pricing. Ids are resolved by
+// listing after each create so the seed stays idempotent across re-runs where
+// a POST returns 409.
 
 log("Creating model catalog...");
 
 const CredentialIdName = type({ id: "string", name: "string" });
 
-// The model provider authenticates with a tenant credential. Reuse the
-// Anthropic API key created above; list and find it so the seed is
-// idempotent across re-runs.
-const { data: acmeCredsData } = await api(
+for (const m of catalogModels) {
+  const { status, data } = await api(
+    "POST",
+    `/api/tenants/${acmeTenantId}/catalog/models`,
+    { canonicalName: m.canonicalName, displayName: m.displayName },
+    aliceCookies,
+  );
+  checkOrSkip(`create model ${m.canonicalName}`, status, 201, data);
+}
+
+const { data: catalogModelListData } = await api(
   "GET",
-  `/api/tenants/${acmeTenantId}/credentials`,
+  `/api/tenants/${acmeTenantId}/catalog/models`,
   undefined,
   aliceCookies,
 );
-const anthropicCredential = parse(
-  paginatedSchema(CredentialIdName),
-  acmeCredsData,
-  "acme credentials response",
-).data.find((c) => c.name === "Anthropic API Key");
+const modelIdByName = new Map(
+  parse(
+    paginatedSchema(ModelResponse),
+    catalogModelListData,
+    "catalog models response",
+  ).data.map((m) => [m.canonicalName, m.id]),
+);
 
-if (anthropicCredential) {
-  const modelsToSeed = [
-    { canonicalName: "claude-sonnet-4", displayName: "Claude Sonnet 4" },
-    { canonicalName: "claude-haiku-4", displayName: "Claude Haiku 4" },
-  ];
-  for (const m of modelsToSeed) {
-    const { status, data } = await api(
-      "POST",
-      `/api/tenants/${acmeTenantId}/catalog/models`,
-      m,
-      aliceCookies,
-    );
-    checkOrSkip(`create model ${m.canonicalName}`, status, 201, data);
-  }
+for (const p of catalogProviders) {
+  // Old-system provider that owns the credential. Its plugin mirrors the
+  // catalog plugin (the old provider's plugin is free-form) and the metadata
+  // baseURL matches the catalog endpoint.
+  const { status: intgStatus, data: intgData } = await api(
+    "POST",
+    `/api/tenants/${acmeTenantId}/providers`,
+    { name: p.name, plugin: p.plugin, metadata: { baseURL: p.baseURL } },
+    aliceCookies,
+  );
+  checkOrSkip(
+    `create integration provider ${p.name}`,
+    intgStatus,
+    201,
+    intgData,
+  );
+
+  const { data: intgListData } = await api(
+    "GET",
+    `/api/tenants/${acmeTenantId}/providers`,
+    undefined,
+    aliceCookies,
+  );
+  const integrationProvider = parse(
+    paginatedSchema(ProviderResponse),
+    intgListData,
+    "integration providers response",
+  ).data.find((x) => x.name === p.name);
+  if (!integrationProvider) fatalMissing(`integration provider ${p.name}`);
+
+  // Every dev deployment authenticates with an API key.
+  const { status: credStatus, data: credData } = await api(
+    "POST",
+    `/api/tenants/${acmeTenantId}/credentials`,
+    {
+      name: p.credentialName,
+      type: "api_key",
+      providerId: integrationProvider.id,
+      secret: p.credentialSecret,
+      scopes: ["chat"],
+    },
+    aliceCookies,
+  );
+  checkOrSkip(
+    `create credential ${p.credentialName}`,
+    credStatus,
+    201,
+    credData,
+  );
+
+  const { data: credListData } = await api(
+    "GET",
+    `/api/tenants/${acmeTenantId}/credentials`,
+    undefined,
+    aliceCookies,
+  );
+  const credential = parse(
+    paginatedSchema(CredentialIdName),
+    credListData,
+    "credentials response",
+  ).data.find((c) => c.name === p.credentialName);
+  if (!credential) fatalMissing(`credential ${p.credentialName}`);
 
   const { status: provStatus, data: provData } = await api(
     "POST",
     `/api/tenants/${acmeTenantId}/catalog/providers`,
     {
-      name: "Anthropic Direct",
-      plugin: "anthropic",
-      baseURL: "https://api.anthropic.com",
-      credentialId: anthropicCredential.id,
+      name: p.name,
+      plugin: p.plugin,
+      baseURL: p.baseURL,
+      credentialId: credential.id,
     },
     aliceCookies,
   );
-  checkOrSkip("create provider Anthropic Direct", provStatus, 201, provData);
+  checkOrSkip(`create catalog provider ${p.name}`, provStatus, 201, provData);
 
-  // Resolve catalog ids by listing, so offering/pricing creation works on a
-  // re-run where the create calls above returned 409.
-  const { data: modelListData } = await api(
-    "GET",
-    `/api/tenants/${acmeTenantId}/catalog/models`,
-    undefined,
-    aliceCookies,
-  );
-  const catalogModels = parse(
-    paginatedSchema(ModelResponse),
-    modelListData,
-    "catalog models response",
-  ).data;
   const { data: provListData } = await api(
     "GET",
     `/api/tenants/${acmeTenantId}/catalog/providers`,
     undefined,
     aliceCookies,
   );
-  const anthropicProviderRow = parse(
+  const catalogProviderRow = parse(
     paginatedSchema(ModelProviderResponse),
     provListData,
     "catalog providers response",
-  ).data.find((p) => p.name === "Anthropic Direct");
+  ).data.find((x) => x.name === p.name);
+  if (!catalogProviderRow) fatalMissing(`catalog provider ${p.name}`);
 
-  const sonnet = catalogModels.find(
-    (m) => m.canonicalName === "claude-sonnet-4",
-  );
-  const haiku = catalogModels.find((m) => m.canonicalName === "claude-haiku-4");
-
-  if (anthropicProviderRow && sonnet && haiku) {
-    const offeringSpecs = [
-      {
-        model: sonnet,
-        priority: 0,
-        capabilities: ["tool-use", "long-context"],
-      },
-      { model: haiku, priority: 10, capabilities: ["tool-use"] },
-    ];
-    for (const spec of offeringSpecs) {
-      const { status, data } = await api(
-        "POST",
-        `/api/tenants/${acmeTenantId}/catalog/offerings`,
-        {
-          modelId: spec.model.id,
-          providerId: anthropicProviderRow.id,
-          priority: spec.priority,
-          capabilities: spec.capabilities,
-        },
-        aliceCookies,
-      );
-      checkOrSkip(
-        `create offering ${spec.model.canonicalName}`,
-        status,
-        201,
-        data,
-      );
+  for (const o of p.offerings) {
+    const modelId = modelIdByName.get(o.model);
+    if (modelId === undefined) {
+      log(`  SKIP offering ${p.name}/${o.model} (model not seeded)`);
+      continue;
     }
-
-    const { data: offeringListData } = await api(
-      "GET",
+    const { status, data } = await api(
+      "POST",
       `/api/tenants/${acmeTenantId}/catalog/offerings`,
-      undefined,
+      {
+        modelId,
+        providerId: catalogProviderRow.id,
+        priority: o.priority,
+        capabilities: o.capabilities,
+        quirks: o.quirks,
+      },
       aliceCookies,
     );
-    const catalogOfferings = parse(
-      paginatedSchema(ModelOfferingResponse),
-      offeringListData,
-      "catalog offerings response",
-    ).data;
-    const priceByModel: Record<string, { input: string; output: string }> = {
-      [sonnet.id]: { input: "0.000003", output: "0.000015" },
-      [haiku.id]: { input: "0.0000008", output: "0.000004" },
-    };
-    for (const offering of catalogOfferings) {
-      const price = priceByModel[offering.modelId];
-      if (!price) continue;
-      const { status, data } = await api(
-        "POST",
-        `/api/tenants/${acmeTenantId}/catalog/offerings/${offering.id}/pricing`,
-        {
-          currency: "USD",
-          // Pinned so a seed re-run collides on (offering, currency,
-          // effectiveFrom) and skips rather than appending a duplicate.
-          effectiveFrom: "2024-01-01T00:00:00.000Z",
-          inputTokenPrice: price.input,
-          outputTokenPrice: price.output,
-        },
-        aliceCookies,
-      );
-      checkOrSkip(`create pricing for ${offering.id}`, status, 201, data);
-    }
+    checkOrSkip(`create offering ${p.name}/${o.model}`, status, 201, data);
+  }
+
+  const { data: offeringListData } = await api(
+    "GET",
+    `/api/tenants/${acmeTenantId}/catalog/offerings`,
+    undefined,
+    aliceCookies,
+  );
+  const catalogOfferings = parse(
+    paginatedSchema(ModelOfferingResponse),
+    offeringListData,
+    "catalog offerings response",
+  ).data;
+  for (const o of p.offerings) {
+    const modelId = modelIdByName.get(o.model);
+    // The create loop already logged and skipped an offering whose model was
+    // not seeded; skip pricing for it too rather than treating it as missing.
+    if (modelId === undefined) continue;
+    const offering = catalogOfferings.find(
+      (x) => x.providerId === catalogProviderRow.id && x.modelId === modelId,
+    );
+    if (!offering) fatalMissing(`offering ${p.name}/${o.model}`);
+    const { status, data } = await api(
+      "POST",
+      `/api/tenants/${acmeTenantId}/catalog/offerings/${offering.id}/pricing`,
+      {
+        currency: "USD",
+        // Pinned so a seed re-run collides on (offering, currency,
+        // effectiveFrom) and skips rather than appending a duplicate.
+        effectiveFrom: "2024-01-01T00:00:00.000Z",
+        inputTokenPrice: o.price.input,
+        outputTokenPrice: o.price.output,
+      },
+      aliceCookies,
+    );
+    checkOrSkip(`create pricing for ${p.name}/${o.model}`, status, 201, data);
   }
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1385,12 +1385,13 @@ Source: packages/types/src/catalog.ts
 **canonicalName**: Tenant-unique canonical model name agents match their requirements against.
 
 ### CreateModelOffering
-`{ modelId: string, providerId: string, capabilities?: ("audio-input" | "extended-thinking" | "long-context" | "prompt-caching" | "structured-output" | "tool-use" | "vision")[], deploymentTags?: string[], priority?: number }`
+`{ modelId: string, providerId: string, capabilities?: ("audio-input" | "extended-thinking" | "long-context" | "prompt-caching" | "structured-output" | "tool-use" | "vision")[], deploymentTags?: string[], priority?: number, quirks?: { [string]: unknown } }`
 Source: packages/types/src/catalog.ts
 
 **modelId**: Catalog id of a model owned by this tenant.
 **providerId**: Catalog id of a model-provider owned by this tenant.
 **priority**: Ordering hint for source resolution; lower values are preferred first. Defaults to 0.
+**quirks**: Opaque per-deployment adapter accommodations for this offering; the adapter factory validates the provider-specific shape. Omit when the deployment needs none.
 
 ### CreateModelProvider
 `{ baseURL: string, name: string, plugin: "anthropic" | "google-genai" | "openai" | "openai-compatible", credentialId?: string | null, walletId?: string | null }`
@@ -1525,11 +1526,12 @@ Source: packages/types/src/models.ts
 **offerings**: One entry per provider that offers this model in the tenant's resolved catalog, ordered by resolution priority.
 
 ### ModelOfferingResponse
-`{ capabilities: ("audio-input" | "extended-thinking" | "long-context" | "prompt-caching" | "structured-output" | "tool-use" | "vision")[], createdAt: string, deploymentTags: string[], disabled: boolean, id: string, modelId: string, priority: number, providerId: string, tenantId: string, updatedAt: string }`
+`{ capabilities: ("audio-input" | "extended-thinking" | "long-context" | "prompt-caching" | "structured-output" | "tool-use" | "vision")[], createdAt: string, deploymentTags: string[], disabled: boolean, id: string, modelId: string, priority: number, providerId: string, quirks: { [string]: unknown } | null, tenantId: string, updatedAt: string }`
 Source: packages/types/src/catalog.ts
 
 **capabilities**: Curated capability tags this provider advertises for this model.
 **priority**: Ordering hint for source resolution; lower values are preferred first.
+**quirks**: Opaque per-deployment adapter accommodations, or null when the deployment needs none.
 
 ### ModelProviderResponse
 `{ baseURL: string, createdAt: string, disabled: boolean, id: string, name: string, plugin: "anthropic" | "google-genai" | "openai" | "openai-compatible", tenantId: string, updatedAt: string, credentialId?: string | null, walletId?: string | null }`
@@ -1642,8 +1644,10 @@ Source: packages/types/src/grants.ts
 Source: packages/types/src/catalog.ts
 
 ### UpdateModelOffering
-`{ capabilities?: ("audio-input" | "extended-thinking" | "long-context" | "prompt-caching" | "structured-output" | "tool-use" | "vision")[], deploymentTags?: string[], disabled?: boolean, priority?: number }`
+`{ capabilities?: ("audio-input" | "extended-thinking" | "long-context" | "prompt-caching" | "structured-output" | "tool-use" | "vision")[], deploymentTags?: string[], disabled?: boolean, priority?: number, quirks?: { [string]: unknown } | null }`
 Source: packages/types/src/catalog.ts
+
+**quirks**: Replacement quirks bag, or null to clear it back to the adapter's default behavior. Omit to leave unchanged.
 
 ### UpdateModelProvider
 `{ baseURL?: string, disabled?: boolean, name?: string }`

--- a/packages/agent/src/source.test.ts
+++ b/packages/agent/src/source.test.ts
@@ -116,13 +116,14 @@ describe("createSourceRegistry", () => {
     expect(reg.active.model).toBe("claude-3-5-haiku");
   });
 
-  test("setSource overwrites defaults and capabilities, including deletion", () => {
+  test("setSource overwrites defaults, capabilities, and quirks, including deletion", () => {
     const reg = createSourceRegistry({
       sources: [
         {
           ...S_ANTHROPIC,
           defaults: { maxTokens: 1024 },
           capabilities: ["text"],
+          quirks: { forceAssistantReasoningContent: true },
         },
       ],
       defaultSource: S_ANTHROPIC.id,
@@ -132,13 +133,16 @@ describe("createSourceRegistry", () => {
       ...S_ANTHROPIC,
       defaults: { maxTokens: 4096 },
       capabilities: ["text", "vision"],
+      quirks: { reasoningFieldNames: ["reasoning"] },
     });
     expect(reg.active.defaults).toEqual({ maxTokens: 4096 });
     expect(reg.active.capabilities).toEqual(["text", "vision"]);
+    expect(reg.active.quirks).toEqual({ reasoningFieldNames: ["reasoning"] });
 
     reg.setSource(S_ANTHROPIC);
     expect(reg.active.defaults).toBeUndefined();
     expect(reg.active.capabilities).toBeUndefined();
+    expect(reg.active.quirks).toBeUndefined();
   });
 
   test("setSource throws InvalidInferenceSourceError on invalid input", () => {

--- a/packages/db/migrations/0044_model_offering_quirks.sql
+++ b/packages/db/migrations/0044_model_offering_quirks.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "model_offering" ADD COLUMN "quirks" jsonb;

--- a/packages/db/migrations/meta/0044_snapshot.json
+++ b/packages/db/migrations/meta/0044_snapshot.json
@@ -1,0 +1,3504 @@
+{
+  "id": "b06fd4d3-a75e-4e9c-996d-7c1793d4c65a",
+  "prevId": "2b3a91d7-8655-4e78-a7b6-12d22df0692a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.federation_trust": {
+      "name": "federation_trust",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_tenant_id": {
+          "name": "target_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "federation_trust_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "federation_trust_target_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_target_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "tableTo": "tenant",
+          "columnsFrom": ["target_tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federation_trust_tenant_id_target_tenant_id_unique": {
+          "name": "federation_trust_tenant_id_target_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "target_tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant": {
+      "name": "tenant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_parent_id_tenant_id_fk": {
+          "name": "tenant_parent_id_tenant_id_fk",
+          "tableFrom": "tenant",
+          "tableTo": "tenant",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_slug_unique": {
+          "name": "tenant_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "tenant_domain_unique": {
+          "name": "tenant_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": ["domain"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal": {
+      "name": "principal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_tenant_id_tenant_id_fk": {
+          "name": "principal_tenant_id_tenant_id_fk",
+          "tableFrom": "principal",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "principal_tenant_id_kind_ref_id_unique": {
+          "name": "principal_tenant_id_kind_ref_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "kind", "ref_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_role": {
+      "name": "agent_role",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_role_agent_id_agent_id_fk": {
+          "name": "agent_role_agent_id_agent_id_fk",
+          "tableFrom": "agent_role",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_role_role_id_role_id_fk": {
+          "name": "agent_role_role_id_role_id_fk",
+          "tableFrom": "agent_role",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_role_agent_id_role_id_pk": {
+          "name": "agent_role_agent_id_role_id_pk",
+          "columns": ["agent_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal_role": {
+      "name": "principal_role",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_role_principal_id_principal_id_fk": {
+          "name": "principal_role_principal_id_principal_id_fk",
+          "tableFrom": "principal_role",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "principal_role_role_id_role_id_fk": {
+          "name": "principal_role_role_id_role_id_fk",
+          "tableFrom": "principal_role",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "principal_role_principal_id_role_id_pk": {
+          "name": "principal_role_principal_id_role_id_pk",
+          "columns": ["principal_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_tenant_id_tenant_id_fk": {
+          "name": "role_tenant_id_tenant_id_fk",
+          "tableFrom": "role",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grant": {
+      "name": "grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grant_tenant_id_tenant_id_fk": {
+          "name": "grant_tenant_id_tenant_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grant_role_id_role_id_fk": {
+          "name": "grant_role_id_role_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grant_principal_id_principal_id_fk": {
+          "name": "grant_principal_id_principal_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval": {
+      "name": "approval",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_address": {
+          "name": "agent_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_definition": {
+          "name": "tool_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_arguments": {
+          "name": "tool_arguments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "timeout_at": {
+          "name": "timeout_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approval_tenant_status_idx": {
+          "name": "approval_tenant_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_deployment_idx": {
+          "name": "approval_deployment_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_tenant_id_tenant_id_fk": {
+          "name": "approval_tenant_id_tenant_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_deployment_id_workflow_deployment_id_fk": {
+          "name": "approval_deployment_id_workflow_deployment_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "workflow_deployment",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approval_correlation_id_unique": {
+          "name": "approval_correlation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["correlation_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_correlation": {
+      "name": "signal_correlation",
+      "schema": "",
+      "columns": {
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_address": {
+          "name": "agent_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_name": {
+          "name": "signal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_id": {
+          "name": "signal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signal_correlation_tenant_id_tenant_id_fk": {
+          "name": "signal_correlation_tenant_id_tenant_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signal_correlation_deployment_id_workflow_deployment_id_fk": {
+          "name": "signal_correlation_deployment_id_workflow_deployment_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "workflow_deployment",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_config": {
+          "name": "context_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_state": {
+          "name": "initial_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_config": {
+          "name": "model_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_requirements": {
+          "name": "credential_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_requirements": {
+          "name": "model_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_packages": {
+          "name": "tool_packages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "grant_requirements": {
+          "name": "grant_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_tenant_id_tenant_id_fk": {
+          "name": "agent_tenant_id_tenant_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_creator_principal_id_principal_id_fk": {
+          "name": "agent_creator_principal_id_principal_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "principal",
+          "columnsFrom": ["creator_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version": {
+      "name": "agent_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_agent_id_agent_id_fk": {
+          "name": "agent_version_agent_id_agent_id_fk",
+          "tableFrom": "agent_version",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_info_url": {
+          "name": "user_info_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_tenant_id_tenant_id_fk": {
+          "name": "provider_tenant_id_tenant_id_fk",
+          "tableFrom": "provider",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_tenant_name": {
+          "name": "provider_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_scopes": {
+          "name": "default_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_tenant_id_tenant_id_fk": {
+          "name": "oauth_client_tenant_id_tenant_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_client_provider_id_provider_id_fk": {
+          "name": "oauth_client_provider_id_provider_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_tenant_provider": {
+          "name": "oauth_client_tenant_provider",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "provider_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credential": {
+      "name": "credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_secret": {
+          "name": "refresh_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credential_tenant_id_tenant_id_fk": {
+          "name": "credential_tenant_id_tenant_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_principal_id_principal_id_fk": {
+          "name": "credential_principal_id_principal_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credential_provider_id_provider_id_fk": {
+          "name": "credential_provider_id_provider_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_oauth_client_id_oauth_client_id_fk": {
+          "name": "credential_oauth_client_id_oauth_client_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "credential_tenant_name": {
+          "name": "credential_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset": {
+      "name": "asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_tenant_id_tenant_id_fk": {
+          "name": "asset_tenant_id_tenant_id_fk",
+          "tableFrom": "asset",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "asset_creator_principal_id_principal_id_fk": {
+          "name": "asset_creator_principal_id_principal_id_fk",
+          "tableFrom": "asset",
+          "tableTo": "principal",
+          "columnsFrom": ["creator_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_tenant_kind_name": {
+          "name": "asset_tenant_kind_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "kind", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_asset": {
+      "name": "agent_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_mode": {
+          "name": "access_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read-only'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_asset_agent_id_agent_id_fk": {
+          "name": "agent_asset_agent_id_agent_id_fk",
+          "tableFrom": "agent_asset",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_asset_asset_id_asset_id_fk": {
+          "name": "agent_asset_asset_id_asset_id_fk",
+          "tableFrom": "agent_asset",
+          "tableTo": "asset",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_asset_agent_asset": {
+          "name": "agent_asset_agent_asset",
+          "nullsNotDistinct": false,
+          "columns": ["agent_id", "asset_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_wallet_id_wallet_id_fk": {
+          "name": "transaction_wallet_id_wallet_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_agent_id_agent_id_fk": {
+          "name": "transaction_agent_id_agent_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet": {
+      "name": "wallet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend_type": {
+          "name": "backend_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallet_tenant_id_tenant_id_fk": {
+          "name": "wallet_tenant_id_tenant_id_fk",
+          "tableFrom": "wallet",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offering": {
+      "name": "offering",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "offering_agent_id_agent_id_fk": {
+          "name": "offering_agent_id_agent_id_fk",
+          "tableFrom": "offering",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "offering_tenant_id_tenant_id_fk": {
+          "name": "offering_tenant_id_tenant_id_fk",
+          "tableFrom": "offering",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model": {
+      "name": "model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_tenant_id_tenant_id_fk": {
+          "name": "model_tenant_id_tenant_id_fk",
+          "tableFrom": "model",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_tenant_canonical_name": {
+          "name": "model_tenant_canonical_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "canonical_name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_offering": {
+      "name": "model_offering",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_tags": {
+          "name": "deployment_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "quirks": {
+          "name": "quirks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_offering_tenant_id_tenant_id_fk": {
+          "name": "model_offering_tenant_id_tenant_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_offering_model_id_model_id_fk": {
+          "name": "model_offering_model_id_model_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_offering_provider_id_model_provider_id_fk": {
+          "name": "model_offering_provider_id_model_provider_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "model_provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_offering_tenant_model_provider": {
+          "name": "model_offering_tenant_model_provider",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "model_id", "provider_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_pricing": {
+      "name": "model_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offering_id": {
+          "name": "offering_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_token_price": {
+          "name": "input_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_token_price": {
+          "name": "output_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_token_price": {
+          "name": "cache_read_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_write_token_price": {
+          "name": "cache_write_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thinking_token_price": {
+          "name": "thinking_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_request_fee": {
+          "name": "per_request_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_image_fee": {
+          "name": "per_image_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_audio_fee": {
+          "name": "per_audio_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_pricing_tenant_id_tenant_id_fk": {
+          "name": "model_pricing_tenant_id_tenant_id_fk",
+          "tableFrom": "model_pricing",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_pricing_offering_id_model_offering_id_fk": {
+          "name": "model_pricing_offering_id_model_offering_id_fk",
+          "tableFrom": "model_pricing",
+          "tableTo": "model_offering",
+          "columnsFrom": ["offering_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_pricing_offering_currency_effective_from": {
+          "name": "model_pricing_offering_currency_effective_from",
+          "nullsNotDistinct": false,
+          "columns": ["offering_id", "currency", "effective_from"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider": {
+      "name": "model_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_provider_tenant_id_tenant_id_fk": {
+          "name": "model_provider_tenant_id_tenant_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_credential_id_credential_id_fk": {
+          "name": "model_provider_credential_id_credential_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "credential",
+          "columnsFrom": ["credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "model_provider_wallet_id_wallet_id_fk": {
+          "name": "model_provider_wallet_id_wallet_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_provider_tenant_name": {
+          "name": "model_provider_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "model_provider_auth_xor": {
+          "name": "model_provider_auth_xor",
+          "value": "(\"model_provider\".\"credential_id\" is not null) <> (\"model_provider\".\"wallet_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sidecar": {
+      "name": "sidecar",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash_sha256": {
+          "name": "token_hash_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sidecar_token_hash_sha256_unique": {
+          "name": "sidecar_token_hash_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash_sha256"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_session": {
+      "name": "agent_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_session_tenant_id_tenant_id_fk": {
+          "name": "agent_session_tenant_id_tenant_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_agent_id_agent_id_fk": {
+          "name": "agent_session_agent_id_agent_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_principal_id_principal_id_fk": {
+          "name": "agent_session_principal_id_principal_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_instance": {
+      "name": "agent_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployed'"
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kernel_id": {
+          "name": "kernel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_preferences": {
+          "name": "model_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_instance_agent_id_agent_id_fk": {
+          "name": "agent_instance_agent_id_agent_id_fk",
+          "tableFrom": "agent_instance",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_instance_tenant_id_tenant_id_fk": {
+          "name": "agent_instance_tenant_id_tenant_id_fk",
+          "tableFrom": "agent_instance",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_instance_principal_id_principal_id_fk": {
+          "name": "agent_instance_principal_id_principal_id_fk",
+          "tableFrom": "agent_instance",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_instance_version_id_agent_version_id_fk": {
+          "name": "agent_instance_version_id_agent_version_id_fk",
+          "tableFrom": "agent_instance",
+          "tableTo": "agent_version",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_instance_session_id_agent_session_id_fk": {
+          "name": "agent_instance_session_id_agent_session_id_fk",
+          "tableFrom": "agent_instance",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_instance_sidecar_id_sidecar_id_fk": {
+          "name": "agent_instance_sidecar_id_sidecar_id_fk",
+          "tableFrom": "agent_instance",
+          "tableTo": "sidecar",
+          "columnsFrom": ["sidecar_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_instance_address_unique": {
+          "name": "agent_instance_address_unique",
+          "nullsNotDistinct": false,
+          "columns": ["address"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_asset": {
+      "name": "session_asset",
+      "schema": "",
+      "columns": {
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_asset_id": {
+          "name": "agent_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mount_path": {
+          "name": "mount_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_pack_sha": {
+          "name": "asset_pack_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "materialized_at": {
+          "name": "materialized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_asset_pack_sha_idx": {
+          "name": "session_asset_pack_sha_idx",
+          "columns": [
+            {
+              "expression": "asset_pack_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_asset_instance_id_agent_instance_id_fk": {
+          "name": "session_asset_instance_id_agent_instance_id_fk",
+          "tableFrom": "session_asset",
+          "tableTo": "agent_instance",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_asset_agent_asset_id_agent_asset_id_fk": {
+          "name": "session_asset_agent_asset_id_agent_asset_id_fk",
+          "tableFrom": "session_asset",
+          "tableTo": "agent_asset",
+          "columnsFrom": ["agent_asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_asset_instance_id_mount_path_pk": {
+          "name": "session_asset_instance_id_mount_path_pk",
+          "columns": ["instance_id", "mount_path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inference_turn": {
+      "name": "inference_turn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "inference_turn_instance_id_started_at_idx": {
+          "name": "inference_turn_instance_id_started_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inference_turn_session_id_agent_session_id_fk": {
+          "name": "inference_turn_session_id_agent_session_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inference_turn_instance_id_agent_instance_id_fk": {
+          "name": "inference_turn_instance_id_agent_instance_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "agent_instance",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inference_turn_tenant_id_tenant_id_fk": {
+          "name": "inference_turn_tenant_id_tenant_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_mail": {
+      "name": "session_mail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "raw": {
+          "name": "raw",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_mail_instance_id_created_at_idx": {
+          "name": "session_mail_instance_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_mail_session_id_agent_session_id_fk": {
+          "name": "session_mail_session_id_agent_session_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_mail_instance_id_agent_instance_id_fk": {
+          "name": "session_mail_instance_id_agent_instance_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "agent_instance",
+          "columnsFrom": ["instance_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "session_mail_tenant_id_tenant_id_fk": {
+          "name": "session_mail_tenant_id_tenant_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turn_part": {
+      "name": "turn_part",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "turn_part_turn_id_inference_turn_id_fk": {
+          "name": "turn_part_turn_id_inference_turn_id_fk",
+          "tableFrom": "turn_part",
+          "tableTo": "inference_turn",
+          "columnsFrom": ["turn_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_part_session_id_agent_session_id_fk": {
+          "name": "turn_part_session_id_agent_session_id_fk",
+          "tableFrom": "turn_part",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_token": {
+      "name": "git_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash_sha256": {
+          "name": "token_hash_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_pattern": {
+          "name": "ref_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "git_token_user_id_name_active_idx": {
+          "name": "git_token_user_id_name_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"git_token\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "git_token_tenant_id_tenant_id_fk": {
+          "name": "git_token_tenant_id_tenant_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "git_token_user_id_user_id_fk": {
+          "name": "git_token_user_id_user_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_token_principal_id_principal_id_fk": {
+          "name": "git_token_principal_id_principal_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "git_token_token_hash_sha256_unique": {
+          "name": "git_token_token_hash_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash_sha256"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_deployment": {
+      "name": "workflow_deployment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_asset_id": {
+          "name": "definition_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_deployment_tenant_idx": {
+          "name": "workflow_deployment_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_deployment_address_idx": {
+          "name": "workflow_deployment_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_deployment_tenant_id_tenant_id_fk": {
+          "name": "workflow_deployment_tenant_id_tenant_id_fk",
+          "tableFrom": "workflow_deployment",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_deployment_definition_asset_id_asset_id_fk": {
+          "name": "workflow_deployment_definition_asset_id_asset_id_fk",
+          "tableFrom": "workflow_deployment",
+          "tableTo": "asset",
+          "columnsFrom": ["definition_asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1784574028729,
       "tag": "0043_signal_correlation_deployment_fk",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1784647908094,
+      "tag": "0044_model_offering_quirks",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -57,6 +57,7 @@ export {
   parseApprovalRow,
   parseSignalCorrelationRow,
   parseOfferingRow,
+  parseModelOfferingRow,
   parseCredentialRow,
   parseProviderRow,
   parseTenantRow,

--- a/packages/db/src/model-source-resolution.ts
+++ b/packages/db/src/model-source-resolution.ts
@@ -17,6 +17,7 @@ import {
 import type { DB } from "./client";
 import { resolveCredentialById } from "./credential-resolution";
 import { createGrantStore } from "./grant-store";
+import { parseModelOfferingRow } from "./parse-row";
 import { agent } from "./schema/agents";
 
 /**
@@ -165,6 +166,15 @@ async function buildSource(
     };
   }
 
+  // Validate the row once at this DB-to-runtime boundary. This narrows the
+  // jsonb `quirks` from `unknown` to a `Record | null` and checks
+  // `capabilities` against the curated enum. `quirks` is spread in only when
+  // non-null so a source with no accommodations omits the key entirely
+  // (InferenceSource.quirks is present-or-absent, never null). The capability
+  // filter in resolveModelSources still reads the raw row's `capabilities`
+  // for its `.includes` check; that read-only comparison cannot be corrupted
+  // into a wrong routing decision, so it is left as-is.
+  const parsed = parseModelOfferingRow(offering);
   return {
     ok: true,
     source: {
@@ -173,7 +183,8 @@ async function buildSource(
       baseURL: provider.baseURL,
       apiKey: credential.secret,
       model: model.canonicalName,
-      capabilities: offering.capabilities,
+      capabilities: parsed.capabilities,
+      ...(parsed.quirks !== null ? { quirks: parsed.quirks } : {}),
     },
   };
 }

--- a/packages/db/src/parse-row.test.ts
+++ b/packages/db/src/parse-row.test.ts
@@ -159,6 +159,7 @@ function makeOfferingRow(
     priority: 0,
     deploymentTags: [],
     capabilities: ["vision", "tool-use"],
+    quirks: null,
     disabled: false,
     createdAt: now,
     updatedAt: now,
@@ -180,6 +181,28 @@ describe("parseModelOfferingRow", () => {
   test("rejects a non-curated capability", () => {
     expect(() =>
       parseModelOfferingRow(makeOfferingRow({ capabilities: ["telepathy"] })),
+    ).toThrow();
+  });
+
+  test("passes a null quirks bag through unchanged", () => {
+    const parsed = parseModelOfferingRow(makeOfferingRow({ quirks: null }));
+    expect(parsed.quirks).toBeNull();
+  });
+
+  test("preserves an empty quirks object", () => {
+    const parsed = parseModelOfferingRow(makeOfferingRow({ quirks: {} }));
+    expect(parsed.quirks).toEqual({});
+  });
+
+  test("preserves a populated quirks bag", () => {
+    const quirks = { forceAssistantReasoningContent: true };
+    const parsed = parseModelOfferingRow(makeOfferingRow({ quirks }));
+    expect(parsed.quirks).toEqual(quirks);
+  });
+
+  test("rejects a scalar quirks value", () => {
+    expect(() =>
+      parseModelOfferingRow(makeOfferingRow({ quirks: "not-an-object" })),
     ).toThrow();
   });
 });

--- a/packages/db/src/parse-row.ts
+++ b/packages/db/src/parse-row.ts
@@ -189,6 +189,7 @@ export function parseModelOfferingRow(row: typeof modelOffering.$inferSelect) {
   return {
     ...row,
     capabilities: Capability.array().assert(row.capabilities),
+    quirks: row.quirks !== null ? JSONObject.assert(row.quirks) : null,
   };
 }
 

--- a/packages/db/src/schema/catalog.ts
+++ b/packages/db/src/schema/catalog.ts
@@ -3,6 +3,7 @@ import {
   boolean,
   check,
   integer,
+  jsonb,
   pgTable,
   text,
   timestamp,
@@ -88,6 +89,12 @@ export const modelOffering = pgTable(
     // Curated-capability tags. This issue creates the column; the values are
     // populated by the discovery-support-matrix seeding work.
     capabilities: text("capabilities").array().notNull().default([]),
+    // Opaque per-deployment bag of provider-specific adapter accommodations
+    // (e.g. OpenAI's forceAssistantReasoningContent). Interpreted and
+    // validated only at the adapter factory, which alone knows the provider
+    // shape. NULL means the factory receives no bag and applies its default
+    // behavior.
+    quirks: jsonb("quirks"),
     // Own-row disable. Inherited-row suppression is resolved separately.
     disabled: boolean("disabled").notNull().default(false),
     createdAt: timestamp("created_at").notNull().defaultNow(),

--- a/packages/hub-api/src/routes/catalog-routes.test.ts
+++ b/packages/hub-api/src/routes/catalog-routes.test.ts
@@ -62,6 +62,7 @@ const ALL_CATALOG_GRANTS = [
 ];
 
 type InsertCapture = { table: string; rows: Record<string, unknown>[] };
+type UpdateCapture = { table: string; set: Record<string, unknown> };
 
 function tableName(table: unknown): string {
   if (table && typeof table === "object") {
@@ -84,6 +85,7 @@ type CatalogDBOpts = {
   modelPricing?: Record<string, unknown>;
   credential?: Record<string, unknown>;
   inserts: InsertCapture[];
+  updates?: UpdateCapture[];
 };
 
 function notImplemented(path: string) {
@@ -102,6 +104,29 @@ function createMockDB(opts: CatalogDBOpts) {
         const rows = Array.isArray(rowsOrRow) ? rowsOrRow : [rowsOrRow];
         opts.inserts.push({ table: name, rows });
         return { returning: () => Promise.resolve(rows) };
+      },
+    };
+  }
+
+  function updateChain(table: unknown) {
+    const name = tableName(table);
+    const base =
+      name === "model_offering"
+        ? opts.modelOffering
+        : name === "model_provider"
+          ? opts.modelProvider
+          : undefined;
+    return {
+      set: (values: Record<string, unknown>) => {
+        opts.updates?.push({ table: name, set: values });
+        // A real `.returning()` yields the full post-update row, not just the
+        // changed columns, so merge the set values onto the seeded base row.
+        return {
+          where: () => ({
+            returning: () =>
+              Promise.resolve(base ? [{ ...base, ...values }] : []),
+          }),
+        };
       },
     };
   }
@@ -152,6 +177,7 @@ function createMockDB(opts: CatalogDBOpts) {
       },
     },
     insert: insertChain,
+    update: updateChain,
   } as unknown as Parameters<typeof createApp>[0]["db"];
 }
 
@@ -466,6 +492,55 @@ describe("POST /catalog/offerings", () => {
     expect(res.status).toBe(409);
     expect(inserts.filter((i) => i.table === "model_offering")).toHaveLength(0);
   });
+
+  test("persists an explicit quirks bag and echoes it in the response", async () => {
+    const inserts: InsertCapture[] = [];
+    const app = createTestApp({
+      db: { inserts, model: { id: "mdl_1" }, modelProvider: { id: "mpv_1" } },
+    });
+    const res = await postJSON(app, offeringsURL, {
+      modelId: "mdl_1",
+      providerId: "mpv_1",
+      quirks: { forceAssistantReasoningContent: true },
+    });
+    expect(res.status).toBe(201);
+    const captured = inserts.filter((i) => i.table === "model_offering");
+    expect(captured[0]?.rows[0]).toMatchObject({
+      quirks: { forceAssistantReasoningContent: true },
+    });
+    const json = await res.json();
+    expect(json).toMatchObject({
+      quirks: { forceAssistantReasoningContent: true },
+    });
+  });
+
+  test("stores null quirks when the request omits the bag", async () => {
+    const inserts: InsertCapture[] = [];
+    const app = createTestApp({
+      db: { inserts, model: { id: "mdl_1" }, modelProvider: { id: "mpv_1" } },
+    });
+    const res = await postJSON(app, offeringsURL, {
+      modelId: "mdl_1",
+      providerId: "mpv_1",
+    });
+    expect(res.status).toBe(201);
+    const captured = inserts.filter((i) => i.table === "model_offering");
+    expect(captured[0]?.rows[0]?.quirks).toBeNull();
+  });
+
+  test("rejects a non-object quirks value", async () => {
+    const inserts: InsertCapture[] = [];
+    const app = createTestApp({
+      db: { inserts, model: { id: "mdl_1" }, modelProvider: { id: "mpv_1" } },
+    });
+    const res = await postJSON(app, offeringsURL, {
+      modelId: "mdl_1",
+      providerId: "mpv_1",
+      quirks: "not-an-object",
+    });
+    expect(res.status).toBe(400);
+    expect(inserts.filter((i) => i.table === "model_offering")).toHaveLength(0);
+  });
 });
 
 describe("PATCH /catalog/providers/:id", () => {
@@ -479,6 +554,63 @@ describe("PATCH /catalog/providers/:id", () => {
       name: "taken",
     });
     expect(res.status).toBe(409);
+  });
+});
+
+describe("PATCH /catalog/offerings/:id", () => {
+  const baseOffering = {
+    id: "mof_1",
+    tenantId: TENANT_ID,
+    modelId: "mdl_1",
+    providerId: "mpv_1",
+    priority: 0,
+    deploymentTags: [],
+    capabilities: [],
+    quirks: null,
+    disabled: false,
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-01-01"),
+  };
+
+  test("sets a quirks bag on the offering", async () => {
+    const inserts: InsertCapture[] = [];
+    const updates: UpdateCapture[] = [];
+    const app = createTestApp({
+      db: { inserts, updates, modelOffering: baseOffering },
+    });
+    const res = await patchJSON(app, `${offeringsURL}/mof_1`, {
+      quirks: { reasoningFieldNames: ["reasoning"] },
+    });
+    expect(res.status).toBe(200);
+    const captured = updates.filter((u) => u.table === "model_offering");
+    expect(captured[0]?.set).toMatchObject({
+      quirks: { reasoningFieldNames: ["reasoning"] },
+    });
+    const json = await res.json();
+    expect(json).toMatchObject({
+      quirks: { reasoningFieldNames: ["reasoning"] },
+    });
+  });
+
+  test("clears the quirks bag when the patch sets it to null", async () => {
+    const inserts: InsertCapture[] = [];
+    const updates: UpdateCapture[] = [];
+    const app = createTestApp({
+      db: {
+        inserts,
+        updates,
+        modelOffering: {
+          ...baseOffering,
+          quirks: { forceAssistantReasoningContent: true },
+        },
+      },
+    });
+    const res = await patchJSON(app, `${offeringsURL}/mof_1`, { quirks: null });
+    expect(res.status).toBe(200);
+    const captured = updates.filter((u) => u.table === "model_offering");
+    expect(captured[0]?.set.quirks).toBeNull();
+    const json = await res.json();
+    expect(json).toMatchObject({ quirks: null });
   });
 });
 

--- a/packages/hub-api/src/routes/instances.test.ts
+++ b/packages/hub-api/src/routes/instances.test.ts
@@ -1241,6 +1241,7 @@ describe("POST /agents/instances seeds creator agent-state grant", () => {
       priority: 0,
       deploymentTags: [],
       capabilities: [],
+      quirks: null,
       disabled: false,
       createdAt: new Date("2025-01-01"),
       updatedAt: new Date("2025-01-01"),

--- a/packages/hub-api/src/routes/model-offerings.ts
+++ b/packages/hub-api/src/routes/model-offerings.ts
@@ -9,6 +9,7 @@ import {
   modelPricing,
 } from "@intx/db/schema";
 import type { DB } from "@intx/db";
+import { parseModelOfferingRow } from "@intx/db";
 import {
   CreateModelOffering,
   UpdateModelOffering,
@@ -37,17 +38,22 @@ import {
 } from "../pagination";
 
 export function formatModelOffering(row: typeof modelOffering.$inferSelect) {
+  // Validate the row once so the jsonb `quirks` is narrowed from `unknown`
+  // to a `Record | null` and `capabilities` is checked against the curated
+  // enum, mirroring how formatApproval formats a parsed row.
+  const parsed = parseModelOfferingRow(row);
   return {
-    id: row.id,
-    tenantId: row.tenantId,
-    modelId: row.modelId,
-    providerId: row.providerId,
-    priority: row.priority,
-    deploymentTags: row.deploymentTags,
-    capabilities: row.capabilities,
-    disabled: row.disabled,
-    createdAt: ts(row.createdAt),
-    updatedAt: ts(row.updatedAt),
+    id: parsed.id,
+    tenantId: parsed.tenantId,
+    modelId: parsed.modelId,
+    providerId: parsed.providerId,
+    priority: parsed.priority,
+    deploymentTags: parsed.deploymentTags,
+    capabilities: parsed.capabilities,
+    quirks: parsed.quirks,
+    disabled: parsed.disabled,
+    createdAt: ts(parsed.createdAt),
+    updatedAt: ts(parsed.updatedAt),
   };
 }
 
@@ -229,6 +235,7 @@ export function createModelOfferingRoutes({
             priority: body.priority ?? 0,
             deploymentTags: body.deploymentTags ?? [],
             capabilities: body.capabilities ?? [],
+            quirks: body.quirks ?? null,
             createdAt: now,
             updatedAt: now,
           })
@@ -313,6 +320,7 @@ export function createModelOfferingRoutes({
         updates["deploymentTags"] = body.deploymentTags;
       if (body.capabilities !== undefined)
         updates["capabilities"] = body.capabilities;
+      if (body.quirks !== undefined) updates["quirks"] = body.quirks;
       if (body.disabled !== undefined) updates["disabled"] = body.disabled;
 
       const [updated] = await db

--- a/packages/hub-api/src/routes/models.test.ts
+++ b/packages/hub-api/src/routes/models.test.ts
@@ -54,6 +54,7 @@ function offering(
     priority,
     deploymentTags: [],
     capabilities: [],
+    quirks: null,
     disabled: false,
     createdAt: D,
     updatedAt: D,

--- a/packages/inference/src/harness.test.ts
+++ b/packages/inference/src/harness.test.ts
@@ -12,7 +12,7 @@ import {
   createDefaultDependencies,
   loadAdapterRegistry,
 } from "./providers";
-import type { AdapterFactory } from "./adapter";
+import type { AdapterFactory, AdapterRegistry } from "./adapter";
 import type {
   ConversationTurn,
   InferenceEvent,
@@ -668,5 +668,74 @@ describe("runInference — source-identity stamping", () => {
       provider: "anthropic",
       model: "claude-pre",
     });
+  });
+});
+
+describe("runInference — source quirks reach the adapter registry", () => {
+  // A registry that records the quirks argument every resolve receives and
+  // returns a do-nothing adapter, so the test observes exactly what the
+  // harness forwards without depending on any real provider.
+  function spyRegistry(): {
+    registry: AdapterRegistry;
+    quirksCalls: unknown[];
+  } {
+    const quirksCalls: unknown[] = [];
+    const registry: AdapterRegistry = {
+      has: () => true,
+      resolve: (_source, quirks) => {
+        quirksCalls.push(quirks);
+        return {
+          buildRequest: () => ({
+            url: "/v1/messages",
+            headers: {},
+            body: "{}",
+          }),
+          parseResponse: () => [],
+        };
+      },
+    };
+    return { registry, quirksCalls };
+  }
+
+  function depsWith(registry: AdapterRegistry): Dependencies {
+    return {
+      fetch: () =>
+        Promise.resolve(
+          new Response("", {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }),
+        ),
+      scheduler: createDefaultScheduler(),
+      adapters: registry,
+    };
+  }
+
+  test("forwards the source's quirks bag to resolve", async () => {
+    const { registry, quirksCalls } = spyRegistry();
+    let seq = 0;
+    await collect(
+      runInference({
+        turns: [userTurn("hi")],
+        source: { ...SOURCE, quirks: { forceAssistantReasoningContent: true } },
+        nextSeq: () => ++seq,
+        deps: depsWith(registry),
+      }),
+    );
+    expect(quirksCalls).toEqual([{ forceAssistantReasoningContent: true }]);
+  });
+
+  test("resolves with undefined quirks when the source has none", async () => {
+    const { registry, quirksCalls } = spyRegistry();
+    let seq = 0;
+    await collect(
+      runInference({
+        turns: [userTurn("hi")],
+        source: SOURCE,
+        nextSeq: () => ++seq,
+        deps: depsWith(registry),
+      }),
+    );
+    expect(quirksCalls).toEqual([undefined]);
   });
 });

--- a/packages/inference/src/harness.ts
+++ b/packages/inference/src/harness.ts
@@ -275,7 +275,7 @@ async function* runSingleAttempt(
 
   let adapter;
   try {
-    adapter = deps.adapters.resolve(lastCycleSource);
+    adapter = deps.adapters.resolve(lastCycleSource, source.quirks);
   } catch (cause) {
     yield {
       type: "inference.error",

--- a/packages/types/src/catalog.test.ts
+++ b/packages/types/src/catalog.test.ts
@@ -58,6 +58,7 @@ describe("ModelOfferingResponse", () => {
     priority: 0,
     deploymentTags: [],
     capabilities: ["vision", "tool-use"],
+    quirks: null,
     disabled: false,
     createdAt: "2026-06-18T00:00:00Z",
     updatedAt: "2026-06-18T00:00:00Z",
@@ -70,6 +71,16 @@ describe("ModelOfferingResponse", () => {
   test("rejects a non-curated capability", () => {
     const bad = { ...base, capabilities: ["telepathy"] };
     expect(ModelOfferingResponse(bad) instanceof type.errors).toBe(true);
+  });
+
+  test("accepts a populated quirks bag", () => {
+    const withQuirks = {
+      ...base,
+      quirks: { forceAssistantReasoningContent: true },
+    };
+    expect(ModelOfferingResponse(withQuirks) instanceof type.errors).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/types/src/catalog.ts
+++ b/packages/types/src/catalog.ts
@@ -130,12 +130,18 @@ export const CreateModelOffering = type({
   ),
   "deploymentTags?": "string[]",
   "capabilities?": Capability.array(),
+  "quirks?": type("Record<string, unknown>").describe(
+    "Opaque per-deployment adapter accommodations for this offering; the adapter factory validates the provider-specific shape. Omit when the deployment needs none.",
+  ),
 });
 
 export const UpdateModelOffering = type({
   "priority?": "number",
   "deploymentTags?": "string[]",
   "capabilities?": Capability.array(),
+  "quirks?": type("Record<string, unknown> | null").describe(
+    "Replacement quirks bag, or null to clear it back to the adapter's default behavior. Omit to leave unchanged.",
+  ),
   "disabled?": "boolean",
 });
 
@@ -212,6 +218,9 @@ export const ModelOfferingResponse = type({
   deploymentTags: "string[]",
   capabilities: Capability.array().describe(
     "Curated capability tags this provider advertises for this model.",
+  ),
+  quirks: type("Record<string, unknown> | null").describe(
+    "Opaque per-deployment adapter accommodations, or null when the deployment needs none.",
   ),
   disabled: "boolean",
   createdAt: "string",

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -2180,6 +2180,15 @@ export type InferenceSourceDefaults = typeof InferenceSourceDefaults.infer;
  * selector consumes it). The runtime ignores it; populating the field
  * later is not a wire-format change.
  *
+ * `quirks` is the opaque per-deployment bag of provider-specific adapter
+ * accommodations. The harness reads it once, at adapter instantiation, and
+ * passes it to `AdapterRegistry.resolve` as a sibling of the slim
+ * `LastCycleSource` — quirks are deliberately kept off `LastCycleSource`,
+ * which rides on every usage event. The field is present-and-populated or
+ * absent; it is never `null`. A source row with no quirks stores SQL `NULL`,
+ * and the catalog resolver translates that absence into an omitted key here,
+ * so downstream code sees `undefined`, never `null`.
+ *
  * (INFERENCE.md § Providers)
  */
 export const InferenceSource = type({
@@ -2190,14 +2199,15 @@ export const InferenceSource = type({
   model: "string",
   "defaults?": InferenceSourceDefaults,
   "capabilities?": "string[]",
+  "quirks?": "Record<string, unknown>",
 });
 export type InferenceSource = typeof InferenceSource.infer;
 
 /**
  * Replace every field on `active` with the corresponding field from
- * `next`, in place. Optional fields (`defaults`, `capabilities`) are
- * `delete`d from `active` when absent on `next` so the swap is exact —
- * no stale value from a previous rotation can survive.
+ * `next`, in place. Optional fields (`defaults`, `capabilities`,
+ * `quirks`) are `delete`d from `active` when absent on `next` so the
+ * swap is exact — no stale value from a previous rotation can survive.
  *
  * Used by both the agent's source registry and the harness's source
  * hot-swap path to mutate the single shared `InferenceSource` object the
@@ -2224,6 +2234,11 @@ export function applyInferenceSourceFields(
   } else {
     delete active.capabilities;
   }
+  if (next.quirks !== undefined) {
+    active.quirks = next.quirks;
+  } else {
+    delete active.quirks;
+  }
 
   // Compile-time exhaustiveness check. `Required<>` forces optional
   // keys to also be required in the guard — so a future optional field
@@ -2237,6 +2252,7 @@ export function applyInferenceSourceFields(
     model: true,
     defaults: true,
     capabilities: true,
+    quirks: true,
   };
   void _handled;
 }

--- a/tests/db/model-source-resolution.test.ts
+++ b/tests/db/model-source-resolution.test.ts
@@ -71,6 +71,7 @@ describe.skipIf(!harnessDbEnvAvailable())(
     async function seedBase(opts?: {
       offeringPriority?: number;
       offeringCapabilities?: string[];
+      offeringQuirks?: Record<string, unknown>;
     }): Promise<void> {
       await seedTenants(h.db, [{ id: "tnt_root" }]);
       await seedProvider(h.db, {
@@ -103,6 +104,9 @@ describe.skipIf(!harnessDbEnvAvailable())(
         providerId: "mpv_anthropic",
         priority: opts?.offeringPriority ?? 0,
         capabilities: opts?.offeringCapabilities ?? [],
+        ...(opts?.offeringQuirks !== undefined
+          ? { quirks: opts.offeringQuirks }
+          : {}),
       });
     }
 
@@ -162,6 +166,39 @@ describe.skipIf(!harnessDbEnvAvailable())(
             capabilities: [],
           },
         ]);
+      });
+
+      test("carries the offering row's quirks bag on the resolved source", async () => {
+        await seedBase({
+          offeringQuirks: { forceAssistantReasoningContent: true },
+        });
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_root",
+          REQ_OPUS,
+          AUTHORIZED_CREATOR_GRANTS,
+        );
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        const [source] = result.sources;
+        expect(source?.quirks).toEqual({
+          forceAssistantReasoningContent: true,
+        });
+      });
+
+      test("omits quirks on the resolved source when the row has none", async () => {
+        await seedBase();
+        const result = await resolveModelSources(
+          h.db,
+          "tnt_root",
+          REQ_OPUS,
+          AUTHORIZED_CREATOR_GRANTS,
+        );
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        const [source] = result.sources;
+        if (source === undefined) throw new Error("expected one source");
+        expect("quirks" in source).toBe(false);
       });
 
       test("orders sources by ascending priority", async () => {

--- a/tests/lib/seed.ts
+++ b/tests/lib/seed.ts
@@ -274,6 +274,7 @@ export type SeedModelOffering = {
   priority?: number;
   capabilities?: string[];
   deploymentTags?: string[];
+  quirks?: Record<string, unknown>;
   disabled?: boolean;
 };
 
@@ -289,6 +290,7 @@ export async function seedModelOffering(
     priority: o.priority ?? 0,
     capabilities: o.capabilities ?? [],
     deploymentTags: o.deploymentTags ?? [],
+    quirks: o.quirks ?? null,
     disabled: o.disabled ?? false,
   });
 }


### PR DESCRIPTION
## Summary

- The model offering catalog row carries a nullable `quirks` jsonb bag, the
  runtime `InferenceSource` type carries it, and the catalog resolver hands a
  resolved source's quirks to the adapter factory at instantiation.
- The catalog offering API accepts quirks on create, replaces or clears it on
  patch, and returns it; the development seed provisions the known deployments
  — Anthropic/OpenAI/Gemini direct plus the Fireworks, Moonshot, OpenRouter,
  and OpenCode Zen kimi backends — each with an explicit quirks bag.
- A CI guard validates every seeded offering's quirks bag against its adapter's
  quirk schema, so a bag the adapter would reject cannot be seeded.

## Verification

- `make all` passes: lint, `tsc -b --noEmit --force`, the admin-ui production
  bundle, and the unit and integration test suites all exit 0.
- Migration `0044` applies cleanly against a fresh schema, landing
  `model_offering.quirks` as a nullable `jsonb` column.
- The seed guard test validates each seeded offering's quirks against its
  adapter's quirk schema.
- The seed's catalog rewrite type-checks and lints; a live `bin/dev --seed`
  run is recommended as manual QA, since it resets the development database.

Closes INTR-140