### PR TITLE
Stop the openai adapter forcing reasoning_content by default

### DIFF
--- a/bin/lib/catalog-seed-data.ts
+++ b/bin/lib/catalog-seed-data.ts
@@ -50,7 +50,7 @@ export type CatalogOfferingSpec = {
   curatedCapabilities: Capability[];
   // Per-deployment adapter accommodations, explicit on every offering (the
   // guard enforces it) even when empty. See OPENAI_REASONING_QUIRKS for why
-  // the openai-plugin deployments spell out today's universal defaults.
+  // the openai-plugin deployments carry explicit reasoning quirks.
   quirks: Record<string, unknown>;
   // Dev pricing as decimal strings, matching the API's string money fields.
   price: { input: string; output: string };
@@ -68,13 +68,13 @@ export type CatalogProviderSpec = {
   offerings: CatalogOfferingSpec[];
 };
 
-// The OpenAI adapter today forces reasoning_content on every assistant turn
-// and reads reasoning tokens from these fields, applying this to every
-// openai/openai-compatible source by default. kimi-serving backends depend on
-// that behavior. Spelling it out per deployment matches what these sources
-// implicitly rely on now, so the universal default can later be removed
-// without regressing them. The value equals the current default on purpose:
-// it is the accommodation being made explicit, not a deviation from it.
+// kimi-serving backends require reasoning_content on every assistant turn. The
+// OpenAI adapter no longer forces that by default, so
+// forceAssistantReasoningContent is a required override here: drop it and these
+// deployments regress. reasoningFieldNames instead restates the adapter's
+// still-lenient default (read reasoning_content, then reasoning); it is
+// redundant with that default but kept as explicit catalog documentation of the
+// reasoning fields these backends emit.
 const OPENAI_REASONING_QUIRKS: Record<string, unknown> = {
   forceAssistantReasoningContent: true,
   reasoningFieldNames: ["reasoning_content", "reasoning"],

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -234,15 +234,9 @@ function toOpenAIMessage(
     // forceAssistantReasoningContent true, which keeps the field always
     // present, empty on a turn with no thinking. The default is false: the
     // field is emitted only on turns that actually have thinking.
-    if (forceAssistantReasoningContent) {
-      result["reasoning_content"] =
-        thinkingBlocks.length > 0
-          ? thinkingBlocks.map((b) => b.thinking).join("")
-          : "";
-    } else if (thinkingBlocks.length > 0) {
-      result["reasoning_content"] = thinkingBlocks
-        .map((b) => b.thinking)
-        .join("");
+    const reasoning = thinkingBlocks.map((b) => b.thinking).join("");
+    if (forceAssistantReasoningContent || thinkingBlocks.length > 0) {
+      result["reasoning_content"] = reasoning;
     }
 
     if (toolCalls.length > 0) {

--- a/packages/inference/src/providers/openai.ts
+++ b/packages/inference/src/providers/openai.ts
@@ -27,12 +27,14 @@ const OPENAI_TOOL_NAME_LIMIT: ToolNameLimit = {
 };
 
 // Per-source accommodations for the OpenAI-compatible backends this adapter
-// serves. Every field is optional; an absent field resolves to today's
-// universal behavior, so a source that supplies no quirks is unchanged.
+// serves. Every field is optional; an absent field resolves to the strict
+// protocol default, so a source that supplies no quirks gets no accommodation
+// and must opt into lenient behavior explicitly.
 export const OpenAIQuirks = type({
-  // Emit `reasoning_content` on every assistant message even when the turn
-  // carried no thinking (kimi requires it whenever thinking is enabled). When
-  // false, the field is emitted only on turns that actually have thinking.
+  // When true, emit `reasoning_content` on every assistant message even when
+  // the turn carried no thinking (kimi requires it whenever thinking is
+  // enabled). Defaults to false: the field is emitted only on turns that
+  // actually have thinking.
   "forceAssistantReasoningContent?": "boolean",
   // Which delta fields to read reasoning tokens from, in precedence order.
   // Constrained to the fields the chunk schema declares so the type cannot
@@ -228,11 +230,10 @@ function toOpenAIMessage(
 
     // kimi requires reasoning_content on every assistant message once thinking
     // is enabled anywhere in the conversation, even on turns that carried no
-    // thinking of their own. forceAssistantReasoningContent (the universal
-    // default, true) satisfies that: the field is always present, empty on a
-    // turn with no thinking. A source whose backend does not share that
-    // requirement sets the quirk false, and the field is emitted only on turns
-    // that actually have thinking.
+    // thinking of their own. A source serving such a backend sets
+    // forceAssistantReasoningContent true, which keeps the field always
+    // present, empty on a turn with no thinking. The default is false: the
+    // field is emitted only on turns that actually have thinking.
     if (forceAssistantReasoningContent) {
       result["reasoning_content"] =
         thinkingBlocks.length > 0
@@ -782,7 +783,7 @@ export function createOpenAIAdapter(
   }
   const resolvedQuirks: ResolvedOpenAIQuirks = {
     forceAssistantReasoningContent:
-      parsedQuirks.forceAssistantReasoningContent ?? true,
+      parsedQuirks.forceAssistantReasoningContent ?? false,
     reasoningFieldNames:
       parsedQuirks.reasoningFieldNames ?? DEFAULT_REASONING_FIELDS,
   };

--- a/tests/inference/providers/openai.test.ts
+++ b/tests/inference/providers/openai.test.ts
@@ -1044,12 +1044,22 @@ describe("OpenAI adapter: quirks", () => {
     return message;
   }
 
-  test("absent quirks emit reasoning_content on assistant turns without thinking", () => {
+  test("absent quirks omit reasoning_content on a turn without thinking", () => {
     const message = assistantMessage(
       createOpenAIAdapter(TEST_SOURCE),
       assistantWithText,
     );
-    expect(ReasoningContentView.assert(message).reasoning_content).toBe("");
+    expect("reasoning_content" in message).toBe(false);
+  });
+
+  test("absent quirks emit reasoning_content on a turn with thinking", () => {
+    const message = assistantMessage(
+      createOpenAIAdapter(TEST_SOURCE),
+      assistantWithThinking,
+    );
+    expect(ReasoningContentView.assert(message).reasoning_content).toBe(
+      "pondering",
+    );
   });
 
   test("forceAssistantReasoningContent false omits reasoning_content on turns without thinking", () => {
@@ -1066,6 +1076,28 @@ describe("OpenAI adapter: quirks", () => {
     const message = assistantMessage(
       createOpenAIAdapter(TEST_SOURCE, {
         forceAssistantReasoningContent: false,
+      }),
+      assistantWithThinking,
+    );
+    expect(ReasoningContentView.assert(message).reasoning_content).toBe(
+      "pondering",
+    );
+  });
+
+  test("forceAssistantReasoningContent true forces reasoning_content on a turn without thinking", () => {
+    const message = assistantMessage(
+      createOpenAIAdapter(TEST_SOURCE, {
+        forceAssistantReasoningContent: true,
+      }),
+      assistantWithText,
+    );
+    expect(ReasoningContentView.assert(message).reasoning_content).toBe("");
+  });
+
+  test("forceAssistantReasoningContent true emits reasoning_content on a turn with thinking", () => {
+    const message = assistantMessage(
+      createOpenAIAdapter(TEST_SOURCE, {
+        forceAssistantReasoningContent: true,
       }),
       assistantWithThinking,
     );


### PR DESCRIPTION
## Summary

- The openai adapter defaults `forceAssistantReasoningContent` to false:
  `reasoning_content` is emitted on an assistant message only when that turn
  carries thinking. Forcing it onto every assistant message requires the
  explicit per-source quirk.
- The six catalog offerings whose backends require the forced field carry
  `forceAssistantReasoningContent` explicitly, so the strict default leaves
  them unchanged while any source without the quirk gets the strict protocol.

## Verification

The build passes (`make all` exits 0: lint, `tsc -b`, the admin-ui bundle, and
both test passes). The openai adapter suite pins the strict default (no
`reasoning_content` on a thinking-free assistant turn), the explicit-quirk
forcing path, and the reasoning-field precedence.

Closes INTR-141