### PR TITLE
Validate publishable sideEffects per-manifest and document dist-rewrite

### DIFF
--- a/bin/dist-rewrite.test.ts
+++ b/bin/dist-rewrite.test.ts
@@ -162,6 +162,26 @@ test("a sibling file resolves to `.js` and a directory barrel to `/index.js`", (
   expect(out).toContain('import { b } from "./bar/index.js";');
 });
 
+test("a compiling `.json` import resolves without aborting", () => {
+  // A `resolveJsonModule` import that type-checks emits with its `.json`
+  // extension, which `isRewritable` treats as already resolved. The
+  // rewriter must leave it in place, not report it unresolved. A naive
+  // "make `.json` rewritable" change would send `./data.json` to the
+  // resolver, which finds neither `./data.json.js` nor
+  // `./data.json/index.js`, falsely report it unresolved, and abort the
+  // build — which the empty-`unresolved` assertion below guards against.
+  const dir = makeTree({
+    "index.js":
+      'import data from "./data.json";\nexport const v = data.value;\n',
+    "data.json": '{ "value": 42 }\n',
+  });
+  const report = rewriteDistTree(dir);
+  expect(report.unresolved).toEqual([]);
+  expect(readFileSync(join(dir, "index.js"), "utf8")).toContain(
+    'import data from "./data.json";',
+  );
+});
+
 test("an unresolvable relative specifier is reported and left in place", () => {
   const dir = makeTree({
     "index.js": 'import { c } from "./missing";\n',

--- a/bin/dist-rewrite.ts
+++ b/bin/dist-rewrite.ts
@@ -129,7 +129,20 @@ export function rewriteSpecifiers(
 /** Resolve a relative specifier against the emitted tree: a sibling file
  *  (`spec.js`) or a directory barrel (`spec/index.js`). `tsc` emits a
  *  `.js` beside every `.d.ts`, so probing the `.js` covers both file
- *  kinds. Returns null when neither exists. */
+ *  kinds. Returns null when neither exists.
+ *
+ *  Probing only `.js`/`index.js` is complete, not a coverage gap: every
+ *  extensionless relative specifier that reaches here targets a file
+ *  `tsc` emitted as `.js`. A specifier already carrying a Node-resolvable
+ *  extension (`.json`, `.node`, `.mjs`, `.cjs`) is treated as resolved by
+ *  `isRewritable` and never reaches this function; and an extensionless
+ *  specifier pointing at a non-`.js` file (e.g. a bare `./data` for a
+ *  sibling `./data.json`) cannot be emitted at all — under this repo's
+ *  `moduleResolution: "bundler"` config it fails to type-check (TS2307)
+ *  and the build aborts before the rewriter runs. The invariant holds
+ *  only while that resolution mode and the all-`.ts`-sources assumption
+ *  do; switching `moduleResolution`, or adding `.mts`/`.cts` sources,
+ *  would require revisiting the probe set. */
 function resolveAgainstTree(spec: string, fromDir: string): string | null {
   if (existsSync(join(fromDir, `${spec}.js`))) return `${spec}.js`;
   if (existsSync(join(fromDir, spec, "index.js"))) return `${spec}/index.js`;

--- a/bin/publish-metadata.test.ts
+++ b/bin/publish-metadata.test.ts
@@ -250,6 +250,20 @@ test("fix never overwrites an existing sideEffects glob list", async () => {
   expect(m.publishConfig).toEqual({ access: "public" });
 });
 
+test("fix leaves a malformed sideEffects untouched for the check to reject", async () => {
+  const root = makeWorkspace([{ name: "@x/a", sideEffects: true }]);
+  await fixWorkspaceMetadata(root);
+  const m = JSON.parse(
+    readFileSync(join(root, "packages", "p0", "package.json"), "utf8"),
+  );
+  // A malformed value is the author's to correct; fix must not seed `false`
+  // over it (that would silently invent the declaration), only when absent.
+  expect(m.sideEffects).toBe(true);
+  // The value survives, so the check still flags it — fix cannot silence it.
+  const { violations } = await checkWorkspaceMetadata(root);
+  expect(violations.some((v) => v.includes("sideEffects"))).toBe(true);
+});
+
 test("fix is idempotent on an already-canonical workspace", async () => {
   const root = makeWorkspace([canonical("@x/a")]);
   expect(await fixWorkspaceMetadata(root)).toEqual([]);

--- a/bin/publish-metadata.test.ts
+++ b/bin/publish-metadata.test.ts
@@ -13,7 +13,6 @@ import {
   checkWorkspaceDescriptions,
   checkWorkspaceMetadata,
   expectedFiles,
-  expectedSideEffects,
   fixWorkspaceMetadata,
 } from "./publish-metadata";
 
@@ -58,23 +57,14 @@ function makeWorkspace(
   return root;
 }
 
-const canonical = (name: string): Record<string, unknown> => ({
+const canonical = (
+  name: string,
+  sideEffects: false | string[] = false,
+): Record<string, unknown> => ({
   name,
   files: expectedFiles(name),
-  sideEffects: expectedSideEffects(name),
+  sideEffects,
   publishConfig: { access: "public" },
-});
-
-test("expectedSideEffects is false except for @intx/log", () => {
-  expect(expectedSideEffects("@intx/mime")).toBe(false);
-  expect(expectedSideEffects("@intx/log")).toEqual([
-    "./src/index.ts",
-    "./src/hono.ts",
-    "./src/default-sink.ts",
-    "./dist/index.js",
-    "./dist/hono.js",
-    "./dist/default-sink.js",
-  ]);
 });
 
 test("expectedFiles adds package-root data dirs for db and inference-discovery", () => {
@@ -95,7 +85,10 @@ test("expectedFiles adds package-root data dirs for db and inference-discovery",
 
 test("a fully-set package produces no violations", async () => {
   const { violations } = await checkWorkspaceMetadata(
-    makeWorkspace([canonical("@x/a"), canonical("@intx/log")]),
+    makeWorkspace([
+      canonical("@x/a"),
+      canonical("@x/side", ["./src/index.ts", "./dist/index.js"]),
+    ]),
   );
   expect(violations).toEqual([]);
 });
@@ -114,11 +107,29 @@ test("a missing or wrong publishConfig.access is flagged", async () => {
   expect(violations.some((v) => v.includes("publishConfig"))).toBe(true);
 });
 
-test("@intx/log with sideEffects:false is flagged", async () => {
-  const pkg = canonical("@intx/log");
-  pkg["sideEffects"] = false;
+test("any package may declare its own non-false sideEffects", async () => {
+  const { violations } = await checkWorkspaceMetadata(
+    makeWorkspace([
+      canonical("@x/registry", ["./src/register.ts", "./dist/register.js"]),
+    ]),
+  );
+  expect(violations).toEqual([]);
+});
+
+test("an absent sideEffects is flagged", async () => {
+  const pkg = canonical("@x/a");
+  delete pkg["sideEffects"];
   const { violations } = await checkWorkspaceMetadata(makeWorkspace([pkg]));
   expect(violations.some((v) => v.includes("sideEffects"))).toBe(true);
+});
+
+test("a malformed sideEffects is flagged", async () => {
+  for (const bad of [true, [], [123], "false"]) {
+    const pkg = canonical("@x/a");
+    pkg["sideEffects"] = bad;
+    const { violations } = await checkWorkspaceMetadata(makeWorkspace([pkg]));
+    expect(violations.some((v) => v.includes("sideEffects"))).toBe(true);
+  }
 });
 
 test("a private package is not checked", async () => {
@@ -129,30 +140,39 @@ test("a private package is not checked", async () => {
   expect(packageCount).toBe(0);
 });
 
-test("fix sets the fields, then check passes; log gets its glob list", async () => {
+test("fix sets mechanical fields, seeds sideEffects false, then check passes", async () => {
   const root = makeWorkspace([
     { name: "@x/a" },
-    { name: "@intx/log" },
     { name: "@x/private", private: true },
   ]);
   const changed = await fixWorkspaceMetadata(root);
-  expect(changed.sort()).toEqual(["@intx/log", "@x/a"]);
+  expect(changed).toEqual(["@x/a"]);
   const a = JSON.parse(
     readFileSync(join(root, "packages", "p0", "package.json"), "utf8"),
   );
   expect(a.files).toEqual(expectedFiles("@x/a"));
   expect(a.sideEffects).toBe(false);
   expect(a.publishConfig).toEqual({ access: "public" });
-  const log = JSON.parse(
-    readFileSync(join(root, "packages", "p1", "package.json"), "utf8"),
-  );
-  expect(log.sideEffects).toEqual(expectedSideEffects("@intx/log"));
   // Private package untouched.
   const priv = JSON.parse(
-    readFileSync(join(root, "packages", "p2", "package.json"), "utf8"),
+    readFileSync(join(root, "packages", "p1", "package.json"), "utf8"),
   );
   expect(priv.files).toBeUndefined();
   expect((await checkWorkspaceMetadata(root)).violations).toEqual([]);
+});
+
+test("fix never overwrites an existing sideEffects glob list", async () => {
+  const globs = ["./src/register.ts", "./dist/register.js"];
+  const root = makeWorkspace([{ name: "@x/registry", sideEffects: globs }]);
+  const changed = await fixWorkspaceMetadata(root);
+  expect(changed).toEqual(["@x/registry"]);
+  const m = JSON.parse(
+    readFileSync(join(root, "packages", "p0", "package.json"), "utf8"),
+  );
+  // The hand-authored glob list survives; the mechanical fields are set.
+  expect(m.sideEffects).toEqual(globs);
+  expect(m.files).toEqual(expectedFiles("@x/registry"));
+  expect(m.publishConfig).toEqual({ access: "public" });
 });
 
 test("fix is idempotent on an already-canonical workspace", async () => {

--- a/bin/publish-metadata.test.ts
+++ b/bin/publish-metadata.test.ts
@@ -57,6 +57,16 @@ function makeWorkspace(
   return root;
 }
 
+// Create empty files under `packages/pN` so a `sideEffects` glob has
+// something to match on disk.
+function seedPackageFiles(root: string, index: number, relPaths: string[]) {
+  for (const rel of relPaths) {
+    const path = join(root, "packages", `p${index}`, rel);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, "");
+  }
+}
+
 const canonical = (
   name: string,
   sideEffects: false | string[] = false,
@@ -84,12 +94,12 @@ test("expectedFiles adds package-root data dirs for db and inference-discovery",
 });
 
 test("a fully-set package produces no violations", async () => {
-  const { violations } = await checkWorkspaceMetadata(
-    makeWorkspace([
-      canonical("@x/a"),
-      canonical("@x/side", ["./src/index.ts", "./dist/index.js"]),
-    ]),
-  );
+  const root = makeWorkspace([
+    canonical("@x/a"),
+    canonical("@x/side", ["./src/index.ts", "./dist/index.js"]),
+  ]);
+  seedPackageFiles(root, 1, ["src/index.ts"]);
+  const { violations } = await checkWorkspaceMetadata(root);
   expect(violations).toEqual([]);
 });
 
@@ -108,12 +118,77 @@ test("a missing or wrong publishConfig.access is flagged", async () => {
 });
 
 test("any package may declare its own non-false sideEffects", async () => {
+  const root = makeWorkspace([
+    canonical("@x/registry", ["./src/register.ts", "./dist/register.js"]),
+  ]);
+  seedPackageFiles(root, 0, ["src/register.ts"]);
+  const { violations } = await checkWorkspaceMetadata(root);
+  expect(violations).toEqual([]);
+});
+
+test("a sideEffects array of only unshipped paths is flagged", async () => {
+  // `./src/*` matches on disk at lint time but is absent from the published
+  // tarball (files ships `dist`), so a source-only declaration would be
+  // silently tree-shaken. At least one entry must be under a shipped path.
+  const root = makeWorkspace([canonical("@x/a", ["./src/index.ts"])]);
+  seedPackageFiles(root, 0, ["src/index.ts"]);
+  const { violations } = await checkWorkspaceMetadata(root);
+  expect(violations.some((v) => v.includes("only unshipped modules"))).toBe(
+    true,
+  );
+});
+
+test("a sideEffects glob matching no file and no shipped path is flagged", async () => {
+  const root = makeWorkspace([canonical("@x/a", ["./src/nope.ts"])]);
+  const { violations } = await checkWorkspaceMetadata(root);
+  expect(violations.some((v) => v.includes("./src/nope.ts"))).toBe(true);
+});
+
+test("a log-shaped src-and-dist array passes with dist unbuilt", async () => {
+  const root = makeWorkspace([
+    canonical("@x/logish", [
+      "./src/index.ts",
+      "./src/hono.ts",
+      "./src/default-sink.ts",
+      "./dist/index.js",
+      "./dist/hono.js",
+      "./dist/default-sink.js",
+    ]),
+  ]);
+  // Source present, `dist` shipped via `files` but unbuilt — as at lint time.
+  seedPackageFiles(root, 0, [
+    "src/index.ts",
+    "src/hono.ts",
+    "src/default-sink.ts",
+  ]);
+  expect((await checkWorkspaceMetadata(root)).violations).toEqual([]);
+});
+
+test("a dist glob is flagged when the package does not ship dist", async () => {
   const { violations } = await checkWorkspaceMetadata(
     makeWorkspace([
-      canonical("@x/registry", ["./src/register.ts", "./dist/register.js"]),
+      {
+        name: "@x/a",
+        files: ["README.md", "LICENSE"],
+        sideEffects: ["./dist/index.js"],
+        publishConfig: { access: "public" },
+      },
     ]),
   );
-  expect(violations).toEqual([]);
+  expect(violations.some((v) => v.includes("./dist/index.js"))).toBe(true);
+});
+
+test("a glob is flagged when files is absent, shipping nothing", async () => {
+  const { violations } = await checkWorkspaceMetadata(
+    makeWorkspace([
+      {
+        name: "@x/a",
+        sideEffects: ["./dist/index.js"],
+        publishConfig: { access: "public" },
+      },
+    ]),
+  );
+  expect(violations.some((v) => v.includes("./dist/index.js"))).toBe(true);
 });
 
 test("an absent sideEffects is flagged", async () => {

--- a/bin/publish-metadata.ts
+++ b/bin/publish-metadata.ts
@@ -13,10 +13,15 @@
 //   - `publishConfig.access: "public"`: scoped packages default to
 //     restricted; without this an `@intx/*` publish is not installable by
 //     outside consumers.
-//   - `sideEffects`: `false` so bundlers may tree-shake, except where a
-//     module installs something at import time. `@intx/log` does (its
-//     entry points import the default console sink), so it names those
-//     files instead.
+//   - `sideEffects`: each publishable package declares its own — `false`
+//     so bundlers may tree-shake, or a list of the modules that install
+//     something at import time so those survive tree-shaking. Whether a
+//     module has an import-time side effect is a fact about that package's
+//     own source, known only to its author, so the guard validates that
+//     the declaration is present and well-formed rather than computing it
+//     from a central list of package names. A package that forgets to
+//     declare it fails the gate loudly instead of being silently forced to
+//     `false` and tree-shaken away.
 //
 // Those three are publish-tarball concerns, so they apply only to the
 // non-private packages under `packages/` (the ones that ship). A fourth
@@ -28,13 +33,17 @@
 //     private members included — so this check enumerates all members the
 //     root `workspaces` globs declare, not just the publishable packages.
 //
-// This module is both the one-time transform that sets the three tarball
-// fields and the check that keeps them, mirroring `exports-shape`. It runs
-// in `make lint`, so a package added later without the fields fails the
-// gate rather than shipping a broken or oversized tarball. The transform
-// never authors a `description` — wording is written by hand — so `--fix`
-// sets the three mechanical fields and then fails loudly on any member
-// still missing one rather than reporting a success a later check-mode run
+// This module is both the one-time transform that sets the tarball fields
+// and the check that keeps them, mirroring `exports-shape`. It runs in
+// `make lint`, so a package added later without the fields fails the gate
+// rather than shipping a broken or oversized tarball. `files` and
+// `publishConfig` are mechanical — the transform computes and sets them —
+// but `sideEffects` and `description` are author-owned: `--fix` seeds a
+// missing `sideEffects` with the safe `false` default and never overwrites
+// a real declaration, and it never authors a `description`. So `--fix`
+// sets the mechanical fields, seeds a missing `sideEffects`, and then fails
+// loudly on any member still carrying a malformed `sideEffects` or missing
+// a `description` rather than reporting a success a later check-mode run
 // would contradict.
 
 import { join } from "node:path";
@@ -61,23 +70,18 @@ export function expectedFiles(name: string): string[] {
   return ["dist", ...(EXTRA_FILES[name] ?? []), "README.md", "LICENSE"];
 }
 
-// The only package with an import-time side effect: `src/index.ts` and
-// `src/hono.ts` both `import "./default-sink"`, which installs the default
-// console sink. Both source and emitted paths are named so the import
-// survives tree-shaking whichever a downstream bundler resolves.
-const LOG_SIDE_EFFECTS = [
-  "./src/index.ts",
-  "./src/hono.ts",
-  "./src/default-sink.ts",
-  "./dist/index.js",
-  "./dist/hono.js",
-  "./dist/default-sink.js",
-];
-
-/** The canonical `sideEffects` value for a package by name. */
-export function expectedSideEffects(name: string): false | string[] {
-  return name === "@intx/log" ? LOG_SIDE_EFFECTS : false;
-}
+// A well-formed `sideEffects` declaration: `false` (tree-shakeable), or a
+// non-empty list of non-empty glob strings naming the modules that install
+// something at import time. An empty array is rejected — "nothing has side
+// effects" is spelled `false`, not `[]`.
+const sideEffectsSchema = type("false | string[]").narrow((value, ctx) => {
+  if (value === false) return true;
+  if (value.length === 0)
+    return ctx.mustBe("false or a non-empty array of glob strings");
+  if (value.some((glob) => glob.trim().length === 0))
+    return ctx.mustBe("false or an array of non-empty glob strings");
+  return true;
+});
 
 const rawObjectSchema = type({ "[string]": "unknown" }).narrow((value, ctx) =>
   Array.isArray(value) ? ctx.mustBe("a non-array object") : true,
@@ -116,9 +120,14 @@ export async function checkWorkspaceMetadata(
         `${name}: "publishConfig" must be ${JSON.stringify({ access: ACCESS })}`,
       );
     }
-    if (!eq(raw["sideEffects"], expectedSideEffects(name))) {
+    const sideEffects = raw["sideEffects"];
+    if (sideEffects === undefined) {
       violations.push(
-        `${name}: "sideEffects" must be ${JSON.stringify(expectedSideEffects(name))}`,
+        `${name}: "sideEffects" must be declared (false or a non-empty array of glob strings)`,
+      );
+    } else if (sideEffectsSchema(sideEffects) instanceof type.errors) {
+      violations.push(
+        `${name}: "sideEffects" must be false or a non-empty array of glob strings`,
       );
     }
   }
@@ -154,27 +163,34 @@ export async function checkWorkspaceDescriptions(
   return { violations, manifestCount: paths.length };
 }
 
-/** Set the three fields on every non-private package. Returns the packages
- *  changed. */
+/** Set the mechanical fields (`files`, `publishConfig`) on every non-private
+ *  package and seed a missing `sideEffects` with the safe `false` default.
+ *  An existing `sideEffects` declaration is never overwritten — a real glob
+ *  list is authored knowledge, and a malformed value is left for the check
+ *  to reject. Returns the packages changed. */
 export async function fixWorkspaceMetadata(
   repoRoot: string,
 ): Promise<string[]> {
   const changed: string[] = [];
   for (const { name, manifestPath: path } of readWorkspacePackages(repoRoot)) {
     const raw = await readRaw(path);
-    const sideEffects = expectedSideEffects(name);
-    if (
-      eq(raw["files"], expectedFiles(name)) &&
-      eq(raw["publishConfig"], { access: ACCESS }) &&
-      eq(raw["sideEffects"], sideEffects)
-    ) {
-      continue;
+    let mutated = false;
+    if (!eq(raw["files"], expectedFiles(name))) {
+      raw["files"] = expectedFiles(name);
+      mutated = true;
     }
-    raw["files"] = expectedFiles(name);
-    raw["sideEffects"] = sideEffects;
-    raw["publishConfig"] = { access: ACCESS };
-    await Bun.write(path, JSON.stringify(raw, null, 2) + "\n");
-    changed.push(name);
+    if (!eq(raw["publishConfig"], { access: ACCESS })) {
+      raw["publishConfig"] = { access: ACCESS };
+      mutated = true;
+    }
+    if (raw["sideEffects"] === undefined) {
+      raw["sideEffects"] = false;
+      mutated = true;
+    }
+    if (mutated) {
+      await Bun.write(path, JSON.stringify(raw, null, 2) + "\n");
+      changed.push(name);
+    }
   }
   return changed;
 }
@@ -190,13 +206,17 @@ if (import.meta.main) {
     const changed = await fixWorkspaceMetadata(repoRoot);
     for (const name of changed) console.log(`  set metadata on ${name}`);
     console.log(`publish-metadata: updated ${changed.length} package(s)`);
-    // `--fix` never authors a description. A member left without one is a
-    // real failure, so surface it and exit non-zero rather than reporting a
-    // success that the check-mode run in `make lint` would contradict.
-    const { violations } = await checkWorkspaceDescriptions(repoRoot);
+    // `--fix` cannot author a `description` or repair a malformed
+    // `sideEffects` — both are author-owned. Anything still wrong after the
+    // fix is a real failure, so surface it and exit non-zero rather than
+    // reporting a success that the check-mode run in `make lint` would
+    // contradict.
+    const metadata = await checkWorkspaceMetadata(repoRoot);
+    const descriptions = await checkWorkspaceDescriptions(repoRoot);
+    const violations = [...metadata.violations, ...descriptions.violations];
     if (violations.length > 0) {
       console.error(
-        `\npublish-metadata: ${violations.length} member(s) still need a hand-written "description":\n`,
+        `\npublish-metadata: ${violations.length} violation(s) remain after --fix:\n`,
       );
       for (const v of violations) console.error(`  - ${v}`);
       process.exit(1);

--- a/bin/publish-metadata.ts
+++ b/bin/publish-metadata.ts
@@ -21,7 +21,9 @@
 //     the declaration is present and well-formed rather than computing it
 //     from a central list of package names. A package that forgets to
 //     declare it fails the gate loudly instead of being silently forced to
-//     `false` and tree-shaken away.
+//     `false` and tree-shaken away. Each declared glob must also name a
+//     module that exists on disk or ships via `files`, so a typo or an
+//     unshipped path is caught rather than shipped as a dead declaration.
 //
 // Those three are publish-tarball concerns, so they apply only to the
 // non-private packages under `packages/` (the ones that ship). A fourth
@@ -103,12 +105,49 @@ function eq(a: unknown, b: unknown): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
+// Validate a package's declared `sideEffects` globs against what it ships.
+// A glob is satisfied when it matches a file on disk or its root segment is
+// a directory the package ships via `files`; the latter accepts a `./dist/*`
+// entry even though `dist` is unbuilt at check time (this runs in `make
+// lint`, before any dist emit). The array as a whole must also name at least
+// one shipped module — a declaration of only source paths would be absent
+// from the published tarball and silently tree-shaken — which `anyShipped`
+// reports.
+//
+// Because `dist` is unbuilt here, this guard cannot confirm the emitted
+// filenames themselves: a glob whose root ships (like `./dist/foo.js`)
+// passes even if `foo.js` is never emitted. Confirming an emitted filename
+// needs a built or packed tree, which a lint-time guard does not have.
+function resolveSideEffectGlobs(
+  dir: string,
+  files: unknown,
+  globs: string[],
+): { unshipped: string[]; anyShipped: boolean } {
+  const shipped = new Set(
+    Array.isArray(files)
+      ? files.filter((f): f is string => typeof f === "string")
+      : [],
+  );
+  const unshipped: string[] = [];
+  let anyShipped = false;
+  for (const glob of globs) {
+    const matches = !new Bun.Glob(glob).scanSync(dir).next().done;
+    const relative = glob.replace(/^\.\//, "");
+    const slash = relative.indexOf("/");
+    const rootSegment = slash === -1 ? relative : relative.slice(0, slash);
+    const rootShipped = shipped.has(rootSegment);
+    if (rootShipped) anyShipped = true;
+    if (!matches && !rootShipped) unshipped.push(glob);
+  }
+  return { unshipped, anyShipped };
+}
+
 export async function checkWorkspaceMetadata(
   repoRoot: string,
 ): Promise<MetadataReport> {
   const violations: string[] = [];
   const list = readWorkspacePackages(repoRoot);
-  for (const { name, manifestPath } of list) {
+  for (const { name, dir, manifestPath } of list) {
     const raw = await readRaw(manifestPath);
     if (!eq(raw["files"], expectedFiles(name))) {
       violations.push(
@@ -125,10 +164,29 @@ export async function checkWorkspaceMetadata(
       violations.push(
         `${name}: "sideEffects" must be declared (false or a non-empty array of glob strings)`,
       );
-    } else if (sideEffectsSchema(sideEffects) instanceof type.errors) {
-      violations.push(
-        `${name}: "sideEffects" must be false or a non-empty array of glob strings`,
-      );
+    } else {
+      const validated = sideEffectsSchema(sideEffects);
+      if (validated instanceof type.errors) {
+        violations.push(
+          `${name}: "sideEffects" must be false or a non-empty array of glob strings`,
+        );
+      } else if (validated !== false) {
+        const { unshipped, anyShipped } = resolveSideEffectGlobs(
+          dir,
+          raw["files"],
+          validated,
+        );
+        for (const glob of unshipped) {
+          violations.push(
+            `${name}: "sideEffects" entry ${glob} matches no file on disk and is not under a shipped path`,
+          );
+        }
+        if (!anyShipped) {
+          violations.push(
+            `${name}: "sideEffects" declares only unshipped modules; at least one entry must be under a shipped path (e.g. ./dist/...)`,
+          );
+        }
+      }
     }
   }
   return { violations, packageCount: list.length };


### PR DESCRIPTION
## Summary

- Derive each publishable package's `sideEffects` from its own manifest,
  validated present, well-formed, and naming at least one shipped
  module, instead of hardcoding `@intx/log`. `--fix` seeds `false` only
  when absent and never overwrites a declaration.
- Validate each declared `sideEffects` glob against what the package
  ships: it must match a file on disk or fall under the package's
  `files` allowlist, so a typo or a source-only declaration is caught at
  lint.
- Document why `bin/dist-rewrite.ts`'s resolver probes only
  `.js`/`index.js` — extensioned specifiers are already resolved, and an
  extensionless non-`.js` target cannot be emitted under
  `moduleResolution: "bundler"` — with a regression test that a
  compiling `./data.json` import survives the rewrite untouched.

## Verification

- `make all` passes (lint, type-check, admin-ui bundle, tests) on the
  branch.
- The publish-metadata guard passes against all 28 non-private packages;
  `@intx/log` passes on its own src+dist `sideEffects` declaration.

Closes INTR-303
Closes INTR-305