### PR TITLE
INTR 451 - Remove hardlinks from pack publishing and tool

### DIFF
--- a/packages/storage-isogit/src/pack-receive.test.ts
+++ b/packages/storage-isogit/src/pack-receive.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterEach } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -11,6 +11,7 @@ import {
 import { initAgentRepo } from "./init";
 import {
   applyPack,
+  publishPackAtomically,
   receivePackObjects,
   type CommitVerifier,
   type TreeValidator,
@@ -405,6 +406,181 @@ describe("applyPack", () => {
     );
     await expect(fs.promises.access(packPath)).rejects.toThrow();
     await expect(fs.promises.access(idxPath)).rejects.toThrow();
+  });
+});
+
+describe("publishPackAtomically", () => {
+  test("renames the completed pack before publishing its index", async () => {
+    const source = await makeSourceRepo();
+    const pack = await createPackFromRepo(source.dir, source.oids);
+    const targetDir = await tempDir();
+    await initAgentRepo(targetDir);
+
+    const originalRename = fs.promises.rename.bind(fs.promises);
+    const renames: { from: string; to: string }[] = [];
+    const renameSpy = spyOn(fs.promises, "rename").mockImplementation(
+      async (from, to) => {
+        await originalRename(from, to);
+        renames.push({ from: from.toString(), to: to.toString() });
+      },
+    );
+
+    try {
+      await publishPackAtomically(targetDir, pack, "rename-order");
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    const finalPack = path.join(
+      targetDir,
+      ".git",
+      "objects",
+      "pack",
+      "pack-recv-rename-order.pack",
+    );
+    const finalIdx = finalPack.replace(/\.pack$/, ".idx");
+    expect(renames).toEqual([
+      {
+        from: path.join(
+          targetDir,
+          ".git",
+          "objects",
+          "pack-staging",
+          "rename-order",
+          "pack.pack",
+        ),
+        to: finalPack,
+      },
+      {
+        from: path.join(
+          targetDir,
+          ".git",
+          "objects",
+          "pack-staging",
+          "rename-order",
+          "pack.idx",
+        ),
+        to: finalIdx,
+      },
+    ]);
+    await fs.promises.access(finalPack);
+    await fs.promises.access(finalIdx);
+    await expect(
+      fs.promises.access(
+        path.join(targetDir, ".git", "objects", "pack-staging", "rename-order"),
+      ),
+    ).rejects.toThrow();
+  });
+
+  test.each(["pack", "idx"] as const)(
+    "does not overwrite an existing final %s",
+    async (extension) => {
+      const source = await makeSourceRepo();
+      const pack = await createPackFromRepo(source.dir, source.oids);
+      const targetDir = await tempDir();
+      await initAgentRepo(targetDir);
+
+      const packDir = path.join(targetDir, ".git", "objects", "pack");
+      const existingPath = path.join(
+        packDir,
+        `pack-recv-duplicate.${extension}`,
+      );
+      await fs.promises.mkdir(packDir, { recursive: true });
+      await fs.promises.writeFile(existingPath, "existing");
+
+      await expect(
+        publishPackAtomically(targetDir, pack, "duplicate"),
+      ).rejects.toThrow(/already published/);
+      expect(await fs.promises.readFile(existingPath, "utf8")).toBe("existing");
+    },
+  );
+
+  test("rejects concurrent publishers using the same transfer ID", async () => {
+    const source = await makeSourceRepo();
+    const pack = await createPackFromRepo(source.dir, source.oids);
+    const targetDir = await tempDir();
+    await initAgentRepo(targetDir);
+
+    const originalIndexPack = git.indexPack.bind(git);
+    let signalIndexingStarted: () => void = () => undefined;
+    const indexingStarted = new Promise<void>((resolve) => {
+      signalIndexingStarted = resolve;
+    });
+    let releaseIndexing: () => void = () => undefined;
+    const indexingReleased = new Promise<void>((resolve) => {
+      releaseIndexing = resolve;
+    });
+    let blockNextIndex = true;
+    const indexPackSpy = spyOn(git, "indexPack").mockImplementation(
+      async (args) => {
+        if (blockNextIndex) {
+          blockNextIndex = false;
+          signalIndexingStarted();
+          await indexingReleased;
+        }
+        return originalIndexPack(args);
+      },
+    );
+
+    let firstPublish: Promise<string[]> | undefined;
+    try {
+      firstPublish = publishPackAtomically(targetDir, pack, "concurrent");
+      await indexingStarted;
+
+      await expect(
+        publishPackAtomically(targetDir, pack, "concurrent"),
+      ).rejects.toThrow(/already published or in progress/);
+      expect(indexPackSpy).toHaveBeenCalledTimes(1);
+
+      releaseIndexing();
+      await firstPublish;
+    } finally {
+      releaseIndexing();
+      await firstPublish?.catch(() => undefined);
+      indexPackSpy.mockRestore();
+    }
+  });
+
+  test("cleans up when index publication fails after the pack rename", async () => {
+    const source = await makeSourceRepo();
+    const pack = await createPackFromRepo(source.dir, source.oids);
+    const targetDir = await tempDir();
+    await initAgentRepo(targetDir);
+
+    const originalRename = fs.promises.rename.bind(fs.promises);
+    let renameCount = 0;
+    const renameSpy = spyOn(fs.promises, "rename").mockImplementation(
+      async (from, to) => {
+        renameCount += 1;
+        if (renameCount === 2) throw new Error("index publish failed");
+        await originalRename(from, to);
+      },
+    );
+
+    try {
+      await expect(
+        publishPackAtomically(targetDir, pack, "partial"),
+      ).rejects.toThrow("index publish failed");
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    const finalPack = path.join(
+      targetDir,
+      ".git",
+      "objects",
+      "pack",
+      "pack-recv-partial.pack",
+    );
+    await expect(fs.promises.access(finalPack)).rejects.toThrow();
+    await expect(
+      fs.promises.access(finalPack.replace(/\.pack$/, ".idx")),
+    ).rejects.toThrow();
+    await expect(
+      fs.promises.access(
+        path.join(targetDir, ".git", "objects", "pack-staging", "partial"),
+      ),
+    ).rejects.toThrow();
   });
 });
 

--- a/packages/storage-isogit/src/pack-receive.ts
+++ b/packages/storage-isogit/src/pack-receive.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import git from "isomorphic-git";
+
+import { hasCode } from "@intx/types";
+
 import { readRawObject } from "./isogit-helpers";
 import { withRepoDirLock } from "./repo-lock";
 
@@ -75,8 +78,8 @@ function stripGpgsig(raw: string): string {
 
 const SAFE_PATH_SEGMENT = /^[a-zA-Z0-9_-]+$/;
 
-// Sibling of objects/pack/. Lives on the same filesystem so fs.link and
-// fs.rename between staging and pack/ are atomic metadata operations.
+// Sibling of objects/pack/. Lives on the same filesystem so fs.rename
+// between staging and pack/ is an atomic metadata operation.
 const STAGING_DIR_NAME = "pack-staging";
 
 /**
@@ -93,6 +96,27 @@ function publishedPackPaths(
   const finalPackPath = path.join(packDir, `pack-recv-${transferId}.pack`);
   const finalIdxPath = finalPackPath.replace(/\.pack$/, ".idx");
   return { finalPackPath, finalIdxPath };
+}
+
+async function pathExists(filepath: string): Promise<boolean> {
+  try {
+    await fs.promises.lstat(filepath);
+    return true;
+  } catch (cause) {
+    if (hasCode(cause) && cause.code === "ENOENT") return false;
+    throw cause;
+  }
+}
+
+function transferIdCollisionError(
+  dir: string,
+  transferId: string,
+  cause?: unknown,
+): Error {
+  return new Error(
+    `transferId "${transferId}" already published or in progress in ${dir}; callers must guarantee transferId uniqueness across all historical and concurrent receives`,
+    { cause },
+  );
 }
 
 /**
@@ -261,18 +285,20 @@ async function writeTreeEntries(
  * non-recursively (verified at the source line refs above), so any
  * sibling directory under `objects/` is invisible to discovery.
  *
- * We stage in `objects/pack-staging/<transferId>/`. The per-transfer
- * subdirectory keeps concurrent receives' temp pairs isolated from each
- * other; the kernel guarantees that the staging directory and the
- * final `objects/pack/` are on the same filesystem (they share a
- * parent), so `fs.link` and `fs.rename` between them are atomic
- * metadata operations.
+ * We stage in `objects/pack-staging/<transferId>/`. Exclusive creation
+ * of the per-transfer subdirectory reserves the transfer ID and keeps
+ * concurrent receives' temp pairs isolated from each other. The kernel
+ * guarantees that the staging directory and the final `objects/pack/`
+ * are on the same filesystem (they share a parent), so `fs.rename`
+ * between them is an atomic metadata operation.
  *
  * # Sequence (numbered for cross-reference with cleanup contract)
  *
- *   1. Create `objects/pack-staging/<transferId>/` and write the pack
- *      bytes to `pack.pack` inside it. Readers scanning
- *      `objects/pack/` do not see this file (different directory).
+ *   1. Reserve the transfer ID by exclusively creating
+ *      `objects/pack-staging/<transferId>/`, reject any existing final
+ *      path for the same ID, and write the pack bytes to `pack.pack`
+ *      inside it. Readers scanning `objects/pack/` do not see this file
+ *      (different directory).
  *
  *   2. Run `git.indexPack` against the staging path — iso-git derives
  *      the `.idx` filename from the `.pack` filename and writes
@@ -284,11 +310,11 @@ async function writeTreeEntries(
  *   3. Atomic publish (transitions readers from "no new pack" to "new
  *      pack visible"):
  *
- *        a. `fs.link` staging `.pack` -> final `.pack`. The new
+ *        a. `fs.rename` staging `.pack` -> final `.pack`. The new
  *           `.pack` now exists in `objects/pack/`. Readers scanning
  *           for `.idx` files still do not see the new pack (no `.idx`
  *           for it in `objects/pack/` yet). The staging `.pack`
- *           directory entry is still present.
+ *           directory entry vanishes.
  *
  *        b. `fs.rename` staging `.idx` -> final `.idx`. The new `.idx`
  *           appears atomically in `objects/pack/`; readers' next
@@ -298,9 +324,7 @@ async function writeTreeEntries(
  *           the first place, this transition is observable only to
  *           this function.
  *
- *        c. Remove the staging directory recursively (`unlink` of the
- *           remaining `.pack` plus `rmdir`). The final `.pack` inode
- *           persists via the link created in 3a.
+ *        c. Remove the now-empty staging directory.
  *
  *   4. On any throw before publish completes, recursively remove the
  *      staging directory. `fs.rm({recursive: true, force: true})`
@@ -311,13 +335,17 @@ async function writeTreeEntries(
  *
  * On successful return, no staging files remain. On throw before
  * publish (steps 1-2), the staging directory and any files inside it
- * are removed. A throw partway through publish (between 3a and 3b)
- * leaves a linked-but-unindexed `.pack` in `objects/pack/`; this is
- * harmless (iso-git ignores `.pack` files with no matching `.idx`,
- * verified at `index.cjs:3394-3398`) and the recovery path on the next
- * call would re-write the same content. The cleanup-on-throw path
- * here attempts to remove the orphan `.pack` but does not mask the
- * original publish error.
+ * are removed. On a throw partway through publish (between 3a and 3b),
+ * cleanup attempts to remove both the staging directory and the
+ * unindexed `.pack` published by this call without masking the original
+ * error. An abrupt process termination or a cleanup failure can still
+ * leave an unindexed `.pack` in `objects/pack/` and files in the staging
+ * directory. Iso-git ignores `.pack` files with no matching `.idx`
+ * (verified at `index.cjs:3394-3398`), so repository reads remain
+ * unaffected. The staging reservation rejects concurrent reuse, and the
+ * final-path guard rejects historical reuse of that transfer ID. Callers
+ * must retry with a fresh ID; orphaned files remain harmless until
+ * manually removed.
  *
  * # Validation timing
  *
@@ -370,13 +398,36 @@ export async function publishPackAtomically(
   const packDir = path.join(dir, ".git", "objects", "pack");
   const stagingRoot = path.join(dir, ".git", "objects", STAGING_DIR_NAME);
   const stagingDir = path.join(stagingRoot, transferId);
-
-  await fs.promises.mkdir(packDir, { recursive: true });
-  await fs.promises.mkdir(stagingDir, { recursive: true });
-
   const stagingPackPath = path.join(stagingDir, "pack.pack");
   const stagingIdxPath = stagingPackPath.replace(/\.pack$/, ".idx");
   const { finalPackPath, finalIdxPath } = publishedPackPaths(dir, transferId);
+
+  await fs.promises.mkdir(packDir, { recursive: true });
+  await fs.promises.mkdir(stagingRoot, { recursive: true });
+  try {
+    // mkdir without recursive is an atomic reservation for concurrent
+    // calls using the same transfer ID.
+    await fs.promises.mkdir(stagingDir);
+  } catch (cause) {
+    if (hasCode(cause) && cause.code === "EEXIST") {
+      throw transferIdCollisionError(dir, transferId, cause);
+    }
+    throw cause;
+  }
+
+  try {
+    // Unlike link, rename may replace an existing destination. Check for
+    // a historical publication after acquiring the staging reservation.
+    if ((await pathExists(finalPackPath)) || (await pathExists(finalIdxPath))) {
+      throw transferIdCollisionError(dir, transferId);
+    }
+  } catch (err) {
+    await fs.promises
+      .rm(stagingDir, { recursive: true, force: true })
+      .catch(() => undefined);
+    throw err;
+  }
+
   // iso-git's indexPack takes a repo-root-relative filepath; derive it
   // from the absolute path rather than rebuilding the segment list so
   // the two stay coupled.
@@ -406,50 +457,32 @@ export async function publishPackAtomically(
     throw err;
   }
 
-  // Step 3: atomic publish. The .pack link (3a) and the .idx rename
+  // Step 3: atomic publish. The .pack rename (3a) and the .idx rename
   // (3b) are the two operations that determine externally-observable
   // state; a failure inside this block means the publish is partial
   // or absent, and the recovery rms below clear the half-published
   // pack from objects/pack/. Staging-directory cleanup is NOT part of
   // this block — see below.
+  let packPublished = false;
   try {
-    await fs.promises.link(stagingPackPath, finalPackPath); // 3a
+    await fs.promises.rename(stagingPackPath, finalPackPath); // 3a
+    packPublished = true;
     await fs.promises.rename(stagingIdxPath, finalIdxPath); // 3b
   } catch (err) {
-    // EEXIST on the link means `finalPackPath` already exists, which
-    // can only happen if a prior publishPackAtomically call on the
-    // same `dir` used the same `transferId`. The contract is that
-    // transferId is unique across all historical receives on `dir`;
-    // both production callers honour this (hub uses crypto.randomUUID,
-    // sidecar uses a per-process monotonic counter). Treat the EEXIST
-    // as a programmer error and surface it cleanly without running
-    // the recovery rms — those would destroy the earlier call's
-    // published pack and break any reader holding it.
-    if (
-      err !== null &&
-      typeof err === "object" &&
-      "code" in err &&
-      err.code === "EEXIST"
-    ) {
-      await fs.promises
-        .rm(stagingDir, { recursive: true, force: true })
-        .catch(() => undefined);
-      throw new Error(
-        `transferId "${transferId}" already published in ${dir}; callers must guarantee transferId uniqueness across all historical receives`,
-        { cause: err },
-      );
-    }
     // Partial-publish recovery: if 3a succeeded and 3b failed we
-    // leave a linked-but-unindexed .pack in objects/pack/. The rm of
-    // finalPackPath clears it; finalIdxPath cannot exist here (3b
-    // never completed), so no rm is needed for it. Each recovery rm
-    // is wrapped so a secondary failure (permissions, I/O) does not
-    // mask the original publish error — the caller needs to see the
-    // publish failure, not whatever the cleanup tripped on.
+    // leave an unindexed .pack in objects/pack/. Remove it only when
+    // this call completed 3a; a failure during 3a must not remove a
+    // file another publisher may own. Each recovery rm is wrapped so
+    // a secondary failure (permissions, I/O) does not mask the
+    // original publish failure.
     await fs.promises
       .rm(stagingDir, { recursive: true, force: true })
       .catch(() => undefined);
-    await fs.promises.rm(finalPackPath, { force: true }).catch(() => undefined);
+    if (packPublished) {
+      await fs.promises
+        .rm(finalPackPath, { force: true })
+        .catch(() => undefined);
+    }
     throw err;
   }
 
@@ -461,8 +494,8 @@ export async function publishPackAtomically(
   // EACCES/EBUSY/EIO on the staging rm trigger the recovery rms above
   // and delete a pack that was already published and (potentially)
   // already read by concurrent observers. A leftover staging
-  // directory on rm failure leaks disk until external cleanup; that
-  // is strictly preferable to retroactively destroying a successful
+  // directory on rm failure leaks disk until manually removed; that is
+  // strictly preferable to retroactively destroying a successful
   // publish.
   await fs.promises
     .rm(stagingDir, { recursive: true, force: true })

--- a/packages/tool-packaging/README.md
+++ b/packages/tool-packaging/README.md
@@ -29,13 +29,12 @@ Concretely the loader:
    `cache.extractTarball`. A single sha512 produces a single
    extraction shared across instances.
 3. Lays out each entry under `<scratch>/store/<name>/<version>/` by
-   hardlinking the file tree from the cache extraction. Each layout
+   copying the file tree from the cache extraction. Each layout
    directory then gets `node_modules/<dep>` symlinked into it pointing
    at the sibling `store/<dep>/<depVersion>/` chosen for that
-   requirer. Hardlinks keep on-disk usage to one copy per integrity
-   per filesystem; symlinks at the `node_modules/` boundary let
-   Node's realpath-based resolver walk to the dep's own layout dir
-   (which has its own `node_modules/`).
+   requirer. Symlinks at the `node_modules/` boundary let Node's
+   realpath-based resolver walk to the dep's own layout dir (which has
+   its own `node_modules/`).
 4. Dynamically imports each top-level entry's `interchange.tools`
    module and collects the `AnnotatedToolFactory` /
    `AnnotatedPluginFactory` values it exports.

--- a/packages/tool-packaging/src/cache.test.ts
+++ b/packages/tool-packaging/src/cache.test.ts
@@ -189,7 +189,7 @@ describe("LRU eviction when over cap", () => {
     // The cap-driven sweep removes the tarball blob immediately but
     // must defer the extraction-tree rm until every in-flight reader
     // releases — the same refcount/deferred-reclaim contract `evict`
-    // honors. Without that gate, a concurrent `hardlinkTree` walk
+    // honors. Without that gate, a concurrent `copyTree` walk
     // against the LRU victim would observe ENOENT mid-readdir when
     // the sweep fires.
     const a = await packFixtureTarball(scratch, {
@@ -463,7 +463,7 @@ describe("extractTarball", () => {
   });
 
   test("evict defers extraction removal while a reader still holds an unreleased handle", async () => {
-    // An in-flight `hardlinkTree` walk against an integrity's
+    // An in-flight `copyTree` walk against an integrity's
     // extraction tree must not see the tree disappear mid-readdir when
     // another agent in the same sidecar process trips an
     // integrity-mismatch evict for the same integrity. The cache holds

--- a/packages/tool-packaging/src/cache.ts
+++ b/packages/tool-packaging/src/cache.ts
@@ -11,10 +11,11 @@
 // one entry (used after extraction discovers a corrupted file on disk).
 //
 // `maxBytes` covers both the tarball bytes and the size of the
-// extracted directory tree the loader hardlinks from. The extraction
+// extracted directory tree the loader copies from. The extraction
 // tree dominates disk usage in practice (tarballs are gzip-compressed;
-// the unpacked tree is multiples larger), so the cap reflects the
-// caller-visible cost of holding an entry.
+// the unpacked tree is multiples larger), so the cap reflects the cost
+// of holding one cache entry but excludes the loader's per-instance
+// copies.
 //
 // Integrity is verified on store and re-verified inside
 // `extractTarball` before unpacking. `get` returns bytes without
@@ -24,7 +25,7 @@
 //
 // `extractTarball` is the second face of the same on-disk store: it
 // unpacks the tarball into a sibling `extracted/` directory keyed by
-// the same integrity, so the per-instance loader can symlink into a
+// the same integrity, so the per-instance loader can copy from a
 // stable, deduplicated extraction without re-doing the tar work on
 // every apply. The unpack is gated by a per-integrity tmp-and-rename
 // dance with the same crash-safety properties as `put`.
@@ -73,7 +74,7 @@ export interface TarballCache {
    * cannot reuse the on-disk extraction. The extraction directory's
    * physical reclaim is deferred until every in-flight reader released
    * by `extractTarball` has dropped its reference, so an evict that
-   * races a concurrent `hardlinkTree` walk of the same extraction does
+   * races a concurrent `copyTree` walk of the same extraction does
    * not pull the tree out from under the walk and surface as ENOENT.
    *
    * Until every reader releases, the on-disk extraction is left in
@@ -160,7 +161,7 @@ export function createTarballCache(config: TarballCacheConfig): TarballCache {
   // defers physical removal of the extraction tree until the count
   // reaches zero. This decouples mark-as-bad (atomic, prompt) from
   // physical reclaim (deferred, safe) so an integrity-mismatch evict
-  // that races a concurrent `hardlinkTree` walk against the same
+  // that races a concurrent `copyTree` walk against the same
   // extraction does not pull the tree out from under the walk and
   // surface as ENOENT mid-readdir.
   //
@@ -342,21 +343,15 @@ export function createTarballCache(config: TarballCacheConfig): TarballCache {
 
   /**
    * Sum the on-disk size of every regular file under `dir` recursively.
-   * Returns 0 when `dir` does not exist. Hardlinks are counted once
-   * per inode would be ideal, but `node:fs` does not expose inode-
-   * dedup walking without a manual ino map; the loader hardlinks
-   * extraction trees into per-instance store dirs, so the extraction
-   * tree itself holds one link per file and `stat.size` per entry is
-   * the right number to charge to this cache entry.
+   * Returns 0 when `dir` does not exist. Each regular file's
+   * `stat.size` is charged to this cache entry once.
    *
    * ACCOUNTING vs. DISK USAGE: `maxBytes` bounds the sum reported by
    * this walker, not the actual disk consumption of the cache plus
-   * its downstream hardlink consumers. The loader's per-instance
-   * store dirs share inodes with `cache/extracted/`; evicting an
-   * entry here drops the cache's reference but the underlying file
-   * survives as long as any per-instance dir still points at it.
-   * The cap is a steady-state ceiling on the cache tree's own
-   * accounting, not a disk-usage limit. Concurrent vanishes during
+   * its downstream consumers. The loader's per-instance store dirs
+   * contain independent copies that are outside this cache tree, so
+   * the cap is a steady-state ceiling on the cache's own accounting,
+   * not a sidecar-wide disk-usage limit. Concurrent vanishes during
    * the walk are silently dropped via the inner `lstat` try/catch
    * below; under the single-process contract this is rare, but the
    * returned `total` reports the cap-relevant sum within one sweep's
@@ -366,7 +361,7 @@ export function createTarballCache(config: TarballCacheConfig): TarballCache {
    * `lstat` here returns the link itself rather than its target, and
    * `dirent.isSymbolicLink()` is the entry-walk equivalent. An npm
    * tarball that ships symlinks is preserved verbatim by the loader's
-   * hardlink-tree pass; charging the link's own size (zero in our
+   * copy-tree pass; charging the link's own size (zero in our
    * accounting) avoids both symlink-loop divergence and double-counting
    * the target through whatever path also names it directly.
    *
@@ -568,7 +563,7 @@ export function createTarballCache(config: TarballCacheConfig): TarballCache {
         if (!isENOENT(err)) throw err;
       }
       // The extraction is derived from the tarball bytes and is
-      // useless once the tarball is gone. If a hardlinkTree walk is
+      // useless once the tarball is gone. If a copyTree walk is
       // in-flight for the same integrity, removing the tree now would
       // surface as ENOENT mid-walk; defer the physical reclaim until
       // every outstanding `release` from `extractTarball` has fired.

--- a/packages/tool-packaging/src/loader.test.ts
+++ b/packages/tool-packaging/src/loader.test.ts
@@ -239,6 +239,65 @@ describe("createToolLoader", () => {
     expect(loaded[0]?.credentials).toEqual([]);
   });
 
+  test("materializes package files independently from the cache extraction", async () => {
+    const cache = createTarballCache({
+      rootDir: cacheDir,
+      maxBytes: 10_000_000,
+    });
+    const fixture = await packFixture({
+      name: "copied-tool",
+      version: "1.0.0",
+      entryModuleSource: "original contents",
+    });
+    const loader = createToolLoader({
+      cache,
+      registries: new Map([["npmjs", { url: "https://r.test" }]]),
+      host: { os: "linux", cpu: "x64" },
+      fetchTarball: async () => fixture.bytes,
+      importModule: async () => ({
+        main: makeFakeFactory("@vendor/copied/main"),
+      }),
+    });
+
+    await loader.loadManifest({
+      manifest: {
+        schemaVersion: "1",
+        topLevel: [{ name: "copied-tool", version: "1.0.0" }],
+        entries: [
+          {
+            name: "copied-tool",
+            version: "1.0.0",
+            integrity: fixture.integrity,
+            source: { kind: "registry", registry: "npmjs" },
+          },
+        ],
+      },
+      instanceScratchDir: instanceDir,
+      assetRoot,
+      assetMounts: new Map(),
+    });
+
+    const extraction = await cache.extractTarball(fixture.integrity);
+    try {
+      const cachedFile = path.join(extraction.dir, "tools.js");
+      const materializedFile = path.join(
+        instanceDir,
+        "store",
+        "copied-tool",
+        "1.0.0",
+        "tools.js",
+      );
+      expect(await fs.readFile(materializedFile, "utf8")).toBe(
+        "original contents",
+      );
+
+      await fs.writeFile(materializedFile, "materialized change");
+      expect(await fs.readFile(cachedFile, "utf8")).toBe("original contents");
+    } finally {
+      extraction.release();
+    }
+  });
+
   test("surfaces interchange.credentials declarations on the loaded package", async () => {
     const cache = createTarballCache({
       rootDir: cacheDir,
@@ -939,7 +998,7 @@ describe("loader error categories", () => {
     // matched integrity, then point the manifest at it. Extraction
     // fails inside `tar.extract` (not at the integrity re-check), so
     // the loader must NOT evict — a sibling agent in the same process
-    // may be hardlinking from the same extraction tree at this moment.
+    // may be copying from the same extraction tree at this moment.
     const cache = createTarballCache({
       rootDir: cacheDir,
       maxBytes: 10_000_000,
@@ -2251,7 +2310,7 @@ describe("entry-path containment", () => {
     extractedHandle.release();
 
     // `aaa-jump` is named to sort before the inner directory so
-    // hardlinkTree's walk hits it before recursing into the inner
+    // copyTree's walk hits it before recursing into the inner
     // tree. Its literal target string `inner/escape` resolves to a
     // path inside the extraction root, so the literal-target check
     // accepts it; only the realpath sees through `escape` to the
@@ -3083,7 +3142,7 @@ export const main = Object.assign(
     } catch (err) {
       caught = err;
     }
-    // The symlink fires `hardlinkTree`'s containment guard at layout
+    // The symlink fires `copyTree`'s containment guard at layout
     // time, before either walker runs. The directors walker's own
     // realpath containment check is the second line of defense and
     // shares the same operator-facing category; the test asserts the

--- a/packages/tool-packaging/src/loader.ts
+++ b/packages/tool-packaging/src/loader.ts
@@ -16,7 +16,7 @@
 //      `cache.extractTarball` so a single sha512 has a single extraction
 //      shared across instances.
 //   3. Lays out each entry under `<scratch>/store/<name>/<version>/` by
-//      hardlinking the file tree from the cache extraction. Each layout
+//      copying the file tree from the cache extraction. Each layout
 //      directory gets its own `node_modules/<dep>` symlink to the
 //      sibling `store/<dep>/<depVersion>/` chosen for that requirer.
 //      Diamond dependencies share a single store entry; version
@@ -37,7 +37,7 @@
 // one of the `DeployApplyErrorCategory` values. The atomic-apply layer
 // catches these and translates them into wire-level frames.
 
-import { promises as fs } from "node:fs";
+import { constants as fsConstants, promises as fs } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import semver from "semver";
@@ -338,7 +338,7 @@ export function createToolLoader(config: LoaderConfig): ToolLoader {
       // cache's `evict` defers physical reclaim of the extraction tree
       // until every outstanding `release` from a concurrent
       // `extractTarball` has fired, so a parallel agent's in-flight
-      // `hardlinkTree` walk against the same extraction will not
+      // layout copy against the same extraction will not
       // ENOENT mid-readdir.
       if (err instanceof TarballIntegrityMismatchError) {
         await config.cache.evict(entry.integrity);
@@ -598,14 +598,14 @@ export function createToolLoader(config: LoaderConfig): ToolLoader {
       //    its extraction directory. This validates the manifest is
       //    registry-chain-consistent (each entry resolves end-to-end
       //    against its declared source) and primes the cache so the
-      //    layout step can hardlink without re-fetching.
+      //    layout step can copy without re-fetching.
       //
       //    Each materialize() returns an `{ dir, release }` pair: the
       //    cache treats the returned `dir` as held until `release` is
       //    called, so a concurrent eviction of the same integrity
       //    defers its physical reclaim of the extraction tree until
       //    after the buildStoreLayout pass below has finished walking
-      //    every dir to hardlink files out. Releases are aggregated and
+      //    every dir to copy files out. Releases are aggregated and
       //    drained in a `finally` so an error mid-layout still hands
       //    the cache its references back.
       const extractionByEntry = new Map<string, string>();
@@ -626,7 +626,7 @@ export function createToolLoader(config: LoaderConfig): ToolLoader {
 
         // 2. Build the per-instance store layout. Each filtered entry
         //    gets a real directory at `<store>/<name>/<version>/`
-        //    populated by hardlinks from its cache extraction; the
+        //    populated by copies from its cache extraction; the
         //    direct-dependency walk then symlinks `node_modules/<dep>`
         //    into each layout dir so Node's standard ancestor walk
         //    resolves bare-specifier imports from inside the package's
@@ -971,15 +971,14 @@ interface BuildStoreLayoutArgs {
 
 /**
  * Build the per-instance `<store>/<name>/<version>/` tree for every
- * filtered manifest entry: hardlink each entry's source files in from
+ * filtered manifest entry: copy each entry's source files in from
  * the cache extraction, then symlink each direct dep into the entry's
- * `node_modules/`. Hardlinks keep byte usage to one copy per integrity
- * per filesystem; symlinks at the `node_modules/` boundary let Node's
+ * `node_modules/`. Symlinks at the `node_modules/` boundary let Node's
  * realpath-based resolver walk to the dep's own layout dir (with its
  * own `node_modules/`) so transitive resolution composes recursively.
  */
 async function buildStoreLayout(args: BuildStoreLayoutArgs): Promise<void> {
-  // First materialize every layout dir with its hardlinked contents.
+  // First materialize every layout dir with its copied contents.
   // node_modules symlinks come after, so a dep's layout dir is already
   // populated when its parent's symlink starts pointing at it.
   for (const entry of args.filtered) {
@@ -992,7 +991,7 @@ async function buildStoreLayout(args: BuildStoreLayoutArgs): Promise<void> {
     }
     const layoutDir = storeEntryDir(args.storeDir, entry.name, entry.version);
     await fs.mkdir(path.dirname(layoutDir), { recursive: true });
-    await hardlinkTree(extraction, layoutDir);
+    await copyTree(extraction, layoutDir);
   }
 
   for (const entry of args.filtered) {
@@ -1190,7 +1189,7 @@ async function resolveRangesByFirstArrival(
   };
 }
 
-async function hardlinkTree(
+async function copyTree(
   srcDir: string,
   destDir: string,
   extractionRoot: string = srcDir,
@@ -1201,16 +1200,16 @@ async function hardlinkTree(
     const src = path.join(srcDir, entry.name);
     const dest = path.join(destDir, entry.name);
     if (entry.isDirectory()) {
-      await hardlinkTree(src, dest, extractionRoot);
+      await copyTree(src, dest, extractionRoot);
     } else if (entry.isFile()) {
       try {
-        await fs.link(src, dest);
+        await fs.copyFile(src, dest, fsConstants.COPYFILE_EXCL);
       } catch (err) {
         if (!isEEXIST(err)) throw err;
       }
     } else if (entry.isSymbolicLink()) {
       // Preserve symlinks from the tarball verbatim; npm packages
-      // occasionally ship them and clobbering with a hardlink would
+      // occasionally ship them and replacing one with a regular file would
       // change the file's identity.
       //
       // ISOMORPHIC-LAYOUT ASSUMPTION: writing the source-side


### PR DESCRIPTION
# Remove hardlinks from pack publishing and tool materialization

## Motivation

Hardlinks are not part of the filesystem surface we expect browser-oriented storage backends to provide. Removing this requirement narrows the filesystem API needed by these workflows and unblocks the broader work to make the storage layer runtime-agnostic.

## Summary

Removes the two remaining hardlink requirements:

- Publishes completed Git packs using atomic renames.
- Copies tool-package files from the extraction cache into deployment layouts.

Pack publishing now reserves transfer IDs through exclusive staging-directory creation, preventing concurrent publishers from overwriting each other. Partial publication failures clean up the staged files and unindexed pack where possible.

The tool-package cache still avoids downloading and extracting packages repeatedly, but deployment layouts now contain independent file copies. This increases disk usage and write I/O in exchange for requiring fewer filesystem capabilities.

This is a prerequisite for making the storage layer runtime-agnostic; it does not introduce the pluggable filesystem API itself.

## Testing

- Added coverage for pack rename ordering, existing destinations, concurrent transfer IDs, and partial publication cleanup.
- Added coverage confirming materialized tool files are independent from the cached extraction.
- `make all` passes:
  - 6,494 unit/package tests
  - 753 integration tests
  - 2 expected live tests skipped