### PR TITLE
Add a Playwright harness that brings the full stack up headless

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,18 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # Cache the Playwright browser download, keyed on the resolved
+      # @playwright/test version that bun.lock pins. On a hit the install
+      # step below is a no-op; on a miss it re-downloads Chromium.
+      - name: Cache Playwright browsers
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+
       # Copy the committed dev-default env files. BETTER_AUTH_SECRET ships empty in
       # the example, so set it in place (do not append — a second line would leave
       # the key defined twice and the hub tests read the empty one and hard-fail).
@@ -110,3 +122,10 @@ jobs:
 
       - name: Run make all
         run: make all
+
+      # Browser-driven end-to-end suite. Reuses the container Postgres and
+      # the job-level PG* env: the provisioner's maintenance connection
+      # runs as the postgres superuser, so it can CREATE DATABASE per run.
+      # test-e2e-run skips the bundle build; `make all` above already built it.
+      - name: Run make test-e2e-run
+        run: make test-e2e-run

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,7 @@
 bun.lock
 dist
 docs/API.md
+test-results
+playwright-report
 *~
 *\#*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ The remaining command gets a clean, running system with seed data. It drops and 
 | Bundle the admin UI           | `make build-admin-ui`   |
 | Lint only                     | `make lint`             |
 | Run tests only                | `make test`             |
+| Admin UI e2e suite            | `make test-e2e`         |
 | Auto-format                   | `make format`           |
 | Regenerate API docs           | `make docs`             |
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -53,6 +53,7 @@ make build-admin-ui  # admin-ui production bundle (vite build)
 make lint            # Prettier + ESLint + API docs freshness
 make format          # Auto-format with Prettier
 make test            # Run bun tests
+make test-e2e        # Admin UI browser end-to-end suite (excluded from all)
 make docs            # Regenerate API documentation
 ```
 

--- a/DEV.md
+++ b/DEV.md
@@ -159,6 +159,7 @@ make build-admin-ui # admin-ui production bundle (vite build)
 make lint           # Prettier + ESLint + API docs freshness
 make format         # Prettier auto-fix
 make test           # All tests
+make test-e2e       # Admin UI browser end-to-end suite (excluded from all)
 make docs           # Regenerate API documentation
 make clean          # Remove tsbuildinfo, dist directories, env stamp
 ```
@@ -166,6 +167,28 @@ make clean          # Remove tsbuildinfo, dist directories, env stamp
 The pre-commit hook checks out the staged tree into a temporary
 directory and runs `make lint` against it, so only committed content
 is validated.
+
+### End-to-End Suite
+
+`make test-e2e` runs the Playwright browser suite in `tests/admin-ui-e2e`.
+It builds the admin UI bundle (`make build-admin-ui`), brings up a
+hermetic stack headless -- a fresh per-run database, a hub, and a vite
+preview server serving the built admin UI -- and drives a real browser
+through a login against that UI. It is excluded from `make all` and
+`make test`; run it on its own.
+
+Local prerequisites:
+
+- An already-running PostgreSQL. The suite does not use docker.
+- A maintenance/superuser Postgres connection available through the
+  ambient `PG*` libpq environment (`PGHOST`, `PGPORT`, `PGUSER`, ...),
+  so the per-run provisioner can `CREATE DATABASE`. This is the same
+  superuser basis `bin/db-reset` relies on.
+- A one-time browser install: `bunx playwright install chromium`.
+
+The harness sets `ADMIN_UI_HUB_ORIGIN` for the run; the vite preview
+proxy reads it to point the admin UI's `/api` calls at that run's hub.
+You do not set it by hand.
 
 ## Bin Scripts
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,18 @@ test: FORCE
 test-load: FORCE
 	$(BUN) test --timeout 300000 tests/workflow-deploy/fifo-mail-load.test.ts
 
+# Browser-driven admin UI end-to-end suite (Playwright). Excluded from
+# all/test; needs a running Postgres and a one-time
+# `bunx playwright install chromium`. Builds the admin UI bundle first
+# because the harness globalSetup requires apps/admin-ui/dist.
+test-e2e: build-admin-ui
+	$(MAKE) test-e2e-run
+
+# Run the suite against an already-built bundle (CI builds it via
+# `make all` and must not build it twice).
+test-e2e-run: FORCE
+	cd tests/admin-ui-e2e && bunx playwright test
+
 verify-tool-load: FORCE
 	bun bin/verify-tool-load.ts
 
@@ -54,5 +66,5 @@ clean:
 
 include .env-checked
 
-.PHONY: all build build-admin-ui lint test test-load verify-tool-load format docs clean builtins publish-builtins
+.PHONY: all build build-admin-ui lint test test-load test-e2e test-e2e-run verify-tool-load format docs clean builtins publish-builtins
 FORCE:

--- a/apps/admin-ui/vite.config.ts
+++ b/apps/admin-ui/vite.config.ts
@@ -3,6 +3,12 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defaultClientConditions, defineConfig } from "vite";
 
+// ADMIN_UI_HUB_ORIGIN drives only the preview proxy (the e2e harness
+// points it at a per-run hub port). The dev server proxy stays
+// hardcoded so a stale env var in a dev shell cannot silently redirect
+// `make dev` away from the local hub.
+const hubOrigin = process.env["ADMIN_UI_HUB_ORIGIN"] ?? "http://localhost:3000";
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
@@ -27,6 +33,15 @@ export default defineConfig({
       "/ws": {
         target: "http://localhost:3000",
         ws: true,
+      },
+    },
+  },
+  preview: {
+    proxy: {
+      "/api": {
+        target: hubOrigin,
+        changeOrigin: true,
+        headers: { origin: hubOrigin },
       },
     },
   },

--- a/bin/dev.ts
+++ b/bin/dev.ts
@@ -27,6 +27,7 @@ import {
   publishToolPackages,
 } from "./lib/publish-tool-packages";
 import { WORKSPACE_BUILTINS_REGISTRY } from "@intx/hub-sessions";
+import { waitForHTTP } from "@intx/test-harness/http";
 
 $.verbose = false;
 
@@ -210,24 +211,6 @@ function watchProcess(label: string, proc: ProcessPromise): void {
 }
 
 // ---------------------------------------------------------------------------
