### PR TITLE
Fold child-workflow grant surfaces into the parent deploy approval

### DIFF
--- a/packages/db/migrations/0082_add_workflow_definition_version_approved_grant_surface.sql
+++ b/packages/db/migrations/0082_add_workflow_definition_version_approved_grant_surface.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workflow_definition_version" ADD COLUMN "approved_grant_surface" jsonb;

--- a/packages/db/migrations/meta/0082_snapshot.json
+++ b/packages/db/migrations/meta/0082_snapshot.json
@@ -1,0 +1,4102 @@
+{
+  "id": "3376fa93-1b95-4d59-9736-2556ee62eca6",
+  "prevId": "83d02430-cec6-45a5-a75b-dbaf491fa4bc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.federation_trust": {
+      "name": "federation_trust",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_tenant_id": {
+          "name": "target_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "federation_trust_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "federation_trust_target_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_target_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "tableTo": "tenant",
+          "columnsFrom": ["target_tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federation_trust_tenant_id_target_tenant_id_unique": {
+          "name": "federation_trust_tenant_id_target_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "target_tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant": {
+      "name": "tenant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_parent_id_tenant_id_fk": {
+          "name": "tenant_parent_id_tenant_id_fk",
+          "tableFrom": "tenant",
+          "tableTo": "tenant",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_slug_unique": {
+          "name": "tenant_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "tenant_domain_unique": {
+          "name": "tenant_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": ["domain"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal": {
+      "name": "principal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_tenant_id_tenant_id_fk": {
+          "name": "principal_tenant_id_tenant_id_fk",
+          "tableFrom": "principal",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "principal_tenant_id_kind_ref_id_unique": {
+          "name": "principal_tenant_id_kind_ref_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "kind", "ref_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_role": {
+      "name": "agent_role",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_role_agent_id_workflow_definition_id_fk": {
+          "name": "agent_role_agent_id_workflow_definition_id_fk",
+          "tableFrom": "agent_role",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_role_role_id_role_id_fk": {
+          "name": "agent_role_role_id_role_id_fk",
+          "tableFrom": "agent_role",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_role_agent_id_role_id_pk": {
+          "name": "agent_role_agent_id_role_id_pk",
+          "columns": ["agent_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal_role": {
+      "name": "principal_role",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_role_principal_id_principal_id_fk": {
+          "name": "principal_role_principal_id_principal_id_fk",
+          "tableFrom": "principal_role",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "principal_role_role_id_role_id_fk": {
+          "name": "principal_role_role_id_role_id_fk",
+          "tableFrom": "principal_role",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "principal_role_principal_id_role_id_pk": {
+          "name": "principal_role_principal_id_role_id_pk",
+          "columns": ["principal_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_tenant_id_tenant_id_fk": {
+          "name": "role_tenant_id_tenant_id_fk",
+          "tableFrom": "role",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grant": {
+      "name": "grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grant_tenant_id_tenant_id_fk": {
+          "name": "grant_tenant_id_tenant_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grant_role_id_role_id_fk": {
+          "name": "grant_role_id_role_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grant_principal_id_principal_id_fk": {
+          "name": "grant_principal_id_principal_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grant_target_exactly_one": {
+          "name": "grant_target_exactly_one",
+          "value": "num_nonnulls(\"grant\".\"principal_id\", \"grant\".\"role_id\") = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.approval": {
+      "name": "approval",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_address": {
+          "name": "agent_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_definition": {
+          "name": "tool_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_arguments": {
+          "name": "tool_arguments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "timeout_at": {
+          "name": "timeout_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approval_tenant_status_idx": {
+          "name": "approval_tenant_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_anchor_run_idx": {
+          "name": "approval_anchor_run_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_tenant_id_tenant_id_fk": {
+          "name": "approval_tenant_id_tenant_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_anchor_run_id_workflow_run_id_fk": {
+          "name": "approval_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_run_id_workflow_run_id_fk": {
+          "name": "approval_run_id_workflow_run_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approval_correlation_id_unique": {
+          "name": "approval_correlation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["correlation_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_correlation": {
+      "name": "signal_correlation",
+      "schema": "",
+      "columns": {
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_address": {
+          "name": "agent_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_name": {
+          "name": "signal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_id": {
+          "name": "signal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signal_correlation_tenant_id_tenant_id_fk": {
+          "name": "signal_correlation_tenant_id_tenant_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signal_correlation_anchor_run_id_workflow_run_id_fk": {
+          "name": "signal_correlation_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signal_correlation_run_id_workflow_run_id_fk": {
+          "name": "signal_correlation_run_id_workflow_run_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_info_url": {
+          "name": "user_info_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_tenant_id_tenant_id_fk": {
+          "name": "provider_tenant_id_tenant_id_fk",
+          "tableFrom": "provider",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_tenant_name": {
+          "name": "provider_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_scopes": {
+          "name": "default_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_tenant_id_tenant_id_fk": {
+          "name": "oauth_client_tenant_id_tenant_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_client_provider_id_provider_id_fk": {
+          "name": "oauth_client_provider_id_provider_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_tenant_provider": {
+          "name": "oauth_client_tenant_provider",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "provider_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credential": {
+      "name": "credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_secret": {
+          "name": "refresh_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credential_tenant_id_tenant_id_fk": {
+          "name": "credential_tenant_id_tenant_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_principal_id_principal_id_fk": {
+          "name": "credential_principal_id_principal_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credential_provider_id_provider_id_fk": {
+          "name": "credential_provider_id_provider_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_oauth_client_id_oauth_client_id_fk": {
+          "name": "credential_oauth_client_id_oauth_client_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "credential_tenant_name": {
+          "name": "credential_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset": {
+      "name": "asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_tenant_id_tenant_id_fk": {
+          "name": "asset_tenant_id_tenant_id_fk",
+          "tableFrom": "asset",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "asset_creator_principal_id_principal_id_fk": {
+          "name": "asset_creator_principal_id_principal_id_fk",
+          "tableFrom": "asset",
+          "tableTo": "principal",
+          "columnsFrom": ["creator_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_tenant_kind_name": {
+          "name": "asset_tenant_kind_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "kind", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_wallet_id_wallet_id_fk": {
+          "name": "transaction_wallet_id_wallet_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_run_id_workflow_run_id_fk": {
+          "name": "transaction_run_id_workflow_run_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet": {
+      "name": "wallet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend_type": {
+          "name": "backend_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallet_tenant_id_tenant_id_fk": {
+          "name": "wallet_tenant_id_tenant_id_fk",
+          "tableFrom": "wallet",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offering": {
+      "name": "offering",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "offering_agent_id_workflow_definition_id_fk": {
+          "name": "offering_agent_id_workflow_definition_id_fk",
+          "tableFrom": "offering",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "offering_tenant_id_tenant_id_fk": {
+          "name": "offering_tenant_id_tenant_id_fk",
+          "tableFrom": "offering",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model": {
+      "name": "model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_tenant_id_tenant_id_fk": {
+          "name": "model_tenant_id_tenant_id_fk",
+          "tableFrom": "model",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_tenant_canonical_name": {
+          "name": "model_tenant_canonical_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "canonical_name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_offering": {
+      "name": "model_offering",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_tags": {
+          "name": "deployment_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "quirks": {
+          "name": "quirks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_offering_tenant_id_tenant_id_fk": {
+          "name": "model_offering_tenant_id_tenant_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_offering_model_id_model_id_fk": {
+          "name": "model_offering_model_id_model_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_offering_provider_id_model_provider_id_fk": {
+          "name": "model_offering_provider_id_model_provider_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "model_provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_offering_tenant_model_provider": {
+          "name": "model_offering_tenant_model_provider",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "model_id", "provider_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_pricing": {
+      "name": "model_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offering_id": {
+          "name": "offering_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_token_price": {
+          "name": "input_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_token_price": {
+          "name": "output_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_token_price": {
+          "name": "cache_read_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_write_token_price": {
+          "name": "cache_write_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thinking_token_price": {
+          "name": "thinking_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_request_fee": {
+          "name": "per_request_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_image_fee": {
+          "name": "per_image_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_audio_fee": {
+          "name": "per_audio_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_pricing_tenant_id_tenant_id_fk": {
+          "name": "model_pricing_tenant_id_tenant_id_fk",
+          "tableFrom": "model_pricing",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_pricing_offering_id_model_offering_id_fk": {
+          "name": "model_pricing_offering_id_model_offering_id_fk",
+          "tableFrom": "model_pricing",
+          "tableTo": "model_offering",
+          "columnsFrom": ["offering_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_pricing_offering_currency_effective_from": {
+          "name": "model_pricing_offering_currency_effective_from",
+          "nullsNotDistinct": false,
+          "columns": ["offering_id", "currency", "effective_from"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider": {
+      "name": "model_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_provider_tenant_id_tenant_id_fk": {
+          "name": "model_provider_tenant_id_tenant_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_credential_id_credential_id_fk": {
+          "name": "model_provider_credential_id_credential_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "credential",
+          "columnsFrom": ["credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "model_provider_wallet_id_wallet_id_fk": {
+          "name": "model_provider_wallet_id_wallet_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_provider_tenant_name": {
+          "name": "model_provider_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "model_provider_auth_xor": {
+          "name": "model_provider_auth_xor",
+          "value": "(\"model_provider\".\"credential_id\" is not null) <> (\"model_provider\".\"wallet_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sidecar": {
+      "name": "sidecar",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash_sha256": {
+          "name": "token_hash_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_scope": {
+          "name": "credential_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'shared'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sidecar_token_hash_sha256_unique": {
+          "name": "sidecar_token_hash_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash_sha256"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sidecar_credential_scope_check": {
+          "name": "sidecar_credential_scope_check",
+          "value": "\"sidecar\".\"credential_scope\" in ('shared', 'allocated')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sidecar_allocation": {
+      "name": "sidecar_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_api_version": {
+          "name": "provisioner_api_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_binding_fingerprint": {
+          "name": "provisioner_binding_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement_sharing": {
+          "name": "placement_sharing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sidecar_reuse": {
+          "name": "sidecar_reuse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'never'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ensure_accepted_generation": {
+          "name": "ensure_accepted_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation_lease_id": {
+          "name": "reconciliation_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation_lease_expires_at": {
+          "name": "reconciliation_lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ensure_attempts": {
+          "name": "ensure_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "destroy_attempts": {
+          "name": "destroy_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connect_deadline": {
+          "name": "connect_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sidecar_allocation_anchor_run_idx": {
+          "name": "sidecar_allocation_anchor_run_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sidecar_allocation_active_sidecar_idx": {
+          "name": "sidecar_allocation_active_sidecar_idx",
+          "columns": [
+            {
+              "expression": "sidecar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sidecar_allocation\".\"status\" in ('provisioning', 'allocated', 'replacing', 'releasing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sidecar_allocation_sidecar_idx": {
+          "name": "sidecar_allocation_sidecar_idx",
+          "columns": [
+            {
+              "expression": "sidecar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sidecar_allocation_reconciliation_idx": {
+          "name": "sidecar_allocation_reconciliation_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sidecar_allocation\".\"status\" in ('pending', 'provisioning', 'allocated', 'replacing', 'releasing') and \"sidecar_allocation\".\"next_attempt_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sidecar_allocation_anchor_run_id_workflow_run_id_fk": {
+          "name": "sidecar_allocation_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "sidecar_allocation",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sidecar_allocation_tenant_id_tenant_id_fk": {
+          "name": "sidecar_allocation_tenant_id_tenant_id_fk",
+          "tableFrom": "sidecar_allocation",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sidecar_allocation_sidecar_id_sidecar_id_fk": {
+          "name": "sidecar_allocation_sidecar_id_sidecar_id_fk",
+          "tableFrom": "sidecar_allocation",
+          "tableTo": "sidecar",
+          "columnsFrom": ["sidecar_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sidecar_allocation_status_check": {
+          "name": "sidecar_allocation_status_check",
+          "value": "\"sidecar_allocation\".\"status\" in ('pending', 'provisioning', 'allocated', 'replacing', 'releasing', 'released', 'failed')"
+        },
+        "sidecar_allocation_placement_check": {
+          "name": "sidecar_allocation_placement_check",
+          "value": "\"sidecar_allocation\".\"placement_sharing\" = 'exclusive'"
+        },
+        "sidecar_allocation_generation_check": {
+          "name": "sidecar_allocation_generation_check",
+          "value": "\"sidecar_allocation\".\"generation\" >= 0"
+        },
+        "sidecar_allocation_accepted_generation_check": {
+          "name": "sidecar_allocation_accepted_generation_check",
+          "value": "\"sidecar_allocation\".\"ensure_accepted_generation\" is null or \"sidecar_allocation\".\"ensure_accepted_generation\" <= \"sidecar_allocation\".\"generation\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_session": {
+      "name": "agent_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_session_tenant_id_tenant_id_fk": {
+          "name": "agent_session_tenant_id_tenant_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_agent_id_workflow_definition_id_fk": {
+          "name": "agent_session_agent_id_workflow_definition_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_session_principal_id_principal_id_fk": {
+          "name": "agent_session_principal_id_principal_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_asset": {
+      "name": "session_asset",
+      "schema": "",
+      "columns": {
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mount_path": {
+          "name": "mount_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_pack_sha": {
+          "name": "asset_pack_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "materialized_at": {
+          "name": "materialized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_asset_pack_sha_idx": {
+          "name": "session_asset_pack_sha_idx",
+          "columns": [
+            {
+              "expression": "asset_pack_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_asset_instance_id_mount_path_pk": {
+          "name": "session_asset_instance_id_mount_path_pk",
+          "columns": ["instance_id", "mount_path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inference_turn": {
+      "name": "inference_turn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "inference_turn_instance_id_started_at_idx": {
+          "name": "inference_turn_instance_id_started_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inference_turn_session_id_agent_session_id_fk": {
+          "name": "inference_turn_session_id_agent_session_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inference_turn_tenant_id_tenant_id_fk": {
+          "name": "inference_turn_tenant_id_tenant_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_mail": {
+      "name": "session_mail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "raw": {
+          "name": "raw",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_mail_instance_id_created_at_idx": {
+          "name": "session_mail_instance_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_mail_session_id_created_at_idx": {
+          "name": "session_mail_session_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_mail_session_id_agent_session_id_fk": {
+          "name": "session_mail_session_id_agent_session_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_mail_tenant_id_tenant_id_fk": {
+          "name": "session_mail_tenant_id_tenant_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turn_part": {
+      "name": "turn_part",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "turn_part_turn_id_inference_turn_id_fk": {
+          "name": "turn_part_turn_id_inference_turn_id_fk",
+          "tableFrom": "turn_part",
+          "tableTo": "inference_turn",
+          "columnsFrom": ["turn_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_part_session_id_agent_session_id_fk": {
+          "name": "turn_part_session_id_agent_session_id_fk",
+          "tableFrom": "turn_part",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_token": {
+      "name": "git_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash_sha256": {
+          "name": "token_hash_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_pattern": {
+          "name": "ref_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "git_token_user_id_name_active_idx": {
+          "name": "git_token_user_id_name_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"git_token\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "git_token_tenant_id_tenant_id_fk": {
+          "name": "git_token_tenant_id_tenant_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "git_token_user_id_user_id_fk": {
+          "name": "git_token_user_id_user_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_token_principal_id_principal_id_fk": {
+          "name": "git_token_principal_id_principal_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "git_token_token_hash_sha256_unique": {
+          "name": "git_token_token_hash_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash_sha256"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition": {
+      "name": "workflow_definition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wire_hash": {
+          "name": "wire_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_requirements": {
+          "name": "grant_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_requirements": {
+          "name": "model_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_bindings": {
+          "name": "credential_bindings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_definition_tenant_idx": {
+          "name": "workflow_definition_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_definition_asset_wire_hash_idx": {
+          "name": "workflow_definition_asset_wire_hash_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wire_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definition_tenant_id_tenant_id_fk": {
+          "name": "workflow_definition_tenant_id_tenant_id_fk",
+          "tableFrom": "workflow_definition",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_definition_creator_principal_id_principal_id_fk": {
+          "name": "workflow_definition_creator_principal_id_principal_id_fk",
+          "tableFrom": "workflow_definition",
+          "tableTo": "principal",
+          "columnsFrom": ["creator_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_definition_asset_id_asset_id_fk": {
+          "name": "workflow_definition_asset_id_asset_id_fk",
+          "tableFrom": "workflow_definition",
+          "tableTo": "asset",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_version": {
+      "name": "workflow_definition_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "approved_wire_hash": {
+          "name": "approved_wire_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_grant_surface": {
+          "name": "approved_grant_surface",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_definition_version_definition_idx": {
+          "name": "workflow_definition_version_definition_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definition_version_definition_id_workflow_definition_id_fk": {
+          "name": "workflow_definition_version_definition_id_workflow_definition_id_fk",
+          "tableFrom": "workflow_definition_version",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["definition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_definition_version_definition_version": {
+          "name": "workflow_definition_version_definition_version",
+          "nullsNotDistinct": false,
+          "columns": ["definition_id", "version"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run": {
+      "name": "workflow_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kernel_id": {
+          "name": "kernel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_preferences": {
+          "name": "model_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_definition_idx": {
+          "name": "workflow_run_definition_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_address_idx": {
+          "name": "workflow_run_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_run\".\"address\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_definition_id_workflow_definition_id_fk": {
+          "name": "workflow_run_definition_id_workflow_definition_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["definition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_anchor_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_tenant_id_tenant_id_fk": {
+          "name": "workflow_run_tenant_id_tenant_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_principal_id_principal_id_fk": {
+          "name": "workflow_run_principal_id_principal_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflow_run_sidecar_id_sidecar_id_fk": {
+          "name": "workflow_run_sidecar_id_sidecar_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "sidecar",
+          "columnsFrom": ["sidecar_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_dispatch": {
+      "name": "workflow_run_dispatch",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mail'"
+        },
+        "raw_message": {
+          "name": "raw_message",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_grants": {
+          "name": "step_grants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "acknowledged_generation": {
+          "name": "acknowledged_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "delivery_lease_id": {
+          "name": "delivery_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_lease_expires_at": {
+          "name": "delivery_lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_dispatch_anchor_message_idx": {
+          "name": "workflow_run_dispatch_anchor_message_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_dispatch_delivery_idx": {
+          "name": "workflow_run_dispatch_delivery_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_run_dispatch\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_dispatch_anchor_status_idx": {
+          "name": "workflow_run_dispatch_anchor_status_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_dispatch_anchor_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_dispatch_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run_dispatch",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_dispatch_status_check": {
+          "name": "workflow_run_dispatch_status_check",
+          "value": "\"workflow_run_dispatch\".\"status\" in ('pending', 'acknowledged', 'settled', 'failed')"
+        },
+        "workflow_run_dispatch_kind_check": {
+          "name": "workflow_run_dispatch_kind_check",
+          "value": "\"workflow_run_dispatch\".\"kind\" in ('mail', 'signal')"
+        },
+        "workflow_run_dispatch_attempt_count_check": {
+          "name": "workflow_run_dispatch_attempt_count_check",
+          "value": "\"workflow_run_dispatch\".\"attempt_count\" >= 0"
+        },
+        "workflow_run_dispatch_acknowledged_generation_check": {
+          "name": "workflow_run_dispatch_acknowledged_generation_check",
+          "value": "\"workflow_run_dispatch\".\"acknowledged_generation\" is null or \"workflow_run_dispatch\".\"acknowledged_generation\" >= 0"
+        },
+        "workflow_run_dispatch_acknowledged_state_check": {
+          "name": "workflow_run_dispatch_acknowledged_state_check",
+          "value": "\"workflow_run_dispatch\".\"status\" <> 'acknowledged' or \"workflow_run_dispatch\".\"acknowledged_generation\" is not null"
+        },
+        "workflow_run_dispatch_pending_schedule_check": {
+          "name": "workflow_run_dispatch_pending_schedule_check",
+          "value": "\"workflow_run_dispatch\".\"status\" <> 'pending' or \"workflow_run_dispatch\".\"next_attempt_at\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_launch_spec": {
+      "name": "workflow_run_launch_spec",
+      "schema": "",
+      "columns": {
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_domain": {
+          "name": "deployment_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_authority_principal_id": {
+          "name": "source_authority_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_snapshot": {
+          "name": "definition_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_hash": {
+          "name": "definition_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_offering_ids": {
+          "name": "source_offering_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_source_offering_id": {
+          "name": "default_source_offering_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deploy_content": {
+          "name": "deploy_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_package_pins": {
+          "name": "tool_package_pins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_run_launch_spec_anchor_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_launch_spec_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run_launch_spec",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_launch_spec_source_authority_principal_id_principal_id_fk": {
+          "name": "workflow_run_launch_spec_source_authority_principal_id_principal_id_fk",
+          "tableFrom": "workflow_run_launch_spec",
+          "tableTo": "principal",
+          "columnsFrom": ["source_authority_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_execution": {
+      "name": "workflow_run_execution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_execution_run_id_id_idx": {
+          "name": "workflow_run_execution_run_id_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_execution_status_idx": {
+          "name": "workflow_run_execution_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_execution_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_execution_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run_execution",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -568,6 +568,13 @@
       "when": 1786665226312,
       "tag": "0081_workflow_definition_content_hash_and_approved_wire_hash",
       "breakpoints": true
+    },
+    {
+      "idx": 82,
+      "version": "7",
+      "when": 1786759823544,
+      "tag": "0082_add_workflow_definition_version_approved_grant_surface",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -60,8 +60,10 @@ export {
 export {
   createWorkflowDefinitionStore,
   readApprovedGrantSurface,
+  resolveDefinitionForAsset,
   resolveDefinitionIdForAsset,
   writeApprovedGrantSurface,
+  type ResolvedWorkflowDefinition,
   type WorkflowDefinitionRollbackResult,
   type WorkflowDefinitionSelector,
 } from "./workflow-definition-store";

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -59,7 +59,9 @@ export {
 } from "./sidecar-allocation-store";
 export {
   createWorkflowDefinitionStore,
+  readApprovedGrantSurface,
   resolveDefinitionIdForAsset,
+  writeApprovedGrantSurface,
   type WorkflowDefinitionRollbackResult,
   type WorkflowDefinitionSelector,
 } from "./workflow-definition-store";

--- a/packages/db/src/parse-row.test.ts
+++ b/packages/db/src/parse-row.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import type { ApprovedGrantSurface } from "@intx/types";
 import { RepoAction } from "@intx/types/sidecar";
 
 import {
@@ -263,6 +264,7 @@ function makeWorkflowDefinitionVersionRow(
     version: "1",
     status: "active",
     approvedWireHash: null,
+    approvedGrantSurface: null,
     createdAt: new Date(),
     ...overrides,
   };
@@ -282,6 +284,37 @@ describe("parseWorkflowDefinitionVersionRow", () => {
       makeWorkflowDefinitionVersionRow({ approvedWireHash }),
     );
     expect(parsed.approvedWireHash).toBe(approvedWireHash);
+  });
+
+  test("passes a null approvedGrantSurface through as null", () => {
+    const parsed = parseWorkflowDefinitionVersionRow(
+      makeWorkflowDefinitionVersionRow(),
+    );
+    expect(parsed.approvedGrantSurface).toBeNull();
+  });
+
+  test("validates and returns a present approvedGrantSurface", () => {
+    const approvedGrantSurface: ApprovedGrantSurface = {
+      grants: ["tool:search", "capability:mail"],
+      grantEffects: { "tool:search": "ask" },
+    };
+    const parsed = parseWorkflowDefinitionVersionRow(
+      makeWorkflowDefinitionVersionRow({ approvedGrantSurface }),
+    );
+    expect(parsed.approvedGrantSurface).toEqual(approvedGrantSurface);
+  });
+
+  test("rejects an approvedGrantSurface with a malformed effect", () => {
+    expect(() =>
+      parseWorkflowDefinitionVersionRow(
+        makeWorkflowDefinitionVersionRow({
+          approvedGrantSurface: {
+            grants: ["tool:search"],
+            grantEffects: { "tool:search": "maybe" },
+          },
+        }),
+      ),
+    ).toThrow();
   });
 });
 

--- a/packages/db/src/parse-row.ts
+++ b/packages/db/src/parse-row.ts
@@ -1,6 +1,7 @@
 import { type } from "arktype";
 
 import {
+  ApprovedGrantSurface,
   Capability,
   CredentialBinding,
   GrantRequirement,
@@ -159,6 +160,15 @@ export function parseWorkflowDefinitionVersionRow(
   return {
     ...row,
     status: WorkflowDefinitionVersionStatusValidator.assert(row.status),
+    // Nullable jsonb: `null` on a real drizzle row, `undefined` only on a
+    // partial row-shaped test stub that predates the column. Both mean "no
+    // approved surface yet" -- treat them alike rather than asserting
+    // `undefined` as a surface.
+    approvedGrantSurface:
+      row.approvedGrantSurface === null ||
+      row.approvedGrantSurface === undefined
+        ? null
+        : ApprovedGrantSurface.assert(row.approvedGrantSurface),
   };
 }
 

--- a/packages/db/src/schema/workflow-definitions.ts
+++ b/packages/db/src/schema/workflow-definitions.ts
@@ -105,8 +105,11 @@ export const workflowDefinitionVersion = pgTable(
     // a legitimate state, so the column takes no NOT NULL constraint.
     approvedWireHash: text("approved_wire_hash"),
     // The transitively-folded approved grant surface for this version: the
-    // deployment-flattened union of the definition's own walked grants and its
-    // direct children's pinned surfaces (own ∪ ⋃ pinned(directChild)).
+    // deployment-flattened union of the definition's own runtime-enforced
+    // grants and its direct children's pinned surfaces (own ∪ ⋃
+    // pinned(directChild)). It carries only the runtime-enforced grants -- the
+    // tool:/effect: grants a run's ceiling materializes and gates fail-closed --
+    // not the walk's approval-surface-only grants (director/capability/etc.).
     // Approval-scoped, not content-derived: it carries an external child
     // contribution that is not recomputable from this definition's own content,
     // and it is pinned to this approved version alongside `approved_wire_hash`.

--- a/packages/db/src/schema/workflow-definitions.ts
+++ b/packages/db/src/schema/workflow-definitions.ts
@@ -104,6 +104,17 @@ export const workflowDefinitionVersion = pgTable(
     // and read back during re-verify to detect drift. Null before approval is
     // a legitimate state, so the column takes no NOT NULL constraint.
     approvedWireHash: text("approved_wire_hash"),
+    // The transitively-folded approved grant surface for this version: the
+    // deployment-flattened union of the definition's own walked grants and its
+    // direct children's pinned surfaces (own ∪ ⋃ pinned(directChild)).
+    // Approval-scoped, not content-derived: it carries an external child
+    // contribution that is not recomputable from this definition's own content,
+    // and it is pinned to this approved version alongside `approved_wire_hash`.
+    // A childWorkflow-bearing definition's runtime ceiling is read from here;
+    // a parent folds its direct children's values in from this column. Null
+    // before approval and on versions predating the column, so no NOT NULL
+    // constraint. Validated as ApprovedGrantSurface at parse time.
+    approvedGrantSurface: jsonb("approved_grant_surface"),
     createdAt: timestamp("created_at").notNull().defaultNow(),
   },
   (t) => [

--- a/packages/db/src/workflow-definition-store.ts
+++ b/packages/db/src/workflow-definition-store.ts
@@ -1,11 +1,16 @@
 import { and, eq } from "drizzle-orm";
 
+import type { ApprovedGrantSurface } from "@intx/types";
+
 import type { DB, DBExecutor } from "./client";
 import {
   workflowDefinition,
   workflowDefinitionVersion,
 } from "./schema/workflow-definitions";
-import { parseWorkflowDefinitionRow } from "./parse-row";
+import {
+  parseWorkflowDefinitionRow,
+  parseWorkflowDefinitionVersionRow,
+} from "./parse-row";
 
 type DBHandle = DB["db"];
 type ParsedWorkflowDefinition = ReturnType<typeof parseWorkflowDefinitionRow>;
@@ -46,6 +51,63 @@ export async function resolveDefinitionIdForAsset(
     .limit(1)
     .then((rows) => rows[0]);
   return row?.id ?? null;
+}
+
+/**
+ * Persist the transitively-folded approved grant surface for one definition
+ * version. Takes a `DBExecutor` so the write joins the surrounding transaction:
+ * the deploy path stamps this column in the same transaction that stamps
+ * `approved_wire_hash`, so a version never carries one facet of its approval
+ * without the other. Asserts exactly one row updated -- `(definitionId,
+ * version)` is unique, so zero rows means the caller named a version that does
+ * not exist, which is a bug rather than a silent no-op.
+ */
+export async function writeApprovedGrantSurface(
+  db: DBExecutor,
+  definitionId: string,
+  version: string,
+  surface: ApprovedGrantSurface,
+): Promise<void> {
+  const updated = await db
+    .update(workflowDefinitionVersion)
+    .set({ approvedGrantSurface: surface })
+    .where(
+      and(
+        eq(workflowDefinitionVersion.definitionId, definitionId),
+        eq(workflowDefinitionVersion.version, version),
+      ),
+    )
+    .returning({ id: workflowDefinitionVersion.id });
+  if (updated.length !== 1) {
+    throw new Error(
+      `writeApprovedGrantSurface: expected exactly one version row for ` +
+        `(${definitionId}, ${version}), updated ${String(updated.length)}`,
+    );
+  }
+}
+
+/**
+ * Read the approved grant surface a definition version carries, or null when
+ * the version exists but was never stamped (pre-approval, or a version
+ * predating the column) or when the version row is absent. Validation of the
+ * `jsonb` column runs through `parseWorkflowDefinitionVersionRow`, so the
+ * caller receives an `ApprovedGrantSurface`, never a raw row value.
+ */
+export async function readApprovedGrantSurface(
+  db: DBExecutor,
+  definitionId: string,
+  version: string,
+): Promise<ApprovedGrantSurface | null> {
+  const row = await db.query.workflowDefinitionVersion.findFirst({
+    where: and(
+      eq(workflowDefinitionVersion.definitionId, definitionId),
+      eq(workflowDefinitionVersion.version, version),
+    ),
+  });
+  if (row === undefined) {
+    return null;
+  }
+  return parseWorkflowDefinitionVersionRow(row).approvedGrantSurface;
 }
 
 export type WorkflowDefinitionRollbackResult =

--- a/packages/db/src/workflow-definition-store.ts
+++ b/packages/db/src/workflow-definition-store.ts
@@ -54,6 +54,47 @@ export async function resolveDefinitionIdForAsset(
 }
 
 /**
+ * The definition a selector names together with its current version pointer.
+ * A caller that must then read a version-scoped column (e.g. the approved
+ * grant surface) needs both the definition id and the version it should read;
+ * `current_version` names the active version, which `rollback` can repoint.
+ */
+export type ResolvedWorkflowDefinition = {
+  definitionId: string;
+  currentVersion: string;
+};
+
+/**
+ * Resolve a selector to its definition id and current version, or null on a
+ * miss. Like `resolveDefinitionIdForAsset`, but also returns the version
+ * pointer so the caller reads the right version's columns rather than assuming
+ * the literal `"1"` -- a `rollback` can repoint `current_version` to another
+ * active version.
+ */
+export async function resolveDefinitionForAsset(
+  db: DBExecutor,
+  selector: WorkflowDefinitionSelector,
+): Promise<ResolvedWorkflowDefinition | null> {
+  const row = await db
+    .select({
+      id: workflowDefinition.id,
+      currentVersion: workflowDefinition.currentVersion,
+    })
+    .from(workflowDefinition)
+    .where(
+      and(
+        eq(workflowDefinition.assetId, selector.assetId),
+        eq(workflowDefinition.wireHash, selector.wireHash),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0]);
+  return row === undefined
+    ? null
+    : { definitionId: row.id, currentVersion: row.currentVersion };
+}
+
+/**
  * Persist the transitively-folded approved grant surface for one definition
  * version. Takes a `DBExecutor` so the write joins the surrounding transaction:
  * the deploy path stamps this column in the same transaction that stamps

--- a/packages/hub-api/src/routes/workflows.ts
+++ b/packages/hub-api/src/routes/workflows.ts
@@ -28,6 +28,7 @@ import { ToolPackagePinArray } from "@intx/types/tool-packages";
 import {
   createWorkflowRunReader,
   ExclusiveWorkflowPlacementError,
+  hydrateDefinition,
   resolveWorkflowSidecarPlacement,
   type AssetService,
   type RepoStore,
@@ -47,7 +48,6 @@ import {
 import type { TenantEnv } from "../context";
 import { idResource, type RequireGrant } from "../middleware/grant";
 import {
-  hydrateDefinition,
   lockDispatchableAllocation,
   lockWorkflowRunState,
 } from "../run-grant-materialization";

--- a/packages/hub-api/src/run-grant-materialization.test.ts
+++ b/packages/hub-api/src/run-grant-materialization.test.ts
@@ -2,10 +2,23 @@ import { describe, test, expect } from "bun:test";
 
 import { createInMemoryGrantStore } from "@intx/authz";
 import type { GrantRule } from "@intx/types/authz";
+import type { GrantEffect } from "@intx/types";
 import type { AssetService } from "@intx/hub-sessions";
 import { workflowRun as workflowRunTable } from "@intx/db/schema";
+import {
+  createDefaultDirectorRegistry,
+  defineAgent,
+  type AnnotatedToolFactory,
+  type BaseEnv,
+  type ToolDeclaration,
+} from "@intx/agent";
+import { action, defineWorkflow, step } from "@intx/workflow/definition";
+import { flattenWalkToSurface, walkCapabilities } from "@intx/workflow-deploy";
 
-import { createMailTriggeredRunGrantsMaterializer } from "./run-grant-materialization";
+import {
+  createMailTriggeredRunGrantsMaterializer,
+  deriveRunRuntimeGrantRows,
+} from "./run-grant-materialization";
 
 const TENANT_ID = "tenant-1";
 const ASSET_ID = "asset-wf";
@@ -445,5 +458,72 @@ describe("createMailTriggeredRunGrantsMaterializer frozen basis", () => {
     expect(secondResources).toEqual(firstResources);
     expect(secondResources).toContain("tool:read_file/invoke");
     expect(secondResources).not.toContain("tool:write_file/invoke");
+  });
+});
+
+function makeFactory(
+  id: string,
+  definitions: readonly ToolDeclaration[],
+): AnnotatedToolFactory<BaseEnv> {
+  const factory = (_env: BaseEnv) => ({
+    definitions: [],
+    run: () =>
+      Promise.resolve({ callId: "", content: "", isError: false as const }),
+  });
+  return Object.assign(factory, {
+    id,
+    requires: [] as readonly string[],
+    definitions,
+  });
+}
+
+describe("flattenWalkToSurface agrees with deriveRunRuntimeGrantRows", () => {
+  // The equality is the whole point of extracting the shared core: a child
+  // workflow's stored pinned surface (built via flattenWalkToSurface) must
+  // equal the runtime ceiling the run-grant materializer emits from the same
+  // walk. This pins the two producers together across the
+  // workflow-deploy/hub-api boundary so neither can drift.
+  test("same resources and effects on a walk with ask, allow, and effect grants", () => {
+    const registry = createDefaultDirectorRegistry();
+    const agent = defineAgent({
+      id: "ag_equal",
+      systemPrompt: "gated + ungated tools",
+      tools: [
+        makeFactory("@intx/tools-posix/sidecar-bundle", [
+          { name: "run_shell", approval: "ask" },
+          { name: "list_dir" },
+        ]),
+      ],
+      capabilities: [],
+      inference: { sources: [{ provider: "anthropic", model: "m" }] },
+    });
+    const workflow = defineWorkflow({
+      id: "wf_equal",
+      trigger: { type: "manual" },
+      steps: {
+        run: step({ agent }),
+        commit: action({
+          handler: "commit",
+          effect: { requires: ["git:commit"] },
+          after: ["run"],
+        }),
+      },
+    });
+
+    const walk = walkCapabilities(workflow, registry);
+    const surface = flattenWalkToSurface(walk);
+    const rows = deriveRunRuntimeGrantRows(
+      walk,
+      "tnt",
+      "prn",
+      new Date("2020-01-01T00:00:00Z"),
+    );
+
+    const rowEffects: Record<string, GrantEffect> = {};
+    for (const row of rows) {
+      rowEffects[row.resource] = row.effect;
+    }
+    expect(surface.grants).toEqual(rows.map((r) => r.resource).sort());
+    expect(surface.grantEffects).toEqual(rowEffects);
   });
 });

--- a/packages/hub-api/src/run-grant-materialization.ts
+++ b/packages/hub-api/src/run-grant-materialization.ts
@@ -37,8 +37,7 @@ import {
 } from "@intx/types";
 import { RunGrantsFrame } from "@intx/types/sidecar";
 import {
-  workflowDefinitionEnvelopeSchema,
-  WORKFLOW_JSON_PATH,
+  hydrateDefinition,
   type AssetService,
   type MailTriggeredRunGrantsResult,
   type WorkflowDefinition,
@@ -144,41 +143,6 @@ export function deriveRunRuntimeGrantRows(
     });
   }
   return rows;
-}
-
-/**
- * Read and hydrate the workflow definition from a workflow asset's
- * `workflow.json`. Validates the structural envelope at this boundary,
- * mirroring the workflow-host child's `loadWorkflowDefinition`: the
- * per-primitive narrows live in the runtime layer that consumes the
- * definition, so the envelope check plus the documented narrow is the
- * canonical hydration shape.
- */
-export async function hydrateDefinition(
-  assetService: AssetService,
-  assetId: string,
-): Promise<WorkflowDefinition> {
-  const raw = await assetService.readAssetBlob({
-    assetId,
-    path: WORKFLOW_JSON_PATH,
-  });
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(new TextDecoder().decode(raw));
-  } catch (cause) {
-    throw new Error(
-      `workflow asset ${assetId} ${WORKFLOW_JSON_PATH} is not valid JSON`,
-      { cause },
-    );
-  }
-  const validated = workflowDefinitionEnvelopeSchema(parsed);
-  if (validated instanceof type.errors) {
-    throw new Error(
-      `workflow asset ${assetId} ${WORKFLOW_JSON_PATH} failed envelope validation: ${validated.summary}`,
-    );
-  }
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- envelope schema enforces structural shape; per-primitive narrows live in the runtime layer that consumes the definition, matching loadWorkflowDefinition in @intx/workflow-host
-  return validated as unknown as WorkflowDefinition;
 }
 
 /**

--- a/packages/hub-api/src/run-grant-materialization.ts
+++ b/packages/hub-api/src/run-grant-materialization.ts
@@ -30,11 +30,7 @@ import {
 import type { DB, DBExecutor } from "@intx/db";
 import { createWorkflowRunStore } from "@intx/db";
 import type { GrantStore, GrantRule } from "@intx/types/authz";
-import {
-  GrantRequirement,
-  isSidecarAllocationDispatchable,
-  type GrantEffect,
-} from "@intx/types";
+import { GrantRequirement, isSidecarAllocationDispatchable } from "@intx/types";
 import { RunGrantsFrame } from "@intx/types/sidecar";
 import {
   hydrateDefinition,
@@ -44,6 +40,7 @@ import {
 } from "@intx/hub-sessions";
 import {
   walkCapabilities,
+  resolveRuntimeGrantEffects,
   type CapabilityWalkResult,
 } from "@intx/workflow-deploy";
 import { createDefaultDirectorRegistry } from "@intx/agent";
@@ -67,8 +64,6 @@ const GrantRequirements = GrantRequirement.array();
 // loaded factory's already-namespaced definitions. The `effect:<cap>` rows are
 // different: an action's EffectContext authorizes the bare `effect:<cap>` on
 // both sides, so those rows ARE name-matched and operative at run time.
-const TOOL_GRANT_PREFIX = "tool:";
-const EFFECT_GRANT_PREFIX = "effect:";
 
 /**
  * Project the capability walk into the run's runtime grant rows -- the
@@ -78,16 +73,10 @@ const EFFECT_GRANT_PREFIX = "effect:";
  * definition-pure for the deployment's stable top-level run, so the walk
  * output alone determines it.
  *
- * Tool grants carry the effect the tool's static declaration requested (`ask`
- * for approval-gated tools, `allow` otherwise) via the walk's `grantEffects`
- * map. A tool in more than one step is emitted once; when two steps disagree
- * on its effect, `ask` wins over `allow` so an approval-gated declaration is
- * never silently downgraded.
- *
- * Effect grants are always `allow` -- the `effect.requires` set names the
- * capability floor an action needs, with no per-effect ask/allow distinction,
- * so they are NOT routed through the `grantEffects` map (which covers tool
- * grants only). An `effect:<cap>` in more than one step is emitted once.
+ * The `tool:`/`effect:` effect resolution is owned by
+ * `resolveRuntimeGrantEffects`; a child-workflow parent's pinned surface reads
+ * the SAME projection (via `flattenWalkToSurface`), so a folded ceiling and the
+ * runtime ceiling cannot drift.
  */
 export function deriveRunRuntimeGrantRows(
   walk: CapabilityWalkResult,
@@ -95,36 +84,7 @@ export function deriveRunRuntimeGrantRows(
   runPrincipalId: string,
   now: Date,
 ): MaterializedGrantRow[] {
-  const effectByResource = new Map<string, GrantEffect>();
-  for (const declarations of walk.perStep.values()) {
-    for (const grant of declarations.grants) {
-      if (grant.startsWith(TOOL_GRANT_PREFIX)) {
-        // Every `tool:` grant the walk emits carries a `grantEffects`
-        // entry (the tool-mark floor: `ask` for an approval-gated tool,
-        // `allow` otherwise). A missing entry means the walk's `grants`
-        // and `grantEffects` maps have diverged -- a defaulted `allow`
-        // here would silently DOWNGRADE an `ask` tool below its floor,
-        // defeating the approval gate. Fail loudly instead.
-        const effect = declarations.grantEffects.get(grant);
-        if (effect === undefined) {
-          throw new Error(
-            `deriveRunRuntimeGrantRows: tool grant ${JSON.stringify(grant)} has no grantEffects entry; the capability walk must emit an effect for every tool grant`,
-          );
-        }
-        const existing = effectByResource.get(grant);
-        if (existing === "ask" || effect === "ask") {
-          effectByResource.set(grant, "ask");
-        } else if (existing === undefined) {
-          effectByResource.set(grant, effect);
-        }
-      } else if (grant.startsWith(EFFECT_GRANT_PREFIX)) {
-        // Effect grants are always allow; a repeat across steps is idempotent.
-        if (!effectByResource.has(grant)) {
-          effectByResource.set(grant, "allow");
-        }
-      }
-    }
-  }
+  const effectByResource = resolveRuntimeGrantEffects(walk);
 
   const rows: MaterializedGrantRow[] = [];
   for (const [resource, effect] of effectByResource) {

--- a/packages/hub-api/src/run-grant-materialization.ts
+++ b/packages/hub-api/src/run-grant-materialization.ts
@@ -28,11 +28,17 @@ import {
   workflowRun,
 } from "@intx/db/schema";
 import type { DB, DBExecutor } from "@intx/db";
-import { createWorkflowRunStore } from "@intx/db";
+import { createWorkflowRunStore, readApprovedGrantSurface } from "@intx/db";
 import type { GrantStore, GrantRule } from "@intx/types/authz";
-import { GrantRequirement, isSidecarAllocationDispatchable } from "@intx/types";
+import {
+  GrantRequirement,
+  isSidecarAllocationDispatchable,
+  type ApprovedGrantSurface,
+  type GrantEffect,
+} from "@intx/types";
 import { RunGrantsFrame } from "@intx/types/sidecar";
 import {
+  enumerateChildWorkflowRefs,
   hydrateDefinition,
   type AssetService,
   type MailTriggeredRunGrantsResult,
@@ -84,8 +90,53 @@ export function deriveRunRuntimeGrantRows(
   runPrincipalId: string,
   now: Date,
 ): MaterializedGrantRow[] {
-  const effectByResource = resolveRuntimeGrantEffects(walk);
+  return projectRuntimeGrantRows(
+    resolveRuntimeGrantEffects(walk),
+    tenantId,
+    runPrincipalId,
+    now,
+  );
+}
 
+/**
+ * Project a deploy-stamped pinned surface into the run's runtime grant rows.
+ * Used for a childWorkflow-bearing definition, whose runtime ceiling is the
+ * stamped surface (own ∪ children) rather than a fresh own-walk -- so a child's
+ * folded authority actually reaches the run.
+ *
+ * Iterates `grants` (the authoritative resource list) and requires an effect
+ * for each, throwing on a missing one -- mirroring the walk projection's
+ * fail-loud invariant (`resolveRuntimeGrantEffects`), which refuses to default
+ * a missing effect lest it downgrade an `ask` tool. A well-formed surface (from
+ * `flattenWalkToSurface`/`mergeGrantSurfaces`) carries an effect for every
+ * grant, so this never fires in practice; reading `grants` rather than
+ * `grantEffects` also means a stray effect key with no matching grant is never
+ * materialized.
+ */
+export function deriveRunRuntimeGrantRowsFromSurface(
+  surface: ApprovedGrantSurface,
+  tenantId: string,
+  runPrincipalId: string,
+  now: Date,
+): MaterializedGrantRow[] {
+  const entries = surface.grants.map((resource): [string, GrantEffect] => {
+    const effect = surface.grantEffects[resource];
+    if (effect === undefined) {
+      throw new Error(
+        `run-grant materialization: pinned surface grant ${JSON.stringify(resource)} has no effect; the stored surface is malformed`,
+      );
+    }
+    return [resource, effect];
+  });
+  return projectRuntimeGrantRows(entries, tenantId, runPrincipalId, now);
+}
+
+function projectRuntimeGrantRows(
+  effectByResource: Iterable<readonly [string, GrantEffect]>,
+  tenantId: string,
+  runPrincipalId: string,
+  now: Date,
+): MaterializedGrantRow[] {
   const rows: MaterializedGrantRow[] = [];
   for (const [resource, effect] of effectByResource) {
     rows.push({
@@ -103,6 +154,72 @@ export function deriveRunRuntimeGrantRows(
     });
   }
   return rows;
+}
+
+/**
+ * The runtime grant ceiling for a definition being materialized, or undefined
+ * when the definition has no childWorkflow steps (its runtime rows then project
+ * from a fresh own-walk, unchanged). A childWorkflow-bearing definition's
+ * ceiling is the deploy-stamped pinned surface (own ∪ children): reading it
+ * back is how a child's folded authority reaches the run.
+ *
+ * The surface is read at the definition's CURRENT version. Unlike the walk, it
+ * is not a pure function of the definition's content -- it carries an external
+ * child contribution and is version-scoped, and `currentVersion` is mutable
+ * (a rollback repoints it). So it must be read per run, never cached by
+ * `definitionId`, or a superseded version's ceiling could over-grant a later
+ * run. Callers with a per-deployment cache freeze only the content-pure
+ * `hasChildWorkflow` predicate (`definitionHasChildWorkflow`) and read the
+ * surface fresh each run via `readChildWorkflowCeiling`.
+ */
+export async function resolveChildWorkflowRuntimeCeiling(
+  db: DBExecutor,
+  definition: WorkflowDefinition,
+  definitionId: string,
+  currentVersion: string,
+): Promise<ApprovedGrantSurface | undefined> {
+  if (!definitionHasChildWorkflow(definition)) {
+    return undefined;
+  }
+  return readChildWorkflowCeiling(db, definitionId, currentVersion);
+}
+
+/** Whether a definition references any childWorkflow -- a pure function of its
+ * content, so a per-deployment cache may freeze it. */
+export function definitionHasChildWorkflow(
+  definition: WorkflowDefinition,
+): boolean {
+  return enumerateChildWorkflowRefs(definition).length > 0;
+}
+
+/**
+ * Read a childWorkflow-bearing definition's stamped pinned surface at a
+ * specific version, failing closed when it is absent. `definitionId` is a live
+ * foreign key from the run's anchor and `currentVersion` is read off that same
+ * definition row, so the version row is present -- a null surface therefore
+ * means the deploy never folded and stamped this definition's children (a
+ * deploy bug, or a deployment predating the fold). Fail closed loudly rather
+ * than run the parent and its children under a ceiling that omits the child
+ * authority no operator reviewed. This also gates un-stubbing childWorkflow
+ * execution (INTR-310): a run cannot reach a child step without a stamped
+ * surface.
+ */
+export async function readChildWorkflowCeiling(
+  db: DBExecutor,
+  definitionId: string,
+  currentVersion: string,
+): Promise<ApprovedGrantSurface> {
+  const surface = await readApprovedGrantSurface(
+    db,
+    definitionId,
+    currentVersion,
+  );
+  if (surface === null) {
+    throw new Error(
+      `run-grant materialization: childWorkflow-bearing definition ${definitionId} (version ${currentVersion}) has no approved grant surface; its deploy must fold and stamp its children's surfaces before it can run`,
+    );
+  }
+  return surface;
 }
 
 /**
@@ -146,6 +263,16 @@ export type StageRunGrantsArgs = {
    * definition's requirements unfiltered.
    */
   grantRequirements: readonly GrantRequirement[];
+  /**
+   * The runtime grant ceiling for a childWorkflow-bearing definition -- the
+   * deploy-stamped pinned surface (own ∪ children). When set, the run's
+   * runtime `tool:`/`effect:` rows project from it instead of the own-walk, so
+   * a child's folded authority reaches the run. Undefined for a definition with
+   * no childWorkflow steps (its rows project from the walk, unchanged).
+   * Resolved by `resolveChildWorkflowRuntimeCeiling`, which fails closed when a
+   * childWorkflow-bearing definition has no stamped surface.
+   */
+  runtimeCeiling?: ApprovedGrantSurface;
 };
 
 export type StageRunGrantsResult =
@@ -198,12 +325,23 @@ export type StageRunGrantsFromWalkArgs = Omit<
 export async function stageRunGrantsFromWalk(
   args: StageRunGrantsFromWalkArgs,
 ): Promise<StageRunGrantsResult> {
-  const runtimeGrantRows = deriveRunRuntimeGrantRows(
-    args.walk,
-    args.tenantId,
-    args.runPrincipalId,
-    args.now,
-  );
+  // A childWorkflow-bearing definition's runtime ceiling is the deploy-stamped
+  // pinned surface (own ∪ children); every other definition projects its rows
+  // from the walk exactly as before.
+  const runtimeGrantRows =
+    args.runtimeCeiling !== undefined
+      ? deriveRunRuntimeGrantRowsFromSurface(
+          args.runtimeCeiling,
+          args.tenantId,
+          args.runPrincipalId,
+          args.now,
+        )
+      : deriveRunRuntimeGrantRows(
+          args.walk,
+          args.tenantId,
+          args.runPrincipalId,
+          args.now,
+        );
 
   const materialization = await resolveGrantMaterialization({
     tenantId: args.tenantId,
@@ -241,6 +379,9 @@ export async function stageRunGrants(
     invokerGrants: args.invokerGrants,
     creatorGrants: args.creatorGrants,
     grantRequirements: args.grantRequirements,
+    ...(args.runtimeCeiling !== undefined
+      ? { runtimeCeiling: args.runtimeCeiling }
+      : {}),
   });
 }
 
@@ -520,14 +661,21 @@ export type MailTriggeredRunGrantsDeps = {
 
 /**
  * A deployment's deploy-approved grant basis: the frozen capability walk the
- * run's runtime `tool:`/`effect:` grants project from, and the creator-sourced
- * grant requirements resolved against it. Both are pure functions of the
- * approved definition content, so they are computed once per deployment and
- * cached; nothing here depends on a live re-read of the asset blob.
+ * run's runtime `tool:`/`effect:` grants project from, the creator-sourced grant
+ * requirements resolved against it, and whether the definition references any
+ * childWorkflow. All three are pure functions of the approved definition
+ * content, so they are computed once per deployment and cached; nothing here
+ * depends on a live re-read of the asset blob.
+ *
+ * The childWorkflow runtime ceiling is deliberately NOT cached here: it is the
+ * version-scoped pinned surface, and `currentVersion` is mutable (a rollback
+ * repoints it), so it is read fresh each run. Caching it by `definitionId`
+ * would over-grant a later run under a superseded version's ceiling.
  */
 type FrozenRunGrantBasis = {
   readonly walk: CapabilityWalkResult;
   readonly creatorRequirements: readonly GrantRequirement[];
+  readonly hasChildWorkflow: boolean;
 };
 
 /**
@@ -574,6 +722,7 @@ export function createMailTriggeredRunGrantsMaterializer(
         tenantId: workflowRun.tenantId,
         definitionId: workflowRun.definitionId,
         definitionAssetId: workflowDefinition.assetId,
+        definitionVersion: workflowDefinition.currentVersion,
         anchorStatus: workflowRun.status,
         topLevelRunStatus: topLevelRun.status,
       })
@@ -655,12 +804,30 @@ export function createMailTriggeredRunGrantsMaterializer(
       const creatorRequirements = parsedRequirements.requirements.filter(
         (r) => r.source !== "invoker",
       );
+      // Freeze whether this definition references a childWorkflow -- a pure
+      // function of its content. The ceiling surface itself is NOT frozen: it
+      // is version-scoped and `currentVersion` can be rolled back, so it is
+      // read fresh each run below.
       basis = {
         walk: buildCapabilityWalk(definition),
         creatorRequirements,
+        hasChildWorkflow: definitionHasChildWorkflow(definition),
       };
       frozenBasisByDefinition.set(definitionId, basis);
     }
+
+    // A childWorkflow-bearing definition's runtime ceiling is read fresh each
+    // run at the definition's current version, so a rollback that repoints
+    // `currentVersion` cannot leave a later run staged from a superseded
+    // (possibly broader) ceiling. Fails closed if the current version carries
+    // no stamped surface.
+    const runtimeCeiling = basis.hasChildWorkflow
+      ? await readChildWorkflowCeiling(
+          deps.db,
+          definitionId,
+          anchor.definitionVersion,
+        )
+      : undefined;
 
     // Creator authority is resolved LIVE per run: the definition's grant SHAPE
     // is frozen above, but which grants the creator currently holds is not part
@@ -692,6 +859,7 @@ export function createMailTriggeredRunGrantsMaterializer(
       invokerGrants: [],
       creatorGrants,
       grantRequirements: basis.creatorRequirements,
+      ...(runtimeCeiling !== undefined ? { runtimeCeiling } : {}),
     });
     if (!staged.ok) {
       return {

--- a/packages/hub-api/src/workflow-run-trigger.ts
+++ b/packages/hub-api/src/workflow-run-trigger.ts
@@ -39,6 +39,7 @@ import {
   type AttachmentError,
 } from "@intx/types";
 import type { RunGrantsFrame } from "@intx/types/sidecar";
+import { hydrateDefinition } from "@intx/hub-sessions";
 import type {
   AssetService,
   RepoStore,
@@ -53,7 +54,6 @@ import type { PrincipalRow, TenantRow } from "./context";
 import {
   collectCreatorGrants,
   commitRunGrants,
-  hydrateDefinition,
   loadCommittedRunGrants,
   lockDispatchableAllocation,
   lockWorkflowRunState,

--- a/packages/hub-api/src/workflow-run-trigger.ts
+++ b/packages/hub-api/src/workflow-run-trigger.ts
@@ -58,6 +58,7 @@ import {
   lockDispatchableAllocation,
   lockWorkflowRunState,
   parseGrantRequirements,
+  resolveChildWorkflowRuntimeCeiling,
   stageRunGrants,
 } from "./run-grant-materialization";
 import type { MaterializedGrantRow } from "./grant-materialization";
@@ -174,6 +175,7 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
       .select({
         definitionId: workflowRun.definitionId,
         definitionAssetId: workflowDefinition.assetId,
+        definitionVersion: workflowDefinition.currentVersion,
         allocationId: sidecarAllocation.id,
         allocationStatus: sidecarAllocation.status,
         anchorStatus: workflowRun.status,
@@ -357,6 +359,14 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
         assetRow.creatorPrincipalId,
         declaredGrantRequirements,
       );
+      // A childWorkflow-bearing definition's runtime ceiling is its
+      // deploy-stamped pinned surface; fails closed if it has none.
+      const runtimeCeiling = await resolveChildWorkflowRuntimeCeiling(
+        db,
+        definition,
+        anchor.definitionId,
+        anchor.definitionVersion,
+      );
       const staged = await stageRunGrants({
         definition,
         tenantId: tenant.id,
@@ -365,6 +375,7 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
         invokerGrants,
         creatorGrants,
         grantRequirements: declaredGrantRequirements,
+        ...(runtimeCeiling !== undefined ? { runtimeCeiling } : {}),
       });
       if (!staged.ok) {
         const { status, code, message } = staged.rejection;

--- a/packages/hub-sessions/src/child-workflow-fold.test.ts
+++ b/packages/hub-sessions/src/child-workflow-fold.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  childWorkflow,
+  defineWorkflow,
+  onTrigger,
+  sleep,
+  step,
+  type WorkflowDefinition,
+} from "@intx/workflow/definition";
+import { computeLiveDefinitionHash, projectLiveToInert } from "@intx/workflow";
+import { defineAgent } from "@intx/agent";
+import type { ApprovedGrantSurface } from "@intx/types";
+import { computeWireDefinitionHash } from "@intx/types/wire-definition-hash";
+
+import {
+  enumerateChildWorkflowRefs,
+  mergeGrantSurfaces,
+} from "./child-workflow-fold";
+
+/** An agent-bearing definition whose inert projection is the shape a child's
+ * workflow.json holds. */
+function agentWorkflow(): WorkflowDefinition {
+  return defineWorkflow({
+    id: "agent-child",
+    trigger: { type: "manual" },
+    steps: {
+      run: step({
+        agent: defineAgent({
+          id: "a",
+          systemPrompt: "s",
+          tools: [],
+          capabilities: [],
+          inference: { sources: [{ provider: "anthropic", model: "m" }] },
+        }),
+      }),
+    },
+  });
+}
+
+describe("enumerateChildWorkflowRefs", () => {
+  test("returns no refs for a workflow with no childWorkflow steps", () => {
+    const wf = defineWorkflow({
+      id: "leaf",
+      trigger: { type: "manual" },
+      steps: { wait: sleep({ duration: 1 }) },
+    });
+    expect(enumerateChildWorkflowRefs(wf)).toEqual([]);
+  });
+
+  test("collects a top-level childWorkflow reference", () => {
+    const wf = defineWorkflow({
+      id: "parent",
+      trigger: { type: "manual" },
+      steps: {
+        a: childWorkflow({ definitionRef: "ast_a" }),
+        b: childWorkflow({ definitionRef: "ast_b", after: ["a"] }),
+      },
+    });
+    expect(enumerateChildWorkflowRefs(wf)).toEqual([
+      { stepId: "a", definitionRef: "ast_a" },
+      { stepId: "b", definitionRef: "ast_b" },
+    ]);
+  });
+
+  test("descends into an onTrigger inline body and labels the step path", () => {
+    const address = "wf@example.com";
+    const body = defineWorkflow({
+      id: "body",
+      trigger: { type: "manual" },
+      steps: { sub: childWorkflow({ definitionRef: "ast_nested" }) },
+    });
+    const wf = defineWorkflow({
+      id: "parent",
+      trigger: { type: "mail", to: address },
+      steps: {
+        section: onTrigger({ on: { type: "mail", to: address }, body }),
+      },
+    });
+    expect(enumerateChildWorkflowRefs(wf)).toEqual([
+      { stepId: "section/sub", definitionRef: "ast_nested" },
+    ]);
+  });
+
+  test("skips an onTrigger body already extracted to a ref", () => {
+    // A deployed `{ ref }` body is an independent asset with its own folded
+    // surface. The authored form the fold runs on carries `{ inline }`, so this
+    // shape only appears post-extraction; assert the enumerator skips it rather
+    // than dereferencing a ref that is not a childWorkflow.
+    const base = defineWorkflow({
+      id: "parent",
+      trigger: { type: "mail", to: "wf@example.com" },
+      steps: {
+        section: onTrigger({
+          on: { type: "mail", to: "wf@example.com" },
+          body: defineWorkflow({
+            id: "body",
+            trigger: { type: "manual" },
+            steps: { sub: childWorkflow({ definitionRef: "ast_nested" }) },
+          }),
+        }),
+      },
+    });
+    const section = base.steps["section"];
+    if (section === undefined || section.kind !== "onTrigger") {
+      throw new Error("test setup: expected an onTrigger section");
+    }
+    const extracted: WorkflowDefinition = {
+      ...base,
+      steps: { section: { ...section, body: { ref: "ast_body" } } },
+    };
+    expect(enumerateChildWorkflowRefs(extracted)).toEqual([]);
+  });
+});
+
+describe("mergeGrantSurfaces", () => {
+  test("unions grants and sorts them deterministically", () => {
+    const a: ApprovedGrantSurface = {
+      grants: ["tool:z", "capability:mail"],
+      grantEffects: {},
+    };
+    const b: ApprovedGrantSurface = {
+      grants: ["tool:a", "capability:mail"],
+      grantEffects: {},
+    };
+    expect(mergeGrantSurfaces(a, b)).toEqual({
+      grants: ["capability:mail", "tool:a", "tool:z"],
+      grantEffects: {},
+    });
+  });
+
+  test("ask wins over allow regardless of side", () => {
+    const asking: ApprovedGrantSurface = {
+      grants: ["tool:x"],
+      grantEffects: { "tool:x": "ask" },
+    };
+    const allowing: ApprovedGrantSurface = {
+      grants: ["tool:x"],
+      grantEffects: { "tool:x": "allow" },
+    };
+    expect(mergeGrantSurfaces(allowing, asking).grantEffects).toEqual({
+      "tool:x": "ask",
+    });
+    expect(mergeGrantSurfaces(asking, allowing).grantEffects).toEqual({
+      "tool:x": "ask",
+    });
+  });
+
+  test("deny wins over ask and allow regardless of side", () => {
+    const denying: ApprovedGrantSurface = {
+      grants: ["tool:x", "tool:y"],
+      grantEffects: { "tool:x": "deny", "tool:y": "deny" },
+    };
+    const softer: ApprovedGrantSurface = {
+      grants: ["tool:x", "tool:y"],
+      grantEffects: { "tool:x": "ask", "tool:y": "allow" },
+    };
+    expect(mergeGrantSurfaces(softer, denying).grantEffects).toEqual({
+      "tool:x": "deny",
+      "tool:y": "deny",
+    });
+    expect(mergeGrantSurfaces(denying, softer).grantEffects).toEqual({
+      "tool:x": "deny",
+      "tool:y": "deny",
+    });
+  });
+
+  test("keeps disjoint effects and the incoming effect on no conflict", () => {
+    const base: ApprovedGrantSurface = {
+      grants: ["tool:x"],
+      grantEffects: { "tool:x": "allow" },
+    };
+    const incoming: ApprovedGrantSurface = {
+      grants: ["tool:y"],
+      grantEffects: { "tool:y": "allow" },
+    };
+    expect(mergeGrantSurfaces(base, incoming)).toEqual({
+      grants: ["tool:x", "tool:y"],
+      grantEffects: { "tool:x": "allow", "tool:y": "allow" },
+    });
+  });
+
+  test("an empty base is the identity for a fold accumulator", () => {
+    const empty: ApprovedGrantSurface = { grants: [], grantEffects: {} };
+    const surface: ApprovedGrantSurface = {
+      grants: ["tool:a"],
+      grantEffects: { "tool:a": "ask" },
+    };
+    expect(mergeGrantSurfaces(empty, surface)).toEqual(surface);
+  });
+});
+
+describe("child workflow.json hash equivalence (fold precondition)", () => {
+  // The fold resolves a child by hashing its workflow.json, which holds the
+  // inert projection. These pin the invariant the fold's hash choice rests on,
+  // unconditionally (no DB harness needed): the DB-backed resolution test that
+  // also exercises this is gated behind the Postgres harness.
+  test("computeWireDefinitionHash of the inert workflow.json equals the stored live hash", async () => {
+    const live = agentWorkflow();
+    const workflowJson: unknown = JSON.parse(
+      JSON.stringify(projectLiveToInert(live)),
+    );
+    expect(await computeWireDefinitionHash(workflowJson)).toBe(
+      await computeLiveDefinitionHash(live),
+    );
+  });
+
+  test("re-projecting the inert workflow.json throws (the fold must not do this)", async () => {
+    const live = agentWorkflow();
+    const workflowJson = JSON.parse(JSON.stringify(projectLiveToInert(live)));
+    // computeLiveDefinitionHash re-projects its argument; an already-inert
+    // agent step is no longer a live factory, so this rejects.
+    await expect(computeLiveDefinitionHash(workflowJson)).rejects.toThrow();
+  });
+});

--- a/packages/hub-sessions/src/child-workflow-fold.ts
+++ b/packages/hub-sessions/src/child-workflow-fold.ts
@@ -1,0 +1,305 @@
+// Fold a workflow's direct childWorkflow references into a single approved
+// grant surface. A `childWorkflow` step names a separately-deployed workflow
+// asset by `definitionRef`; the referenced child's needs-surface is invisible
+// to the parent's approval and its runtime ceiling unless it is folded in here.
+//
+// The fold reads each direct child's already-stored `approved_grant_surface`
+// and unions it. Because a deployed child's stored surface is itself the
+// transitive fold of its own children, a parent unions only its DIRECT
+// children -- grandchildren are already inside the child's surface, so there is
+// no recursion and no cross-definition re-walk. This is the recurrence
+//
+//   pinned(W) = ownWalk(W) ∪ ⋃ pinned(directChild(W))
+//
+// computed at W's deploy; the caller supplies `ownWalk(W)` and unions it with
+// the child contribution this module returns.
+//
+// A cross-workflow reference cycle (a → b → a) is structurally un-deployable:
+// to deploy `a` its child `b` must already be approved with a stored surface,
+// and vice versa, so neither can be first. That deploy-ordering requirement is
+// the cycle guard -- an unresolved or unapproved child is rejected by
+// `ChildWorkflowNotApprovedError`. A self-reference is rejected directly,
+// before any blob read, so a stale prior-version self-fold can never happen.
+
+import { and, eq } from "drizzle-orm";
+
+import type { WorkflowDefinition } from "@intx/workflow/definition";
+import type { ApprovedGrantSurface, GrantEffect } from "@intx/types";
+import { computeWireDefinitionHash } from "@intx/types/wire-definition-hash";
+import {
+  readApprovedGrantSurface,
+  resolveDefinitionForAsset,
+  type DBExecutor,
+} from "@intx/db";
+import { asset } from "@intx/db/schema";
+
+import type { AssetService } from "./asset-service";
+import { hydrateDefinition } from "./workflow-kind";
+
+/** A childWorkflow reference the fold discovered, labelled by its step path. */
+export interface ChildWorkflowRef {
+  /** The step id, or `parentStepId/bodyStepId` for a childWorkflow nested in an
+   * onTrigger body -- carried only to make errors point at the right step. */
+  readonly stepId: string;
+  readonly definitionRef: string;
+}
+
+/** A childWorkflow whose `definitionRef` is the very asset being deployed. */
+export class ChildWorkflowSelfReferenceError extends Error {
+  readonly definitionRef: string;
+
+  constructor(definitionRef: string) {
+    super(
+      `child workflow ${JSON.stringify(definitionRef)} references the ` +
+        `workflow being deployed; a workflow cannot fold its own surface`,
+    );
+    this.name = "ChildWorkflowSelfReferenceError";
+    this.definitionRef = definitionRef;
+  }
+}
+
+/** A childWorkflow `definitionRef` names no workflow asset in the deploy
+ * tenant. Absent and cross-tenant collapse into one error on purpose: a
+ * distinct cross-tenant error would confirm the asset's existence to a tenant
+ * that cannot see it. */
+export class ChildWorkflowNotFoundError extends Error {
+  readonly definitionRef: string;
+
+  constructor(definitionRef: string) {
+    super(
+      `child workflow ${JSON.stringify(definitionRef)} is not a workflow ` +
+        `asset in this tenant`,
+    );
+    this.name = "ChildWorkflowNotFoundError";
+    this.definitionRef = definitionRef;
+  }
+}
+
+/** A childWorkflow `definitionRef` names an asset that is not workflow-kind. */
+export class ChildWorkflowKindError extends Error {
+  readonly definitionRef: string;
+  readonly kind: string;
+
+  constructor(definitionRef: string, kind: string) {
+    super(
+      `child workflow ${JSON.stringify(definitionRef)} is a ` +
+        `${JSON.stringify(kind)} asset, not a workflow`,
+    );
+    this.name = "ChildWorkflowKindError";
+    this.definitionRef = definitionRef;
+    this.kind = kind;
+  }
+}
+
+/** A childWorkflow's referenced content resolves to no approved definition
+ * carrying a grant surface. Covers a child that is not deployed, not yet
+ * approved, or a participant in a reference cycle -- all of which mean the
+ * parent has no surface to fold and must not deploy first. */
+export class ChildWorkflowNotApprovedError extends Error {
+  readonly definitionRef: string;
+
+  constructor(definitionRef: string) {
+    super(
+      `child workflow ${JSON.stringify(definitionRef)} is not deployed and ` +
+        `approved with a grant surface; deploy the child before the parent`,
+    );
+    this.name = "ChildWorkflowNotApprovedError";
+    this.definitionRef = definitionRef;
+  }
+}
+
+/**
+ * Enumerate the childWorkflow references reachable from a definition's authored
+ * form. A `childWorkflow` is legal at top level and one subscription layer
+ * deep, inside an onTrigger section's authored `{ inline }` body (loops ban
+ * childWorkflow; nested onTrigger is banned, so there is no deeper nesting).
+ * The fold runs before the deploy step rewrites an inline body to `{ ref }`, so
+ * a `{ ref }` body -- already its own asset with its own folded surface -- is
+ * skipped here, mirroring `collectOnTriggerBodyGrants`.
+ */
+export function enumerateChildWorkflowRefs(
+  definition: WorkflowDefinition,
+): ChildWorkflowRef[] {
+  const refs: ChildWorkflowRef[] = [];
+  for (const stepId of definition.stepOrder) {
+    const primitive = definition.steps[stepId];
+    if (primitive === undefined) {
+      throw new Error(
+        `child-workflow fold: step ${stepId} listed in stepOrder is missing ` +
+          `from steps`,
+      );
+    }
+    if (primitive.kind === "childWorkflow") {
+      refs.push({ stepId, definitionRef: primitive.definitionRef });
+      continue;
+    }
+    if (primitive.kind === "onTrigger" && "inline" in primitive.body) {
+      const body = primitive.body.inline;
+      for (const bodyStepId of body.stepOrder) {
+        const bodyPrimitive = body.steps[bodyStepId];
+        if (bodyPrimitive === undefined) {
+          throw new Error(
+            `child-workflow fold: onTrigger body step ${bodyStepId} listed ` +
+              `in stepOrder is missing from steps`,
+          );
+        }
+        if (bodyPrimitive.kind === "childWorkflow") {
+          refs.push({
+            stepId: `${stepId}/${bodyStepId}`,
+            definitionRef: bodyPrimitive.definitionRef,
+          });
+        }
+      }
+    }
+  }
+  return refs;
+}
+
+// Effect strength for the fold: the strongest effect wins, matching the
+// documented grant precedence (`deny` over `ask` over `allow`). The capability
+// walk mints only `ask`/`allow` today, so for currently-reachable inputs this
+// reduces to the walk's ask-wins merge; carrying `deny` through correctly keeps
+// the fold from ever weakening a stronger effect a future producer might stamp.
+const EFFECT_STRENGTH: Record<GrantEffect, number> = {
+  allow: 0,
+  ask: 1,
+  deny: 2,
+};
+
+function strongestEffect(a: GrantEffect, b: GrantEffect): GrantEffect {
+  return EFFECT_STRENGTH[a] >= EFFECT_STRENGTH[b] ? a : b;
+}
+
+/**
+ * Union two approved grant surfaces into a ceiling. Grants are set-unioned and
+ * sorted for a deterministic stored value. When the same grant carries an
+ * effect on both sides, the stronger effect wins (`deny` > `ask` > `allow`), so
+ * folding can never silently downgrade an approval gate.
+ */
+export function mergeGrantSurfaces(
+  base: ApprovedGrantSurface,
+  incoming: ApprovedGrantSurface,
+): ApprovedGrantSurface {
+  const grants = new Set<string>(base.grants);
+  for (const grant of incoming.grants) {
+    grants.add(grant);
+  }
+  const grantEffects: Record<string, GrantEffect> = { ...base.grantEffects };
+  for (const [grant, effect] of Object.entries(incoming.grantEffects)) {
+    const existing = grantEffects[grant];
+    grantEffects[grant] =
+      existing === undefined ? effect : strongestEffect(existing, effect);
+  }
+  return { grants: [...grants].sort(), grantEffects };
+}
+
+/** The read-only capabilities the fold needs: an executor for the definition
+ * store and the asset service for the child's `workflow.json`. */
+export interface ChildWorkflowFoldDeps {
+  readonly db: DBExecutor;
+  readonly assetService: AssetService;
+}
+
+export interface ChildWorkflowFoldParams {
+  /** The parent definition, in its authored form (inline onTrigger bodies not
+   * yet extracted). */
+  readonly definition: WorkflowDefinition;
+  /** The asset id of the workflow being deployed, for the self-reference
+   * check. */
+  readonly deployingAssetId: string;
+  /** The deploy tenant; every referenced child must belong to it. */
+  readonly tenantId: string;
+}
+
+/**
+ * Resolve and union the approved grant surfaces of a parent's direct
+ * childWorkflow references. Returns the child contribution
+ * (`⋃ pinned(directChild)`); the caller unions it with the parent's own walk
+ * to form `pinned(parent)`. A parent with no childWorkflow steps yields an
+ * empty surface.
+ *
+ * Each reference is validated fail-closed and in this order: a self-reference
+ * is rejected first; then the asset is confirmed to exist in the deploy tenant
+ * and be workflow-kind BEFORE its blob is read (so a cross-tenant asset is
+ * never touched); then its current content resolves to an approved definition
+ * whose stored surface is folded in. A child referenced by more than one step
+ * is folded once.
+ */
+export async function resolveChildWorkflowSurface(
+  params: ChildWorkflowFoldParams,
+  deps: ChildWorkflowFoldDeps,
+): Promise<ApprovedGrantSurface> {
+  let folded: ApprovedGrantSurface = { grants: [], grantEffects: {} };
+  const seen = new Set<string>();
+  for (const { definitionRef } of enumerateChildWorkflowRefs(
+    params.definition,
+  )) {
+    if (seen.has(definitionRef)) {
+      continue;
+    }
+    seen.add(definitionRef);
+    const surface = await resolveOneChildSurface(definitionRef, params, deps);
+    folded = mergeGrantSurfaces(folded, surface);
+  }
+  return folded;
+}
+
+async function resolveOneChildSurface(
+  definitionRef: string,
+  params: ChildWorkflowFoldParams,
+  deps: ChildWorkflowFoldDeps,
+): Promise<ApprovedGrantSurface> {
+  if (definitionRef === params.deployingAssetId) {
+    throw new ChildWorkflowSelfReferenceError(definitionRef);
+  }
+
+  // Same-tenant + kind validation before any blob read: a cross-tenant or
+  // absent asset is never read. The query is scoped to the deploy tenant, so a
+  // cross-tenant asset is indistinguishable from a missing one here.
+  const assetRow = await deps.db.query.asset.findFirst({
+    where: and(
+      eq(asset.id, definitionRef),
+      eq(asset.tenantId, params.tenantId),
+    ),
+  });
+  if (assetRow === undefined) {
+    throw new ChildWorkflowNotFoundError(definitionRef);
+  }
+  if (assetRow.kind !== "workflow") {
+    throw new ChildWorkflowKindError(definitionRef, assetRow.kind);
+  }
+
+  // Bind to the child's current content: hydrate its workflow.json, hash it,
+  // and resolve the definition row that content keys. This pins the child's
+  // surface at parent-deploy time; the runtime binds the child's content
+  // afresh at spawn time, and on drift the child fails closed against this
+  // pinned ceiling.
+  //
+  // workflow.json holds the inert wire projection, so its hash is the wire
+  // hash directly: the stored `wire_hash` is `computeLiveDefinitionHash(live)`
+  // = `computeWireDefinitionHash(projectLiveToInert(live))`, and the hydrated
+  // definition IS that inert projection. Re-projecting it (as
+  // `computeLiveDefinitionHash` would) throws, because an already-inert agent
+  // step is no longer a live factory to project.
+  const childDefinition = await hydrateDefinition(
+    deps.assetService,
+    definitionRef,
+  );
+  const wireHash = await computeWireDefinitionHash(childDefinition);
+  const resolved = await resolveDefinitionForAsset(deps.db, {
+    assetId: definitionRef,
+    wireHash,
+  });
+  if (resolved === null) {
+    throw new ChildWorkflowNotApprovedError(definitionRef);
+  }
+  const surface = await readApprovedGrantSurface(
+    deps.db,
+    resolved.definitionId,
+    resolved.currentVersion,
+  );
+  if (surface === null) {
+    throw new ChildWorkflowNotApprovedError(definitionRef);
+  }
+  return surface;
+}

--- a/packages/hub-sessions/src/index.ts
+++ b/packages/hub-sessions/src/index.ts
@@ -133,6 +133,7 @@ export {
   WORKSPACE_BUILTINS_REGISTRY,
 } from "./package-registry-kind";
 export {
+  hydrateDefinition,
   workflowKindHandler,
   workflowAuthorize,
   workflowDefinitionEnvelopeSchema,

--- a/packages/hub-sessions/src/index.ts
+++ b/packages/hub-sessions/src/index.ts
@@ -145,6 +145,18 @@ export {
   type WorkflowSidecarPrincipal,
 } from "./workflow-kind";
 export {
+  enumerateChildWorkflowRefs,
+  mergeGrantSurfaces,
+  resolveChildWorkflowSurface,
+  ChildWorkflowSelfReferenceError,
+  ChildWorkflowNotFoundError,
+  ChildWorkflowKindError,
+  ChildWorkflowNotApprovedError,
+  type ChildWorkflowRef,
+  type ChildWorkflowFoldDeps,
+  type ChildWorkflowFoldParams,
+} from "./child-workflow-fold";
+export {
   workflowRunKindHandler,
   workflowRunAuthorize,
   enqueueInbox,

--- a/packages/hub-sessions/src/index.ts
+++ b/packages/hub-sessions/src/index.ts
@@ -87,7 +87,10 @@ export {
   type SidecarAllocationReconciler,
   type SidecarAllocationReconcilerDeps,
 } from "./sidecar-allocation";
-export { ensureWorkflowDefinitionForAsset } from "./workflow-definition-ensure";
+export {
+  ensureWorkflowDefinitionForAsset,
+  INITIAL_WORKFLOW_DEFINITION_VERSION,
+} from "./workflow-definition-ensure";
 export {
   createWorkflowAllocationService,
   ExclusiveWorkflowPlacementError,

--- a/packages/hub-sessions/src/session-service.test.ts
+++ b/packages/hub-sessions/src/session-service.test.ts
@@ -25,7 +25,13 @@ import {
 } from "@intx/db/schema";
 import type { DB } from "@intx/db";
 import { generateId } from "@intx/hub-common";
-import { deriveRunAddress } from "@intx/workflow-deploy";
+import {
+  deriveRunAddress,
+  flattenWalkToSurface,
+  walkCapabilities,
+} from "@intx/workflow-deploy";
+import { createDefaultDirectorRegistry } from "@intx/agent";
+import type { ApprovedGrantSurface } from "@intx/types";
 import type { AgentRepoStore, DeployContent } from "./agent-repo";
 import type { AssetService } from "./asset-service";
 import type { Principal, RepoId, RepoStore } from "./repo-store";
@@ -1271,6 +1277,7 @@ describe("deployWorkflowDefinition", () => {
     const definitionRows: CapturedDefinitionRow[] = [];
     const definitionVersionRows: { definitionId: string; version: string }[] =
       [];
+    const definitionSurfaceStamps: ApprovedGrantSurface[] = [];
     const workflowRepoWrites: { repoId: RepoId; files: string[] }[] = [];
 
     // The workflow asset the definition is projected from. `ensureWorkflow-
@@ -1330,6 +1337,31 @@ describe("deployWorkflowDefinition", () => {
       throw new Error("deployWorkflowDefinition fixture: unexpected insert");
     };
 
+    // The deploy stamps the version row's approved grant surface via
+    // `writeApprovedGrantSurface`, a single UPDATE ... RETURNING. Capture the
+    // stamped surface and echo one updated row so the store's one-row
+    // assertion passes. The fixture deploys a single definition, so the surface
+    // alone identifies the stamp.
+    const update = (table: unknown) => {
+      if (table === workflowDefinitionVersionTable) {
+        return {
+          set(values: { approvedGrantSurface: ApprovedGrantSurface }) {
+            return {
+              where() {
+                return {
+                  returning() {
+                    definitionSurfaceStamps.push(values.approvedGrantSurface);
+                    return Promise.resolve([{ id: "wdv-stamped" }]);
+                  },
+                };
+              },
+            };
+          },
+        };
+      }
+      throw new Error("deployWorkflowDefinition fixture: unexpected update");
+    };
+
     // `ensureWorkflowDefinitionForAsset` selects the workflow asset by id; every
     // other select in the deploy path is served elsewhere, so only the asset
     // table is answered here.
@@ -1348,13 +1380,15 @@ describe("deployWorkflowDefinition", () => {
     const fakeDb = {
       insert,
       select,
+      update,
       transaction(
         fn: (tx: {
           insert: typeof insert;
           select: typeof select;
+          update: typeof update;
         }) => Promise<void>,
       ) {
-        return fn({ insert, select });
+        return fn({ insert, select, update });
       },
     };
 
@@ -1387,6 +1421,7 @@ describe("deployWorkflowDefinition", () => {
       runRows,
       definitionRows,
       definitionVersionRows,
+      definitionSurfaceStamps,
       workflowRepoWrites,
       fakeDb,
       repoStore,
@@ -1399,6 +1434,7 @@ describe("deployWorkflowDefinition", () => {
       runRows,
       definitionRows,
       definitionVersionRows,
+      definitionSurfaceStamps,
       workflowRepoWrites,
       fakeDb,
       repoStore,
@@ -1516,6 +1552,17 @@ describe("deployWorkflowDefinition", () => {
     expect(definitionVersionRows[0]?.definitionId).toBe(definitionRow.id);
     expect(definitionVersionRows[0]?.version).toBe("1");
 
+    // The deploy stamps the version's approved grant surface in the same
+    // transaction that creates the row -- its own runtime-enforced surface,
+    // since this definition has no childWorkflow steps to fold. This proves
+    // the stamp is wired into the deploy tx and keyed to the created version.
+    expect(definitionSurfaceStamps).toHaveLength(1);
+    expect(definitionSurfaceStamps[0]).toEqual(
+      flattenWalkToSurface(
+        walkCapabilities(definition, createDefaultDirectorRegistry()),
+      ),
+    );
+
     // The deployment's anchor run is recorded in the same transaction: one
     // workflow_run 1:1 with the deployment, its id and routing address both
     // derived from the deployment, born "deployed" in its pre-trigger window
@@ -1590,6 +1637,7 @@ describe("deployPreparedWorkflowDefinition recovery", () => {
       generation: 3,
       ensureAcceptedGeneration: 3,
     };
+    const preparedSurfaceStamps: ApprovedGrantSurface[] = [];
     const fakeTx = {
       select() {
         return {
@@ -1609,11 +1657,22 @@ describe("deployPreparedWorkflowDefinition recovery", () => {
         };
       },
       update(table: unknown) {
-        if (table !== workflowRunTable) {
+        // The prepared deploy publishes the supervisor key on the anchor and
+        // stamps the pinned surface on the version row -- both single
+        // UPDATE ... RETURNING calls with a one-row result. Capture the version
+        // stamp so a test can assert the prepared path stamps the right value.
+        if (
+          table !== workflowRunTable &&
+          table !== workflowDefinitionVersionTable
+        ) {
           throw new Error("unexpected prepared-deploy update table");
         }
+        const capturesSurface = table === workflowDefinitionVersionTable;
         return {
-          set(_values: unknown) {
+          set(values: { approvedGrantSurface?: ApprovedGrantSurface }) {
+            if (capturesSurface && values.approvedGrantSurface !== undefined) {
+              preparedSurfaceStamps.push(values.approvedGrantSurface);
+            }
             return {
               where(_predicate: unknown) {
                 return {
@@ -1627,8 +1686,20 @@ describe("deployPreparedWorkflowDefinition recovery", () => {
         };
       },
     };
+    // The prepared deploy resolves the anchor's definition + asset to fold the
+    // pinned surface. This definition is childless, so the fold reads no child
+    // assets; only the anchor -> definition -> assetId resolution is served.
+    const fakeQuery = {
+      workflowRun: {
+        findFirst: async () => ({ definitionId: "wfd_restore_order" }),
+      },
+      workflowDefinition: {
+        findFirst: async () => ({ assetId: "ast_restore_order" }),
+      },
+    };
     const fakeDb = {
       ...fakeTx,
+      query: fakeQuery,
       transaction: async <T>(callback: (tx: typeof fakeTx) => Promise<T>) =>
         callback(fakeTx),
     };
@@ -1685,11 +1756,18 @@ describe("deployPreparedWorkflowDefinition recovery", () => {
       >,
     });
 
-    return { allocationRouter, allocationState, params, repoStore, service };
+    return {
+      allocationRouter,
+      allocationState,
+      params,
+      preparedSurfaceStamps,
+      repoStore,
+      service,
+    };
   }
 
   test("acknowledges restored history before sending the frame that spawns the supervisor", async () => {
-    const { allocationRouter, params, service } =
+    const { allocationRouter, params, preparedSurfaceStamps, service } =
       await createPreparedDeployFixture();
 
     await service.deployPreparedWorkflowDefinition(params);
@@ -1699,6 +1777,17 @@ describe("deployPreparedWorkflowDefinition recovery", () => {
     const spawnIndex = methods.indexOf("sendAgentDeployToAllocation");
     expect(restoreIndex).toBeGreaterThanOrEqual(0);
     expect(spawnIndex).toBeGreaterThan(restoreIndex);
+
+    // The prepared deploy stamps the version's approved grant surface too --
+    // its own runtime-enforced surface, since the recovered definition has no
+    // childWorkflow steps. This proves the prepared path resolves the anchor's
+    // definition and stamps the folded surface, not just the supervisor key.
+    const { definition } = params;
+    expect(preparedSurfaceStamps).toEqual([
+      flattenWalkToSurface(
+        walkCapabilities(definition, createDefaultDirectorRegistry()),
+      ),
+    ]);
   });
 
   test("does not stage or spawn the workflow when history restoration fails", async () => {

--- a/packages/hub-sessions/src/session-service.ts
+++ b/packages/hub-sessions/src/session-service.ts
@@ -15,6 +15,7 @@ import {
 import {
   buildCredentialDelivery,
   listAssetsForTenant,
+  writeApprovedGrantSurface,
   type DB,
 } from "@intx/db";
 import {
@@ -25,9 +26,17 @@ import {
 } from "@intx/db/schema";
 import { base64Encode, hexEncode } from "@intx/types";
 import type { CredentialDelivery } from "@intx/types/sidecar";
-import type { CredentialCipher } from "@intx/types";
+import type { ApprovedGrantSurface, CredentialCipher } from "@intx/types";
 import { generateId } from "@intx/hub-common";
-import { ensureWorkflowDefinitionForAsset } from "./workflow-definition-ensure";
+import {
+  ensureWorkflowDefinitionForAsset,
+  INITIAL_WORKFLOW_DEFINITION_VERSION,
+} from "./workflow-definition-ensure";
+import {
+  enumerateChildWorkflowRefs,
+  mergeGrantSurfaces,
+  resolveChildWorkflowSurface,
+} from "./child-workflow-fold";
 import { sessionAsset as sessionAssetTable } from "@intx/db/schema";
 import type {
   CryptoProvider,
@@ -65,6 +74,7 @@ import {
   createWorkflowDeployOrchestrator,
   deriveRunAddress,
   enumerateInertOnTriggerBodies,
+  flattenWalkToSurface,
   pickStepInferenceSource,
   walkCapabilities,
   wrapHarnessAsSingleStepWorkflow,
@@ -1495,6 +1505,44 @@ export function createSessionService(
     };
   }
 
+  // Fold a definition's own runtime-enforced surface with its direct children's
+  // already-approved surfaces -- the composite approval-of-record a deploy
+  // stamps on the version row and the runtime ceiling reads back. Walks the
+  // definition itself (a cheap, deterministic re-walk) so a caller needs only
+  // the definition, its asset id, and the tenant. A definition with no
+  // childWorkflow steps needs no asset resolution and never touches the fold
+  // deps; one that references children requires `assetService` and `db`, whose
+  // absence is a deploy-time configuration error surfaced loudly here rather
+  // than a null-surface guard trip at run time.
+  async function computePinnedSurface(args: {
+    definition: WorkflowDefinition;
+    definitionAssetId: string;
+    tenantId: string;
+  }): Promise<ApprovedGrantSurface> {
+    const walk = walkCapabilities(
+      args.definition,
+      createDefaultDirectorRegistry(),
+    );
+    const ownSurface = flattenWalkToSurface(walk);
+    if (enumerateChildWorkflowRefs(args.definition).length === 0) {
+      return ownSurface;
+    }
+    if (assetService === undefined || db === undefined) {
+      throw new Error(
+        "workflow deploy: a workflow with childWorkflow steps requires an asset service and db handle to fold its children's approved grant surfaces",
+      );
+    }
+    const childContribution = await resolveChildWorkflowSurface(
+      {
+        definition: args.definition,
+        deployingAssetId: args.definitionAssetId,
+        tenantId: args.tenantId,
+      },
+      { db, assetService },
+    );
+    return mergeGrantSurfaces(ownSurface, childContribution);
+  }
+
   async function deployWorkflowDefinition(
     params: DeployWorkflowDefinitionParams,
   ): Promise<DeployWorkflowDefinitionResult> {
@@ -1506,6 +1554,14 @@ export function createSessionService(
       definitionAssetId,
       config,
     } = params;
+    // Fold the child surfaces before the deploy frame goes out, so an
+    // unresolved/unapproved/cross-tenant child aborts the deploy rather than
+    // shipping an uncovered childWorkflow.
+    const pinnedSurface = await computePinnedSurface({
+      definition,
+      definitionAssetId,
+      tenantId,
+    });
     const result = await executeWorkflowDefinitionDeploy(params);
 
     if (db === undefined) {
@@ -1527,6 +1583,14 @@ export function createSessionService(
         assetId: definitionAssetId,
         wireHash,
       });
+      // Stamp the pinned surface on the version this deploy just created, in
+      // the same transaction, so the row is never live-and-surface-less.
+      await writeApprovedGrantSurface(
+        tx,
+        definitionId,
+        INITIAL_WORKFLOW_DEFINITION_VERSION,
+        pinnedSurface,
+      );
 
       // The deployment's anchor run: the one workflow_run that carries the
       // deployment's routing identity, 1:1 with the deployment (id and address
@@ -1583,6 +1647,53 @@ export function createSessionService(
         "deployPreparedWorkflowDefinition requires a db handle to update the prepared anchor run",
       );
     }
+    // Stamp the pinned surface before anything can make the prepared anchor a
+    // trigger-routable recipient -- ahead of both the allocation restore and
+    // the deploy frame. The anchor and its version row were born at prepare
+    // (born "deployed"), but prepare has no asset service to fold children
+    // with, so the surface is stamped here. Stamping this early closes any
+    // window in which a trigger could reach the null-surface guard against a
+    // routable-but-unstamped childWorkflow deployment, and folds before the
+    // deploy commits, so an unresolved child aborts before the allocation is
+    // touched. The prepared params omit the asset id, so resolve it from the
+    // anchor's definition. The surface is a pure function of the definition, so
+    // the standalone stamp is idempotent under a retry.
+    const preparedAnchor = await db.query.workflowRun.findFirst({
+      where: eq(workflowRunTable.id, params.anchorRunId),
+      columns: { definitionId: true },
+    });
+    if (preparedAnchor === undefined || preparedAnchor.definitionId === null) {
+      throw new Error(
+        `deployPreparedWorkflowDefinition: prepared anchor ${params.anchorRunId} has no definition to stamp`,
+      );
+    }
+    const preparedDefinitionId = preparedAnchor.definitionId;
+    const preparedDefinitionAsset = await db.query.workflowDefinition.findFirst(
+      {
+        where: eq(workflowDefinitionTable.id, preparedDefinitionId),
+        columns: { assetId: true },
+      },
+    );
+    if (
+      preparedDefinitionAsset === undefined ||
+      preparedDefinitionAsset.assetId === null
+    ) {
+      throw new Error(
+        `deployPreparedWorkflowDefinition: definition ${preparedDefinitionId} has no asset to fold child surfaces against`,
+      );
+    }
+    const pinnedSurface = await computePinnedSurface({
+      definition: params.definition,
+      definitionAssetId: preparedDefinitionAsset.assetId,
+      tenantId: params.tenantId,
+    });
+    await writeApprovedGrantSurface(
+      db,
+      preparedDefinitionId,
+      INITIAL_WORKFLOW_DEFINITION_VERSION,
+      pinnedSurface,
+    );
+
     await restoreWorkflowRunToAllocation({
       agentRepoStore,
       allocationRouter: requireAllocationRouter(),

--- a/packages/hub-sessions/src/workflow-definition-ensure.ts
+++ b/packages/hub-sessions/src/workflow-definition-ensure.ts
@@ -12,6 +12,13 @@ import {
 } from "@intx/db/schema";
 import { generateId } from "@intx/hub-common";
 
+// The version this projection creates. A native workflow deploy mints exactly
+// one version per definition; a rollback can later repoint `currentVersion` to
+// another version, but the version born here is always this. The deploy stamp
+// sites (approved wire hash, approved grant surface) reference this same
+// constant so the write version can never drift from the created one.
+export const INITIAL_WORKFLOW_DEFINITION_VERSION = "1";
+
 /**
  * The first-class `workflow_definition` a selector names, created if absent. A
  * native workflow carries its body in the asset it points at, so this only
@@ -84,7 +91,7 @@ export async function ensureWorkflowDefinitionForAsset(
     .values({
       id: generateId("workflowDefinitionVersion"),
       definitionId,
-      version: "1",
+      version: INITIAL_WORKFLOW_DEFINITION_VERSION,
     })
     .onConflictDoNothing({
       target: [

--- a/packages/hub-sessions/src/workflow-kind.ts
+++ b/packages/hub-sessions/src/workflow-kind.ts
@@ -25,6 +25,7 @@ import { type } from "arktype";
 import { getLogger } from "@intx/log";
 import { CredentialBinding, GrantRequirement } from "@intx/types";
 import { glob, repoActionToGrantVerb } from "@intx/hub-common";
+import type { WorkflowDefinition } from "@intx/workflow/definition";
 import {
   UserPrincipal,
   type AuthorizeFn,
@@ -32,6 +33,7 @@ import {
   type Principal,
   type ValidatePushResult,
 } from "./repo-store";
+import type { AssetService } from "./asset-service";
 
 const logger = getLogger(["hub-sessions", "workflow-kind"]);
 
@@ -108,6 +110,41 @@ export const workflowDefinitionEnvelopeSchema = type({
   // passed through to launch-time resolution unchecked.
   "credentialBindings?": CredentialBinding.array(),
 }).onUndeclaredKey("ignore");
+
+/**
+ * Read and hydrate the workflow definition from a workflow asset's
+ * `workflow.json`. Validates the structural envelope at this boundary,
+ * mirroring the workflow-host child's `loadWorkflowDefinition`: the
+ * per-primitive narrows live in the runtime layer that consumes the
+ * definition, so the envelope check plus the documented narrow is the
+ * canonical hydration shape.
+ */
+export async function hydrateDefinition(
+  assetService: AssetService,
+  assetId: string,
+): Promise<WorkflowDefinition> {
+  const raw = await assetService.readAssetBlob({
+    assetId,
+    path: WORKFLOW_JSON_PATH,
+  });
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(raw));
+  } catch (cause) {
+    throw new Error(
+      `workflow asset ${assetId} ${WORKFLOW_JSON_PATH} is not valid JSON`,
+      { cause },
+    );
+  }
+  const validated = workflowDefinitionEnvelopeSchema(parsed);
+  if (validated instanceof type.errors) {
+    throw new Error(
+      `workflow asset ${assetId} ${WORKFLOW_JSON_PATH} failed envelope validation: ${validated.summary}`,
+    );
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- envelope schema enforces structural shape; per-primitive narrows live in the runtime layer that consumes the definition, matching loadWorkflowDefinition in @intx/workflow-host
+  return validated as unknown as WorkflowDefinition;
+}
 
 /**
  * Capability-declarations.json is held to "is a JSON object" at this

--- a/packages/types/src/grants.ts
+++ b/packages/types/src/grants.ts
@@ -114,14 +114,18 @@ export const GrantRequirement = type({
 export type GrantRequirement = typeof GrantRequirement.infer;
 
 // The transitively-folded approved grant surface for one workflow definition
-// version: the deployment-flattened union of the definition's own walked grants
-// and its direct children's pinned surfaces. `grants` is the flat set of grant
-// strings a run's ceiling authorizes; `grantEffects` maps a `tool:` grant to
-// its resolved effect. This is the serialized shape -- `grantEffects` is a
-// plain object, not a `Map`, because a `Map` serializes to `{}` under
-// `JSON.stringify` and would drop every effect. Producers convert their
-// `ReadonlyMap<string, GrantEffect>` to this object form at the boundary; a
-// consumer wanting a `Map` rebuilds one from the entries.
+// version: the deployment-flattened union of the definition's own
+// runtime-enforced grants and its direct children's pinned surfaces. It carries
+// only the grants a run's ceiling materializes and gates fail-closed -- the
+// `tool:` and `effect:` grants -- not the walk's approval-surface-only grants
+// (director/capability/inference.source/mail.*). `grants` is the flat set of
+// those grant strings; `grantEffects` maps each to its resolved effect (`ask`
+// for an approval-gated tool, `allow` otherwise; an `effect:` grant is always
+// `allow`). This is the serialized shape -- `grantEffects` is a plain object,
+// not a `Map`, because a `Map` serializes to `{}` under `JSON.stringify` and
+// would drop every effect. Producers convert their `ReadonlyMap<string,
+// GrantEffect>` to this object form at the boundary; a consumer wanting a `Map`
+// rebuilds one from the entries.
 export const ApprovedGrantSurface = type({
   grants: "string[]",
   grantEffects: { "[string]": Effect },

--- a/packages/types/src/grants.ts
+++ b/packages/types/src/grants.ts
@@ -112,3 +112,18 @@ export const GrantRequirement = type({
   "conditions?": "Record<string, unknown> | null",
 });
 export type GrantRequirement = typeof GrantRequirement.infer;
+
+// The transitively-folded approved grant surface for one workflow definition
+// version: the deployment-flattened union of the definition's own walked grants
+// and its direct children's pinned surfaces. `grants` is the flat set of grant
+// strings a run's ceiling authorizes; `grantEffects` maps a `tool:` grant to
+// its resolved effect. This is the serialized shape -- `grantEffects` is a
+// plain object, not a `Map`, because a `Map` serializes to `{}` under
+// `JSON.stringify` and would drop every effect. Producers convert their
+// `ReadonlyMap<string, GrantEffect>` to this object form at the boundary; a
+// consumer wanting a `Map` rebuilds one from the entries.
+export const ApprovedGrantSurface = type({
+  grants: "string[]",
+  grantEffects: { "[string]": Effect },
+});
+export type ApprovedGrantSurface = typeof ApprovedGrantSurface.infer;

--- a/packages/workflow-deploy/src/capability-walk.test.ts
+++ b/packages/workflow-deploy/src/capability-walk.test.ts
@@ -20,7 +20,13 @@ import {
   type WorkflowDefinition,
 } from "@intx/workflow/definition";
 
-import { DuplicateWalkToolError, walkCapabilities } from "./capability-walk";
+import {
+  DuplicateWalkToolError,
+  flattenWalkToSurface,
+  resolveRuntimeGrantEffects,
+  walkCapabilities,
+  type CapabilityWalkResult,
+} from "./capability-walk";
 
 // A synthetic mail factory that declares one tool, `mail_send`. The walk
 // keys `tool:` grants on each declared definition name (not on the
@@ -516,6 +522,78 @@ describe("walkCapabilities", () => {
 
     expect(() => walkCapabilities(workflow, registry)).toThrow(
       DuplicateWalkToolError,
+    );
+  });
+});
+
+describe("flattenWalkToSurface", () => {
+  test("projects only the runtime-enforced tool/effect grants with effects", () => {
+    const registry = createDefaultDirectorRegistry();
+    const agent = defineAgent({
+      id: "ag_surface",
+      systemPrompt: "gated + ungated tools",
+      tools: [
+        makeFactory("@intx/tools-posix/sidecar-bundle", [
+          { name: "run_shell", approval: "ask" },
+          { name: "list_dir" },
+        ]),
+      ],
+      capabilities: [],
+      inference: { sources: [{ provider: "anthropic", model: "mock-model" }] },
+    });
+    const workflow = defineWorkflow({
+      id: "wf_surface",
+      trigger: { type: "manual" },
+      steps: {
+        run: step({ agent }),
+        commit: action({
+          handler: "commit",
+          effect: { requires: ["git:commit"] },
+          after: ["run"],
+        }),
+      },
+    });
+
+    const surface = flattenWalkToSurface(walkCapabilities(workflow, registry));
+
+    expect(surface.grants).toEqual([
+      "effect:git:commit",
+      "tool:list_dir",
+      "tool:run_shell",
+    ]);
+    expect(surface.grantEffects).toEqual({
+      "tool:run_shell": "ask",
+      "tool:list_dir": "allow",
+      "effect:git:commit": "allow",
+    });
+    // director:/inference.source: grants are approval-surface only, never
+    // runtime-enforced, so they do not appear in the flattened surface.
+    expect(surface.grants.some((g) => g.startsWith("director:"))).toBe(false);
+    expect(surface.grants.some((g) => g.startsWith("inference.source:"))).toBe(
+      false,
+    );
+  });
+});
+
+describe("resolveRuntimeGrantEffects", () => {
+  test("throws when a tool grant carries no effect entry", () => {
+    // A hand-built walk whose grants and grantEffects have diverged: a
+    // defaulted allow here would silently downgrade an ask tool, so this must
+    // fail loud.
+    const walk: CapabilityWalkResult = {
+      perStep: new Map([
+        [
+          "s",
+          {
+            grants: ["tool:orphan"],
+            grantEffects: new Map(),
+          },
+        ],
+      ]),
+      unresolvedDirectors: [],
+    };
+    expect(() => resolveRuntimeGrantEffects(walk)).toThrow(
+      /has no grantEffects entry/,
     );
   });
 });

--- a/packages/workflow-deploy/src/capability-walk.ts
+++ b/packages/workflow-deploy/src/capability-walk.ts
@@ -56,7 +56,7 @@ import {
   toolApprovalEffect,
   UnknownDirectorIdError,
 } from "@intx/agent";
-import type { GrantEffect } from "@intx/types";
+import type { ApprovedGrantSurface, GrantEffect } from "@intx/types";
 import type { WorkflowDefinition } from "@intx/workflow/definition";
 
 /**
@@ -395,4 +395,79 @@ export class DuplicateWalkToolError extends Error {
     this.toolName = toolName;
     this.factoryId = factoryId;
   }
+}
+
+// The runtime-enforced grant prefixes. `tool:<name>` and `effect:<cap>` are the
+// only grants a workflow run's ceiling materializes and gates fail-closed; the
+// walk's other grants (director/capability/inference.source/mail.*) are
+// approval-surface only and carry no runtime row.
+const TOOL_GRANT_PREFIX = "tool:";
+const EFFECT_GRANT_PREFIX = "effect:";
+
+/**
+ * Resolve a walk into the effect each runtime-enforced grant carries: the
+ * `tool:<name>` and `effect:<cap>` grants a run's ceiling materializes. This is
+ * the single owner of that projection -- both the run-grant materializer (which
+ * turns it into grant rows) and the child-workflow fold (which turns it into a
+ * stored surface) read it, so a parent's pinned surface can never disagree with
+ * the runtime ceiling it is meant to equal.
+ *
+ * A `tool:` grant carries the effect its static declaration requested via the
+ * walk's `grantEffects` map (`ask` for an approval-gated tool, `allow`
+ * otherwise); a tool in more than one step resolves ask-wins so an approval
+ * gate is never downgraded. A missing entry is a walk-invariant violation --
+ * `grants` and `grantEffects` diverged -- and throws rather than defaulting to
+ * `allow`, which would silently downgrade an `ask` tool. An `effect:` grant is
+ * always `allow` (the capability floor an action needs has no ask/allow
+ * distinction) and is not routed through `grantEffects`. Every other grant is
+ * not runtime-enforced and is skipped.
+ */
+export function resolveRuntimeGrantEffects(
+  walk: CapabilityWalkResult,
+): Map<string, GrantEffect> {
+  const effectByResource = new Map<string, GrantEffect>();
+  for (const declarations of walk.perStep.values()) {
+    for (const grant of declarations.grants) {
+      if (grant.startsWith(TOOL_GRANT_PREFIX)) {
+        const effect = declarations.grantEffects.get(grant);
+        if (effect === undefined) {
+          throw new Error(
+            `resolveRuntimeGrantEffects: tool grant ${JSON.stringify(grant)} has no grantEffects entry; the capability walk must emit an effect for every tool grant`,
+          );
+        }
+        const existing = effectByResource.get(grant);
+        if (existing === "ask" || effect === "ask") {
+          effectByResource.set(grant, "ask");
+        } else if (existing === undefined) {
+          effectByResource.set(grant, effect);
+        }
+      } else if (grant.startsWith(EFFECT_GRANT_PREFIX)) {
+        if (!effectByResource.has(grant)) {
+          effectByResource.set(grant, "allow");
+        }
+      }
+    }
+  }
+  return effectByResource;
+}
+
+/**
+ * Flatten a walk into the deployment-wide runtime-enforced grant surface: the
+ * `tool:`/`effect:` grants and their resolved effects. Grants are sorted for a
+ * deterministic stored value. This is the own-surface half of a definition's
+ * pinned surface; the child-workflow fold unions it with its children's stored
+ * surfaces.
+ */
+export function flattenWalkToSurface(
+  walk: CapabilityWalkResult,
+): ApprovedGrantSurface {
+  const effectByResource = resolveRuntimeGrantEffects(walk);
+  const grantEffects: Record<string, GrantEffect> = {};
+  for (const [resource, effect] of effectByResource) {
+    grantEffects[resource] = effect;
+  }
+  return {
+    grants: [...effectByResource.keys()].sort(),
+    grantEffects,
+  };
 }

--- a/packages/workflow-deploy/src/index.ts
+++ b/packages/workflow-deploy/src/index.ts
@@ -13,6 +13,8 @@
 
 export {
   walkCapabilities,
+  resolveRuntimeGrantEffects,
+  flattenWalkToSurface,
   type CapabilityWalkResult,
   type GrantDeclarations,
 } from "./capability-walk";

--- a/tests/db/approved-surface-write-read-seam.test.ts
+++ b/tests/db/approved-surface-write-read-seam.test.ts
@@ -1,0 +1,128 @@
+// The write->read seam for the approved grant surface, on a real DB.
+//
+// This is the feature's core R2 invariant: the surface a deploy STAMPS is the
+// surface run materialization READS, at the same (definitionId, version) key.
+// A deploy creates the version row via `ensureWorkflowDefinitionForAsset` (at
+// INITIAL_WORKFLOW_DEFINITION_VERSION) and stamps it via
+// `writeApprovedGrantSurface` (at the same constant); a run reads it via
+// `readApprovedGrantSurface` at the definition's currentVersion. This test runs
+// exactly those functions against a real Postgres so the real UPDATE query and
+// the key round-trip are executed -- not mocked. The stamp-site unit test uses
+// a mocked DB whose UPDATE returns a row regardless of key match, so it cannot
+// catch a key mismatch; this test does, because `writeApprovedGrantSurface`'s
+// one-row assertion runs against real rows.
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+import { readApprovedGrantSurface, writeApprovedGrantSurface } from "@intx/db";
+import { workflowDefinition } from "@intx/db/schema";
+import {
+  ensureWorkflowDefinitionForAsset,
+  INITIAL_WORKFLOW_DEFINITION_VERSION,
+} from "@intx/hub-sessions";
+import type { ApprovedGrantSurface } from "@intx/types";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import { seedAsset, seedPrincipal, seedTenants } from "@intx/test-harness/seed";
+
+const TENANT = "tnt";
+const ASSET = "ast_wf";
+const CREATOR = "prn_creator";
+const WIRE_HASH = "wirehash_seam";
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "approved grant surface write->read seam (real DB)",
+  () => {
+    let h: TestDb;
+
+    beforeAll(async () => {
+      h = await createTestDb();
+    });
+    afterAll(async () => {
+      await h.close();
+    });
+    beforeEach(async () => {
+      await h.reset();
+      await seedTenants(h.db, [{ id: TENANT }]);
+      await seedPrincipal(h.db, {
+        id: CREATOR,
+        tenantId: TENANT,
+        kind: "user",
+        refId: "creator",
+      });
+      await seedAsset(h.db, {
+        id: ASSET,
+        tenantId: TENANT,
+        kind: "workflow",
+        name: ASSET,
+        creatorPrincipalId: CREATOR,
+      });
+    });
+
+    test("a surface stamped at the version a deploy creates reads back at currentVersion", async () => {
+      // The version row is born the way a deploy creates it.
+      const { definitionId } = await ensureWorkflowDefinitionForAsset(h.db, {
+        assetId: ASSET,
+        wireHash: WIRE_HASH,
+      });
+
+      // Stamped the way a deploy stamps it: the real UPDATE, keyed to the same
+      // constant the version was created with. Its one-row assertion runs
+      // against a real row here.
+      const surface: ApprovedGrantSurface = {
+        grants: ["tool:child_do", "effect:child_cap"],
+        grantEffects: { "tool:child_do": "ask", "effect:child_cap": "allow" },
+      };
+      await writeApprovedGrantSurface(
+        h.db,
+        definitionId,
+        INITIAL_WORKFLOW_DEFINITION_VERSION,
+        surface,
+      );
+
+      // Read the way run materialization reads it: at the definition's
+      // currentVersion, which is the version the row was born with.
+      const definition = await h.db.query.workflowDefinition.findFirst({
+        where: eq(workflowDefinition.id, definitionId),
+      });
+      if (definition === undefined) {
+        throw new Error("definition row missing after ensure");
+      }
+      const readBack = await readApprovedGrantSurface(
+        h.db,
+        definitionId,
+        definition.currentVersion,
+      );
+      expect(readBack).toEqual(surface);
+      // The write key and the read key are the same value -- the seam holds.
+      expect(definition.currentVersion).toBe(
+        INITIAL_WORKFLOW_DEFINITION_VERSION,
+      );
+    });
+
+    test("stamping a version that does not exist fails the one-row assertion", async () => {
+      // The failure mode the mocked stamp-site test cannot catch: a key that
+      // matches zero rows. Against a real DB, writeApprovedGrantSurface refuses.
+      const { definitionId } = await ensureWorkflowDefinitionForAsset(h.db, {
+        assetId: ASSET,
+        wireHash: WIRE_HASH,
+      });
+      const surface: ApprovedGrantSurface = { grants: [], grantEffects: {} };
+      await expect(
+        writeApprovedGrantSurface(h.db, definitionId, "999", surface),
+      ).rejects.toThrow(/expected exactly one version row/);
+    });
+  },
+);

--- a/tests/db/child-workflow-fold.test.ts
+++ b/tests/db/child-workflow-fold.test.ts
@@ -1,0 +1,454 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import { seedAsset, seedPrincipal, seedTenants } from "@intx/test-harness/seed";
+import { workflowDefinition, workflowDefinitionVersion } from "@intx/db/schema";
+import {
+  resolveChildWorkflowSurface,
+  ChildWorkflowSelfReferenceError,
+  ChildWorkflowNotFoundError,
+  ChildWorkflowKindError,
+  ChildWorkflowNotApprovedError,
+  type AssetService,
+} from "@intx/hub-sessions";
+import {
+  childWorkflow,
+  defineWorkflow,
+  sleep,
+  step,
+  type WorkflowDefinition,
+} from "@intx/workflow/definition";
+import { computeLiveDefinitionHash, projectLiveToInert } from "@intx/workflow";
+import { defineAgent } from "@intx/agent";
+import type { ApprovedGrantSurface } from "@intx/types";
+
+const TENANT = "tnt_root";
+const OTHER_TENANT = "tnt_other";
+const CREATOR = "prn_creator";
+const PARENT_ASSET = "ast_parent";
+
+/** A mock asset service that serves canned workflow.json blobs by asset id and
+ * records which assets were read, so a test can assert the fold never touches a
+ * grandchild's asset. */
+function mockAssetService(blobs: Record<string, string>): {
+  service: AssetService;
+  reads: string[];
+} {
+  const reads: string[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- only readAssetBlob is exercised by the fold
+  const service = {
+    readAssetBlob: async (params: { assetId: string; path: string }) => {
+      reads.push(params.assetId);
+      const json = blobs[params.assetId];
+      if (json === undefined) {
+        throw new Error(`mock: no blob for asset ${params.assetId}`);
+      }
+      return new TextEncoder().encode(json);
+    },
+  } as unknown as AssetService;
+  return { service, reads };
+}
+
+/** A minimal child definition with no agent step. */
+function childDefinition(id: string): WorkflowDefinition {
+  return defineWorkflow({
+    id,
+    trigger: { type: "manual" },
+    steps: { wait: sleep({ duration: 1 }) },
+  });
+}
+
+/** A child whose step carries an agent, so its inert workflow.json exercises
+ * the agent-bearing projection -- the shape `computeLiveDefinitionHash` would
+ * throw on and `computeWireDefinitionHash` must hash. */
+function agentChildDefinition(id: string): WorkflowDefinition {
+  return defineWorkflow({
+    id,
+    trigger: { type: "manual" },
+    steps: {
+      run: step({
+        agent: defineAgent({
+          id: `${id}-agent`,
+          systemPrompt: "s",
+          tools: [],
+          capabilities: [],
+          inference: { sources: [{ provider: "anthropic", model: "m" }] },
+        }),
+      }),
+    },
+  });
+}
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "resolveChildWorkflowSurface (real DB)",
+  () => {
+    let h: TestDb;
+
+    beforeAll(async () => {
+      h = await createTestDb();
+    });
+
+    afterAll(async () => {
+      await h.close();
+    });
+
+    beforeEach(async () => {
+      await h.reset();
+      await seedTenants(h.db, [{ id: TENANT }, { id: OTHER_TENANT }]);
+      await seedPrincipal(h.db, {
+        id: CREATOR,
+        tenantId: TENANT,
+        kind: "user",
+        refId: "creator",
+      });
+    });
+
+    /**
+     * Seed a deployed, approved child: its workflow asset, a definition row
+     * keyed by the content hash of `def`, and a version stamped with `surface`.
+     * Returns the child's `workflow.json` blob so the caller wires the mock
+     * asset service.
+     */
+    async function seedApprovedChild(args: {
+      assetId: string;
+      definitionId: string;
+      def: WorkflowDefinition;
+      surface: ApprovedGrantSurface | null;
+      tenantId?: string;
+      version?: string;
+      currentVersion?: string;
+    }): Promise<string> {
+      const tenantId = args.tenantId ?? TENANT;
+      const version = args.version ?? "1";
+      await seedAsset(h.db, {
+        id: args.assetId,
+        tenantId,
+        kind: "workflow",
+        name: args.assetId,
+        creatorPrincipalId: CREATOR,
+      });
+      // The stored wire hash keys on the live definition's projection; the
+      // blob is the inert projection that production writes to workflow.json,
+      // so the fold's `computeWireDefinitionHash(blob)` reproduces this hash.
+      const wireHash = await computeLiveDefinitionHash(args.def);
+      await h.db.insert(workflowDefinition).values({
+        id: args.definitionId,
+        tenantId,
+        name: args.assetId,
+        assetId: args.assetId,
+        wireHash,
+        currentVersion: args.currentVersion ?? version,
+      });
+      await h.db.insert(workflowDefinitionVersion).values({
+        id: `wdv_${args.definitionId}_${version}`,
+        definitionId: args.definitionId,
+        version,
+        approvedGrantSurface: args.surface,
+      });
+      return JSON.stringify(projectLiveToInert(args.def));
+    }
+
+    function parentWith(refs: string[]): WorkflowDefinition {
+      const steps: Record<string, ReturnType<typeof childWorkflow>> = {};
+      refs.forEach((ref, i) => {
+        steps[`c${String(i)}`] = childWorkflow({ definitionRef: ref });
+      });
+      return defineWorkflow({
+        id: "parent",
+        trigger: { type: "manual" },
+        steps,
+      });
+    }
+
+    test("folds a resolved child's stored surface, landing on the stored row", async () => {
+      const def = childDefinition("child");
+      const surface: ApprovedGrantSurface = {
+        grants: ["tool:search"],
+        grantEffects: { "tool:search": "ask" },
+      };
+      const blob = await seedApprovedChild({
+        assetId: "ast_child",
+        definitionId: "wfd_child",
+        def,
+        surface,
+      });
+      const { service } = mockAssetService({ ast_child: blob });
+
+      const folded = await resolveChildWorkflowSurface(
+        {
+          definition: parentWith(["ast_child"]),
+          deployingAssetId: PARENT_ASSET,
+          tenantId: TENANT,
+        },
+        { db: h.db, assetService: service },
+      );
+      expect(folded).toEqual(surface);
+    });
+
+    test("resolves an agent-bearing child from its inert workflow.json", async () => {
+      // The representative case: a child with an agent step, whose workflow.json
+      // is the inert projection. Resolution must hash that projection with
+      // computeWireDefinitionHash and land on the stored row -- re-projecting it
+      // would throw.
+      const def = agentChildDefinition("agent-child");
+      // Grants are stored sorted; the fold returns the surface sorted too.
+      const surface: ApprovedGrantSurface = {
+        grants: ["inference.source:anthropic:m", "tool:do"],
+        grantEffects: { "tool:do": "ask" },
+      };
+      const blob = await seedApprovedChild({
+        assetId: "ast_child",
+        definitionId: "wfd_child",
+        def,
+        surface,
+      });
+      const { service } = mockAssetService({ ast_child: blob });
+
+      const folded = await resolveChildWorkflowSurface(
+        {
+          definition: parentWith(["ast_child"]),
+          deployingAssetId: PARENT_ASSET,
+          tenantId: TENANT,
+        },
+        { db: h.db, assetService: service },
+      );
+      expect(folded).toEqual(surface);
+    });
+
+    test("reads the child's stored surface transitively, never a grandchild", async () => {
+      // The child's stored surface already contains a grandchild's grant. The
+      // parent must union it by reading the child's surface alone -- it must
+      // never resolve the grandchild.
+      const def = childDefinition("child");
+      const surface: ApprovedGrantSurface = {
+        grants: ["tool:child", "tool:grandchild"],
+        grantEffects: { "tool:child": "allow", "tool:grandchild": "ask" },
+      };
+      const blob = await seedApprovedChild({
+        assetId: "ast_child",
+        definitionId: "wfd_child",
+        def,
+        surface,
+      });
+      const { service, reads } = mockAssetService({ ast_child: blob });
+
+      const folded = await resolveChildWorkflowSurface(
+        {
+          definition: parentWith(["ast_child"]),
+          deployingAssetId: PARENT_ASSET,
+          tenantId: TENANT,
+        },
+        { db: h.db, assetService: service },
+      );
+      expect(folded.grants).toEqual(["tool:child", "tool:grandchild"]);
+      expect(folded.grantEffects["tool:grandchild"]).toBe("ask");
+      expect(reads).toEqual(["ast_child"]);
+    });
+
+    test("reads the surface at current_version, not the literal 1", async () => {
+      const def = childDefinition("child");
+      const v2Surface: ApprovedGrantSurface = {
+        grants: ["tool:v2"],
+        grantEffects: {},
+      };
+      const blob = await seedApprovedChild({
+        assetId: "ast_child",
+        definitionId: "wfd_child",
+        def,
+        surface: v2Surface,
+        version: "2",
+        currentVersion: "2",
+      });
+      // A version "1" exists too, with a different surface; reading it would
+      // fold the wrong grants.
+      await h.db.insert(workflowDefinitionVersion).values({
+        id: "wdv_child_1",
+        definitionId: "wfd_child",
+        version: "1",
+        approvedGrantSurface: { grants: ["tool:v1"], grantEffects: {} },
+      });
+      const { service } = mockAssetService({ ast_child: blob });
+
+      const folded = await resolveChildWorkflowSurface(
+        {
+          definition: parentWith(["ast_child"]),
+          deployingAssetId: PARENT_ASSET,
+          tenantId: TENANT,
+        },
+        { db: h.db, assetService: service },
+      );
+      expect(folded.grants).toEqual(["tool:v2"]);
+    });
+
+    test("unions multiple children and folds a repeated ref once", async () => {
+      const defA = childDefinition("child-a");
+      const defB = childDefinition("child-b");
+      const blobA = await seedApprovedChild({
+        assetId: "ast_a",
+        definitionId: "wfd_a",
+        def: defA,
+        surface: { grants: ["tool:a"], grantEffects: { "tool:a": "allow" } },
+      });
+      const blobB = await seedApprovedChild({
+        assetId: "ast_b",
+        definitionId: "wfd_b",
+        def: defB,
+        surface: { grants: ["tool:b"], grantEffects: { "tool:b": "ask" } },
+      });
+      const { service, reads } = mockAssetService({
+        ast_a: blobA,
+        ast_b: blobB,
+      });
+
+      const folded = await resolveChildWorkflowSurface(
+        {
+          definition: parentWith(["ast_a", "ast_b", "ast_a"]),
+          deployingAssetId: PARENT_ASSET,
+          tenantId: TENANT,
+        },
+        { db: h.db, assetService: service },
+      );
+      expect(folded).toEqual({
+        grants: ["tool:a", "tool:b"],
+        grantEffects: { "tool:a": "allow", "tool:b": "ask" },
+      });
+      // ast_a appears twice in the parent but is resolved once.
+      expect(reads.filter((id) => id === "ast_a")).toHaveLength(1);
+    });
+
+    test("yields an empty surface for a parent with no childWorkflow steps", async () => {
+      const { service, reads } = mockAssetService({});
+      const folded = await resolveChildWorkflowSurface(
+        {
+          definition: defineWorkflow({
+            id: "parent",
+            trigger: { type: "manual" },
+            steps: { wait: sleep({ duration: 1 }) },
+          }),
+          deployingAssetId: PARENT_ASSET,
+          tenantId: TENANT,
+        },
+        { db: h.db, assetService: service },
+      );
+      expect(folded).toEqual({ grants: [], grantEffects: {} });
+      expect(reads).toEqual([]);
+    });
+
+    test("rejects a self-reference before any blob read", async () => {
+      const { service, reads } = mockAssetService({});
+      await expect(
+        resolveChildWorkflowSurface(
+          {
+            definition: parentWith([PARENT_ASSET]),
+            deployingAssetId: PARENT_ASSET,
+            tenantId: TENANT,
+          },
+          { db: h.db, assetService: service },
+        ),
+      ).rejects.toBeInstanceOf(ChildWorkflowSelfReferenceError);
+      expect(reads).toEqual([]);
+    });
+
+    test("rejects a cross-tenant ref without reading its blob", async () => {
+      const def = childDefinition("child");
+      // The child exists, but in another tenant.
+      const blob = await seedApprovedChild({
+        assetId: "ast_child",
+        definitionId: "wfd_child",
+        def,
+        surface: { grants: ["tool:x"], grantEffects: {} },
+        tenantId: OTHER_TENANT,
+      });
+      const { service, reads } = mockAssetService({ ast_child: blob });
+      await expect(
+        resolveChildWorkflowSurface(
+          {
+            definition: parentWith(["ast_child"]),
+            deployingAssetId: PARENT_ASSET,
+            tenantId: TENANT,
+          },
+          { db: h.db, assetService: service },
+        ),
+      ).rejects.toBeInstanceOf(ChildWorkflowNotFoundError);
+      expect(reads).toEqual([]);
+    });
+
+    test("rejects a ref to a non-workflow asset", async () => {
+      await seedAsset(h.db, {
+        id: "ast_skill",
+        tenantId: TENANT,
+        kind: "skill",
+        name: "a-skill",
+        creatorPrincipalId: CREATOR,
+      });
+      const { service } = mockAssetService({});
+      await expect(
+        resolveChildWorkflowSurface(
+          {
+            definition: parentWith(["ast_skill"]),
+            deployingAssetId: PARENT_ASSET,
+            tenantId: TENANT,
+          },
+          { db: h.db, assetService: service },
+        ),
+      ).rejects.toBeInstanceOf(ChildWorkflowKindError);
+    });
+
+    test("rejects a child that resolves but carries no approved surface", async () => {
+      const def = childDefinition("child");
+      const blob = await seedApprovedChild({
+        assetId: "ast_child",
+        definitionId: "wfd_child",
+        def,
+        surface: null,
+      });
+      const { service } = mockAssetService({ ast_child: blob });
+      await expect(
+        resolveChildWorkflowSurface(
+          {
+            definition: parentWith(["ast_child"]),
+            deployingAssetId: PARENT_ASSET,
+            tenantId: TENANT,
+          },
+          { db: h.db, assetService: service },
+        ),
+      ).rejects.toBeInstanceOf(ChildWorkflowNotApprovedError);
+    });
+
+    test("rejects a child whose content does not match any stored definition", async () => {
+      // The asset exists and is workflow-kind, but no definition row is keyed
+      // by the blob's content hash -- the child was never approved.
+      await seedAsset(h.db, {
+        id: "ast_child",
+        tenantId: TENANT,
+        kind: "workflow",
+        name: "child",
+        creatorPrincipalId: CREATOR,
+      });
+      const { service } = mockAssetService({
+        ast_child: JSON.stringify(childDefinition("child")),
+      });
+      await expect(
+        resolveChildWorkflowSurface(
+          {
+            definition: parentWith(["ast_child"]),
+            deployingAssetId: PARENT_ASSET,
+            tenantId: TENANT,
+          },
+          { db: h.db, assetService: service },
+        ),
+      ).rejects.toBeInstanceOf(ChildWorkflowNotApprovedError);
+    });
+  },
+);

--- a/tests/db/frozen-ceiling-staleness.test.ts
+++ b/tests/db/frozen-ceiling-staleness.test.ts
@@ -1,0 +1,196 @@
+// The mail materializer caches a per-deployment grant basis for the process
+// lifetime. The childWorkflow runtime ceiling is version-scoped and
+// `currentVersion` is mutable (a rollback repoints it), so the ceiling must be
+// read fresh each run, never frozen with the content-pure basis. This test
+// pins that: a later run of the same definition, after a rollback to a narrower
+// version, must materialize under the CURRENT version's surface -- not the
+// ceiling that a prior run froze at the superseded version.
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+import { createGrantStore, writeApprovedGrantSurface } from "@intx/db";
+import {
+  grant,
+  principal,
+  workflowDefinition,
+  workflowDefinitionVersion,
+  workflowRun,
+} from "@intx/db/schema";
+import type { ApprovedGrantSurface } from "@intx/types";
+import type { AssetService } from "@intx/hub-sessions";
+import { createMailTriggeredRunGrantsMaterializer } from "@intx/hub-api";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import {
+  seedAsset,
+  seedGrant,
+  seedPrincipal,
+  seedTenants,
+} from "@intx/test-harness/seed";
+
+const TENANT = "tnt";
+const ASSET = "ast";
+const DEFINITION = "wfd_real";
+const DEPLOYMENT = "run_real";
+const WORKFLOW_ADDRESS = "run_real@tenant.example";
+const CREATOR = "prn_creator";
+const RUN_A = "<mail-run-A@tenant.example>";
+const RUN_B = "<mail-run-B@tenant.example>";
+
+function childWorkflowParentJson(): string {
+  return JSON.stringify({
+    id: "wf_child_parent",
+    triggers: [{ type: "mail", to: WORKFLOW_ADDRESS }],
+    stepOrder: ["sub"],
+    steps: {
+      sub: {
+        kind: "childWorkflow",
+        id: "sub",
+        definitionRef: "ast_child",
+        drainBehavior: "cancel",
+      },
+    },
+  });
+}
+
+function mockAssetService(json: string): AssetService {
+  function notImpl(name: string): never {
+    throw new Error(`mock: assetService.${name} not implemented`);
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- only readAssetBlob is exercised by the materializer
+  return {
+    createAsset: () => notImpl("createAsset"),
+    populateAsset: () => notImpl("populateAsset"),
+    readAssetBlob: async () => new TextEncoder().encode(json),
+  } as unknown as AssetService;
+}
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "childWorkflow ceiling is read per run, not frozen across a rollback",
+  () => {
+    let h: TestDb;
+
+    beforeAll(async () => {
+      h = await createTestDb();
+    });
+    afterAll(async () => {
+      await h.close();
+    });
+
+    beforeEach(async () => {
+      await h.reset();
+      await seedTenants(h.db, [{ id: TENANT }]);
+      await seedPrincipal(h.db, {
+        id: CREATOR,
+        tenantId: TENANT,
+        kind: "user",
+        refId: "creator-user",
+      });
+      await seedAsset(h.db, {
+        id: ASSET,
+        tenantId: TENANT,
+        kind: "workflow",
+        name: ASSET,
+        creatorPrincipalId: CREATOR,
+      });
+      await h.db.insert(workflowDefinition).values({
+        id: DEFINITION,
+        tenantId: TENANT,
+        name: DEFINITION,
+        assetId: ASSET,
+        currentVersion: "1",
+      });
+      await h.db.insert(workflowRun).values({
+        id: DEPLOYMENT,
+        tenantId: TENANT,
+        anchorRunId: DEPLOYMENT,
+        definitionId: DEFINITION,
+        address: WORKFLOW_ADDRESS,
+        status: "running",
+      });
+      await seedGrant(h.db, {
+        id: "grt_creator_vault",
+        tenantId: TENANT,
+        principalId: CREATOR,
+        resource: "secret:vault",
+        action: "use",
+        effect: "allow",
+        origin: "creator",
+      });
+    });
+
+    test("a run after a rollback uses the current version's surface, not the frozen one", async () => {
+      // Version 1 carries broad child authority; version 2 (the current version
+      // after an operator rollback) carries narrow.
+      const broad: ApprovedGrantSurface = {
+        grants: ["tool:broad_tool"],
+        grantEffects: { "tool:broad_tool": "allow" },
+      };
+      const narrow: ApprovedGrantSurface = {
+        grants: ["tool:narrow_tool"],
+        grantEffects: { "tool:narrow_tool": "allow" },
+      };
+      await h.db.insert(workflowDefinitionVersion).values([
+        { id: "wdv_v1", definitionId: DEFINITION, version: "1" },
+        { id: "wdv_v2", definitionId: DEFINITION, version: "2" },
+      ]);
+      await writeApprovedGrantSurface(h.db, DEFINITION, "1", broad);
+      await writeApprovedGrantSurface(h.db, DEFINITION, "2", narrow);
+
+      // One materializer: its per-definition basis cache lives for the whole
+      // process, as the hub's long-lived sidecar router holds it.
+      const materialize = createMailTriggeredRunGrantsMaterializer({
+        db: h.db,
+        assetService: mockAssetService(childWorkflowParentJson()),
+        grantStore: createGrantStore(h.db),
+      });
+
+      // Run A materializes while currentVersion = 1.
+      const resultA = await materialize({
+        agentAddress: WORKFLOW_ADDRESS,
+        runId: RUN_A,
+      });
+      expect(resultA.outcome).toBe("materialized");
+
+      // An operator rolls the definition's current version forward to 2.
+      await h.db
+        .update(workflowDefinition)
+        .set({ currentVersion: "2" })
+        .where(eq(workflowDefinition.id, DEFINITION));
+
+      // Run B is a brand-new top-level run of the same deployment.
+      const resultB = await materialize({
+        agentAddress: WORKFLOW_ADDRESS,
+        runId: RUN_B,
+      });
+      expect(resultB.outcome).toBe("materialized");
+
+      const [principalB] = await h.db
+        .select()
+        .from(principal)
+        .where(eq(principal.refId, RUN_B));
+      const grantsB = await h.db
+        .select()
+        .from(grant)
+        .where(eq(grant.principalId, principalB?.id ?? ""));
+      const resourcesB = grantsB.map((row) => row.resource).sort();
+
+      // Run B must carry version 2's narrow authority, never version 1's broad
+      // ceiling. A stale frozen ceiling here would be a fail-open over-grant.
+      expect(resourcesB).toEqual(["tool:narrow_tool"]);
+      expect(resourcesB).not.toContain("tool:broad_tool");
+    });
+  },
+);

--- a/tests/db/mail-triggered-run-grants.test.ts
+++ b/tests/db/mail-triggered-run-grants.test.ts
@@ -9,13 +9,15 @@ import {
 
 import { eq } from "drizzle-orm";
 
-import { createGrantStore } from "@intx/db";
+import { createGrantStore, writeApprovedGrantSurface } from "@intx/db";
 import {
   grant,
   principal,
   workflowDefinition,
+  workflowDefinitionVersion,
   workflowRun,
 } from "@intx/db/schema";
+import type { ApprovedGrantSurface } from "@intx/types";
 import type { AssetService } from "@intx/hub-sessions";
 import { createMailTriggeredRunGrantsMaterializer } from "@intx/hub-api";
 import {
@@ -68,6 +70,27 @@ function workflowJson(creatorRequirementResource: string): string {
         source: "creator",
       },
     ],
+  });
+}
+
+// A parent workflow whose only step is a childWorkflow reference. Its own walk
+// yields NO runtime tool grants (a childWorkflow contributes none), so the
+// materialized ceiling for this definition comes entirely from its
+// deploy-stamped pinned surface, not the walk -- which is exactly what the
+// ceiling test asserts.
+function childWorkflowParentJson(): string {
+  return JSON.stringify({
+    id: "wf_child_parent",
+    triggers: [{ type: "mail", to: WORKFLOW_ADDRESS }],
+    stepOrder: ["sub"],
+    steps: {
+      sub: {
+        kind: "childWorkflow",
+        id: "sub",
+        definitionRef: "ast_child",
+        drainBehavior: "cancel",
+      },
+    },
   });
 }
 
@@ -198,6 +221,61 @@ describe.skipIf(!harnessDbEnvAvailable())(
       const resources = grants.map((g) => `${g.resource}/${g.action}`).sort();
       expect(resources).toContain("tool:read_file/invoke");
       expect(resources).toContain("secret:vault/use");
+    });
+
+    test("a childWorkflow parent's ceiling comes from its stamped pinned surface", async () => {
+      // The parent references a child; its own walk yields no tool grants. The
+      // deploy-stamped pinned surface carries the child's folded authority, and
+      // the materialized run ceiling must be that surface -- proving the child's
+      // authority reaches the run rather than being lost.
+      // A well-formed pinned surface (as flattenWalkToSurface produces) carries
+      // an effect for every runtime-enforced grant: tool grants keep their
+      // ask/allow mark, effect grants are allow.
+      const surface: ApprovedGrantSurface = {
+        grants: ["tool:child_do", "effect:child_cap"],
+        grantEffects: { "tool:child_do": "ask", "effect:child_cap": "allow" },
+      };
+      // Stamp through the SAME writer the deploy path uses, on the same
+      // (definitionId, version) key -- so this closes the real write-fn ->
+      // read-path loop, not just a raw column insert.
+      await h.db.insert(workflowDefinitionVersion).values({
+        id: "wdv_child_parent",
+        definitionId: DEFINITION,
+        version: "1",
+      });
+      await writeApprovedGrantSurface(h.db, DEFINITION, "1", surface);
+
+      const result = await materializeOnce(childWorkflowParentJson(), RUN_ID);
+      if (result.outcome !== "materialized") {
+        throw new Error(`expected materialized, got ${result.outcome}`);
+      }
+
+      const principals = await h.db
+        .select()
+        .from(principal)
+        .where(eq(principal.refId, RUN_ID));
+      const runPrincipalId = principals[0]?.id;
+      const grants = await h.db
+        .select()
+        .from(grant)
+        .where(eq(grant.principalId, runPrincipalId ?? ""));
+      const resources = grants.map((g) => `${g.resource}/${g.action}`).sort();
+      // The ceiling is the stamped surface, not the (empty) own-walk.
+      expect(resources).toContain("tool:child_do/invoke");
+      expect(resources).toContain("effect:child_cap/invoke");
+      // The ask effect the surface pinned survives into the committed row.
+      const askRow = grants.find((g) => g.resource === "tool:child_do");
+      expect(askRow?.effect).toBe("ask");
+    });
+
+    test("fails closed when a childWorkflow parent has no stamped surface", async () => {
+      // A childWorkflow-bearing definition that reaches materialization without
+      // a stamped surface is a deploy that never folded its children. The
+      // materializer must refuse rather than run the parent under a ceiling that
+      // omits the child authority. No version row is stamped here.
+      await expect(
+        materializeOnce(childWorkflowParentJson(), RUN_ID),
+      ).rejects.toThrow(/has no approved grant surface/);
     });
 
     test("throws when the anchor run's definition has no asset", async () => {

--- a/tests/db/workflow-definition-store.test.ts
+++ b/tests/db/workflow-definition-store.test.ts
@@ -20,8 +20,11 @@ import {
 } from "@intx/db/schema";
 import {
   createWorkflowDefinitionStore,
+  readApprovedGrantSurface,
   resolveDefinitionIdForAsset,
+  writeApprovedGrantSurface,
 } from "@intx/db";
+import type { ApprovedGrantSurface } from "@intx/types";
 import { and, eq } from "drizzle-orm";
 
 describe.skipIf(!harnessDbEnvAvailable())(
@@ -118,6 +121,39 @@ describe.skipIf(!harnessDbEnvAvailable())(
       expect(result).toEqual({ ok: false, reason: "version_not_found" });
       // No partial write: the active version is unchanged.
       expect(await versionStatus("2")).toBe("active");
+    });
+
+    test("approved grant surface round-trips through write and read", async () => {
+      await seedDefinition();
+      const surface: ApprovedGrantSurface = {
+        grants: ["tool:search", "effect:mail.send:example.com"],
+        grantEffects: { "tool:search": "ask" },
+      };
+
+      await writeApprovedGrantSurface(h.db, "wfd_1", "2", surface);
+
+      expect(await readApprovedGrantSurface(h.db, "wfd_1", "2")).toEqual(
+        surface,
+      );
+      // The sibling version was never stamped: null, not the other version's
+      // surface.
+      expect(await readApprovedGrantSurface(h.db, "wfd_1", "1")).toBeNull();
+    });
+
+    test("reading an unstamped or absent version yields null", async () => {
+      await seedDefinition();
+      // Version exists but carries no surface yet.
+      expect(await readApprovedGrantSurface(h.db, "wfd_1", "2")).toBeNull();
+      // Version row absent entirely.
+      expect(await readApprovedGrantSurface(h.db, "wfd_1", "99")).toBeNull();
+    });
+
+    test("writing to a nonexistent version throws rather than no-oping", async () => {
+      await seedDefinition();
+      const surface: ApprovedGrantSurface = { grants: [], grantEffects: {} };
+      await expect(
+        writeApprovedGrantSurface(h.db, "wfd_1", "99", surface),
+      ).rejects.toThrow(/expected exactly one version row/);
     });
 
     test("resolveDefinitionIdForAsset resolves a folded selector and nulls a miss", async () => {


### PR DESCRIPTION
## Summary

- Store an approved grant surface per workflow definition version: the
  deployment-flattened union of a definition's own runtime-enforced
  (`tool:`/`effect:`) grants and its direct children's pinned surfaces
  (own ∪ ⋃ pinned(directChild)), so an operator approves the whole
  surface a run can reach through its children.
- At deploy, resolve each direct `childWorkflow` reference to its approved
  surface and fold it into the parent's pinned surface before the
  deployment becomes trigger-routable; a self-referential, wrong-kind,
  missing, or unapproved child aborts the deploy.
- Materialize a run's runtime ceiling from the stamped surface, read fresh
  per run at the anchor's version; a `childWorkflow`-bearing definition
  with no stamped surface fails closed at materialization instead of
  running unbounded.

## Verification

- `make all` passes: 780 tests pass, 0 fail across 123 files; lint,
  dependency check, and generated-doc check green; exits 0.
- The child-workflow fold, the fail-closed guard, and the per-run ceiling
  read are covered by DB-backed tests (fold resolution, frozen-ceiling
  staleness regression, and the approved-surface write-read seam).

Closes INTR-421
