### PR TITLE
Forward contextTransforms from agent env into reactor assembly

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -640,6 +640,9 @@ export async function createAgent<EnvReq extends BaseEnv>(
         : {}),
       deps,
       ...(env.compactors !== undefined ? { compactors: env.compactors } : {}),
+      ...(env.contextTransforms !== undefined
+        ? { contextTransforms: env.contextTransforms }
+        : {}),
     });
 
     sendQueue = createSendQueue<InboundMessage, SendResult>({

--- a/packages/agent/src/env.ts
+++ b/packages/agent/src/env.ts
@@ -17,6 +17,7 @@ import type {
   AuditStore,
   Compactor,
   ContextStore,
+  ContextTransform,
   InferenceSource,
 } from "@intx/types/runtime";
 
@@ -140,6 +141,13 @@ export interface BaseEnv {
    * Forwarded to the reactor assembly's size-cap transform.
    */
   sizeCapMaxChars?: number;
+
+  /**
+   * Pre-inference context transforms applied in order before every model call.
+   * Output materializes into the cycle prompt only; durable turns stay untouched.
+   * Optional — omit for the default empty chain.
+   */
+  contextTransforms?: ContextTransform[];
 
   /**
    * Maximum number of pending sends (active + queued). Beyond this,

--- a/packages/inference/src/reactor.ts
+++ b/packages/inference/src/reactor.ts
@@ -446,6 +446,11 @@ export function createReactor(config: ReactorConfig): Reactor {
       await persistBlobs(result.blobs);
     }
 
+    const ephemeral = options?.ephemeralTurns;
+    if (ephemeral !== undefined && ephemeral.length > 0) {
+      prompt = [...prompt, ...ephemeral];
+    }
+
     // Tripwire: a malformed tool sequence is invalid in a coherent tool
     // conversation and would otherwise surface as an opaque provider rejection.
     // Catch it here, before the prompt is persisted or sent, so the corruption

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -2234,6 +2234,12 @@ export type InferenceOptions = {
    * omitted, a built-in default policy is applied.
    */
   retryPolicy?: RetryPolicy;
+  /**
+   * Conversation turns prepended to the materialized prompt for this
+   * inference only. Not committed to durable history, so transient director
+   * guidance does not alter the cached baseline system prompt on later turns.
+   */
+  ephemeralTurns?: ConversationTurn[];
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds optional contextTransforms on agent BaseEnv and forwards them into createReactorAssembly. Needed by corbits-code PR #254 (attachment rehydrate).