-// Health check
-// ---------------------------------------------------------------------------
-
-async function waitForHub(url: string, timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(url);
-      if (res.status < 500) return;
-    } catch {
-      // Not up yet.
-    }
-    await new Promise((r) => setTimeout(r, 500));
-  }
-  throw new Error(`Hub did not become ready within ${timeoutMs / 1000}s`);
-}
-
-// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -333,7 +316,7 @@ const hubProc = spawnLabeled(
 watchProcess("hub", hubProc);
 
 try {
-  await waitForHub(`${hubURL}/api/auth/get-session`, 30_000);
+  await waitForHTTP(`${hubURL}/api/auth/get-session`, 30_000);
 } catch (err) {
   console.error(err instanceof Error ? err.message : String(err));
   await shutdown(1);

--- a/bin/e2e-provision.ts
+++ b/bin/e2e-provision.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env bun
+
+// Standalone provisioning CLI for the browser end-to-end harness.
+//
+// The Playwright harness (`tests/admin-ui-e2e`) must not import `@intx/*`
+// — it is a leaf test package with only `@playwright/test`, `arktype`,
+// and `zx` as dependencies. This CLI is the single boundary that reaches
+// into the `@intx/test-harness` primitives on its behalf: `up` provisions
+// a fresh migrated database and prints the hub's connection env as one
+// line of JSON on stdout, and `down` drops a named database again. The
+// harness's global setup shells out to both.
+//
+// Run under `bun --conditions=intx-src` so the `@intx/*` specifiers
+// resolve to TypeScript source, exactly as `bin/dev.ts` does.
+
+import path from "node:path";
+
+import {
+  dropProvisionedDatabase,
+  provisionDatabase,
+} from "@intx/test-harness/db-provision";
+import {
+  REPO_ROOT,
+  loadEnvFile,
+  optionalKey,
+  requireKey,
+} from "@intx/test-harness/env";
+
+async function up(): Promise<void> {
+  const provisioned = await provisionDatabase();
+
+  // `provisionDatabase` has already created and migrated the database;
+  // if the env resolution or stdout write below throws, drop it so the
+  // failure does not orphan a database in the cluster.
+  try {
+    // DB_HOST/DB_PORT come from `.env` (the shared connection target);
+    // DB_USER/DB_PASSWORD/BETTER_AUTH_SECRET come from `.env.hub` (the
+    // hub app's own role and auth secret). The spawned hub runs as the
+    // hub role against the freshly-provisioned database name.
+    const shared = await loadEnvFile(path.join(REPO_ROOT, ".env"));
+    const hubEnv = await loadEnvFile(path.join(REPO_ROOT, ".env.hub"));
+
+    const payload = {
+      database: provisioned.database,
+      hubEnv: {
+        DB_HOST: requireKey(shared, "DB_HOST", ".env"),
+        DB_PORT: requireKey(shared, "DB_PORT", ".env"),
+        DB_USER: requireKey(hubEnv, "DB_USER", ".env.hub"),
+        DB_PASSWORD: optionalKey(hubEnv, "DB_PASSWORD"),
+        BETTER_AUTH_SECRET: requireKey(
+          hubEnv,
+          "BETTER_AUTH_SECRET",
+          ".env.hub",
+        ),
+      },
+    };
+
+    // Await the write callback so a piped stdout is fully drained
+    // before the process exits; exiting early can truncate the JSON
+    // line the parent parses.
+    const line = `${JSON.stringify(payload)}\n`;
+    await new Promise<void>((resolve, reject) => {
+      process.stdout.write(line, (err) => (err ? reject(err) : resolve()));
+    });
+  } catch (err) {
+    try {
+      await dropProvisionedDatabase(provisioned.database);
+    } catch {
+      // A secondary drop failure must not mask the original error.
+    }
+    throw err;
+  }
+}
+
+async function down(database: string): Promise<void> {
+  await dropProvisionedDatabase(database);
+}
+
+// Success paths let the process exit naturally so stdio drains fully;
+// `process.exit` races exit against pending pipe writes. Bad argv sets
+// `process.exitCode` instead, which still yields a non-zero exit
+// without cutting off the usage message.
+const args = process.argv.slice(2);
+const command = args[0];
+
+if (command === "up") {
+  if (args.length !== 1) {
+    process.stderr.write("e2e-provision: usage: e2e-provision up\n");
+    process.exitCode = 1;
+  } else {
+    await up();
+  }
+} else if (command === "down") {
+  const database = args[1];
+  if (args.length !== 2 || database === undefined || database === "") {
+    process.stderr.write(
+      "e2e-provision: usage: e2e-provision down <database>\n",
+    );
+    process.exitCode = 1;
+  } else {
+    await down(database);
+  }
+} else {
+  process.stderr.write(
+    `e2e-provision: unknown command ${JSON.stringify(command)}; expected "up" or "down <database>"\n`,
+  );
+  process.exitCode = 1;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "hono": "catalog:",
         "isomorphic-git": "catalog:",
         "jiti": "2.5.1",
-        "postgres": "^3.4.8",
+        "postgres": "catalog:",
         "prettier": "3.6.2",
         "ssri": "catalog:",
         "tar": "catalog:",
@@ -284,7 +284,7 @@
         "@intx/types": "workspace:*",
         "arktype": "catalog:",
         "drizzle-orm": "catalog:",
-        "postgres": "^3.4.8",
+        "postgres": "catalog:",
       },
       "devDependencies": {
         "drizzle-kit": "^0.31.9",
@@ -614,6 +614,7 @@
       "dependencies": {
         "@intx/db": "workspace:*",
         "drizzle-orm": "catalog:",
+        "postgres": "catalog:",
       },
     },
   },
@@ -624,6 +625,7 @@
     "drizzle-orm": "^0.45.1",
     "hono": "^4.11.9",
     "isomorphic-git": "^1.27.2",
+    "postgres": "^3.4.8",
     "semver": "^7.7.2",
     "ssri": "^12.0.0",
     "tar": "^7.5.1",

--- a/bun.lock
+++ b/bun.lock
@@ -608,6 +608,14 @@
         "arktype": "catalog:",
       },
     },
