### PR TITLE
Reconcile the Anthropic adaptive-thinking effort as a deliberate pair

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build-admin-ui: FORCE
 
 lint: FORCE
 	prettier -c .
-	eslint --cache .
+	NODE_OPTIONS=--max-old-space-size=8192 eslint --cache .
 	$(BUN) bin/gen-api-docs.ts --check
 	$(BUN) bin/check-deps.ts
 	$(BUN) bin/check-launchers.ts

--- a/packages/inference-discovery-anthropic/docs/discovery.md
+++ b/packages/inference-discovery-anthropic/docs/discovery.md
@@ -46,7 +46,7 @@ thinks). This is a capture-time choice and does not mirror the
 production effort, which is the lower API default (see
 `ADAPTIVE_THINKING_EFFORT` in the runtime adapter). The committed
 adaptive fixtures therefore carry `max`, not the production effort
-value.
+value. A guard test checks both the runtime and capture effort values.
 
 | Model                       | Tier      | Extended thinking | Vision | Document input | Code execution | Web search |
 | --------------------------- | --------- | ----------------- | ------ | -------------- | -------------- | ---------- |

--- a/packages/inference-discovery-anthropic/docs/discovery.md
+++ b/packages/inference-discovery-anthropic/docs/discovery.md
@@ -39,6 +39,15 @@ the adaptive shape `thinking: {type: "adaptive"}` paired with
 `output_config: {effort}`; the request builder selects the shape by
 model. `claude-haiku-4-5-20251001` still uses the classic shape.
 
+On the adaptive shape the rig sends `output_config: {effort: "max"}`
+deliberately: only `max` reliably elicits a thinking block to capture
+(the lower effort levels are non-deterministic about whether the model
+thinks). This is a capture-time choice and does not mirror the
+production effort, which is the lower API default (see
+`ADAPTIVE_THINKING_EFFORT` in the runtime adapter). The committed
+adaptive fixtures therefore carry `max`, not the production effort
+value.
+
 | Model                       | Tier      | Extended thinking | Vision | Document input | Code execution | Web search |
 | --------------------------- | --------- | ----------------- | ------ | -------------- | -------------- | ---------- |
 | `claude-fable-5`            | Flagship  | yes (adaptive)    | yes    | yes            | yes            | yes        |

--- a/packages/inference-discovery-anthropic/src/adaptive-thinking-alignment.test.ts
+++ b/packages/inference-discovery-anthropic/src/adaptive-thinking-alignment.test.ts
@@ -1,6 +1,12 @@
 import { describe, test, expect } from "bun:test";
