### PR TITLE
Deduplicate the discovery turn-1 resolver and support-matrix factories

### DIFF
--- a/packages/inference-discovery-anthropic/src/index.ts
+++ b/packages/inference-discovery-anthropic/src/index.ts
@@ -4,11 +4,13 @@ import {
   type Capability,
   type CapabilityIntent,
 } from "@intx/inference-discovery/catalog";
-import type {
-  CaptureStep,
-  CapturedResponse,
-  IterateCaptureStepsOpts,
-  ProviderPlugin,
+import {
+  resolveTurn1Response,
+  type CaptureStep,
+  type CapturedResponse,
+  type IterateCaptureStepsOpts,
+  type ProviderPlugin,
+  type Turn1Reconstructor,
 } from "@intx/inference-discovery";
 import { buildAuthHeaders } from "./auth";
 import {
@@ -198,21 +200,14 @@ function makeJsonStep(opts: {
   });
 }
 
-// Reconstructs the assistant content blocks from turn-1's CapturedResponse.
-// For JSON turn-1, that is the parsed message body. For SSE turn-1, the
-// runner returns bytes and we parse them through the SSE event stream.
-// Both paths surface the blocks in the shape buildFunctionCallingTurn2Body
-// and buildRedactedThinkingTurn2Body expect.
-function turn1AssistantResponse(turn1: CapturedResponse): unknown {
-  if (turn1.parsed !== null) return turn1.parsed;
-  if (turn1.bytes === null) {
-    throw new Error(
-      "anthropic multi-turn: turn-1 CapturedResponse had neither parsed body nor SSE bytes",
-    );
-  }
-  const blocks = extractContentBlocksFromSSE(turn1.bytes);
-  return { content: blocks };
-}
+// Reconstructs the assistant response from turn-1's SSE bytes into the shape
+// buildFunctionCallingTurn2Body and buildRedactedThinkingTurn2Body expect:
+// the content blocks wrapped as { content: blocks }. The parsed/bytes/throw
+// dispatch lives in the shared resolveTurn1Response; this callback owns only
+// Anthropic's wire shape.
+const reconstructTurn1Blocks: Turn1Reconstructor = (bytes) => ({
+  content: extractContentBlocksFromSSE(bytes),
+});
 
 export function* iterateCaptureSteps(
   opts: IterateCaptureStepsOpts,
@@ -249,7 +244,10 @@ export function* iterateCaptureSteps(
       capability,
       intent,
       turn1Body,
-      turn1Response: turn1AssistantResponse(turn1Response),
+      turn1Response: resolveTurn1Response(
+        turn1Response,
+        reconstructTurn1Blocks,
+      ),
     });
     yield makeJsonStep({
       capability,
@@ -275,7 +273,10 @@ export function* iterateCaptureSteps(
       model,
       intent,
       turn1Body,
-      turn1Response: turn1AssistantResponse(turn1Response),
+      turn1Response: resolveTurn1Response(
+        turn1Response,
+        reconstructTurn1Blocks,
+      ),
     });
     yield makeJsonStep({
       capability,

--- a/packages/inference-discovery-google-genai/src/index.ts
+++ b/packages/inference-discovery-google-genai/src/index.ts
@@ -5,11 +5,12 @@ import {
   type CapabilityIntent,
   type MediaRef,
 } from "@intx/inference-discovery/catalog";
-import type {
-  CaptureStep,
-  CapturedResponse,
-  IterateCaptureStepsOpts,
-  ProviderPlugin,
+import {
+  resolveTurn1Response,
+  type CaptureStep,
+  type CapturedResponse,
+  type IterateCaptureStepsOpts,
+  type ProviderPlugin,
 } from "@intx/inference-discovery";
 import { buildAuthHeaders } from "./auth";
 import { buildEndpointURL } from "./endpoint";
@@ -202,19 +203,6 @@ function deriveToolFollowUp(intent: CapabilityIntent): {
   return { toolName: tool.name, content: "{}" };
 }
 
-// Resolves turn-1's assistant response for the multi-turn builder. A
-// non-streaming turn-1 arrives as parsed JSON; a streaming turn-1 arrives as
-// SSE bytes and is reconstructed into the same response shape.
-function turn1AssistantResponse(turn1: CapturedResponse): unknown {
-  if (turn1.parsed !== null) return turn1.parsed;
-  if (turn1.bytes === null) {
-    throw new Error(
-      "google-genai multi-turn: turn-1 had neither a parsed body nor SSE bytes",
-    );
-  }
-  return reconstructResponseFromSSE(turn1.bytes);
-}
-
 function buildMultiTurnTurn2Body(opts: {
   capability: Capability;
   intent: CapabilityIntent;
@@ -311,7 +299,10 @@ export function* iterateCaptureSteps(
       capability,
       intent,
       turn1Body,
-      turn1Response: turn1AssistantResponse(turn1Response),
+      turn1Response: resolveTurn1Response(
+        turn1Response,
+        reconstructResponseFromSSE,
+      ),
     });
     yield {
       kind: "json",

--- a/packages/inference-discovery/src/catalog/support-matrix.test.ts
+++ b/packages/inference-discovery/src/catalog/support-matrix.test.ts
@@ -1,6 +1,11 @@
 import { describe, test, expect } from "bun:test";
 import { type } from "arktype";
-import { SUPPORT_MATRIX, SupportEntry, getFixtureDir } from "./support-matrix";
+import {
+  SUPPORT_MATRIX,
+  SupportEntry,
+  STRUCTURED_OUTPUT_CAPABILITIES,
+  getFixtureDir,
+} from "./support-matrix";
 
 describe("SUPPORT_MATRIX validation", () => {
   test("every entry parses as a SupportEntry", () => {
@@ -45,6 +50,18 @@ describe("SUPPORT_MATRIX validation", () => {
       expect(seen.has(key)).toBe(false);
       seen.add(key);
     }
+  });
+});
+
+describe("STRUCTURED_OUTPUT_CAPABILITIES", () => {
+  // Pins the shared constant's exact membership so that adding a member fails
+  // here loudly rather than silently fanning an extra row across every model
+  // that references it.
+  test("is exactly the two structured-output capabilities", () => {
+    expect(STRUCTURED_OUTPUT_CAPABILITIES).toEqual([
+      "structured-output",
+      "structured-output-streaming",
+    ]);
   });
 });
 

--- a/packages/inference-discovery/src/catalog/support-matrix.test.ts
+++ b/packages/inference-discovery/src/catalog/support-matrix.test.ts
@@ -4,6 +4,7 @@ import {
   SUPPORT_MATRIX,
   SupportEntry,
   STRUCTURED_OUTPUT_CAPABILITIES,
+  assertNotesDiscipline,
   getFixtureDir,
 } from "./support-matrix";
 
@@ -50,6 +51,55 @@ describe("SUPPORT_MATRIX validation", () => {
       expect(seen.has(key)).toBe(false);
       seen.add(key);
     }
+  });
+});
+
+describe("assertNotesDiscipline", () => {
+  const base = {
+    provider: "opencode-zen",
+    model: "kimi-k3",
+    capability: "plain-text",
+  } as const;
+
+  const deviations = [
+    "misled",
+    "unsupported",
+    "refused",
+    "http-error",
+  ] as const;
+
+  test("accepts a captured row with no notes", () => {
+    expect(() =>
+      assertNotesDiscipline({ ...base, outcome: "captured" }),
+    ).not.toThrow();
+  });
+
+  test("rejects a captured row that carries notes", () => {
+    expect(() =>
+      assertNotesDiscipline({ ...base, outcome: "captured", notes: "oops" }),
+    ).toThrow(/must not carry notes/);
+  });
+
+  test("accepts every deviation outcome with a non-empty note", () => {
+    for (const outcome of deviations) {
+      expect(() =>
+        assertNotesDiscipline({ ...base, outcome, notes: "explained" }),
+      ).not.toThrow();
+    }
+  });
+
+  test("rejects a deviation outcome with no notes", () => {
+    for (const outcome of deviations) {
+      expect(() => assertNotesDiscipline({ ...base, outcome })).toThrow(
+        /requires a non-empty notes/,
+      );
+    }
+  });
+
+  test("rejects a deviation outcome with blank notes", () => {
+    expect(() =>
+      assertNotesDiscipline({ ...base, outcome: "unsupported", notes: "   " }),
+    ).toThrow(/requires a non-empty notes/);
   });
 });
 

--- a/packages/inference-discovery/src/catalog/support-matrix.ts
+++ b/packages/inference-discovery/src/catalog/support-matrix.ts
@@ -137,9 +137,9 @@ const OPENAI_UNSUPPORTED_REASONING = [
 
 // Builds one SupportEntry per capability for a single (provider, model,
 // outcome). notes is included only when supplied, so captured rows stay
-// notes-free while misled/unsupported rows carry their explanation. The
-// per-outcome notes pairing (captured carries no notes; misled/unsupported
-// always do) is the caller's responsibility: this helper does not enforce it.
+// notes-free while misled/unsupported rows carry their explanation. rows does
+// not itself check the notes/outcome pairing; assertNotesDiscipline enforces it
+// over the assembled matrix at module load.
 function rows(
   provider: string,
   model: string,
@@ -421,6 +421,13 @@ const FIXTURE_BEARING_OUTCOMES = new Set<SupportEntry["outcome"]>([
   "misled",
 ]);
 
+// captured is the sole self-explanatory outcome: its fixture is the evidence, so
+// the row carries no notes. Every other outcome is a deviation that must justify
+// itself, so it requires a non-empty notes explanation. This is a DIFFERENT axis
+// from FIXTURE_BEARING_OUTCOMES — misled is fixture-bearing yet still requires
+// notes — so the two sets are intentionally distinct; do not unify them.
+const NOTES_FREE_OUTCOMES = new Set<SupportEntry["outcome"]>(["captured"]);
+
 // captured and misled rows both point to a captured wire flow on disk that the
 // smoke tests replay, so both are empirical proof the capability works; refused,
 // http-error, and unsupported rows carry no fixture. This is the single owner of
@@ -440,4 +447,31 @@ export function getFixtureDir(entry: SupportEntry): string | null {
     );
   }
   return `${root}/${entry.provider}/${entry.model}/${entry.capability}`;
+}
+
+// Enforces the notes/outcome pairing on a single entry: a notes-free outcome
+// must carry no notes; every other outcome must carry a non-empty notes
+// explanation. Applied to every entry at module load below, so it covers the
+// inline refused/http-error rows that never flow through rows() as well.
+export function assertNotesDiscipline(entry: SupportEntry): void {
+  const site = `${entry.provider}/${entry.model}/${entry.capability}`;
+  if (NOTES_FREE_OUTCOMES.has(entry.outcome)) {
+    if (entry.notes !== undefined) {
+      throw new Error(
+        `support-matrix: ${site} is ${entry.outcome} and must not carry ` +
+          `notes (got ${JSON.stringify(entry.notes)})`,
+      );
+    }
+    return;
+  }
+  if (entry.notes === undefined || entry.notes.trim().length === 0) {
+    throw new Error(
+      `support-matrix: ${site} is ${entry.outcome} and requires a non-empty ` +
+        `notes explanation`,
+    );
+  }
+}
+
+for (const entry of SUPPORT_MATRIX) {
+  assertNotesDiscipline(entry);
 }

--- a/packages/inference-discovery/src/catalog/support-matrix.ts
+++ b/packages/inference-discovery/src/catalog/support-matrix.ts
@@ -50,6 +50,17 @@ const GEMINI_IMAGE_MODEL = "gemini-2.5-flash-image";
 const OPENCODE_PROVIDER = "opencode-zen";
 const OPENAI_PROVIDER = "openai";
 
+// The structured-output capability pair, shared by the rows whose entire
+// capability list is exactly this pair — several opencode models with outcome
+// captured, and Anthropic with outcome unsupported — so they need not re-spell
+// it. These two capabilities also appear as members of the larger
+// GEMINI_TEXT_CAPABILITIES and OPENAI_CAPTURED_CAPABILITIES lists, where they
+// stay inline as part of those providers' full captured sets.
+export const STRUCTURED_OUTPUT_CAPABILITIES = [
+  "structured-output",
+  "structured-output-streaming",
+] as const satisfies readonly SupportEntry["capability"][];
+
 const GEMINI_TEXT_CAPABILITIES = [
   "plain-text",
   "plain-text-streaming",
@@ -184,11 +195,6 @@ const ANTHROPIC_UNSUPPORTED_OUTPUT_MODALITIES = [
   "image-output-streaming",
 ] as const satisfies readonly SupportEntry["capability"][];
 
-const ANTHROPIC_UNSUPPORTED_STRUCTURED_OUTPUTS = [
-  "structured-output",
-  "structured-output-streaming",
-] as const satisfies readonly SupportEntry["capability"][];
-
 const MATRIX: SupportEntry[] = [
   ...ANTHROPIC_MODELS.flatMap((model) =>
     rows(
@@ -229,7 +235,7 @@ const MATRIX: SupportEntry[] = [
     rows(
       ANTHROPIC_PROVIDER,
       model,
-      ANTHROPIC_UNSUPPORTED_STRUCTURED_OUTPUTS,
+      STRUCTURED_OUTPUT_CAPABILITIES,
       "unsupported",
       "Anthropic's Messages API has no native structured-outputs surface. The internal adapter rejects responseFormat values of json and json-schema at the marshaling boundary rather than synthesizing a hidden tool-input wrapper; callers needing structured output route through a provider with native support.",
     ),
@@ -299,20 +305,20 @@ const MATRIX: SupportEntry[] = [
   ...rows(
     OPENCODE_PROVIDER,
     "gpt-5.4-mini",
-    ["structured-output", "structured-output-streaming"],
+    STRUCTURED_OUTPUT_CAPABILITIES,
     "captured",
   ),
   ...rows(
     OPENCODE_PROVIDER,
     "kimi-k2.6",
-    ["structured-output", "structured-output-streaming"],
+    STRUCTURED_OUTPUT_CAPABILITIES,
     "captured",
   ),
   ...rows(OPENCODE_PROVIDER, "kimi-k3", OPENCODE_FULL_CAPABILITIES, "captured"),
   ...rows(
     OPENCODE_PROVIDER,
     "kimi-k3",
-    ["structured-output", "structured-output-streaming"],
+    STRUCTURED_OUTPUT_CAPABILITIES,
     "captured",
   ),
   ...rows(
@@ -324,19 +330,19 @@ const MATRIX: SupportEntry[] = [
   ...rows(
     OPENCODE_PROVIDER,
     "kimi-k2.7-code",
-    ["structured-output", "structured-output-streaming"],
+    STRUCTURED_OUTPUT_CAPABILITIES,
     "captured",
   ),
   ...rows(
     OPENCODE_PROVIDER,
     "glm-5.1",
-    ["structured-output", "structured-output-streaming"],
+    STRUCTURED_OUTPUT_CAPABILITIES,
     "captured",
   ),
   ...rows(
     OPENCODE_PROVIDER,
     "qwen3.6-plus",
-    ["structured-output", "structured-output-streaming"],
+    STRUCTURED_OUTPUT_CAPABILITIES,
     "captured",
   ),
   {

--- a/packages/inference-discovery/src/catalog/support-matrix.ts
+++ b/packages/inference-discovery/src/catalog/support-matrix.ts
@@ -124,67 +124,24 @@ const OPENAI_UNSUPPORTED_REASONING = [
   "reasoning-content-streaming",
 ] as const satisfies readonly SupportEntry["capability"][];
 
-function gemini(
+// Builds one SupportEntry per capability for a single (provider, model,
+// outcome). notes is included only when supplied, so captured rows stay
+// notes-free while misled/unsupported rows carry their explanation. The
+// per-outcome notes pairing (captured carries no notes; misled/unsupported
+// always do) is the caller's responsibility: this helper does not enforce it.
+function rows(
+  provider: string,
   model: string,
   capabilities: readonly SupportEntry["capability"][],
+  outcome: SupportEntry["outcome"],
+  notes?: string,
 ): SupportEntry[] {
   return capabilities.map((capability) => ({
-    provider: GEMINI_PROVIDER,
+    provider,
     model,
     capability,
-    outcome: "captured",
-  }));
-}
-
-function geminiMisled(
-  model: string,
-  capabilities: readonly SupportEntry["capability"][],
-  notes: string,
-): SupportEntry[] {
-  return capabilities.map((capability) => ({
-    provider: GEMINI_PROVIDER,
-    model,
-    capability,
-    outcome: "misled",
-    notes,
-  }));
-}
-
-function opencode(
-  model: string,
-  capabilities: readonly SupportEntry["capability"][],
-): SupportEntry[] {
-  return capabilities.map((capability) => ({
-    provider: OPENCODE_PROVIDER,
-    model,
-    capability,
-    outcome: "captured",
-  }));
-}
-
-function openai(
-  model: string,
-  capabilities: readonly SupportEntry["capability"][],
-): SupportEntry[] {
-  return capabilities.map((capability) => ({
-    provider: OPENAI_PROVIDER,
-    model,
-    capability,
-    outcome: "captured",
-  }));
-}
-
-function openaiUnsupported(
-  model: string,
-  capabilities: readonly SupportEntry["capability"][],
-  notes: string,
-): SupportEntry[] {
-  return capabilities.map((capability) => ({
-    provider: OPENAI_PROVIDER,
-    model,
-    capability,
-    outcome: "unsupported",
-    notes,
+    outcome,
+    ...(notes === undefined ? {} : { notes }),
   }));
 }
 
@@ -232,116 +189,156 @@ const ANTHROPIC_UNSUPPORTED_STRUCTURED_OUTPUTS = [
   "structured-output-streaming",
 ] as const satisfies readonly SupportEntry["capability"][];
 
-function anthropic(
-  model: string,
-  capabilities: readonly SupportEntry["capability"][],
-): SupportEntry[] {
-  return capabilities.map((capability) => ({
-    provider: ANTHROPIC_PROVIDER,
-    model,
-    capability,
-    outcome: "captured",
-  }));
-}
-
-function anthropicUnsupported(
-  model: string,
-  capabilities: readonly SupportEntry["capability"][],
-  notes: string,
-): SupportEntry[] {
-  return capabilities.map((capability) => ({
-    provider: ANTHROPIC_PROVIDER,
-    model,
-    capability,
-    outcome: "unsupported",
-    notes,
-  }));
-}
-
-function anthropicMisled(
-  model: string,
-  capabilities: readonly SupportEntry["capability"][],
-  notes: string,
-): SupportEntry[] {
-  return capabilities.map((capability) => ({
-    provider: ANTHROPIC_PROVIDER,
-    model,
-    capability,
-    outcome: "misled",
-    notes,
-  }));
-}
-
 const MATRIX: SupportEntry[] = [
   ...ANTHROPIC_MODELS.flatMap((model) =>
-    anthropic(model, ANTHROPIC_CAPTURED_CAPABILITIES),
+    rows(
+      ANTHROPIC_PROVIDER,
+      model,
+      ANTHROPIC_CAPTURED_CAPABILITIES,
+      "captured",
+    ),
   ),
   ...ANTHROPIC_MODELS.flatMap((model) =>
-    anthropicMisled(
+    rows(
+      ANTHROPIC_PROVIDER,
       model,
       ANTHROPIC_MISLED_CAPABILITIES,
+      "misled",
       "Anthropic's documentation describes the canary prompt as a deterministic trigger for a redacted_thinking content block. On capture day the safety classifier did not fire on any first-party model; the assistant response carries a regular thinking block instead. The fixture on disk documents what the wire actually returned for the documented input. The plug-in and SSE parser already accept redacted_thinking blocks, so a future re-capture on a day the classifier does fire will flip this row to captured without code changes.",
     ),
   ),
   ...ANTHROPIC_MODELS.flatMap((model) =>
-    anthropicUnsupported(
+    rows(
+      ANTHROPIC_PROVIDER,
       model,
       ANTHROPIC_UNSUPPORTED_INPUT_MODALITIES,
+      "unsupported",
       "Anthropic's first-party Claude models do not accept audio or video inputs; the Messages API content array only permits text, image, document, tool_use, and tool_result blocks. No equivalent server-side ingestion path exists today.",
     ),
   ),
   ...ANTHROPIC_MODELS.flatMap((model) =>
-    anthropicUnsupported(
+    rows(
+      ANTHROPIC_PROVIDER,
       model,
       ANTHROPIC_UNSUPPORTED_OUTPUT_MODALITIES,
+      "unsupported",
       "Anthropic's first-party Claude models do not emit images; the Messages API surface is text-only on the output side and has no responseModalities-style toggle.",
     ),
   ),
   ...ANTHROPIC_MODELS.flatMap((model) =>
-    anthropicUnsupported(
+    rows(
+      ANTHROPIC_PROVIDER,
       model,
       ANTHROPIC_UNSUPPORTED_STRUCTURED_OUTPUTS,
+      "unsupported",
       "Anthropic's Messages API has no native structured-outputs surface. The internal adapter rejects responseFormat values of json and json-schema at the marshaling boundary rather than synthesizing a hidden tool-input wrapper; callers needing structured output route through a provider with native support.",
     ),
   ),
-  ...gemini(GEMINI_TEXT_MODEL, GEMINI_TEXT_CAPABILITIES),
-  ...gemini(GEMINI_IMAGE_MODEL, GEMINI_IMAGE_CAPABILITIES),
-  ...geminiMisled(
+  ...rows(
+    GEMINI_PROVIDER,
+    GEMINI_TEXT_MODEL,
+    GEMINI_TEXT_CAPABILITIES,
+    "captured",
+  ),
+  ...rows(
+    GEMINI_PROVIDER,
+    GEMINI_IMAGE_MODEL,
+    GEMINI_IMAGE_CAPABILITIES,
+    "captured",
+  ),
+  ...rows(
+    GEMINI_PROVIDER,
     GEMINI_TEXT_MODEL,
     GEMINI_TEXT_MISLED_CAPABILITIES,
+    "misled",
     'Probe prompt did not engage Gemini\'s structured safety classifier on capture day. The model self-refused via response text content but `safetyRatings`, `promptFeedback`, and `finishReason: "SAFETY"` are all absent from the response. The fixture on disk documents what the wire actually returned for the documented probe input. A future re-capture (different prompt, different classifier thresholds, or different model behavior) may flip this row to captured without code changes once a structured safety signal materializes.',
   ),
-  ...gemini("gemini-2.5-pro", GEMINI_TEXT_CAPABILITIES),
-  ...geminiMisled(
+  ...rows(
+    GEMINI_PROVIDER,
+    "gemini-2.5-pro",
+    GEMINI_TEXT_CAPABILITIES,
+    "captured",
+  ),
+  ...rows(
+    GEMINI_PROVIDER,
     "gemini-2.5-pro",
     GEMINI_TEXT_MISLED_CAPABILITIES,
+    "misled",
     'Probe prompt did not engage gemini-2.5-pro\'s structured safety classifier on capture day. The model self-refused via response text content but `safetyRatings`, `promptFeedback`, and `finishReason: "SAFETY"` are all absent from the response. The fixture on disk documents what the wire actually returned for the documented probe input. A future re-capture may flip this row to captured once a structured safety signal materializes.',
   ),
-  ...opencode("kimi-k2.6", OPENCODE_FULL_CAPABILITIES),
-  ...opencode("mimo-v2-omni", OPENCODE_FULL_CAPABILITIES),
-  ...opencode("qwen3.6-plus", OPENCODE_FULL_CAPABILITIES),
-  ...opencode("glm-5.1", OPENCODE_NON_VISION_CAPABILITIES),
-  ...opencode("deepseek-v4-pro", OPENCODE_NON_VISION_CAPABILITIES),
-  ...opencode("gpt-5.4-mini", [
-    "structured-output",
-    "structured-output-streaming",
-  ]),
-  ...opencode("kimi-k2.6", [
-    "structured-output",
-    "structured-output-streaming",
-  ]),
-  ...opencode("kimi-k3", OPENCODE_FULL_CAPABILITIES),
-  ...opencode("kimi-k3", ["structured-output", "structured-output-streaming"]),
-  ...opencode("kimi-k2.7-code", OPENCODE_FULL_CAPABILITIES),
-  ...opencode("kimi-k2.7-code", [
-    "structured-output",
-    "structured-output-streaming",
-  ]),
-  ...opencode("glm-5.1", ["structured-output", "structured-output-streaming"]),
-  ...opencode("qwen3.6-plus", [
-    "structured-output",
-    "structured-output-streaming",
-  ]),
+  ...rows(
+    OPENCODE_PROVIDER,
+    "kimi-k2.6",
+    OPENCODE_FULL_CAPABILITIES,
+    "captured",
+  ),
+  ...rows(
+    OPENCODE_PROVIDER,
+    "mimo-v2-omni",
+    OPENCODE_FULL_CAPABILITIES,
+    "captured",
+  ),
+  ...rows(
+    OPENCODE_PROVIDER,
+    "qwen3.6-plus",
+    OPENCODE_FULL_CAPABILITIES,
+    "captured",
+  ),
+  ...rows(
+    OPENCODE_PROVIDER,
+    "glm-5.1",
+    OPENCODE_NON_VISION_CAPABILITIES,
+    "captured",
+  ),
+  ...rows(
+    OPENCODE_PROVIDER,
+    "deepseek-v4-pro",
+    OPENCODE_NON_VISION_CAPABILITIES,
+    "captured",
+  ),
+  ...rows(
+    OPENCODE_PROVIDER,
+    "gpt-5.4-mini",
+    ["structured-output", "structured-output-streaming"],
+    "captured",
+  ),
+  ...rows(
+    OPENCODE_PROVIDER,
+    "kimi-k2.6",
+    ["structured-output", "structured-output-streaming"],
+    "captured",
+  ),
+  ...rows(OPENCODE_PROVIDER, "kimi-k3", OPENCODE_FULL_CAPABILITIES, "captured"),
+  ...rows(
+    OPENCODE_PROVIDER,
+    "kimi-k3",
+    ["structured-output", "structured-output-streaming"],
+    "captured",
+  ),
+  ...rows(
+    OPENCODE_PROVIDER,
+    "kimi-k2.7-code",
+    OPENCODE_FULL_CAPABILITIES,
+    "captured",
+  ),
+  ...rows(
+    OPENCODE_PROVIDER,
+    "kimi-k2.7-code",
+    ["structured-output", "structured-output-streaming"],
+    "captured",
+  ),
+  ...rows(
+    OPENCODE_PROVIDER,
+    "glm-5.1",
+    ["structured-output", "structured-output-streaming"],
+    "captured",
+  ),
+  ...rows(
+    OPENCODE_PROVIDER,
+    "qwen3.6-plus",
+    ["structured-output", "structured-output-streaming"],
+    "captured",
+  ),
   {
     provider: OPENCODE_PROVIDER,
     model: "deepseek-v4-pro",
@@ -390,10 +387,12 @@ const MATRIX: SupportEntry[] = [
     notes:
       "OpenAI-style multimodal messages[].content elicits HTTP 400 invalid_request_error \"unknown variant 'image_url', expected 'text'\"; recorded as 'http-error' here so no capture is attempted.",
   },
-  ...openai("gpt-5.5", OPENAI_CAPTURED_CAPABILITIES),
-  ...openaiUnsupported(
+  ...rows(OPENAI_PROVIDER, "gpt-5.5", OPENAI_CAPTURED_CAPABILITIES, "captured"),
+  ...rows(
+    OPENAI_PROVIDER,
     "gpt-5.5",
     OPENAI_UNSUPPORTED_REASONING,
+    "unsupported",
     "OpenAI's first-party api.openai.com Chat Completions responses for the gpt-5 series carry no reasoning or reasoning_content field; the assistant message holds only role, content, refusal, and annotations. OpenAI exposes reasoning tokens solely through the Responses API, which this Chat-Completions plug-in does not probe. The OpenAI-protocol opencode-zen relays do surface reasoning_content on this same wire, so this is a first-party OpenAI behavior, not a protocol limitation.",
   ),
 ];

--- a/packages/inference-discovery/src/index.ts
+++ b/packages/inference-discovery/src/index.ts
@@ -4,6 +4,7 @@ export type {
   CapturedResponse,
   IterateCaptureStepsOpts,
 } from "./plugin";
+export { resolveTurn1Response, type Turn1Reconstructor } from "./plugin";
 export { runCapture, type FetchLike, type RunCaptureOpts } from "./runner";
 export {
   writeCapture,

--- a/packages/inference-discovery/src/plugin.test.ts
+++ b/packages/inference-discovery/src/plugin.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from "bun:test";
+import {
+  resolveTurn1Response,
+  type CapturedResponse,
+  type Turn1Reconstructor,
+} from "./plugin";
+
+function capturedResponse(
+  fields: Pick<CapturedResponse, "parsed" | "bytes">,
+): CapturedResponse {
+  return { status: 200, headers: {}, ...fields };
+}
+
+describe("resolveTurn1Response", () => {
+  test("returns the parsed body without invoking reconstruct", () => {
+    const parsed = { content: [{ type: "text", text: "hi" }] };
+    let called = false;
+    const reconstruct: Turn1Reconstructor = () => {
+      called = true;
+      return null;
+    };
+
+    const result = resolveTurn1Response(
+      capturedResponse({ parsed, bytes: null }),
+      reconstruct,
+    );
+
+    expect(result).toBe(parsed);
+    expect(called).toBe(false);
+  });
+
+  test("reconstructs from SSE bytes when parsed is null", () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const reconstructed = { candidates: [] };
+    const received: Uint8Array[] = [];
+    const reconstruct: Turn1Reconstructor = (input) => {
+      received.push(input);
+      return reconstructed;
+    };
+
+    const result = resolveTurn1Response(
+      capturedResponse({ parsed: null, bytes }),
+      reconstruct,
+    );
+
+    expect(result).toBe(reconstructed);
+    expect(received).toEqual([bytes]);
+  });
+
+  test("throws when the response carries neither parsed body nor bytes", () => {
+    expect(() =>
+      resolveTurn1Response(
+        capturedResponse({ parsed: null, bytes: null }),
+        () => expect.unreachable("reconstruct must not run"),
+      ),
+    ).toThrow(/neither a parsed body nor SSE bytes/);
+  });
+});

--- a/packages/inference-discovery/src/plugin.ts
+++ b/packages/inference-discovery/src/plugin.ts
@@ -11,6 +11,27 @@ export interface CapturedResponse {
   bytes: Uint8Array | null;
 }
 
+export type Turn1Reconstructor = (bytes: Uint8Array) => unknown;
+
+// Resolves turn-1's assistant response for a multi-turn capture. A non-streaming
+// turn-1 arrives as a parsed JSON body; a streaming turn-1 arrives as SSE bytes
+// that the provider reconstructs into the response shape its turn-2 builder
+// expects. Enforces CapturedResponse's parsed-XOR-bytes invariant: exactly one
+// of parsed/bytes is non-null, so a response carrying neither is malformed and
+// throws.
+export function resolveTurn1Response(
+  turn1: CapturedResponse,
+  reconstruct: Turn1Reconstructor,
+): unknown {
+  if (turn1.parsed !== null) return turn1.parsed;
+  if (turn1.bytes === null) {
+    throw new Error(
+      "resolveTurn1Response: CapturedResponse had neither a parsed body nor SSE bytes (violates the parsed-XOR-bytes invariant)",
+    );
+  }
+  return reconstruct(turn1.bytes);
+}
+
 export interface IterateCaptureStepsOpts {
   model: string;
   capability: Capability;


### PR DESCRIPTION
## Summary

- Extracts a shared `resolveTurn1Response` into `@intx/inference-discovery`, so the anthropic and google-genai discovery plug-ins share one turn-1 parsed-or-reconstruct dispatch instead of each carrying an identical copy.
- Collapses the eight per-provider `support-matrix` row factories into one generic `rows(provider, model, capabilities, outcome, notes?)`, and names the structured-output capability pair once as `STRUCTURED_OUTPUT_CAPABILITIES`.
- Enforces the notes/outcome pairing across every assembled row at module load: captured rows carry no notes; every other outcome carries a non-empty note.

## Verification

- `make all` passes (lint, `tsc -b`, admin-ui bundle, tests all exit 0).
- `SUPPORT_MATRIX` serializes byte-identically to `origin/main`, so the support-matrix changes alter no rows or outcomes.
- Unit tests cover the three `resolveTurn1Response` branches, the `assertNotesDiscipline` guard across every outcome, and pin `STRUCTURED_OUTPUT_CAPABILITIES` to its exact members.

Closes INTR-355
Closes INTR-356