+    "tests/admin-ui-e2e": {
+      "name": "@intx/admin-ui-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.50.0",
+        "arktype": "catalog:",
+        "zx": "^8.8.5",
+      },
+    },
     "tests/lib": {
       "name": "@intx/test-harness",
       "version": "0.2.2",
@@ -831,6 +839,8 @@
 
     "@intx/admin-ui": ["@intx/admin-ui@workspace:apps/admin-ui"],
 
+    "@intx/admin-ui-e2e": ["@intx/admin-ui-e2e@workspace:tests/admin-ui-e2e"],
+
     "@intx/agent": ["@intx/agent@workspace:packages/agent"],
 
     "@intx/authz": ["@intx/authz@workspace:packages/authz"],
@@ -966,6 +976,8 @@
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+
+    "@playwright/test": ["@playwright/test@1.62.0", "", { "dependencies": { "playwright": "1.62.0" }, "bin": { "playwright": "cli.js" } }, "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -1873,6 +1885,10 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "playwright": ["playwright@1.62.0", "", { "dependencies": { "playwright-core": "1.62.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw=="],
+
+    "playwright-core": ["playwright-core@1.62.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA=="],
+
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
@@ -2256,6 +2272,8 @@
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "packages/*",
     "apps/*",
     "examples/*",
+    "tests/admin-ui-e2e",
     "tests/lib"
   ],
   "catalog": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "drizzle-orm": "^0.45.1",
     "hono": "^4.11.9",
     "isomorphic-git": "^1.27.2",
+    "postgres": "^3.4.8",
     "semver": "^7.7.2",
     "ssri": "^12.0.0",
     "tar": "^7.5.1"
@@ -31,7 +32,7 @@
     "hono": "catalog:",
     "isomorphic-git": "catalog:",
     "jiti": "2.5.1",
-    "postgres": "^3.4.8",
+    "postgres": "catalog:",
     "prettier": "3.6.2",
     "ssri": "catalog:",
     "tar": "catalog:",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -22,7 +22,7 @@
     "@intx/types": "workspace:*",
     "arktype": "catalog:",
     "drizzle-orm": "catalog:",
-    "postgres": "^3.4.8"
+    "postgres": "catalog:"
   },
   "devDependencies": {
     "drizzle-kit": "^0.31.9"

--- a/tests/admin-ui-e2e/.gitignore
+++ b/tests/admin-ui-e2e/.gitignore
@@ -1,0 +1,2 @@
+test-results/
+playwright-report/

--- a/tests/admin-ui-e2e/harness/global-setup.ts
+++ b/tests/admin-ui-e2e/harness/global-setup.ts
@@ -1,0 +1,346 @@
+// Hermetic stack bring-up for the admin-UI browser end-to-end suite.
+//
+// Mirrors the zx orchestration model of `bin/dev.ts` — labeled
+// background processes, fetch-poll health checks, SIGTERM-then-SIGKILL
+// teardown — but scoped to a single Playwright run. It provisions a
+// fresh database (via `bin/e2e-provision.ts`, the sole `@intx/*`
+// boundary), spawns the hub against it on a per-run port, serves the
+// pre-built admin UI through `vite preview` behind the same-origin
+// `/api` proxy, and publishes the preview URL to the spec through
+// `E2E_BASE_URL`. The returned closure tears the whole stack down and
+// drops the database, leaving nothing orphaned.
+
+import net from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { type } from "arktype";
+import { $, type ProcessPromise } from "zx";
+
+$.verbose = false;
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// harness/ -> admin-ui-e2e/ -> tests/ -> repo root.
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
+const E2E_PROVISION = path.join(REPO_ROOT, "bin", "e2e-provision.ts");
+const ADMIN_UI_DIR = path.join(REPO_ROOT, "apps", "admin-ui");
+const ADMIN_UI_DIST_INDEX = path.join(ADMIN_UI_DIR, "dist", "index.html");
+
+const HOST = "127.0.0.1";
+const HUB_READY_TIMEOUT_MS = 30_000;
+const PREVIEW_READY_TIMEOUT_MS = 30_000;
+
+/** Allocate a free TCP port by binding `:0` on the loopback interface and
+ *  reading the assigned port before releasing it. There is an unavoidable
+ *  race between release and the child process claiming the port; the
+ *  suite runs a single worker, and `vite preview --strictPort` fails
+ *  loudly rather than silently drifting to another port if it is lost. */
+function allocatePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, HOST, () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        server.close();
+        reject(new Error("failed to allocate a port: unexpected address"));
+        return;
+      }
+      const { port } = address;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+/** Forward a child stream to `write` one complete line at a time. A
+ *  single stateful decoder (with `stream: true`) keeps multibyte
+ *  characters split across chunk boundaries intact, and the buffer
+ *  holds a trailing partial line until its newline arrives; whatever
+ *  remains when the stream ends is flushed as a final line. */
+function forwardLines(
+  stream: NodeJS.ReadableStream,
+  write: (line: string) => void,
+): void {
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  const emitCompleteLines = () => {
+    const lastNewline = buffer.lastIndexOf("\n");
+    if (lastNewline < 0) return;
+    for (const line of buffer.slice(0, lastNewline).split("\n")) {
+      if (line) write(line);
+    }
+    buffer = buffer.slice(lastNewline + 1);
+  };
+
+  stream.on("data", (chunk: Uint8Array) => {
+    buffer += decoder.decode(chunk, { stream: true });
+    emitCompleteLines();
+  });
+  stream.on("end", () => {
+    buffer += decoder.decode();
+    emitCompleteLines();
+    if (buffer) write(buffer);
+  });
+}
+
+function spawnLabeled(
+  label: string,
+  cmd: string[],
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+): ProcessPromise {
+  const proc = $({ cwd, env, nothrow: true })`${cmd}`;
+  const prefix = `[${label}]`;
+
+  forwardLines(proc.stdout, (line) =>
+    process.stdout.write(`${prefix} ${line}\n`),
+  );
+  forwardLines(proc.stderr, (line) =>
+    process.stderr.write(`${prefix} ${line}\n`),
+  );
+
+  return proc;
+}
+
+async function waitForHTTP(url: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.status < 500) return;
+    } catch {
+      // Not up yet.
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`${url} did not become ready within ${timeoutMs / 1000}s`);
+}
+
+// The provision CLI output is external data (subprocess stdout), so
+// validate its shape at this boundary rather than trusting it.
+// DB_PASSWORD is plain `string` (not non-empty): under trust or peer
+// authentication an empty password is legitimate.
+const ProvisionResult = type({
+  database: "string",
+  hubEnv: {
+    DB_HOST: "string",
+    DB_PORT: "string",
+    DB_USER: "string",
+    DB_PASSWORD: "string",
+    BETTER_AUTH_SECRET: "string",
+  },
+});
+
+function parseProvisionResult(stdout: string) {
+  const raw: unknown = JSON.parse(stdout.trim());
+  const result = ProvisionResult(raw);
+  if (result instanceof type.errors) {
+    throw new Error(
+      `e2e-provision up returned invalid JSON: ${result.summary}`,
+    );
+  }
+  return result;
+}
+
+// The resources the setup acquires in order. Each is recorded on this
+// record the moment it exists, so a partial-failure cleanup can tear
+// down exactly what was acquired and nothing more.
+type AcquiredStack = {
+  database?: string;
+  hubDataDir?: string;
+  hubProc?: ProcessPromise;
+  previewProc?: ProcessPromise;
+};
+
+/** Wait for a spawned process to exit, but no longer than `ms`. The
+ *  processes are spawned `nothrow`, so their ProcessPromise settles
+ *  (never rejects) when the child exits; racing it against a timer
+ *  bounds the wait without penalizing a child that exits quickly. */
+async function exitedWithin(
+  proc: ProcessPromise,
+  ms: number,
+): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<boolean>((resolve) => {
+    timer = setTimeout(() => resolve(false), ms);
+  });
+  try {
+    return await Promise.race([
+      proc.then(
+        () => true,
+        () => true,
+      ),
+      expired,
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const SIGTERM_GRACE_MS = 2000;
+
+/**
+ * Tear down whatever of the stack was acquired: SIGTERM then SIGKILL any
+ * spawned process still running after the grace period, drop the
+ * provisioned database, and remove the temp HUB_DATA_DIR. Process kills
+ * are individually swallowed because killing an already-exited process
+ * is expected and benign. The database drop and directory removal are
+ * each attempted independently — one failing never skips the other —
+ * and any failure among them is aggregated into a thrown error so the
+ * success-path caller surfaces it. The partial-failure caller wraps
+ * this whole call to swallow that error and preserve the original.
+ */
+async function teardownStack(acquired: AcquiredStack): Promise<void> {
+  const { previewProc, hubProc, database, hubDataDir } = acquired;
+
+  const procs: ProcessPromise[] = [];
+  for (const proc of [previewProc, hubProc]) {
+    if (proc !== undefined) procs.push(proc);
+  }
+
+  for (const proc of procs) {
+    try {
+      await proc.kill("SIGTERM");
+    } catch {
+      // Already exited.
+    }
+  }
+  const surviving: ProcessPromise[] = [];
+  await Promise.all(
+    procs.map(async (proc) => {
+      if (!(await exitedWithin(proc, SIGTERM_GRACE_MS))) surviving.push(proc);
+    }),
+  );
+  for (const proc of surviving) {
+    try {
+      await proc.kill("SIGKILL");
+    } catch {
+      // Already exited.
+    }
+  }
+
+  const failures: unknown[] = [];
+  if (database !== undefined) {
+    try {
+      await $({
+        cwd: REPO_ROOT,
+      })`bun --conditions=intx-src ${E2E_PROVISION} down ${database}`;
+    } catch (err) {
+      failures.push(err);
+    }
+  }
+  if (hubDataDir !== undefined) {
+    try {
+      fs.rmSync(hubDataDir, { recursive: true, force: true });
+    } catch (err) {
+      failures.push(err);
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(`stack teardown failed with ${failures.length} error(s)`, {
+      cause: failures[0],
+    });
+  }
+}
+
+async function globalSetup(): Promise<() => Promise<void>> {
+  if (!fs.existsSync(ADMIN_UI_DIST_INDEX)) {
+    throw new Error(
+      `admin UI bundle is missing at ${ADMIN_UI_DIST_INDEX}; run \`make build-admin-ui\` first`,
+    );
+  }
+
+  // Playwright only runs the teardown this function RETURNS, and that
+  // return does not happen until the whole stack is up. If any step
+  // below throws (most likely a readiness poll timing out) the already-
+  // acquired resources would leak, so track them as they come up and
+  // tear them down in the catch before rethrowing the original error.
+  const acquired: AcquiredStack = {};
+  try {
+    const [hubPort, previewPort] = await Promise.all([
+      allocatePort(),
+      allocatePort(),
+    ]);
+
+    const provisionOutput = await $({
+      cwd: REPO_ROOT,
+    })`bun --conditions=intx-src ${E2E_PROVISION} up`;
+    const { database, hubEnv } = parseProvisionResult(provisionOutput.stdout);
+    acquired.database = database;
+
+    const hubDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "intx-e2e-hub-"));
+    acquired.hubDataDir = hubDataDir;
+    const betterAuthBaseURL = `http://${HOST}:${hubPort}`;
+
+    const hubSpawnEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      ...hubEnv,
+      DB_NAME: database,
+      PORT: String(hubPort),
+      HUB_DATA_DIR: hubDataDir,
+      BETTER_AUTH_BASE_URL: betterAuthBaseURL,
+    };
+    // The hub honors PG_SCHEMA, but the provisioner migrates only the
+    // `public` schema of the fresh database; an ambient PG_SCHEMA (the
+    // hub-subprocess harness sets one) would pin the hub to a schema
+    // that does not exist here.
+    delete hubSpawnEnv["PG_SCHEMA"];
+
+    const hubProc = spawnLabeled(
+      "hub",
+      ["bun", "run", "--conditions=intx-src", "apps/hub/src/index.ts"],
+      hubSpawnEnv,
+      REPO_ROOT,
+    );
+    acquired.hubProc = hubProc;
+
+    // Poll the hub directly, not through the preview proxy: the proxy is
+    // not up yet, and a direct probe isolates a hub-start failure from a
+    // proxy misconfiguration.
+    await waitForHTTP(
+      `http://${HOST}:${hubPort}/api/auth/get-session`,
+      HUB_READY_TIMEOUT_MS,
+    );
+
+    // ADMIN_UI_HUB_ORIGIN is what the preview `/api` proxy rewrites the
+    // Origin to; it must byte-match BETTER_AUTH_BASE_URL or better-auth
+    // rejects the request as a cross-origin POST (403).
+    const previewProc = spawnLabeled(
+      "preview",
+      [
+        "bunx",
+        "vite",
+        "preview",
+        "--host",
+        HOST,
+        "--port",
+        String(previewPort),
+        "--strictPort",
+      ],
+      { ...process.env, ADMIN_UI_HUB_ORIGIN: betterAuthBaseURL },
+      ADMIN_UI_DIR,
+    );
+    acquired.previewProc = previewProc;
+
+    await waitForHTTP(
+      `http://${HOST}:${previewPort}/`,
+      PREVIEW_READY_TIMEOUT_MS,
+    );
+
+    process.env["E2E_BASE_URL"] = `http://${HOST}:${previewPort}`;
+
+    return () => teardownStack(acquired);
+  } catch (err) {
+    try {
+      await teardownStack(acquired);
+    } catch {
+      // A secondary cleanup failure must not mask the original error.
+    }
+    throw err;
+  }
+}
+
+export default globalSetup;

--- a/tests/admin-ui-e2e/login.spec.ts
+++ b/tests/admin-ui-e2e/login.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+
+// The global setup publishes the vite-preview base URL here after the
+// stack is up; the config cannot set `use.baseURL` because it evaluates
+// before the dynamic preview port is known.
+const baseURL = process.env["E2E_BASE_URL"];
+
+test("signs up and loads the authenticated dashboard", async ({ page }) => {
+  if (baseURL === undefined || baseURL === "") {
+    throw new Error("E2E_BASE_URL is not set; global setup did not run");
+  }
+
+  // The gated route's beforeLoad hits /api/me and, unauthenticated,
+  // redirects to /login.
+  await page.goto(baseURL);
+  await expect(page).toHaveURL(`${baseURL}/login`);
+
+  // The fresh database has no user, so drive the sign-up flow: toggle
+  // the form into create-account mode, which reveals the name field.
+  await page.getByRole("button", { name: "Sign up" }).click();
+
+  await page.getByLabel("Name").fill("Alice Admin");
+  await page.getByLabel("Email").fill("alice@example.com");
+  await page.getByLabel("Password").fill("password123");
+
+  // autoSignIn (better-auth default) establishes the session cookie on
+  // sign-up. The cookie is non-Secure because the hub serves over http
+  // (127.0.0.1), so it survives the same-origin preview proxy without
+  // TLS — load-bearing for this harness.
+  await page.getByRole("button", { name: "Create account" }).click();
+
+  // Landing on the dashboard proves the session cookie persisted through
+  // the proxy and the authed route rendered its empty state.
+  await expect(
+    page.getByRole("heading", { name: "Your tenants" }),
+  ).toBeVisible();
+  await expect(page.getByText("No running agents.")).toBeVisible();
+});

--- a/tests/admin-ui-e2e/package.json
+++ b/tests/admin-ui-e2e/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@intx/admin-ui-e2e",
+  "description": "Playwright browser end-to-end suite that drives the served admin UI against a hermetically provisioned hub",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@playwright/test": "^1.50.0",
+    "arktype": "catalog:",
+    "zx": "^8.8.5"
+  }
+}