-import { ADAPTIVE_THINKING_MODELS as RUNTIME_ADAPTIVE_MODELS } from "@intx/inference/providers";
-import { ADAPTIVE_THINKING_MODELS as DISCOVERY_ADAPTIVE_MODELS } from "./request-body";
+import {
+  ADAPTIVE_THINKING_MODELS as RUNTIME_ADAPTIVE_MODELS,
+  ADAPTIVE_THINKING_EFFORT,
+} from "@intx/inference/providers";
+import {
+  ADAPTIVE_THINKING_MODELS as DISCOVERY_ADAPTIVE_MODELS,
+  ADAPTIVE_THINKING_CAPTURE_EFFORT,
+} from "./request-body";
 
 describe("adaptive-thinking model alignment", () => {
   test("the discovery set matches the runtime adapter's set", () => {
@@ -13,5 +19,20 @@ describe("adaptive-thinking model alignment", () => {
     expect(new Set(DISCOVERY_ADAPTIVE_MODELS)).toEqual(
       new Set(RUNTIME_ADAPTIVE_MODELS),
     );
+  });
+});
+
+describe("adaptive-thinking effort pair", () => {
+  test("production sends high and capture sends max", () => {
+    // The runtime adapter and the discovery capture rig deliberately send
+    // different effort on the adaptive-thinking wire: production uses "high"
+    // (the Anthropic API default), while the capture rig uses "max" because
+    // only "max" reliably elicits a thinking block to capture. Unlike the
+    // model sets above, which must stay equal, these two are an intentional
+    // unequal pair. Co-locating both values with that rationale means a change
+    // to either trips here, so it is made as a conscious decision rather than
+    // silent drift.
+    expect(ADAPTIVE_THINKING_EFFORT).toBe("high");
+    expect(ADAPTIVE_THINKING_CAPTURE_EFFORT).toBe("max");
   });
 });

--- a/packages/inference-discovery-anthropic/src/request-body.ts
+++ b/packages/inference-discovery-anthropic/src/request-body.ts
@@ -137,10 +137,14 @@ export const ADAPTIVE_THINKING_MODELS: ReadonlySet<string> = new Set([
   "claude-sonnet-4-6",
 ]);
 
-// Adaptive thinking is the model's own per-request choice; empirically only
-// effort "max" reliably elicits a thinking block to capture (low/medium/high/
-// xhigh are non-deterministic).
-const ADAPTIVE_THINKING_EFFORT: AnthropicEffort = "max";
+// The effort the capture rig sends on the adaptive-thinking wire. Adaptive
+// thinking is the model's own per-request choice, and empirically only effort
+// "max" reliably elicits a thinking block to capture (low/medium/high/xhigh
+// are non-deterministic). Production sends a lower effort (the API default; see
+// ADAPTIVE_THINKING_EFFORT in the runtime adapter), so capturing at "max" is a
+// deliberate capture-time choice: the two efforts are an intentional pair, not
+// drift.
+export const ADAPTIVE_THINKING_CAPTURE_EFFORT: AnthropicEffort = "max";
 
 // The adaptive path carries no budget_tokens, so it cannot reuse the
 // budget-derived THINKING_MAX_TOKENS. A flat ceiling sized to let effort:max
@@ -155,7 +159,7 @@ const ADAPTIVE_THINKING_MAX_TOKENS = 4096;
 function applyThinking(body: AnthropicRequestBody, model: string): void {
   if (ADAPTIVE_THINKING_MODELS.has(model)) {
     body.thinking = { type: "adaptive" };
-    body.output_config = { effort: ADAPTIVE_THINKING_EFFORT };
+    body.output_config = { effort: ADAPTIVE_THINKING_CAPTURE_EFFORT };
     body.max_tokens = ADAPTIVE_THINKING_MAX_TOKENS;
     return;
   }

--- a/packages/inference-discovery-anthropic/src/request-body.ts
+++ b/packages/inference-discovery-anthropic/src/request-body.ts
@@ -143,7 +143,7 @@ export const ADAPTIVE_THINKING_MODELS: ReadonlySet<string> = new Set([
 // are non-deterministic). Production sends a lower effort (the API default; see
 // ADAPTIVE_THINKING_EFFORT in the runtime adapter), so capturing at "max" is a
 // deliberate capture-time choice: the two efforts are an intentional pair, not
-// drift.
+// drift. A guard test in this package checks both effort values.
 export const ADAPTIVE_THINKING_CAPTURE_EFFORT: AnthropicEffort = "max";
 
 // The adaptive path carries no budget_tokens, so it cannot reuse the

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -50,7 +50,8 @@ export const ADAPTIVE_THINKING_MODELS: ReadonlySet<string> = new Set([
 // sends "max" instead: only "max" reliably elicits a thinking block to capture,
 // so the production default and the capture value are an intentional pair, not
 // drift. ADAPTIVE_THINKING_MODELS above must match across the two layers; the
-// effort values, by contrast, are meant to differ.
+// effort values, by contrast, are meant to differ. A guard test in the
+// discovery package checks both effort values.
 export const ADAPTIVE_THINKING_EFFORT = "high";
 
 // ---------------------------------------------------------------------------

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -45,6 +45,14 @@ export const ADAPTIVE_THINKING_MODELS: ReadonlySet<string> = new Set([
   "claude-sonnet-4-6",
 ]);
 
+// The effort this adapter sends on the adaptive-thinking wire in production.
+// "high" is the Anthropic API default. The discovery capture rig deliberately
+// sends "max" instead: only "max" reliably elicits a thinking block to capture,
+// so the production default and the capture value are an intentional pair, not
+// drift. ADAPTIVE_THINKING_MODELS above must match across the two layers; the
+// effort values, by contrast, are meant to differ.
+export const ADAPTIVE_THINKING_EFFORT = "high";
+
 // ---------------------------------------------------------------------------
 // Request building
 // ---------------------------------------------------------------------------
@@ -100,7 +108,7 @@ function buildRequest(
     // plus output_config.effort.
     if (ADAPTIVE_THINKING_MODELS.has(model)) {
       body["thinking"] = { type: "adaptive" };
-      body["output_config"] = { effort: "high" };
+      body["output_config"] = { effort: ADAPTIVE_THINKING_EFFORT };
     } else {
       body["thinking"] = {
         type: "enabled",

--- a/packages/inference/src/providers/index.ts
+++ b/packages/inference/src/providers/index.ts
@@ -11,6 +11,7 @@ export {
   createAnthropicAdapter,
   AnthropicQuirks,
   ADAPTIVE_THINKING_MODELS,
+  ADAPTIVE_THINKING_EFFORT,
 } from "./anthropic";
 export { createGoogleGenAIAdapter, GoogleGenAIQuirks } from "./google-genai";
 export { createOpenAIAdapter, OpenAIQuirks } from "./openai";


### PR DESCRIPTION
## Summary

- Names the runtime adapter's adaptive-thinking effort as
  `ADAPTIVE_THINKING_EFFORT = "high"` (the Anthropic API default) and the
  discovery capture rig's as `ADAPTIVE_THINKING_CAPTURE_EFFORT = "max"`, and
  documents that the two are a deliberate, unequal pair: production runs the
  API default, while the capture rig forces `max` because only `max` reliably
  elicits a capturable thinking block.
- Adds a guard test co-locating both values with that rationale, so a change
  to either surfaces the pair as a conscious decision.
- Raises the Node heap ceiling for the eslint lint step so the pre-commit
  hook's cold-cache lint does not run out of memory.

## Verification

- `make all` passes: lint, forced `tsc -b`, the admin-ui bundle, and the
  two-pass test suite (0 test failures).
- The new effort-pair guard test passes; the existing wire tests still assert
  the built request emits `effort: "high"` (runtime) and `effort: "max"`
  (discovery).

Closes INTR-449