### PR TITLE
Run CI on pushes to main, not only pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,24 @@ name: Continuous Integration
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  # Push to main is a post-merge canary: it re-runs make all against the tip of
+  # main to catch a break that no PR check saw (e.g. two green PRs that conflict
+  # semantically once both land). It reports a broken main; it cannot prevent
+  # the commit landing — that guarantee is branch protection requiring this check.
+  push:
+    branches: [main]
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # PRs group by number so a newer push supersedes and cancels the stale run.
+  # Pushes to main group by commit SHA, giving every commit its own group. A
+  # constant refs/heads/main key would place all main pushes in one group,
+  # where a group holds only one pending run: a newer push would evict the
+  # pending run of a commit still queued behind an in-flight one, and that
+  # mid-flight commit would never be validated. Per-SHA grouping is what
+  # guarantees every commit on main runs; cancel-in-progress only governs PR
+  # supersession (it does not protect a pending run, so it cannot carry this).
+  group: ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Trigger `make all` on pushes to `main`, not only on pull requests, so every
  commit that lands on `main` is validated — including one that reaches `main`
  outside the PR flow.
- Key the push concurrency group on the commit SHA, so each main commit runs in
  its own group and none is evicted from a shared single pending slot. Pull
  requests still group by number and cancel superseded runs.

## Verification

- `make lint` and `make build` pass on the branch (exit 0).
- The full Postgres-backed `make all` runs in CI on this PR.

Closes INTR-381