--- a/tests/admin-ui-e2e/playwright.config.ts
+++ b/tests/admin-ui-e2e/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "@playwright/test";
+
+// The base URL is resolved inside globalSetup (it depends on a per-run
+// dynamic preview port) and published to the spec via E2E_BASE_URL.
+// Setting `use.baseURL` here would evaluate before globalSetup runs, so
+// the spec reads the URL from the environment at runtime instead.
+export default defineConfig({
+  testDir: ".",
+  globalSetup: "./harness/global-setup.ts",
+  fullyParallel: false,
+  workers: 1,
+  reporter: "list",
+  timeout: 60_000,
+  use: { headless: true },
+});

--- a/tests/admin-ui-e2e/tsconfig.json
+++ b/tests/admin-ui-e2e/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["**/*.ts"]
+}

--- a/tests/db/db-provision.test.ts
+++ b/tests/db/db-provision.test.ts
@@ -1,0 +1,89 @@
+import path from "node:path";
+
+import { afterAll, describe, expect, test } from "bun:test";
+import postgres from "postgres";
+
+import {
+  harnessDbEnvAvailable,
+  loadHarnessDbConfig,
+} from "@intx/test-harness/db-harness";
+import { provisionDatabase } from "@intx/test-harness/db-provision";
+import {
+  REPO_ROOT,
+  loadEnvFile,
+  optionalKey,
+  requireKey,
+} from "@intx/test-harness/env";
+
+describe.skipIf(!harnessDbEnvAvailable())("provisionDatabase (real DB)", () => {
+  const clients: ReturnType<typeof postgres>[] = [];
+
+  const openMaintenance = (database: string) => {
+    const base = loadHarnessDbConfig();
+    const client = postgres({
+      host: base.host,
+      port: base.port,
+      database,
+      max: 1,
+      onnotice: () => undefined,
+    });
+    clients.push(client);
+    return client;
+  };
+
+  afterAll(async () => {
+    for (const client of clients) {
+      await client.end();
+    }
+  });
+
+  test("creates, migrates, grants hub DML, and drops on teardown", async () => {
+    const provisioned = await provisionDatabase();
+
+    const admin = openMaintenance("postgres");
+    const existing = await admin`
+      SELECT 1 FROM pg_database WHERE datname = ${provisioned.database}
+    `;
+    expect(existing).toHaveLength(1);
+
+    const inDb = openMaintenance(provisioned.database);
+    const migratedTables = await inDb`
+      SELECT tablename FROM pg_tables
+      WHERE schemaname = 'public' AND tablename = 'tenant'
+    `;
+    expect(migratedTables).toHaveLength(1);
+
+    const hubEnv = await loadEnvFile(path.join(REPO_ROOT, ".env.hub"));
+    const shared = await loadEnvFile(path.join(REPO_ROOT, ".env"));
+    const merged = { ...shared, ...hubEnv };
+    const hub = postgres({
+      host: requireKey(merged, "DB_HOST", ".env"),
+      port: Number(requireKey(merged, "DB_PORT", ".env")),
+      user: requireKey(merged, "DB_USER", ".env.hub"),
+      password: optionalKey(merged, "DB_PASSWORD"),
+      database: provisioned.database,
+      max: 1,
+      onnotice: () => undefined,
+    });
+    try {
+      const id = `prov_${Date.now().toString(36)}`;
+      await hub`
+        INSERT INTO tenant (id, name, slug, domain)
+        VALUES (${id}, ${"Provisioner"}, ${id}, ${id})
+      `;
+      const selected = await hub`SELECT id FROM tenant WHERE id = ${id}`;
+      expect(selected).toHaveLength(1);
+      await hub`DELETE FROM tenant WHERE id = ${id}`;
+    } finally {
+      await hub.end();
+    }
+
+    await provisioned.teardown();
+
+    const admin2 = openMaintenance("postgres");
+    const remaining = await admin2`
+      SELECT 1 FROM pg_database WHERE datname = ${provisioned.database}
+    `;
+    expect(remaining).toHaveLength(0);
+  });
+});

