### PR TITLE
Cover a single-source quota case, stabilize a flaky roundtrip test, and reconcile stale execution-host docs

### DIFF
--- a/apps/sidecar/src/index.ts
+++ b/apps/sidecar/src/index.ts
@@ -21,8 +21,6 @@ import {
   readRegistryMaxTarballBytes,
 } from "./config";
 import { createDefaultHarnessBuilder } from "./default-harness";
-// Pull the workflow-host wiring factory into the sidecar's module
-// graph so the supervisor surface is reachable from this binary.
 // `createSidecarDeployRouter` is the production routing the
 // orchestrator hands to the link's `agent.deploy` handler; every
 // inbound frame stages through the workflow-run substrate, spawning a
@@ -31,7 +29,6 @@ import type { DispatchTimingMark } from "@intx/workflow-host";
 
 import {
   createSidecarDeployRouter,
-  createSidecarWorkflowSupervisor,
   type SidecarDeployRouter,
 } from "./workflow-host-wiring";
 import {
@@ -551,11 +548,3 @@ if (sidecarDeployRouter === undefined) {
 await sidecarDeployRouter.restoreWorkflowRuns();
 
 orchestrator.start();
-
-// Keep `createSidecarWorkflowSupervisor` reachable from this entry
-// point so a deploy handler that branches on workflow kind can
-// instantiate a supervisor per active deployment without forking the
-// boot path. The full wiring -- agent.deploy → kind detect →
-// supervisor.spawn -- threads through the deploy handler in a later
-// commit. The reference here is the seam.
-export { createSidecarWorkflowSupervisor };

--- a/docs/HARNESS_DESIGN.md
+++ b/docs/HARNESS_DESIGN.md
@@ -68,10 +68,10 @@ All communication between hub and sidecar is over a single persistent WebSocket 
 
 **Hub to Sidecar:**
 
-| Frame            | Fields                                                     | Description                       |
-| ---------------- | ---------------------------------------------------------- | --------------------------------- |
-| `agent.deploy`   | `agentAddress`, `agentId`, `config` (full `HarnessConfig`) | Deploy an agent to this sidecar   |
-| `agent.undeploy` | `agentAddress`, `reason`                                   | Remove an agent from this sidecar |
+| Frame            | Fields                                                                                                    | Description                       |
+| ---------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `agent.deploy`   | `agentAddress`, `agentId`, `config` (full `HarnessConfig`), `hubPublicKey`, `workflow?`, `provisionStep?` | Deploy an agent to this sidecar   |
+| `agent.undeploy` | `agentAddress`, `reason`                                                                                  | Remove an agent from this sidecar |
 
 **Sidecar to Hub:**
 

--- a/docs/unified-execution-host-design.md
+++ b/docs/unified-execution-host-design.md
@@ -367,11 +367,11 @@ multi-step durability model:
   `"unbounded"` (interactive) step the runtime re-arms rather than completing
   (§3h), so **one** run spans every turn: a single `RunStarted` ->
   `StepStarted`, then a park/deliver cycle per turn, and no terminal until the
-  run is torn down. A terminal batch deployment is not fired again. The batch bracket is exactly the one the current
-  `driveTrivialRunChain` projector hand-rolls
-  (`apps/sidecar/src/workflow-host-wiring.ts`), except now the runtime emits it
-  natively because a real `runtimeRun` is driving the step. That projector is
-  deleted (§4).
+  run is torn down. A terminal batch deployment is not fired again. The batch bracket is the one the former
+  `driveTrivialRunChain` projector hand-rolled
+  (`apps/sidecar/src/workflow-host-wiring.ts`); the runtime now emits it
+  natively because a real `runtimeRun` drives the step, and that projector has
+  been deleted (§4).
 - **Conversation state across trigger occurrences.** The agent's
   connector/conversation state is committed to the workflow-run substrate at
   turn boundaries (and at connector-state-change points, mirroring the
@@ -463,6 +463,19 @@ lifecycle is the riskiest sub-item, and it is what the sandbox boundary
 (Decision 1) must contain. See §6.
 
 ### 3d-bis. Pluggable sandbox boundary (Decision 1)
+
+> **Status — seam present, concrete boundaries deferred.** The child-launch
+> seam described here exists (`SubprocessSpawner` / `SubprocessHandle` /
+> `defaultSubprocessSpawner`), but the `SandboxBoundary` strategy and the
+> concrete `os-namespace` / `oci-container` implementations are not built yet.
+> The seam is slated
+> to be renamed to the boundary-neutral `ChildSpawner` / `ChildHandle` as part
+> of capability-based placement (see §3f). Whole-sidecar isolation has shipped
+> along a separate axis: an exclusive-placement deployment runs on a dedicated
+> sidecar the hub provisions through a pluggable provisioner (`ensure` /
+> `destroy`) contract with a reconciled allocation lifecycle — currently
+> fail-closed, since the in-tree build registers no concrete provisioner
+> backend.
 
 The child is the isolation unit (§3d). The _mechanism_ that draws that
 boundary must be **pluggable**, not pinned to host subprocesses, because the
@@ -675,6 +688,18 @@ it touches the adapter's public surface, so it is a deliberate API change, not
 a one-line edit.
 
 ### 3f. Multiplexing and workflow-declared isolation granularity (Decision 2)
+
+> **Status — not yet built; direction refined into capability-based placement.**
+> The `isolation` declaration and isolation-domain multiplex described below are
+> not built yet: `activeSupervisors` still keys one child per deployment address,
+> and the workflow-definition types carry no `isolation` field yet. The
+> workflow-declares-isolation direction is refined into **capability-based
+> placement** — a workflow declares the positive runtime capabilities it needs
+> (for example `subprocess`, `filesystem`), derived primarily from the tools it
+> uses; each execution boundary advertises the capability profile it provides;
+> and deploy-time placement selects the cheapest boundary whose profile covers
+> the required floor, failing loudly when none fits. Per-node (spawn-rung)
+> placement and the security/isolation axis remain deferred.
 
 Today one child hosts one deployment: `activeSupervisors` keys one supervisor
 (thus one child) per deployment address in
@@ -1080,6 +1105,12 @@ re-serviced.
 
 ### New design surface (did not exist before this revision)
 
+> **Status — proposed, not yet built.** The isolation surface listed here
+> (`WorkflowDefinition.isolation`, per-node `isolation`, the `SandboxBoundary`
+> strategy, and the isolation-domain multiplex key) is not built yet. See
+> §3d-bis and §3f for the refined capability-based-placement direction and the
+> shipped whole-sidecar exclusive-allocation substrate.
+
 - `WorkflowDefinition.isolation` (workflow-level) **and per-node `isolation`** on
   `StepPrimitive` / `ChildWorkflowPrimitive` / `MapPrimitive` and their
   `StepOpts` / `ChildWorkflowOpts` / `MapOpts` constructors
@@ -1109,17 +1140,29 @@ special case — or deleted where the in-process branch it served is gone:
 - `wrapHarnessAsSingleStepWorkflow`
   (`packages/workflow-deploy/src/orchestrator.ts`) kept its name; still used to
   build the one-step definition.
-- `buildTrivialApprovalSet` -> `buildSingleStepApprovalSet`
-  (`packages/hub-sessions/src/session-service.ts`).
+- `buildTrivialApprovalSet`: deleted. The single-step approval set is built
+  inline over `ApprovalSet` from `@intx/workflow-deploy` in
+  `packages/hub-sessions/src/session-service.ts`; it was not renamed to a
+  `buildSingleStepApprovalSet` helper.
 - `isTrivialDeploy` / `trivialBindings` / the trivial orchestrator branch:
-  **deleted** if single-step routes through the multi-step branch (likely);
-  otherwise renamed `isSingleStepDeploy`. Confirm during build.
+  **deleted** — single-step deploys route through the multi-step branch, so no
+  `isSingleStepDeploy` replacement was needed.
 - `deriveDeploymentId` (`apps/sidecar/src/workflow-host-wiring.ts`): kept; still
   called at the workflow-host wiring sites.
 - `TrivialLaunch` / `trivialLaunch` / `trivialClaimedSlugSucceeded`: deleted
   with the in-process branch.
 
 ## 5. Phased build path
+
+> **Build status.** Phases 1–4 have landed: the sidecar spawns a child that runs
+> a real agent with materialized tools, threads events up, keeps the agent warm,
+> and persists conversation durably across a respawn. Phase 5's retirement of the
+> in-process runtime has landed — `provisionAgent`, the trivial deploy branch,
+> and the `driveTrivialRunChain` projector are gone. Phase 5's workflow-declared
+> multiplex (isolation-domain keying) and Phases 4b/4c (isolation declaration and
+> the sandbox-boundary abstraction) are not built yet; that work is refined into
+> capability-based placement (see §3f). Phase 6 (hardened per-rung boundaries)
+> remains deferred.
 
 The whole thing ships together (INTR-209 held until done), but the build is
 phased so each phase is independently verifiable and the risky work is
@@ -1580,8 +1623,8 @@ are explicitly **not** a go-live gate for INTR-209.
   (mail ingestion, dispatch loop, `spawn`); `supervisor/credentials.ts`
   (`assembleCredentialsSnapshot`, `deriveStepAddress`, `deriveStepRepoId`,
   `STEP_GRANTS_PATH`, `defaultStepRepoId`); `supervisor/types.ts`
-  (`TrivialLaunch`, `SupervisorDeployFrame`); `supervisor/recycle.ts`;
-  `drain-controller.ts`.
+  (`WorkflowSupervisorBindings`, `SubprocessSpawner`, `SubprocessHandle`);
+  `supervisor/recycle.ts`; `drain-controller.ts`.
 - Child: `packages/workflow-host/src/child/run-child.ts`
   (`runWorkflowChild`, `loadWorkflowDefinition`, `discoverInFlightRuns`,
   event sender, `trigger.fired` handling).
@@ -1598,23 +1641,23 @@ are explicitly **not** a go-live gate for INTR-209.
   `runWorkflowChildFromProcessEnv`).
 - Deploy router / wiring: `apps/sidecar/src/workflow-host-wiring.ts`
   (`createSidecarDeployRouter`, `deployMultiStep`, `activeSupervisors`,
-  `deriveDeploymentId`, `driveTrivialRunChain`, `TrivialRunCell`,
-  `publishWorkflowInferenceEvent`).
+  `deriveDeploymentId`, `publishWorkflowInferenceEvent`).
 - Child-launch / sandbox-boundary seam (Decision 1):
   `apps/sidecar/src/workflow-host-wiring.ts` (`SubprocessSpawner`,
   `SubprocessHandle`, `defaultSubprocessSpawner`, `binaryPath`,
   `SIDECAR_WORKFLOW_CHILD_BINARY`; `multistepSubprocessSpawner` /
   `multistepBinaryPath` threaded through `createSidecarDeployRouter`).
-- Workflow-definition isolation surface (Decision 2):
+- Workflow-definition surface (Decision 2, isolation not yet added):
   `packages/workflow/src/definition/workflow.ts` (`WorkflowDefinition`,
   `WorkflowConfig`, `SingularWorkflowConfig`, `defineWorkflow`, `normalize`,
-  `hashDefinition`, `projectForHash`, `projectPrimitive`, `projectAgent` —
-  workflow-level `isolation` added here).
-- Per-node isolation surface (recursive refinement):
+  `hashDefinition`, `projectForHash`, `projectPrimitive`, `projectAgent`). The
+  workflow-level `isolation` field will attach here; the refined direction
+  carries capability requirements rather than an isolation declaration (see §3f).
+- Per-node definition surface (recursive refinement, not yet added):
   `packages/workflow/src/definition/primitives.ts` (`PrimitiveBase`,
   `StepPrimitive`/`StepOpts`, `ChildWorkflowPrimitive`/`ChildWorkflowOpts`,
-  `MapPrimitive`/`MapOpts` — per-node `isolation` added to the spawn-trigger
-  primitives and their constructors).
+  `MapPrimitive`/`MapOpts`). Per-node `isolation` will attach to the
+  spawn-trigger primitives and their constructors.
 - Recursive spawn / per-rung host (already exists; the recursion point):
   `apps/sidecar/src/workflow-substrate-factory.ts` (`createSidecarRunChild`
   self-referential `runChild`, sub-namespace `runs/<runId>/...`, proxy

--- a/packages/inference/src/reactor.test.ts
+++ b/packages/inference/src/reactor.test.ts
@@ -5651,6 +5651,29 @@ describe("createReactor — source failover", () => {
     expect(getEvent(events, "inference.done").data.source.sourceId).toBe("s1");
   });
 
+  test("surfaces quota exhaustion for a single source without failover", async () => {
+    const { reactor, events, waitFor, attemptedSourceIds } = multiSourceReactor(
+      {
+        sourceIds: ["s0"],
+        resultFor: () => ({
+          category: "quota_exhausted",
+          message: "quota exhausted",
+        }),
+      },
+    );
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    // Single source: quota is attempted once, then surfaces. The harness
+    // wrapper owns quota retry, so the reactor does no same-source backoff
+    // and has nowhere to fail over to. attemptedSourceIds must stay ["s0"].
+    expect(attemptedSourceIds).toEqual(["s0"]);
+    expect(getEvent(events, "inference.error").data.error.category).toBe(
+      "quota_exhausted",
+    );
+  });
+
   test("fails over immediately on a transient error already retried by the harness", async () => {
     const { reactor, events, waitFor, attemptedSourceIds } = multiSourceReactor(
       {

--- a/packages/types/src/sidecar.ts
+++ b/packages/types/src/sidecar.ts
@@ -165,8 +165,8 @@ export const SessionErrorFrame = type({
 export type SessionErrorFrame = typeof SessionErrorFrame.infer;
 
 /**
- * Acknowledges that an agent has been fully undeployed: harness stopped,
- * state pushed (best-effort), and directory deleted.
+ * Acknowledges that an agent has been fully undeployed: the deployment's
+ * workflow child stopped, state pushed (best-effort), and directory deleted.
  */
 export const AgentUndeployAckFrame = type({
   type: "'agent.undeploy.ack'",
@@ -495,9 +495,9 @@ export const AgentDeployFrame = type({
 export type AgentDeployFrame = typeof AgentDeployFrame.infer;
 
 /**
- * Remove an agent from this sidecar. The sidecar tears down the harness,
- * pushes state to the hub (best-effort), deletes the agent directory, and
- * responds with agent.undeploy.ack.
+ * Remove an agent from this sidecar. The sidecar shuts the deployment's
+ * supervisor down, pushes state to the hub (best-effort), deletes the agent
+ * directory, and responds with agent.undeploy.ack.
  */
 export const AgentUndeployFrame = type({
   type: "'agent.undeploy'",
@@ -768,13 +768,13 @@ export type PackRejectFrame = typeof PackRejectFrame.infer;
  *                              cannot see `bundle.definitions` without
  *                              invoking the factory, and the `BaseEnv`
  *                              the factory needs is constructed by the
- *                              sidecar harness AFTER the commit. Both
- *                              paths carry the same category so the
- *                              operator-facing failure shape is
- *                              uniform regardless of which check
- *                              fired; only the channel (apply.error
- *                              frame vs runtime construct failure)
- *                              differs.
+ *                              workflow child's step build env AFTER
+ *                              the commit. Both paths carry the same
+ *                              category so the operator-facing failure
+ *                              shape is uniform regardless of which
+ *                              check fired; only the channel
+ *                              (apply.error frame vs runtime construct
+ *                              failure) differs.
  *   apply.swap.failed        — DEPRECATED, no longer emitted. The apply
  *                              protocol stages each deploy into a stable
  *                              per-deploy-id directory and commits via a

--- a/tests/workflow-deploy/child-workflow-roundtrip.test.ts
+++ b/tests/workflow-deploy/child-workflow-roundtrip.test.ts
@@ -470,7 +470,7 @@ describe("parent -> child workflow round-trip", () => {
     if (childRunStartedBody === undefined) throw new Error("unreachable");
     expect(childRunStartedBody["runId"]).toBe(childRunId);
     void parentRunId;
-  });
+  }, 180_000);
 
   // Grandchild-depth recursion. The sidecar's `createSidecarRunChild`
   // wires the child env's `spawnChild` via `createWorkflowSpawnChild`
@@ -838,7 +838,7 @@ describe("parent -> child workflow round-trip", () => {
     // sub-namespace scoping would silently collide if the runtime
     // re-used a runId across rungs.
     expect(new Set([parentRunId, childRunId, grandchildRunId]).size).toBe(3);
-  });
+  }, 180_000);
 
   test(`parent -> ${String(SIBLINGS_CHILD_COUNT)} siblings via stepOrder`, async () => {
     // Sibling-fanout coverage. The runtime resolves
@@ -1170,5 +1170,5 @@ describe("parent -> child workflow round-trip", () => {
       expect(runFailedIdx).toBeGreaterThan(stepFailedIdx);
       expectChildStepNotImplemented(childEvents[stepFailedIdx]);
     }
-  });
+  }, 180_000);
 });


### PR DESCRIPTION
## Summary

- The reactor suite asserts that a single source returning `quota_exhausted`
  is attempted once and then surfaces the error, locking in the
  wrapper-owns-retry contract that had only transitive coverage.
- The child-workflow roundtrip tests carry an explicit 180s per-test budget,
  so the fan-out case no longer times out on Bun's 5s default when the file
  runs standalone.
- The execution-host design docs match the shipped runtime: stale references
  to the deleted trivial/in-process symbols read in past tense, completed
  phases are marked landed, the isolation direction is recorded as
  capability-based placement (with exclusive sidecar allocation as the shipped
  substrate), and the deploy-frame field list is complete.
- The sidecar entry point drops a dead workflow-supervisor re-export, and the
  frame docs describe the supervised workflow child rather than the retired
  in-process harness.

## Verification

- `make all` passes on HEAD (lint, `tsc -b`, admin-ui bundle, 772 tests, 0 fail).
- The child-workflow roundtrip file passes standalone under Bun's default with
  no `--timeout` override — the exact condition that previously failed.

Closes INTR-385
Closes INTR-215
Closes INTR-264