### PR TITLE
Verify sideEffects globs resolve in the built tree before publishing

### DIFF
--- a/bin/publish-metadata.test.ts
+++ b/bin/publish-metadata.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import {
+  checkBuiltSideEffects,
   checkWorkspaceDescriptions,
   checkWorkspaceMetadata,
   expectedFiles,
@@ -205,6 +206,89 @@ test("a malformed sideEffects is flagged", async () => {
     const { violations } = await checkWorkspaceMetadata(makeWorkspace([pkg]));
     expect(violations.some((v) => v.includes("sideEffects"))).toBe(true);
   }
+});
+
+test("checkBuiltSideEffects passes when every glob matches an emitted file", async () => {
+  const root = makeWorkspace([canonical("@x/log", ["./dist/index.js"])]);
+  seedPackageFiles(root, 0, ["dist/index.js"]);
+  const { violations, packageCount } = await checkBuiltSideEffects(root);
+  expect(violations).toEqual([]);
+  expect(packageCount).toBe(1);
+});
+
+test("checkBuiltSideEffects flags a glob matching no emitted file", async () => {
+  // The manifest declares the intended path, but the build emitted a typo'd
+  // name — so the declared glob resolves to nothing in the built tree, the
+  // exact case the lint-time `files`-coverage escape cannot catch.
+  const root = makeWorkspace([canonical("@x/log", ["./dist/register.js"])]);
+  seedPackageFiles(root, 0, ["dist/registr.js"]);
+  const { violations } = await checkBuiltSideEffects(root);
+  expect(violations).toEqual([
+    '@x/log: "sideEffects" entry ./dist/register.js matches no file in the built package directory',
+  ]);
+});
+
+test("checkBuiltSideEffects flags only the unresolved glob in a mixed array", async () => {
+  const root = makeWorkspace([
+    canonical("@x/log", ["./dist/index.js", "./dist/hono.js"]),
+  ]);
+  seedPackageFiles(root, 0, ["dist/index.js"]);
+  const { violations } = await checkBuiltSideEffects(root);
+  expect(violations).toEqual([
+    '@x/log: "sideEffects" entry ./dist/hono.js matches no file in the built package directory',
+  ]);
+});
+
+test("checkBuiltSideEffects accepts a log-shaped src-and-dist array once built", async () => {
+  const root = makeWorkspace([
+    canonical("@x/logish", [
+      "./src/index.ts",
+      "./src/hono.ts",
+      "./src/default-sink.ts",
+      "./dist/index.js",
+      "./dist/hono.js",
+      "./dist/default-sink.js",
+    ]),
+  ]);
+  // Source and freshly-emitted dist both present, as in the package dir after
+  // `buildDist`; the `./src/*.ts` entries must not be treated as unresolved.
+  seedPackageFiles(root, 0, [
+    "src/index.ts",
+    "src/hono.ts",
+    "src/default-sink.ts",
+    "dist/index.js",
+    "dist/hono.js",
+    "dist/default-sink.js",
+  ]);
+  expect((await checkBuiltSideEffects(root)).violations).toEqual([]);
+});
+
+test("checkBuiltSideEffects skips a package declaring sideEffects false", async () => {
+  const root = makeWorkspace([canonical("@x/a")]);
+  expect((await checkBuiltSideEffects(root)).violations).toEqual([]);
+});
+
+test("checkBuiltSideEffects throws on a malformed sideEffects", async () => {
+  const root = makeWorkspace([
+    {
+      name: "@x/a",
+      files: expectedFiles("@x/a"),
+      sideEffects: true,
+      publishConfig: { access: "public" },
+    },
+  ]);
+  // Well-formedness is the lint gate's job; reaching this check with a
+  // malformed value means that gate did not run, so it must surface loudly.
+  await expect(checkBuiltSideEffects(root)).rejects.toThrow(/malformed/);
+});
+
+test("checkBuiltSideEffects throws on an absent sideEffects", async () => {
+  const pkg = canonical("@x/a");
+  delete pkg["sideEffects"];
+  const root = makeWorkspace([pkg]);
+  // An absent declaration is the literal "checkWorkspaceMetadata did not run
+  // first" precondition the throw defends, so it must surface, not be skipped.
+  await expect(checkBuiltSideEffects(root)).rejects.toThrow(/malformed/);
 });
 
 test("a private package is not checked", async () => {

--- a/bin/publish-metadata.ts
+++ b/bin/publish-metadata.ts
@@ -105,6 +105,11 @@ function eq(a: unknown, b: unknown): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
+/** True when `glob` matches at least one real file under `dir`. */
+function globMatches(dir: string, glob: string): boolean {
+  return !new Bun.Glob(glob).scanSync(dir).next().done;
+}
+
 // Validate a package's declared `sideEffects` globs against what it ships.
 // A glob is satisfied when it matches a file on disk or its root segment is
 // a directory the package ships via `files`; the latter accepts a `./dist/*`
@@ -117,7 +122,9 @@ function eq(a: unknown, b: unknown): boolean {
 // Because `dist` is unbuilt here, this guard cannot confirm the emitted
 // filenames themselves: a glob whose root ships (like `./dist/foo.js`)
 // passes even if `foo.js` is never emitted. Confirming an emitted filename
-// needs a built or packed tree, which a lint-time guard does not have.
+// needs a built tree, which a lint-time guard does not have;
+// `checkBuiltSideEffects` performs that confirmation against the tree
+// `buildDist` leaves behind.
 function resolveSideEffectGlobs(
   dir: string,
   files: unknown,
@@ -131,7 +138,7 @@ function resolveSideEffectGlobs(
   const unshipped: string[] = [];
   let anyShipped = false;
   for (const glob of globs) {
-    const matches = !new Bun.Glob(glob).scanSync(dir).next().done;
+    const matches = globMatches(dir, glob);
     const relative = glob.replace(/^\.\//, "");
     const slash = relative.indexOf("/");
     const rootSegment = slash === -1 ? relative : relative.slice(0, slash);
@@ -186,6 +193,44 @@ export async function checkWorkspaceMetadata(
             `${name}: "sideEffects" declares only unshipped modules; at least one entry must be under a shipped path (e.g. ./dist/...)`,
           );
         }
+      }
+    }
+  }
+  return { violations, packageCount: list.length };
+}
+
+// Confirm each package's declared `sideEffects` globs against a tree where
+// `dist` has been emitted (after `buildDist`). Unlike the lint-time check in
+// `checkWorkspaceMetadata`, there is no `files`-coverage escape: with `dist`
+// built, every non-`false` glob must match at least one real file, so a typo
+// in an emitted path (`./dist/registr.js` for `./dist/register.js`) is caught
+// rather than shipped as a dead declaration a consumer's bundler silently
+// tree-shakes.
+//
+// Presence and well-formedness of `sideEffects` are `checkWorkspaceMetadata`'s
+// constraint, enforced before any dist emit; this check owns only the emitted
+// filename. A malformed or absent declaration reaching here means that gate
+// did not run and pass first, so it throws rather than silently skipping a
+// package it cannot check.
+export async function checkBuiltSideEffects(
+  repoRoot: string,
+): Promise<MetadataReport> {
+  const violations: string[] = [];
+  const list = readWorkspacePackages(repoRoot);
+  for (const { name, dir, manifestPath } of list) {
+    const raw = await readRaw(manifestPath);
+    const validated = sideEffectsSchema(raw["sideEffects"]);
+    if (validated instanceof type.errors) {
+      throw new Error(
+        `publish-metadata: ${name} has an absent or malformed "sideEffects"; checkWorkspaceMetadata must run and pass before checkBuiltSideEffects`,
+      );
+    }
+    if (validated === false) continue;
+    for (const glob of validated) {
+      if (!globMatches(dir, glob)) {
+        violations.push(
+          `${name}: "sideEffects" entry ${glob} matches no file in the built package directory`,
+        );
       }
     }
   }

--- a/bin/publish.ts
+++ b/bin/publish.ts
@@ -65,7 +65,10 @@ import {
   topoSortLeafFirst,
 } from "./lib/publish-targets";
 import { makeRun } from "./lib/run";
-import { checkWorkspaceMetadata } from "./publish-metadata";
+import {
+  checkBuiltSideEffects,
+  checkWorkspaceMetadata,
+} from "./publish-metadata";
 
 // ---- effectful orchestration ----
 
@@ -285,6 +288,17 @@ async function main(repoRoot: string, execute: boolean): Promise<void> {
   try {
     // Emit compiled dist for every target.
     await buildDist(repoRoot);
+
+    // With dist emitted, confirm every declared sideEffects glob resolves to a
+    // real file — catching an emitted-path typo the lint-time metadata guard
+    // cannot see before the build. Fails here, before packing, while dist is
+    // fresh; the finally still tears it down.
+    const builtSideEffects = await checkBuiltSideEffects(repoRoot);
+    if (builtSideEffects.violations.length > 0) {
+      throw new Error(
+        `publish: sideEffects globs unresolved in built tree:\n${builtSideEffects.violations.join("\n")}`,
+      );
+    }
 
     // Stage the LICENSE the files allowlist expects (not committed per-package).
     for (const t of ordered) {


### PR DESCRIPTION
## Summary

- `checkBuiltSideEffects` confirms every non-`false` `sideEffects` glob in each
  publishable package resolves to a real file in the built package directory
  (after `build-dist` emits `dist/`), with no `files`-coverage escape — so an
  emitted-path typo like `./dist/registr.js` for `./dist/register.js` is caught
  instead of being silently tree-shaken by a consumer's bundler.
- The guarded publish path runs the check right after `build-dist`, aborting the
  run (dry run and `--execute` alike) when a declared glob names a file the build
  never produced.

## Verification

The build passes (`make all` exits 0; 4803 + 423 tests). Unit tests cover a glob
matching an emitted file, an emitted-path typo, a mixed array, the `@intx/log`
src-and-dist shape, the `false` skip, and the absent/malformed precondition throw.

Closes INTR-415