--- a/tests/hub-api/lib/git-harness.ts
+++ b/tests/hub-api/lib/git-harness.ts
@@ -109,6 +109,8 @@ import {
   loadHarnessDbConfig,
   randomSchemaName,
 } from "@intx/test-harness/db-harness";
+import { grantHubSchemaAccess } from "@intx/test-harness/grants";
+import { waitForHTTP } from "@intx/test-harness/http";
 
 /**
  * Required hub-side env. The harness writes these explicitly into
@@ -432,24 +434,6 @@ export type HubHandle = {
   stop: () => Promise<void>;
 };
 
-async function waitForHub(url: string, timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  let lastErr: Error | null = null;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(url);
-      if (res.status < 500) return;
-      lastErr = new Error(`hub returned status ${res.status}`);
-    } catch (e) {
-      lastErr = e instanceof Error ? e : new Error(String(e));
-    }
-    await new Promise((r) => setTimeout(r, 100));
-  }
-  throw new Error(
-    `hub did not become ready within ${timeoutMs}ms (last: ${lastErr?.message ?? "no probe"})`,
-  );
-}
-
 export async function startHub(
   options: StartHubOptions = {},
 ): Promise<HubHandle> {
@@ -476,16 +460,7 @@ export async function startHub(
       max: 1,
     });
     try {
-      const quote = (n: string) => `"${n.replace(/"/g, '""')}"`;
-      const schemaIdent = quote(schema);
-      const hubRole = quote(hubEnv.db.user);
-      await sql.unsafe(`GRANT USAGE ON SCHEMA ${schemaIdent} TO ${hubRole}`);
-      await sql.unsafe(
-        `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${schemaIdent} TO ${hubRole}`,
-      );
-      await sql.unsafe(
-        `GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA ${schemaIdent} TO ${hubRole}`,
-      );
+      await grantHubSchemaAccess(sql, schema, hubEnv.db.user);
     } finally {
       await sql.end();
     }
@@ -541,7 +516,7 @@ export async function startHub(
   const url = `http://127.0.0.1:${port}`;
 
   try {
-    await waitForHub(url, 30_000);
+    await waitForHTTP(url, 30_000, 100);
   } catch (e) {
     // Surface what the hub printed so the test failure is
     // actionable.

--- a/tests/lib/db-harness.ts
+++ b/tests/lib/db-harness.ts
@@ -19,6 +19,7 @@ import {
 import { sql } from "drizzle-orm";
 
 import { REPO_ROOT, optionalKey, parseEnvFileSync, requireKey } from "./env";
+import { quoteIdent } from "./grants";
 
 /**
  * Returns true when the repo has the `.env` files this harness reads:
@@ -63,10 +64,6 @@ export function randomSchemaName(): string {
   // permissive, but we keep this conservative for diagnostics.
   const rand = Math.random().toString(36).slice(2, 10);
   return `t_${Date.now().toString(36)}_${rand}`;
-}
-
-function quoteIdent(name: string): string {
-  return `"${name.replace(/"/g, '""')}"`;
 }
 
 /**

--- a/tests/lib/db-provision.ts
+++ b/tests/lib/db-provision.ts
@@ -1,0 +1,159 @@
+// Per-run fresh-database provisioner for the browser end-to-end harness.
+//
+// Unlike `db-harness.ts`, which gives each test an isolated *schema*
+// inside the shared `interchange` database, this module provisions a
+// fresh, uniquely-named *database* per run: create, migrate, grant, and
+// drop on teardown. The browser harness spawns a hub against the
+// returned database name and needs the whole database to itself.
+//
+// Database lifecycle (CREATE/DROP DATABASE) is owned by the maintenance
+// connection, exactly as `bin/db-reset` relies on: the connection omits
+// an explicit role so postgres.js inherits the ambient superuser
+// identity, and the migration role is never granted cluster-wide
+// create-database rights. Only the host/port come from `.env`; the
+// identity comes from the ambient libpq environment.
+
+import path from "node:path";
+
+import postgres from "postgres";
+
+import { runMigrations, type DBConfig } from "@intx/db";
+
+import { loadHarnessDbConfig, randomSchemaName } from "./db-harness";
+import { REPO_ROOT, loadEnvFile, requireKey } from "./env";
+import { grantHubSchemaAccess, quoteIdent } from "./grants";
+
+/**
+ * A provisioned, migrated database dedicated to a single harness run.
+ *
+ * `config` connects as the migration role and is what applies DDL. The
+ * spawned hub does NOT use these credentials: it runs as the hub role
+ * (loaded separately) and only reuses the `database` name.
+ */
+export type ProvisionedDatabase = {
+  database: string;
+  config: DBConfig;
+  teardown: () => Promise<void>;
+};
+
+/**
+ * Provision a fresh, uniquely-named postgres database: create it under
+ * the maintenance (superuser) connection, grant the migration and hub
+ * roles what each needs, apply the migrations into `public`, and return
+ * a handle whose `teardown` drops the database again.
+ */
+export async function provisionDatabase(): Promise<ProvisionedDatabase> {
+  const base = loadHarnessDbConfig();
+  const migrateRole = base.user;
+
+  const hubEnv = await loadEnvFile(path.join(REPO_ROOT, ".env.hub"));
+  const hubRole = requireKey(hubEnv, "DB_USER", ".env.hub");
+
+  const database = randomSchemaName();
+  const dbIdent = quoteIdent(database);
+  const migrateRoleIdent = quoteIdent(migrateRole);
+  const hubRoleIdent = quoteIdent(hubRole);
+
+  // Maintenance client: host/port from `.env`, identity inherited from
+  // the ambient libpq environment (no `user`/`password`), mirroring
+  // `bin/db-reset`. `database` selects which database the connection
+  // targets, which is load-bearing for the schema-level grant below.
+  const openMaintenance = (targetDatabase: string) =>
+    postgres({
+      host: base.host,
+      port: base.port,
+      database: targetDatabase,
+      max: 1,
+      onnotice: () => undefined,
+    });
+
+  const dropDatabase = async (): Promise<void> => {
+    const dropClient = openMaintenance("postgres");
+    try {
+      await dropClient`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = ${database} AND pid <> pg_backend_pid()`;
+
+      let lastError: unknown;
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          await dropClient
+            .unsafe(`DROP DATABASE IF EXISTS ${dbIdent} WITH (FORCE)`)
+            .simple();
+          return;
+        } catch (error) {
+          lastError = error;
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+      }
+      throw new Error(`failed to drop database ${database}`, {
+        cause: lastError,
+      });
+    } finally {
+      await dropClient.end();
+    }
+  };
+
+  const admin = openMaintenance("postgres");
+  try {
+    // CREATE DATABASE cannot run inside a transaction, so force simple
+    // query mode. The name is a quoted identifier, not a bind value.
+    await admin.unsafe(`CREATE DATABASE ${dbIdent}`).simple();
+  } finally {
+    await admin.end();
+  }
+
+  const config: DBConfig = { ...base, database };
+
+  // Everything past CREATE DATABASE either completes or the just-created
+  // database is dropped, so a mid-provision failure cannot orphan a
+  // randomly-named database in the cluster.
+  try {
+    // Grants must precede migration. The schema-level grant is
+    // per-database, so it must run on a connection to the NEW database;
+    // without `GRANT ALL ON SCHEMA public`, `runMigrations` fails with
+    // "permission denied for schema public" on fresh PG15+.
+    const adminNewDb = openMaintenance(database);
+    try {
+      await adminNewDb.unsafe(
+        `GRANT ALL ON DATABASE ${dbIdent} TO ${migrateRoleIdent}`,
+      );
+      await adminNewDb.unsafe(
+        `GRANT ALL ON SCHEMA public TO ${migrateRoleIdent}`,
+      );
+      await adminNewDb.unsafe(
+        `GRANT CONNECT ON DATABASE ${dbIdent} TO ${hubRoleIdent}`,
+      );
+    } finally {
+      await adminNewDb.end();
+    }
+
+    await runMigrations(config, { schema: "public" });
+
+    // The migration role owns the freshly-migrated tables, so it is the
+    // role that can grant the hub role access to them.
+    const migrateClient = postgres({
+      host: config.host,
+      port: config.port,
+      user: config.user,
+      password: config.password,
+      database: config.database,
+      max: 1,
+      onnotice: () => undefined,
+    });
+    try {
+      await grantHubSchemaAccess(migrateClient, "public", hubRole);
+    } finally {
+      await migrateClient.end();
+    }
+  } catch (error) {
+    try {
+      await dropDatabase();
+    } catch {
+      // Best-effort cleanup: the original provisioning failure is the
+      // meaningful one, so a failure to drop the half-provisioned
+      // database must not mask it.
+    }
+    throw error;
+  }
+
+  return { database, config, teardown: dropDatabase };
+}

--- a/tests/lib/db-provision.ts
+++ b/tests/lib/db-provision.ts
@@ -37,6 +37,53 @@ export type ProvisionedDatabase = {
 };
 
 /**
+ * Drop a provisioned database by name. Reloads host/port from `.env` via
+ * `loadHarnessDbConfig` and connects to the maintenance `postgres`
+ * database under the ambient superuser identity, exactly as
+ * `provisionDatabase` does when it creates the database. Terminates any
+ * remaining backends against the target, then drops it with `FORCE`,
+ * retrying a bounded number of times so a connection that is still
+ * winding down cannot leave the database orphaned.
+ *
+ * Both `provisionDatabase`'s returned `teardown` and the standalone
+ * provisioning CLI's `down` command route through here, so there is a
+ * single drop implementation with two entry points.
+ */
+export async function dropProvisionedDatabase(name: string): Promise<void> {
+  const base = loadHarnessDbConfig();
+  const dbIdent = quoteIdent(name);
+
+  const dropClient = postgres({
+    host: base.host,
+    port: base.port,
+    database: "postgres",
+    max: 1,
+    onnotice: () => undefined,
+  });
+  try {
+    await dropClient`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = ${name} AND pid <> pg_backend_pid()`;
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        await dropClient
+          .unsafe(`DROP DATABASE IF EXISTS ${dbIdent} WITH (FORCE)`)
+          .simple();
+        return;
+      } catch (error) {
+        lastError = error;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+    }
+    throw new Error(`failed to drop database ${name}`, {
+      cause: lastError,
+    });
+  } finally {
+    await dropClient.end();
+  }
+}
+
+/**
  * Provision a fresh, uniquely-named postgres database: create it under
  * the maintenance (superuser) connection, grant the migration and hub
  * roles what each needs, apply the migrations into `public`, and return
@@ -66,31 +113,6 @@ export async function provisionDatabase(): Promise<ProvisionedDatabase> {
       max: 1,
       onnotice: () => undefined,
     });
-
-  const dropDatabase = async (): Promise<void> => {
-    const dropClient = openMaintenance("postgres");
-    try {
-      await dropClient`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = ${database} AND pid <> pg_backend_pid()`;
-
-      let lastError: unknown;
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          await dropClient
-            .unsafe(`DROP DATABASE IF EXISTS ${dbIdent} WITH (FORCE)`)
-            .simple();
-          return;
-        } catch (error) {
-          lastError = error;
-          await new Promise((resolve) => setTimeout(resolve, 100));
-        }
-      }
-      throw new Error(`failed to drop database ${database}`, {
-        cause: lastError,
-      });
-    } finally {
-      await dropClient.end();
-    }
-  };
 
   const admin = openMaintenance("postgres");
   try {
@@ -146,7 +168,7 @@ export async function provisionDatabase(): Promise<ProvisionedDatabase> {
     }
   } catch (error) {
     try {
-      await dropDatabase();
+      await dropProvisionedDatabase(database);
     } catch {
       // Best-effort cleanup: the original provisioning failure is the
       // meaningful one, so a failure to drop the half-provisioned
@@ -155,5 +177,9 @@ export async function provisionDatabase(): Promise<ProvisionedDatabase> {
     throw error;
   }
 
-  return { database, config, teardown: dropDatabase };
+  return {
+    database,
+    config,
+    teardown: () => dropProvisionedDatabase(database),
+  };
 }

--- a/tests/lib/grants.ts
+++ b/tests/lib/grants.ts
@@ -1,0 +1,43 @@
+// Hub-role grant issuance for the fresh-database provisioner
+// (`db-provision.ts`).
+//
+// The hub app connects under its own postgres role, which is not the
+// role that owns the migrated tables, so the hub role needs DML +
+// USAGE grants before it can read or write. This module issues that
+// grant set for the browser end-to-end harness's per-run databases.
+// The older hub-subprocess harness (`tests/hub-api/lib/git-harness.ts`)
+// still inlines its own copy of the same grants and of the identifier
+// quoting; consolidating it onto this module is deliberate follow-up
+// work.
+
+import postgres from "postgres";
+
+export function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Grant the hub app role the DML + USAGE it needs on a migrated schema
+ * whose tables are owned by the migration role.
+ *
+ * @param sql - A postgres.js client connected to the database that
+ *   contains the schema, as a role able to grant on those objects
+ *   (the migration role, which owns them).
+ * @param schema - The schema the hub reads and writes.
+ * @param hubRole - The hub app's postgres role name.
+ */
+export async function grantHubSchemaAccess(
+  sql: ReturnType<typeof postgres>,
+  schema: string,
+  hubRole: string,
+): Promise<void> {
+  const schemaIdent = quoteIdent(schema);
+  const roleIdent = quoteIdent(hubRole);
+  await sql.unsafe(`GRANT USAGE ON SCHEMA ${schemaIdent} TO ${roleIdent}`);
+  await sql.unsafe(
+    `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${schemaIdent} TO ${roleIdent}`,
+  );
+  await sql.unsafe(
+    `GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA ${schemaIdent} TO ${roleIdent}`,
+  );
+}

--- a/tests/lib/grants.ts
+++ b/tests/lib/grants.ts
@@ -1,14 +1,11 @@
-// Hub-role grant issuance for the fresh-database provisioner
-// (`db-provision.ts`).
+// Shared hub-role grant issuance for the `tests/` harnesses.
 //
 // The hub app connects under its own postgres role, which is not the
-// role that owns the migrated tables, so the hub role needs DML +
-// USAGE grants before it can read or write. This module issues that
-// grant set for the browser end-to-end harness's per-run databases.
-// The older hub-subprocess harness (`tests/hub-api/lib/git-harness.ts`)
-// still inlines its own copy of the same grants and of the identifier
-// quoting; consolidating it onto this module is deliberate follow-up
-// work.
+// role that owns the migrated tables. Whether those tables live in a
+// per-test schema (the hub-subprocess harness) or the `public` schema
+// of a per-run database (the browser end-to-end harness), the hub role
+// needs the same DML + USAGE grants before it can read or write, and
+// both harnesses issue them through this module.
 
 import postgres from "postgres";
 

--- a/tests/lib/http.ts
+++ b/tests/lib/http.ts
@@ -1,0 +1,33 @@
+// HTTP readiness polling shared by the hub-subprocess harness and the
+// dev orchestrator.
+//
+// A connection failure or a 5xx means "still starting"; any routable
+// response (200, 401, 404) proves the listener is up. The last probe
+// failure rides along in the timeout error so a hung start stays
+// diagnosable.
+
+/**
+ * Poll `url` until it responds with a status below 500 or `timeoutMs`
+ * elapses. `intervalMs` sets the probe cadence.
+ */
+export async function waitForHTTP(
+  url: string,
+  timeoutMs: number,
+  intervalMs = 500,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: Error | null = null;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.status < 500) return;
+      lastErr = new Error(`server returned status ${res.status}`);
+    } catch (e) {
+      lastErr = e instanceof Error ? e : new Error(String(e));
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(
+    `${url} did not become ready within ${timeoutMs}ms (last: ${lastErr?.message ?? "no probe"})`,
+  );
+}

--- a/tests/lib/package.json
+++ b/tests/lib/package.json
@@ -14,6 +14,14 @@
       "types": "./db-harness.ts",
       "default": "./db-harness.ts"
     },
+    "./db-provision": {
+      "types": "./db-provision.ts",
+      "default": "./db-provision.ts"
+    },
+    "./grants": {
+      "types": "./grants.ts",
+      "default": "./grants.ts"
+    },
     "./seed": {
       "types": "./seed.ts",
       "default": "./seed.ts"
@@ -21,6 +29,7 @@
   },
   "dependencies": {
     "@intx/db": "workspace:*",
-    "drizzle-orm": "catalog:"
+    "drizzle-orm": "catalog:",
+    "postgres": "catalog:"
   }
 }

--- a/tests/lib/package.json
+++ b/tests/lib/package.json
@@ -22,6 +22,10 @@
       "types": "./grants.ts",
       "default": "./grants.ts"
     },
+    "./http": {
+      "types": "./http.ts",
+      "default": "./http.ts"
+    },
     "./seed": {
       "types": "./seed.ts",
       "default": "./seed.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,6 +46,7 @@
     { "path": "examples/agent-gemini-image" },
     { "path": "examples/posix-demo" },
     { "path": "examples/ring-demo" },
+    { "path": "tests/admin-ui-e2e" },
     { "path": "tests/db" },
     { "path": "tests/hub-agent" },
     { "path": "tests/hub-api" },


### PR DESCRIPTION
## Summary

- A Playwright suite (`tests/admin-ui-e2e`) provisions a fresh database per
  run, spawns the hub on a dynamic port, serves the built admin UI through
  vite preview behind a same-origin `/api` proxy, and drives a real Chromium
  browser through sign-up to an authenticated page before tearing everything
  down.
- `@intx/test-harness/db-provision` creates, migrates, grants, and
  force-drops uniquely named databases over the maintenance connection
  `bin/db-reset` already relies on; the migration role gains no new
  privileges.
- `make test-e2e` runs the suite outside the default build and unit passes;
  continuous integration caches the Chromium install and reuses the bundle
  from the preceding `make all` step.

## Verification

- `make all` exits 0 (lint, forced type check, admin UI bundle, both test
  passes).
- `make test-e2e` passes: a real Chromium sign-up flows through the preview
  proxy's rewritten Origin, the session cookie persists, and the
  authenticated dashboard renders; teardown leaves no stray database.
- The provisioner carries its own integration test proving the hub-role
  grants via a hub-role data round-trip.

Closes INTR-390