### PR TITLE
Remove orphaned per-credential grants and reject in-use deletes

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -879,6 +879,7 @@ Only credentials owned by this tenant can be revoked.
 
 204: (no content) -- Credential revoked
 404: ErrorResponse -- Credential not found
+409: ErrorResponse -- Credential is in use by a model provider
 
 ## Discovery
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -722,6 +722,7 @@ Deactivate a wallet
 
 204: (no content) -- Wallet deactivated
 404: ErrorResponse -- Wallet not found
+409: ErrorResponse -- Wallet is in use by a model provider
 
 ### GET /api/tenants/:tenantId/wallets/:walletId/transactions
 List transactions

--- a/packages/db/migrations/0084_delete_orphaned_credential_grants.sql
+++ b/packages/db/migrations/0084_delete_orphaned_credential_grants.sql
@@ -1,0 +1,22 @@
+-- Remove `credential:{id}` grant rows that reference a credential that no longer
+-- exists. Before credential DELETE cleaned up its per-credential grants, deleting
+-- a personal credential left its `credential:{id}` grant behind, and migration
+-- 0037 backfilled the same shape for pre-existing personal credentials, so a
+-- credential hard-deleted before that cleanup shipped left an orphaned grant.
+--
+-- The coarse wildcard `credential:*` role resource is excluded explicitly: no
+-- credential has the id `*`, so the NOT EXISTS guard alone would wrongly match
+-- it. There is no tenant scope: credential ids are globally unique, so an
+-- orphaned grant is one whose id matches no credential in any tenant. This
+-- removes every action on an orphaned resource, matching the credential DELETE
+-- handler.
+--
+-- Idempotent: after this runs no orphaned row remains, so a re-run is a no-op.
+DELETE FROM "grant"
+WHERE "resource" LIKE 'credential:%'
+  AND "resource" <> 'credential:*'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "credential" c
+    WHERE c."id" = substr("grant"."resource", length('credential:') + 1)
+  );

--- a/packages/db/migrations/meta/0084_snapshot.json
+++ b/packages/db/migrations/meta/0084_snapshot.json
@@ -1,0 +1,4096 @@
+{
+  "id": "b59d8ac7-94a5-477e-9f4d-23138058494b",
+  "prevId": "b84ce2f6-fec4-4c5e-8938-0ca0f32eb128",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.federation_trust": {
+      "name": "federation_trust",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_tenant_id": {
+          "name": "target_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "federation_trust_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "federation_trust_target_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_target_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "tableTo": "tenant",
+          "columnsFrom": ["target_tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federation_trust_tenant_id_target_tenant_id_unique": {
+          "name": "federation_trust_tenant_id_target_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "target_tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant": {
+      "name": "tenant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_parent_id_tenant_id_fk": {
+          "name": "tenant_parent_id_tenant_id_fk",
+          "tableFrom": "tenant",
+          "tableTo": "tenant",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_slug_unique": {
+          "name": "tenant_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "tenant_domain_unique": {
+          "name": "tenant_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": ["domain"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal": {
+      "name": "principal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_tenant_id_tenant_id_fk": {
+          "name": "principal_tenant_id_tenant_id_fk",
+          "tableFrom": "principal",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "principal_tenant_id_kind_ref_id_unique": {
+          "name": "principal_tenant_id_kind_ref_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "kind", "ref_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_role": {
+      "name": "agent_role",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_role_agent_id_workflow_definition_id_fk": {
+          "name": "agent_role_agent_id_workflow_definition_id_fk",
+          "tableFrom": "agent_role",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_role_role_id_role_id_fk": {
+          "name": "agent_role_role_id_role_id_fk",
+          "tableFrom": "agent_role",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_role_agent_id_role_id_pk": {
+          "name": "agent_role_agent_id_role_id_pk",
+          "columns": ["agent_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal_role": {
+      "name": "principal_role",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_role_principal_id_principal_id_fk": {
+          "name": "principal_role_principal_id_principal_id_fk",
+          "tableFrom": "principal_role",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "principal_role_role_id_role_id_fk": {
+          "name": "principal_role_role_id_role_id_fk",
+          "tableFrom": "principal_role",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "principal_role_principal_id_role_id_pk": {
+          "name": "principal_role_principal_id_role_id_pk",
+          "columns": ["principal_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_tenant_id_tenant_id_fk": {
+          "name": "role_tenant_id_tenant_id_fk",
+          "tableFrom": "role",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grant": {
+      "name": "grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grant_tenant_id_tenant_id_fk": {
+          "name": "grant_tenant_id_tenant_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grant_role_id_role_id_fk": {
+          "name": "grant_role_id_role_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grant_principal_id_principal_id_fk": {
+          "name": "grant_principal_id_principal_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grant_target_exactly_one": {
+          "name": "grant_target_exactly_one",
+          "value": "num_nonnulls(\"grant\".\"principal_id\", \"grant\".\"role_id\") = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.approval": {
+      "name": "approval",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_address": {
+          "name": "agent_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_definition": {
+          "name": "tool_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_arguments": {
+          "name": "tool_arguments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "timeout_at": {
+          "name": "timeout_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approval_tenant_status_idx": {
+          "name": "approval_tenant_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_anchor_run_idx": {
+          "name": "approval_anchor_run_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_tenant_id_tenant_id_fk": {
+          "name": "approval_tenant_id_tenant_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_anchor_run_id_workflow_run_id_fk": {
+          "name": "approval_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_run_id_workflow_run_id_fk": {
+          "name": "approval_run_id_workflow_run_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approval_correlation_id_unique": {
+          "name": "approval_correlation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["correlation_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_correlation": {
+      "name": "signal_correlation",
+      "schema": "",
+      "columns": {
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_address": {
+          "name": "agent_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_name": {
+          "name": "signal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_id": {
+          "name": "signal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signal_correlation_tenant_id_tenant_id_fk": {
+          "name": "signal_correlation_tenant_id_tenant_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signal_correlation_anchor_run_id_workflow_run_id_fk": {
+          "name": "signal_correlation_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signal_correlation_run_id_workflow_run_id_fk": {
+          "name": "signal_correlation_run_id_workflow_run_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_info_url": {
+          "name": "user_info_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_tenant_id_tenant_id_fk": {
+          "name": "provider_tenant_id_tenant_id_fk",
+          "tableFrom": "provider",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_tenant_name": {
+          "name": "provider_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_scopes": {
+          "name": "default_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_tenant_id_tenant_id_fk": {
+          "name": "oauth_client_tenant_id_tenant_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_client_provider_id_provider_id_fk": {
+          "name": "oauth_client_provider_id_provider_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_tenant_provider": {
+          "name": "oauth_client_tenant_provider",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "provider_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credential": {
+      "name": "credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_secret": {
+          "name": "refresh_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credential_tenant_id_tenant_id_fk": {
+          "name": "credential_tenant_id_tenant_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_principal_id_principal_id_fk": {
+          "name": "credential_principal_id_principal_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credential_provider_id_provider_id_fk": {
+          "name": "credential_provider_id_provider_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_oauth_client_id_oauth_client_id_fk": {
+          "name": "credential_oauth_client_id_oauth_client_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "credential_tenant_name": {
+          "name": "credential_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset": {
+      "name": "asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_tenant_id_tenant_id_fk": {
+          "name": "asset_tenant_id_tenant_id_fk",
+          "tableFrom": "asset",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "asset_creator_principal_id_principal_id_fk": {
+          "name": "asset_creator_principal_id_principal_id_fk",
+          "tableFrom": "asset",
+          "tableTo": "principal",
+          "columnsFrom": ["creator_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_tenant_kind_name": {
+          "name": "asset_tenant_kind_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "kind", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_wallet_id_wallet_id_fk": {
+          "name": "transaction_wallet_id_wallet_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_run_id_workflow_run_id_fk": {
+          "name": "transaction_run_id_workflow_run_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet": {
+      "name": "wallet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend_type": {
+          "name": "backend_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallet_tenant_id_tenant_id_fk": {
+          "name": "wallet_tenant_id_tenant_id_fk",
+          "tableFrom": "wallet",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offering": {
+      "name": "offering",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "offering_agent_id_workflow_definition_id_fk": {
+          "name": "offering_agent_id_workflow_definition_id_fk",
+          "tableFrom": "offering",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "offering_tenant_id_tenant_id_fk": {
+          "name": "offering_tenant_id_tenant_id_fk",
+          "tableFrom": "offering",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model": {
+      "name": "model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_tenant_id_tenant_id_fk": {
+          "name": "model_tenant_id_tenant_id_fk",
+          "tableFrom": "model",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_tenant_canonical_name": {
+          "name": "model_tenant_canonical_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "canonical_name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_offering": {
+      "name": "model_offering",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_tags": {
+          "name": "deployment_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "quirks": {
+          "name": "quirks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_offering_tenant_id_tenant_id_fk": {
+          "name": "model_offering_tenant_id_tenant_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_offering_model_id_model_id_fk": {
+          "name": "model_offering_model_id_model_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_offering_provider_id_model_provider_id_fk": {
+          "name": "model_offering_provider_id_model_provider_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "model_provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_offering_tenant_model_provider": {
+          "name": "model_offering_tenant_model_provider",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "model_id", "provider_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_pricing": {
+      "name": "model_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offering_id": {
+          "name": "offering_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_token_price": {
+          "name": "input_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_token_price": {
+          "name": "output_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_token_price": {
+          "name": "cache_read_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_write_token_price": {
+          "name": "cache_write_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thinking_token_price": {
+          "name": "thinking_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_request_fee": {
+          "name": "per_request_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_image_fee": {
+          "name": "per_image_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_audio_fee": {
+          "name": "per_audio_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_pricing_tenant_id_tenant_id_fk": {
+          "name": "model_pricing_tenant_id_tenant_id_fk",
+          "tableFrom": "model_pricing",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_pricing_offering_id_model_offering_id_fk": {
+          "name": "model_pricing_offering_id_model_offering_id_fk",
+          "tableFrom": "model_pricing",
+          "tableTo": "model_offering",
+          "columnsFrom": ["offering_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_pricing_offering_currency_effective_from": {
+          "name": "model_pricing_offering_currency_effective_from",
+          "nullsNotDistinct": false,
+          "columns": ["offering_id", "currency", "effective_from"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider": {
+      "name": "model_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_provider_tenant_id_tenant_id_fk": {
+          "name": "model_provider_tenant_id_tenant_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_credential_id_credential_id_fk": {
+          "name": "model_provider_credential_id_credential_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "credential",
+          "columnsFrom": ["credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "model_provider_wallet_id_wallet_id_fk": {
+          "name": "model_provider_wallet_id_wallet_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_provider_tenant_name": {
+          "name": "model_provider_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "model_provider_auth_xor": {
+          "name": "model_provider_auth_xor",
+          "value": "(\"model_provider\".\"credential_id\" is not null) <> (\"model_provider\".\"wallet_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sidecar": {
+      "name": "sidecar",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash_sha256": {
+          "name": "token_hash_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_scope": {
+          "name": "credential_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'shared'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sidecar_token_hash_sha256_unique": {
+          "name": "sidecar_token_hash_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash_sha256"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sidecar_credential_scope_check": {
+          "name": "sidecar_credential_scope_check",
+          "value": "\"sidecar\".\"credential_scope\" in ('shared', 'allocated')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sidecar_allocation": {
+      "name": "sidecar_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_api_version": {
+          "name": "provisioner_api_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_binding_fingerprint": {
+          "name": "provisioner_binding_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement_sharing": {
+          "name": "placement_sharing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sidecar_reuse": {
+          "name": "sidecar_reuse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'never'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ensure_accepted_generation": {
+          "name": "ensure_accepted_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation_lease_id": {
+          "name": "reconciliation_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation_lease_expires_at": {
+          "name": "reconciliation_lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ensure_attempts": {
+          "name": "ensure_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "destroy_attempts": {
+          "name": "destroy_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connect_deadline": {
+          "name": "connect_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sidecar_allocation_anchor_run_idx": {
+          "name": "sidecar_allocation_anchor_run_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sidecar_allocation_active_sidecar_idx": {
+          "name": "sidecar_allocation_active_sidecar_idx",
+          "columns": [
+            {
+              "expression": "sidecar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sidecar_allocation\".\"status\" in ('provisioning', 'allocated', 'replacing', 'releasing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sidecar_allocation_sidecar_idx": {
+          "name": "sidecar_allocation_sidecar_idx",
+          "columns": [
+            {
+              "expression": "sidecar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sidecar_allocation_reconciliation_idx": {
+          "name": "sidecar_allocation_reconciliation_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sidecar_allocation\".\"status\" in ('pending', 'provisioning', 'allocated', 'replacing', 'releasing') and \"sidecar_allocation\".\"next_attempt_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sidecar_allocation_anchor_run_id_workflow_run_id_fk": {
+          "name": "sidecar_allocation_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "sidecar_allocation",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sidecar_allocation_tenant_id_tenant_id_fk": {
+          "name": "sidecar_allocation_tenant_id_tenant_id_fk",
+          "tableFrom": "sidecar_allocation",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sidecar_allocation_sidecar_id_sidecar_id_fk": {
+          "name": "sidecar_allocation_sidecar_id_sidecar_id_fk",
+          "tableFrom": "sidecar_allocation",
+          "tableTo": "sidecar",
+          "columnsFrom": ["sidecar_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sidecar_allocation_status_check": {
+          "name": "sidecar_allocation_status_check",
+          "value": "\"sidecar_allocation\".\"status\" in ('pending', 'provisioning', 'allocated', 'replacing', 'releasing', 'released', 'failed')"
+        },
+        "sidecar_allocation_placement_check": {
+          "name": "sidecar_allocation_placement_check",
+          "value": "\"sidecar_allocation\".\"placement_sharing\" = 'exclusive'"
+        },
+        "sidecar_allocation_generation_check": {
+          "name": "sidecar_allocation_generation_check",
+          "value": "\"sidecar_allocation\".\"generation\" >= 0"
+        },
+        "sidecar_allocation_accepted_generation_check": {
+          "name": "sidecar_allocation_accepted_generation_check",
+          "value": "\"sidecar_allocation\".\"ensure_accepted_generation\" is null or \"sidecar_allocation\".\"ensure_accepted_generation\" <= \"sidecar_allocation\".\"generation\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_session": {
+      "name": "agent_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_session_tenant_id_tenant_id_fk": {
+          "name": "agent_session_tenant_id_tenant_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_agent_id_workflow_definition_id_fk": {
+          "name": "agent_session_agent_id_workflow_definition_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_session_principal_id_principal_id_fk": {
+          "name": "agent_session_principal_id_principal_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_asset": {
+      "name": "session_asset",
+      "schema": "",
+      "columns": {
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mount_path": {
+          "name": "mount_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_pack_sha": {
+          "name": "asset_pack_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "materialized_at": {
+          "name": "materialized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_asset_pack_sha_idx": {
+          "name": "session_asset_pack_sha_idx",
+          "columns": [
+            {
+              "expression": "asset_pack_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_asset_instance_id_mount_path_pk": {
+          "name": "session_asset_instance_id_mount_path_pk",
+          "columns": ["instance_id", "mount_path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inference_turn": {
+      "name": "inference_turn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "inference_turn_instance_id_started_at_idx": {
+          "name": "inference_turn_instance_id_started_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inference_turn_session_id_agent_session_id_fk": {
+          "name": "inference_turn_session_id_agent_session_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inference_turn_tenant_id_tenant_id_fk": {
+          "name": "inference_turn_tenant_id_tenant_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_mail": {
+      "name": "session_mail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "raw": {
+          "name": "raw",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_mail_instance_id_created_at_idx": {
+          "name": "session_mail_instance_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_mail_session_id_created_at_idx": {
+          "name": "session_mail_session_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_mail_session_id_agent_session_id_fk": {
+          "name": "session_mail_session_id_agent_session_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_mail_tenant_id_tenant_id_fk": {
+          "name": "session_mail_tenant_id_tenant_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turn_part": {
+      "name": "turn_part",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "turn_part_turn_id_inference_turn_id_fk": {
+          "name": "turn_part_turn_id_inference_turn_id_fk",
+          "tableFrom": "turn_part",
+          "tableTo": "inference_turn",
+          "columnsFrom": ["turn_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_part_session_id_agent_session_id_fk": {
+          "name": "turn_part_session_id_agent_session_id_fk",
+          "tableFrom": "turn_part",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_token": {
+      "name": "git_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash_sha256": {
+          "name": "token_hash_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_pattern": {
+          "name": "ref_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "git_token_user_id_name_active_idx": {
+          "name": "git_token_user_id_name_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"git_token\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "git_token_tenant_id_tenant_id_fk": {
+          "name": "git_token_tenant_id_tenant_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "git_token_user_id_user_id_fk": {
+          "name": "git_token_user_id_user_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_token_principal_id_principal_id_fk": {
+          "name": "git_token_principal_id_principal_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "git_token_token_hash_sha256_unique": {
+          "name": "git_token_token_hash_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash_sha256"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition": {
+      "name": "workflow_definition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wire_hash": {
+          "name": "wire_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_requirements": {
+          "name": "grant_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_requirements": {
+          "name": "model_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_bindings": {
+          "name": "credential_bindings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_definition_tenant_idx": {
+          "name": "workflow_definition_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_definition_asset_wire_hash_idx": {
+          "name": "workflow_definition_asset_wire_hash_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wire_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definition_tenant_id_tenant_id_fk": {
+          "name": "workflow_definition_tenant_id_tenant_id_fk",
+          "tableFrom": "workflow_definition",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_definition_creator_principal_id_principal_id_fk": {
+          "name": "workflow_definition_creator_principal_id_principal_id_fk",
+          "tableFrom": "workflow_definition",
+          "tableTo": "principal",
+          "columnsFrom": ["creator_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_definition_asset_id_asset_id_fk": {
+          "name": "workflow_definition_asset_id_asset_id_fk",
+          "tableFrom": "workflow_definition",
+          "tableTo": "asset",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_version": {
+      "name": "workflow_definition_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "approved_wire_hash": {
+          "name": "approved_wire_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_snapshot": {
+          "name": "grant_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_definition_version_definition_idx": {
+          "name": "workflow_definition_version_definition_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definition_version_definition_id_workflow_definition_id_fk": {
+          "name": "workflow_definition_version_definition_id_workflow_definition_id_fk",
+          "tableFrom": "workflow_definition_version",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["definition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_definition_version_definition_version": {
+          "name": "workflow_definition_version_definition_version",
+          "nullsNotDistinct": false,
+          "columns": ["definition_id", "version"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run": {
+      "name": "workflow_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kernel_id": {
+          "name": "kernel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_preferences": {
+          "name": "model_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_definition_idx": {
+          "name": "workflow_run_definition_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_address_idx": {
+          "name": "workflow_run_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_run\".\"address\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_definition_id_workflow_definition_id_fk": {
+          "name": "workflow_run_definition_id_workflow_definition_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["definition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_anchor_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_tenant_id_tenant_id_fk": {
+          "name": "workflow_run_tenant_id_tenant_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_principal_id_principal_id_fk": {
+          "name": "workflow_run_principal_id_principal_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflow_run_sidecar_id_sidecar_id_fk": {
+          "name": "workflow_run_sidecar_id_sidecar_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "sidecar",
+          "columnsFrom": ["sidecar_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_dispatch": {
+      "name": "workflow_run_dispatch",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mail'"
+        },
+        "raw_message": {
+          "name": "raw_message",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_grants": {
+          "name": "step_grants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "acknowledged_generation": {
+          "name": "acknowledged_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "delivery_lease_id": {
+          "name": "delivery_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_lease_expires_at": {
+          "name": "delivery_lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_dispatch_anchor_message_idx": {
+          "name": "workflow_run_dispatch_anchor_message_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_dispatch_delivery_idx": {
+          "name": "workflow_run_dispatch_delivery_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_run_dispatch\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_dispatch_anchor_status_idx": {
+          "name": "workflow_run_dispatch_anchor_status_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_dispatch_anchor_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_dispatch_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run_dispatch",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_dispatch_status_check": {
+          "name": "workflow_run_dispatch_status_check",
+          "value": "\"workflow_run_dispatch\".\"status\" in ('pending', 'acknowledged', 'settled', 'failed')"
+        },
+        "workflow_run_dispatch_kind_check": {
+          "name": "workflow_run_dispatch_kind_check",
+          "value": "\"workflow_run_dispatch\".\"kind\" in ('mail', 'signal')"
+        },
+        "workflow_run_dispatch_attempt_count_check": {
+          "name": "workflow_run_dispatch_attempt_count_check",
+          "value": "\"workflow_run_dispatch\".\"attempt_count\" >= 0"
+        },
+        "workflow_run_dispatch_acknowledged_generation_check": {
+          "name": "workflow_run_dispatch_acknowledged_generation_check",
+          "value": "\"workflow_run_dispatch\".\"acknowledged_generation\" is null or \"workflow_run_dispatch\".\"acknowledged_generation\" >= 0"
+        },
+        "workflow_run_dispatch_acknowledged_state_check": {
+          "name": "workflow_run_dispatch_acknowledged_state_check",
+          "value": "\"workflow_run_dispatch\".\"status\" <> 'acknowledged' or \"workflow_run_dispatch\".\"acknowledged_generation\" is not null"
+        },
+        "workflow_run_dispatch_pending_schedule_check": {
+          "name": "workflow_run_dispatch_pending_schedule_check",
+          "value": "\"workflow_run_dispatch\".\"status\" <> 'pending' or \"workflow_run_dispatch\".\"next_attempt_at\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_launch_spec": {
+      "name": "workflow_run_launch_spec",
+      "schema": "",
+      "columns": {
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_domain": {
+          "name": "deployment_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_authority_principal_id": {
+          "name": "source_authority_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frozen_approval_bundle": {
+          "name": "frozen_approval_bundle",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_offering_ids": {
+          "name": "source_offering_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_source_offering_id": {
+          "name": "default_source_offering_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deploy_content": {
+          "name": "deploy_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_package_pins": {
+          "name": "tool_package_pins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_run_launch_spec_anchor_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_launch_spec_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run_launch_spec",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_launch_spec_source_authority_principal_id_principal_id_fk": {
+          "name": "workflow_run_launch_spec_source_authority_principal_id_principal_id_fk",
+          "tableFrom": "workflow_run_launch_spec",
+          "tableTo": "principal",
+          "columnsFrom": ["source_authority_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_execution": {
+      "name": "workflow_run_execution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_execution_run_id_id_idx": {
+          "name": "workflow_run_execution_run_id_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_execution_status_idx": {
+          "name": "workflow_run_execution_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_execution_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_execution_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run_execution",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -582,6 +582,13 @@
       "when": 1787096121244,
       "tag": "0083_replace_launch_spec_snapshot_with_frozen_bundle",
       "breakpoints": true
+    },
+    {
+      "idx": 84,
+      "version": "7",
+      "when": 1787169492000,
+      "tag": "0084_delete_orphaned_credential_grants",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/credential-resolution.ts
+++ b/packages/db/src/credential-resolution.ts
@@ -234,49 +234,33 @@ export type CredentialDeliveryFailure = {
 };
 
 /**
- * A `credential:{id}` / `use` grant the launch stamps onto the instance
- * principal for a resolved binding, scoped to the consuming tool package by the
- * `{ tool }` condition. Ownership is already proven by resolution, so this is a
- * consumer-scoping artifact the runtime per-consumer gate reads -- not a
- * delegation the launch re-authorizes; the caller stamps it with
- * `origin: 'system'` directly.
- */
-export type BindingCredentialGrant = {
-  resource: string;
-  conditions: { tool: string };
-};
-
-/**
  * Outcome of `buildCredentialDelivery`. `ok: true` carries the material +
- * descriptors delivered to the tools and the `credential:{id}` / `use` grants
- * the launch stamps; `delivery` is `undefined` when there are no bindings.
- * `ok: false` carries the first launch-blocking configuration failure for the
- * caller to map to a fail-closed response.
+ * descriptors delivered to the tools; `delivery` is `undefined` when there are
+ * no bindings. `ok: false` carries the first launch-blocking configuration
+ * failure for the caller to map to a fail-closed response.
  */
 export type BuildCredentialDeliveryResult =
   | {
       ok: true;
       delivery: CredentialDelivery | undefined;
-      bindingGrants: BindingCredentialGrant[];
     }
   | { ok: false; reason: CredentialDeliveryFailure };
 
 /**
  * Resolve a definition's credential bindings into the material + per-handle
- * descriptors delivered to its tools, plus the `credential:{id}` / `use` grant
- * requirements the launch materializes. Each credential's secret is decrypted
+ * descriptors delivered to its tools. Each credential's secret is decrypted
  * once, keyed by credentialId (a credential backing several handles is
  * decrypted once).
  *
- * The launch path (`instances.ts`) is the only caller today, using both
- * `delivery` and `bindingGrants`. The shape is built to also serve a planned
- * reconnect re-push that would re-deliver `delivery` alone (the grants survive
- * on the workflow-run substrate, so only the material needs re-sending) --
- * which is why it returns a discriminated result rather than an HTTP response
- * and is safe to call off the request path: a configuration failure is
- * `ok: false`, and a transient DB read fault THROWS so the caller surfaces it
- * (and a future reconnect caller can retry) rather than silently dropping a
- * still-valid credential.
+ * This path delivers credential material only; it does not mint, stamp, or
+ * carry any grant. Credential-use authorization is enforced by a separate grant
+ * layer.
+ *
+ * The workflow-deploy path (`deployCodeSourcedWorkflow`) is the only caller
+ * today, using `delivery`. Returning a discriminated result rather than an HTTP
+ * response keeps it safe to call off the request path: a configuration failure
+ * is `ok: false`, and a transient DB read fault THROWS so the caller surfaces it
+ * rather than silently dropping a still-valid credential.
  */
 export async function buildCredentialDelivery(args: {
   db: DB["db"];
@@ -288,7 +272,6 @@ export async function buildCredentialDelivery(args: {
 }): Promise<BuildCredentialDeliveryResult> {
   const materials = new Map<string, CredentialMaterialEntry>();
   const descriptors: CredentialBindingDescriptor[] = [];
-  const bindingGrants: BindingCredentialGrant[] = [];
 
   for (const binding of args.bindings) {
     const context = {
@@ -356,14 +339,9 @@ export async function buildCredentialDelivery(args: {
     // A binding resolves only a tenant-owned credential (the `tenant` locator
     // filters `principalId IS NULL` in resolveCredentialRequirement), so its use
     // is authorized by ownership -- already proven by this walk-up resolution,
-    // not re-checked downstream. The launch materializes a `credential:{id}` /
-    // `use` grant scoped to this tool package by the `{ tool }` condition; that
-    // grant is what the runtime per-consumer gate reads. No personal grant is
-    // consulted.
-    bindingGrants.push({
-      resource: `credential:${credentialId}`,
-      conditions: { tool: toolConsumer(binding.package) },
-    });
+    // not re-checked here. This path delivers credential material only; it does
+    // not mint or carry any grant. Credential-use authorization is enforced by a
+    // separate grant layer.
     descriptors.push({
       handle: binding.handle,
       credentialId,
@@ -390,6 +368,5 @@ export async function buildCredentialDelivery(args: {
       descriptors.length > 0
         ? { bindings: descriptors, materials: [...materials.values()] }
         : undefined,
-    bindingGrants,
   };
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -78,7 +78,6 @@ export {
 } from "./credential-resolution";
 export type {
   BuildCredentialDeliveryResult,
-  BindingCredentialGrant,
   CredentialDeliveryFailure,
 } from "./credential-resolution";
 export {

--- a/packages/hub-api/src/pg-errors.test.ts
+++ b/packages/hub-api/src/pg-errors.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "bun:test";
+
+import { isReferencedRowViolation } from "./pg-errors";
+
+describe("isReferencedRowViolation", () => {
+  test("matches a restrict_violation (23001) nested on the cause chain", () => {
+    // Mirrors how drizzle surfaces a postgres.js error: the SQLSTATE-bearing
+    // driver error is the `cause` of a wrapper error.
+    const wrapped = new Error("query failed", {
+      cause: Object.assign(new Error("update or delete violates fk"), {
+        code: "23001",
+      }),
+    });
+    expect(isReferencedRowViolation(wrapped)).toBe(true);
+  });
+
+  test("matches a foreign_key_violation (23503) on the top-level error", () => {
+    const err = Object.assign(new Error("fk violation"), { code: "23503" });
+    expect(isReferencedRowViolation(err)).toBe(true);
+  });
+
+  test("does not match an unrelated postgres error code", () => {
+    const err = Object.assign(new Error("unique violation"), { code: "23505" });
+    expect(isReferencedRowViolation(err)).toBe(false);
+  });
+
+  test("does not match an error with no code", () => {
+    expect(isReferencedRowViolation(new Error("boom"))).toBe(false);
+  });
+
+  test("does not match non-error values", () => {
+    expect(isReferencedRowViolation(null)).toBe(false);
+    expect(isReferencedRowViolation("23001")).toBe(false);
+    expect(isReferencedRowViolation(undefined)).toBe(false);
+  });
+
+  test("stops walking a self-referential cause chain", () => {
+    const a: { cause?: unknown } = {};
+    a.cause = a;
+    expect(isReferencedRowViolation(a)).toBe(false);
+  });
+});

--- a/packages/hub-api/src/pg-errors.ts
+++ b/packages/hub-api/src/pg-errors.ts
@@ -1,0 +1,12 @@
+import { PG_FOREIGN_KEY_VIOLATION, pgErrorCode } from "@intx/db";
+
+// A referencing row prevents this delete: 23503 foreign_key_violation (the
+// default ON DELETE NO ACTION) or 23001 restrict_violation (ON DELETE
+// RESTRICT). A restrict foreign key raises 23001, not 23503, so both codes
+// count. pgErrorCode walks the drizzle error cause chain to the driver SQLSTATE.
+const PG_RESTRICT_VIOLATION = "23001";
+
+export function isReferencedRowViolation(err: unknown): boolean {
+  const code = pgErrorCode(err);
+  return code === PG_FOREIGN_KEY_VIOLATION || code === PG_RESTRICT_VIOLATION;
+}

--- a/packages/hub-api/src/routes/credentials.ts
+++ b/packages/hub-api/src/routes/credentials.ts
@@ -473,17 +473,40 @@ export function createCredentialRoutes({
       const tenantCtx = c.get("tenant");
       const credentialId = c.req.param("credentialId");
 
-      const deleted = await db
-        .delete(credential)
-        .where(
-          and(
-            eq(credential.id, credentialId),
-            eq(credential.tenantId, tenantCtx.id),
-          ),
-        )
-        .returning();
+      // Delete the credential and its per-credential grants atomically. The
+      // `credential:{id}` resource is a plain text column with no foreign key
+      // to `credential`, so nothing cascades; every grant naming this exact
+      // resource is orphaned once the credential is gone and must be removed
+      // here. The exact-match resource never touches the coarse `credential:*`
+      // role grant.
+      const outcome = await db.transaction(async (tx) => {
+        const deleted = await tx
+          .delete(credential)
+          .where(
+            and(
+              eq(credential.id, credentialId),
+              eq(credential.tenantId, tenantCtx.id),
+            ),
+          )
+          .returning();
 
-      if (deleted.length === 0) {
+        if (deleted.length === 0) {
+          return "not_found" as const;
+        }
+
+        await tx
+          .delete(grantTable)
+          .where(
+            and(
+              eq(grantTable.tenantId, tenantCtx.id),
+              eq(grantTable.resource, `credential:${credentialId}`),
+            ),
+          );
+
+        return "deleted" as const;
+      });
+
+      if (outcome === "not_found") {
         return c.json(
           { error: { code: "not_found", message: "Credential not found" } },
           404,

--- a/packages/hub-api/src/routes/credentials.ts
+++ b/packages/hub-api/src/routes/credentials.ts
@@ -22,6 +22,7 @@ import type { CredentialCipher } from "@intx/types";
 import type { TenantEnv } from "../context";
 import { first, ts } from "../format";
 import { generateId } from "@intx/hub-common";
+import { isReferencedRowViolation } from "../pg-errors";
 import { idResource } from "../middleware/grant";
 import type { RequireGrant } from "../middleware/grant";
 import {
@@ -467,44 +468,75 @@ export function createCredentialRoutes({
             "application/json": { schema: resolver(ErrorResponse) },
           },
         },
+        409: {
+          description: "Credential is in use by a model provider",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
       },
     }),
     async (c) => {
       const tenantCtx = c.get("tenant");
       const credentialId = c.req.param("credentialId");
 
-      // Delete the credential and its per-credential grants atomically. The
-      // `credential:{id}` resource is a plain text column with no foreign key
-      // to `credential`, so nothing cascades; every grant naming this exact
-      // resource is orphaned once the credential is gone and must be removed
-      // here. The exact-match resource never touches the coarse `credential:*`
-      // role grant.
-      const outcome = await db.transaction(async (tx) => {
-        const deleted = await tx
-          .delete(credential)
-          .where(
-            and(
-              eq(credential.id, credentialId),
-              eq(credential.tenantId, tenantCtx.id),
-            ),
-          )
-          .returning();
+      // Delete the credential and its per-credential grants atomically. Two
+      // invariants, each owned by exactly one layer:
+      //   - Existence within the tenant is owned by the delete's WHERE clause
+      //     (`id` AND `tenantId`). authz cannot own it: the resource string
+      //     `credential:{id}` is opaque, so a wildcard grant matches an id in
+      //     any tenant. A foreign or unknown id matches zero rows -> 404,
+      //     disclosing nothing across the tenant boundary.
+      //   - "Cannot delete a credential a model provider still references" is
+      //     owned by the model_provider.credential_id foreign key, which is
+      //     onDelete "restrict" (catalog.ts). The delete fires it only for a row
+      //     actually being deleted (an in-tenant credential), so the catch maps
+      //     the raw violation to a 409 instead of a 500.
+      // The grant delete keys on the exact `credential:{id}` resource, which has
+      // no foreign key to `credential` (nothing cascades) and never matches the
+      // coarse `credential:*` role grant.
+      let outcome: "not_found" | "deleted";
+      try {
+        outcome = await db.transaction(async (tx) => {
+          const deleted = await tx
+            .delete(credential)
+            .where(
+              and(
+                eq(credential.id, credentialId),
+                eq(credential.tenantId, tenantCtx.id),
+              ),
+            )
+            .returning();
 
-        if (deleted.length === 0) {
-          return "not_found" as const;
+          if (deleted.length === 0) {
+            return "not_found" as const;
+          }
+
+          await tx
+            .delete(grantTable)
+            .where(
+              and(
+                eq(grantTable.tenantId, tenantCtx.id),
+                eq(grantTable.resource, `credential:${credentialId}`),
+              ),
+            );
+
+          return "deleted" as const;
+        });
+      } catch (err) {
+        if (!isReferencedRowViolation(err)) {
+          throw err;
         }
-
-        await tx
-          .delete(grantTable)
-          .where(
-            and(
-              eq(grantTable.tenantId, tenantCtx.id),
-              eq(grantTable.resource, `credential:${credentialId}`),
-            ),
-          );
-
-        return "deleted" as const;
-      });
+        return c.json(
+          {
+            error: {
+              code: "conflict",
+              message: "Credential is in use by a model provider",
+            },
+          },
+          409,
+        );
+      }
 
       if (outcome === "not_found") {
         return c.json(

--- a/packages/hub-api/src/routes/wallets.ts
+++ b/packages/hub-api/src/routes/wallets.ts
@@ -17,6 +17,7 @@ import {
 import type { TenantEnv } from "../context";
 import { first, ts } from "../format";
 import { generateId } from "@intx/hub-common";
+import { isReferencedRowViolation } from "../pg-errors";
 import { idResource } from "../middleware/grant";
 import type { RequireGrant } from "../middleware/grant";
 import {
@@ -265,18 +266,56 @@ export function createWalletRoutes({
             "application/json": { schema: resolver(ErrorResponse) },
           },
         },
+        409: {
+          description: "Wallet is in use by a model provider",
+          content: {
+            "application/json": { schema: resolver(ErrorResponse) },
+          },
+        },
       },
     }),
     async (c) => {
       const tenantCtx = c.get("tenant");
       const walletId = c.req.param("walletId");
 
-      const deleted = await db
-        .delete(wallet)
-        .where(and(eq(wallet.id, walletId), eq(wallet.tenantId, tenantCtx.id)))
-        .returning();
+      // Two invariants, each owned by one layer:
+      //   - Existence within the tenant is owned by the delete's WHERE clause
+      //     (`id` AND `tenantId`). authz cannot own it: the resource string
+      //     `wallet:{id}` is opaque, so a wildcard grant matches an id in any
+      //     tenant. A foreign or unknown id matches zero rows -> 404, disclosing
+      //     nothing across the tenant boundary.
+      //   - "Cannot delete a wallet a model provider still references" is owned
+      //     by the model_provider.wallet_id foreign key (onDelete "restrict",
+      //     catalog.ts). The delete fires it only for a row actually being
+      //     deleted, so the catch maps the raw violation to a 409 instead of a
+      //     500.
+      // Wallets mint no per-wallet grant, so there is no grant cleanup and the
+      // single delete needs no transaction.
+      let outcome: "not_found" | "deleted";
+      try {
+        const deleted = await db
+          .delete(wallet)
+          .where(
+            and(eq(wallet.id, walletId), eq(wallet.tenantId, tenantCtx.id)),
+          )
+          .returning();
+        outcome = deleted.length === 0 ? "not_found" : "deleted";
+      } catch (err) {
+        if (!isReferencedRowViolation(err)) {
+          throw err;
+        }
+        return c.json(
+          {
+            error: {
+              code: "conflict",
+              message: "Wallet is in use by a model provider",
+            },
+          },
+          409,
+        );
+      }
 
-      if (deleted.length === 0) {
+      if (outcome === "not_found") {
         return c.json(
           { error: { code: "not_found", message: "Wallet not found" } },
           404,

--- a/tests/db/orphaned-credential-grant-cleanup.test.ts
+++ b/tests/db/orphaned-credential-grant-cleanup.test.ts
@@ -1,0 +1,161 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { sql } from "drizzle-orm";
+
+import { credential, grant } from "@intx/db/schema";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import { REPO_ROOT } from "@intx/test-harness/env";
+import {
+  seedCredential,
+  seedPrincipal,
+  seedProvider,
+  seedTenants,
+} from "@intx/test-harness/seed";
+
+// Exercise the shipped cleanup migration against the real migrated schema.
+// The migration already ran on the empty schema at creation; re-executing its
+// own SQL after seeding is legitimate because the DELETE is idempotent.
+const MIGRATION_SQL = readFileSync(
+  path.join(
+    REPO_ROOT,
+    "packages/db/migrations/0084_delete_orphaned_credential_grants.sql",
+  ),
+  "utf8",
+);
+
+const TENANT_ID = "tnt_cleanup";
+const PRINCIPAL_ID = "prn_owner";
+const PROVIDER_ID = "prv_test";
+const LIVE_CREDENTIAL_ID = "crd_live";
+
+let h: TestDb;
+
+beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
+  h = await createTestDb();
+});
+
+afterAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
+  await h.close();
+});
+
+beforeEach(async () => {
+  if (!harnessDbEnvAvailable()) return;
+  await h.reset();
+});
+
+function grantRow(id: string, resource: string, action: string) {
+  return {
+    id,
+    tenantId: TENANT_ID,
+    principalId: PRINCIPAL_ID,
+    resource,
+    action,
+    effect: "allow" as const,
+    origin: "creator" as const,
+  };
+}
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "0082 orphaned credential grant cleanup",
+  () => {
+    test("removes only grants naming a credential that no longer exists", async () => {
+      await seedTenants(h.db, [{ id: TENANT_ID }]);
+      await seedPrincipal(h.db, {
+        id: PRINCIPAL_ID,
+        tenantId: TENANT_ID,
+        refId: "usr_owner",
+      });
+      await seedProvider(h.db, {
+        id: PROVIDER_ID,
+        tenantId: TENANT_ID,
+        name: "openai",
+      });
+      await seedCredential(h.db, {
+        id: LIVE_CREDENTIAL_ID,
+        tenantId: TENANT_ID,
+        providerId: PROVIDER_ID,
+        principalId: PRINCIPAL_ID,
+        name: "live",
+        type: "api_key",
+        secret: "sk",
+      });
+
+      await h.db.insert(grant).values([
+        // Orphan: no credential has the id `crd_dead` -> removed.
+        grantRow("grn_orphan", "credential:crd_dead", "use"),
+        // Names a live credential -> survives.
+        grantRow("grn_live", `credential:${LIVE_CREDENTIAL_ID}`, "use"),
+        // Coarse wildcard role resource -> survives (guards the denylist).
+        grantRow("grn_wildcard", "credential:*", "use"),
+        // Unrelated resource sharing no prefix -> survives (guards LIKE).
+        grantRow("grn_unrelated", "workflow-run:*", "read"),
+      ]);
+
+      await h.db.execute(sql.raw(MIGRATION_SQL));
+
+      const remaining = await h.db
+        .select({ id: grant.id })
+        .from(grant)
+        .orderBy(grant.id);
+      const remainingIds = remaining.map((r) => r.id);
+
+      expect(remainingIds).toEqual([
+        "grn_live",
+        "grn_unrelated",
+        "grn_wildcard",
+      ]);
+    });
+
+    test("is a no-op when there are no orphaned grants", async () => {
+      await seedTenants(h.db, [{ id: TENANT_ID }]);
+      await seedPrincipal(h.db, {
+        id: PRINCIPAL_ID,
+        tenantId: TENANT_ID,
+        refId: "usr_owner",
+      });
+      await seedProvider(h.db, {
+        id: PROVIDER_ID,
+        tenantId: TENANT_ID,
+        name: "openai",
+      });
+      await seedCredential(h.db, {
+        id: LIVE_CREDENTIAL_ID,
+        tenantId: TENANT_ID,
+        providerId: PROVIDER_ID,
+        principalId: PRINCIPAL_ID,
+        name: "live",
+        type: "api_key",
+        secret: "sk",
+      });
+      await h.db
+        .insert(grant)
+        .values(
+          grantRow("grn_live", `credential:${LIVE_CREDENTIAL_ID}`, "use"),
+        );
+
+      await h.db.execute(sql.raw(MIGRATION_SQL));
+      await h.db.execute(sql.raw(MIGRATION_SQL));
+
+      const remaining = await h.db.select({ id: grant.id }).from(grant);
+      expect(remaining.map((r) => r.id)).toEqual(["grn_live"]);
+
+      // The live credential itself is untouched by the grant cleanup.
+      const creds = await h.db.select({ id: credential.id }).from(credential);
+      expect(creds.map((r) => r.id)).toEqual([LIVE_CREDENTIAL_ID]);
+    });
+  },
+);

--- a/tests/hub-api/credential-routes.test.ts
+++ b/tests/hub-api/credential-routes.test.ts
@@ -369,3 +369,174 @@ describe.skipIf(!harnessDbEnvAvailable())(
     });
   },
 );
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "DELETE /api/tenants/:tenantId/credentials/:credentialId",
+  () => {
+    test("removes the owner's per-credential use-grant when a personal credential is deleted", async () => {
+      const app = await setup();
+      const createRes = await app.request(
+        `/api/tenants/${TENANT_ID}/credentials`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            providerId: PROVIDER_ID,
+            name: "delete-me",
+            type: "api_key",
+            secret: "sk-personal",
+            principalId: OWNER_PRINCIPAL_ID,
+          }),
+        },
+      );
+      expect(createRes.status).toBe(201);
+      const created: unknown = await createRes.json();
+      if (!isObject(created)) throw new Error("expected object body");
+      const credentialId = created["id"];
+      if (typeof credentialId !== "string") {
+        throw new Error("expected credential id");
+      }
+
+      expect(await useGrantsFor(credentialId, OWNER_PRINCIPAL_ID)).toHaveLength(
+        1,
+      );
+
+      const deleteRes = await app.request(
+        `/api/tenants/${TENANT_ID}/credentials/${credentialId}`,
+        { method: "DELETE" },
+      );
+      expect(deleteRes.status).toBe(204);
+
+      expect(await useGrantsFor(credentialId, OWNER_PRINCIPAL_ID)).toHaveLength(
+        0,
+      );
+    });
+
+    test("deletes an organizational credential that has no use-grant", async () => {
+      const app = await setup();
+      const createRes = await app.request(
+        `/api/tenants/${TENANT_ID}/credentials`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            providerId: PROVIDER_ID,
+            name: "org-delete-me",
+            type: "api_key",
+            secret: "sk-org",
+          }),
+        },
+      );
+      expect(createRes.status).toBe(201);
+      const created: unknown = await createRes.json();
+      if (!isObject(created)) throw new Error("expected object body");
+      const credentialId = created["id"];
+      if (typeof credentialId !== "string") {
+        throw new Error("expected credential id");
+      }
+
+      const deleteRes = await app.request(
+        `/api/tenants/${TENANT_ID}/credentials/${credentialId}`,
+        { method: "DELETE" },
+      );
+      expect(deleteRes.status).toBe(204);
+    });
+
+    test("returns 404 when the credential does not exist", async () => {
+      const app = await setup();
+      const deleteRes = await app.request(
+        `/api/tenants/${TENANT_ID}/credentials/crd_missing`,
+        { method: "DELETE" },
+      );
+      expect(deleteRes.status).toBe(404);
+    });
+
+    test("removes every grant naming the exact resource but spares the wildcard and prefix siblings", async () => {
+      const app = await setup();
+      const createRes = await app.request(
+        `/api/tenants/${TENANT_ID}/credentials`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            providerId: PROVIDER_ID,
+            name: "guarded",
+            type: "api_key",
+            secret: "sk-personal",
+            principalId: OWNER_PRINCIPAL_ID,
+          }),
+        },
+      );
+      expect(createRes.status).toBe(201);
+      const created: unknown = await createRes.json();
+      if (!isObject(created)) throw new Error("expected object body");
+      const credentialId = created["id"];
+      if (typeof credentialId !== "string") {
+        throw new Error("expected credential id");
+      }
+
+      // Alongside the auto-minted `credential:{id}` / `use` grant, seed a
+      // same-resource `manage` grant (must also be removed), a coarse
+      // `credential:*` wildcard grant (must survive), and a prefix-sibling
+      // `credential:{id}-other` grant (must survive). Together these guard the
+      // two design decisions: exact-match never touches the wildcard, and the
+      // delete is action-agnostic.
+      await h.db.insert(grantTable).values([
+        {
+          id: "grn_extra_manage",
+          tenantId: TENANT_ID,
+          principalId: OWNER_PRINCIPAL_ID,
+          resource: `credential:${credentialId}`,
+          action: "manage",
+          effect: "allow",
+          origin: "invoker",
+        },
+        {
+          id: "grn_wildcard",
+          tenantId: TENANT_ID,
+          principalId: OWNER_PRINCIPAL_ID,
+          resource: "credential:*",
+          action: "use",
+          effect: "allow",
+          origin: "invoker",
+        },
+        {
+          id: "grn_sibling",
+          tenantId: TENANT_ID,
+          principalId: OWNER_PRINCIPAL_ID,
+          resource: `credential:${credentialId}-other`,
+          action: "use",
+          effect: "allow",
+          origin: "invoker",
+        },
+      ]);
+
+      const deleteRes = await app.request(
+        `/api/tenants/${TENANT_ID}/credentials/${credentialId}`,
+        { method: "DELETE" },
+      );
+      expect(deleteRes.status).toBe(204);
+
+      const remaining = await h.db
+        .select()
+        .from(grantTable)
+        .where(eq(grantTable.tenantId, TENANT_ID));
+      const remainingResources = remaining.map(
+        (g) => `${g.resource}/${g.action}`,
+      );
+
+      // Both grants naming the exact resource are gone (use + manage).
+      expect(remainingResources).not.toContain(
+        `credential:${credentialId}/use`,
+      );
+      expect(remainingResources).not.toContain(
+        `credential:${credentialId}/manage`,
+      );
+      // The wildcard grant and the prefix sibling are untouched.
+      expect(remainingResources).toContain("credential:*/use");
+      expect(remainingResources).toContain(
+        `credential:${credentialId}-other/use`,
+      );
+    });
+  },
+);

--- a/tests/hub-api/credential-routes.test.ts
+++ b/tests/hub-api/credential-routes.test.ts
@@ -16,6 +16,7 @@ import {
   type SessionService,
   type SidecarRouter,
 } from "@intx/hub-sessions";
+import { pgErrorCode } from "@intx/db";
 import { credential, grant as grantTable } from "@intx/db/schema";
 import type { GrantRule } from "@intx/types/authz";
 import { credentialAad } from "@intx/types";
@@ -26,6 +27,8 @@ import {
 } from "@intx/test-harness/db-harness";
 import { createTestCredentialCipher } from "@intx/test-harness/crypto";
 import {
+  seedCredential,
+  seedModelProvider,
   seedPrincipal,
   seedProvider,
   seedTenants,
@@ -451,6 +454,108 @@ describe.skipIf(!harnessDbEnvAvailable())(
       expect(deleteRes.status).toBe(404);
     });
 
+    test("returns 409 and preserves the credential when a model provider references it", async () => {
+      const app = await setup();
+      const createRes = await app.request(
+        `/api/tenants/${TENANT_ID}/credentials`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            providerId: PROVIDER_ID,
+            name: "bound",
+            type: "api_key",
+            secret: "sk-personal",
+            principalId: OWNER_PRINCIPAL_ID,
+          }),
+        },
+      );
+      expect(createRes.status).toBe(201);
+      const created: unknown = await createRes.json();
+      if (!isObject(created)) throw new Error("expected object body");
+      const credentialId = created["id"];
+      if (typeof credentialId !== "string") {
+        throw new Error("expected credential id");
+      }
+
+      await seedModelProvider(h.db, {
+        id: "mp_bound",
+        tenantId: TENANT_ID,
+        name: "bound-provider",
+        plugin: "openai",
+        baseURL: "https://api.openai.com",
+        credentialId,
+      });
+
+      const deleteRes = await app.request(
+        `/api/tenants/${TENANT_ID}/credentials/${credentialId}`,
+        { method: "DELETE" },
+      );
+      expect(deleteRes.status).toBe(409);
+      const body: unknown = await deleteRes.json();
+      if (!isObject(body)) throw new Error("expected object body");
+      const error = body["error"];
+      if (!isObject(error)) throw new Error("expected error object");
+      expect(error["code"]).toBe("conflict");
+
+      // The rejected delete leaves the credential and its use-grant intact.
+      const [row] = await h.db
+        .select()
+        .from(credential)
+        .where(eq(credential.id, credentialId));
+      expect(row).toBeDefined();
+      expect(await useGrantsFor(credentialId, OWNER_PRINCIPAL_ID)).toHaveLength(
+        1,
+      );
+    });
+
+    test("returns 404 without disclosing a referenced credential in another tenant", async () => {
+      const app = await setup();
+
+      // A credential in a different tenant, referenced by a model provider
+      // there. The acting principal holds a wildcard `credential:*` grant, so
+      // requireGrant admits the request; tenant isolation is owned by the
+      // delete's WHERE clause. A pre-check that queried the referencing row
+      // globally would leak the credential's existence as a 409.
+      const OTHER_TENANT_ID = "tnt_other";
+      await seedTenants(h.db, [{ id: OTHER_TENANT_ID }]);
+      await seedProvider(h.db, {
+        id: "prv_other",
+        tenantId: OTHER_TENANT_ID,
+        name: "openai",
+      });
+      await seedCredential(h.db, {
+        id: "crd_foreign",
+        tenantId: OTHER_TENANT_ID,
+        providerId: "prv_other",
+        name: "foreign",
+        type: "api_key",
+        secret: "sk",
+      });
+      await seedModelProvider(h.db, {
+        id: "mp_foreign",
+        tenantId: OTHER_TENANT_ID,
+        name: "foreign-provider",
+        plugin: "openai",
+        baseURL: "https://api.openai.com",
+        credentialId: "crd_foreign",
+      });
+
+      const deleteRes = await app.request(
+        `/api/tenants/${TENANT_ID}/credentials/crd_foreign`,
+        { method: "DELETE" },
+      );
+      expect(deleteRes.status).toBe(404);
+
+      // The foreign credential is untouched -- the delete matched no row in the
+      // caller's tenant and never reached the foreign referencing row.
+      const creds = await h.db
+        .select({ id: credential.id })
+        .from(credential)
+        .where(eq(credential.id, "crd_foreign"));
+      expect(creds).toHaveLength(1);
+    });
+
     test("removes every grant naming the exact resource but spares the wildcard and prefix siblings", async () => {
       const app = await setup();
       const createRes = await app.request(
@@ -537,6 +642,71 @@ describe.skipIf(!harnessDbEnvAvailable())(
       expect(remainingResources).toContain(
         `credential:${credentialId}-other/use`,
       );
+    });
+  },
+);
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "credential delete foreign-key error shape",
+  () => {
+    test("a restrict violation on credential delete is recognized as a referenced-row violation", async () => {
+      // The DELETE handler's catch maps a model_provider.credential_id restrict
+      // violation to a 409; its isReferencedRowViolation check reads the
+      // SQLSTATE via pgErrorCode. Pin the empirical fact this rests on: a real
+      // restrict-foreign-key delete through drizzle surfaces a referenced-row
+      // violation on the error cause chain -- 23001 (restrict_violation) or
+      // 23503 (foreign_key_violation), depending on the Postgres version. The
+      // route 409 test drives the catch end to end; a driver-wrapping change is
+      // caught here.
+      await seedTenants(h.db, [{ id: TENANT_ID }]);
+      await seedPrincipal(h.db, {
+        id: OWNER_PRINCIPAL_ID,
+        tenantId: TENANT_ID,
+        refId: "usr_owner",
+      });
+      await seedProvider(h.db, {
+        id: PROVIDER_ID,
+        tenantId: TENANT_ID,
+        name: "openai",
+      });
+      await seedCredential(h.db, {
+        id: "crd_bound",
+        tenantId: TENANT_ID,
+        providerId: PROVIDER_ID,
+        principalId: OWNER_PRINCIPAL_ID,
+        name: "bound",
+        type: "api_key",
+        secret: "sk",
+      });
+      await seedModelProvider(h.db, {
+        id: "mp_ref",
+        tenantId: TENANT_ID,
+        name: "ref",
+        plugin: "openai",
+        baseURL: "https://api.openai.com",
+        credentialId: "crd_bound",
+      });
+
+      let caught: unknown = undefined;
+      let deletedWithoutError = false;
+      try {
+        await h.db.transaction(async (tx) => {
+          await tx
+            .delete(credential)
+            .where(eq(credential.id, "crd_bound"))
+            .returning();
+        });
+        deletedWithoutError = true;
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(deletedWithoutError).toBe(false);
+      const code = pgErrorCode(caught);
+      if (code === undefined) {
+        throw new Error("expected a SQLSTATE on the caught error");
+      }
+      expect(["23001", "23503"]).toContain(code);
     });
   },
 );

--- a/tests/hub-api/wallet-routes.test.ts
+++ b/tests/hub-api/wallet-routes.test.ts
@@ -1,0 +1,267 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { eq } from "drizzle-orm";
+
+import { createInMemoryGrantStore } from "@intx/authz";
+import { createApp, type GetSession } from "@intx/hub-api";
+import {
+  createSidecarEmitter,
+  type EventCollectorRegistry,
+  type SessionService,
+  type SidecarRouter,
+} from "@intx/hub-sessions";
+import { wallet } from "@intx/db/schema";
+import type { GrantRule } from "@intx/types/authz";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import { createTestCredentialCipher } from "@intx/test-harness/crypto";
+import {
+  seedModelProvider,
+  seedPrincipal,
+  seedTenants,
+  seedWallet,
+} from "@intx/test-harness/seed";
+
+// These route tests exercise wallet deletion against a real migrated schema so
+// the model_provider.wallet_id restrict foreign key is enforced for real.
+
+const TENANT_ID = "tnt_wallet";
+const ACTOR_PRINCIPAL_ID = "prn_actor";
+const ACTOR_USER_ID = "usr_actor";
+
+function createMockGetSession(userId: string): GetSession {
+  const now = new Date("2025-01-01");
+  return async () => ({
+    user: {
+      id: userId,
+      email: "test@example.com",
+      emailVerified: true,
+      name: "Test User",
+      createdAt: now,
+      updatedAt: now,
+    },
+    session: {
+      id: "session_test",
+      userId,
+      token: "tok_test",
+      expiresAt: new Date("2999-01-01"),
+      createdAt: now,
+      updatedAt: now,
+    },
+  });
+}
+
+function notImpl(name: string): never {
+  throw new Error(`mock: ${name} not implemented`);
+}
+
+function createMockSidecarRouter(): SidecarRouter {
+  return {
+    handleOpen: () => notImpl("handleOpen"),
+    handleMessage: () => notImpl("handleMessage"),
+    handleClose: () => notImpl("handleClose"),
+    routeMail: () => notImpl("routeMail"),
+    sendRunGrants: () => notImpl("sendRunGrants"),
+    sendAgentDeploy: () => notImpl("sendAgentDeploy"),
+    sendAgentUndeploy: () => notImpl("sendAgentUndeploy"),
+    sendSourcesUpdate: () => notImpl("sendSourcesUpdate"),
+    sendCredentialsUpdate: () => notImpl("sendCredentialsUpdate"),
+    sendPack: () => notImpl("sendPack"),
+    sendProvisionStep: () => notImpl("sendProvisionStep"),
+    bindStepRoute: () => notImpl("bindStepRoute"),
+    unbindStepRoute: () => notImpl("unbindStepRoute"),
+    sendSyncRequest: () => notImpl("sendSyncRequest"),
+    sendSignalDeliver: () => notImpl("sendSignalDeliver"),
+    sendDrain: () => notImpl("sendDrain"),
+    subscribeAgent: () => notImpl("subscribeAgent"),
+    dispatchAgentEvent: () => undefined,
+    getConnectedSidecars: () => [],
+    getRoutableAddresses: () => [],
+    getConnectorState: () => null,
+    events: createSidecarEmitter(),
+  };
+}
+
+function createMockSessionService(): SessionService {
+  return {
+    stageWorkflowStep: () => notImpl("stageWorkflowStep"),
+    deployWorkflowFromSource: () => notImpl("deployWorkflowFromSource"),
+    sendUserMessage: () => notImpl("sendUserMessage"),
+    endSession: () => notImpl("endSession"),
+  };
+}
+
+function createMockEventCollectors(): EventCollectorRegistry {
+  return {
+    create: () => notImpl("create"),
+    dispatch: () => notImpl("dispatch"),
+    abandon: () => notImpl("abandon"),
+    has: () => false,
+    getStatus: () => undefined,
+    getAccumulatedText: () => undefined,
+    getCurrentTurnId: () => undefined,
+    getLastTurnId: () => undefined,
+  };
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function createGrant(action: string): GrantRule {
+  return {
+    id: `grant-actor-${action}`,
+    resource: "wallet:*",
+    action,
+    effect: "allow",
+    origin: "system",
+    conditions: null,
+    expiresAt: null,
+    roleId: null,
+    principalId: ACTOR_PRINCIPAL_ID,
+  };
+}
+
+let h: TestDb;
+
+beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
+  h = await createTestDb();
+});
+
+afterAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
+  await h.close();
+});
+
+beforeEach(async () => {
+  if (!harnessDbEnvAvailable()) return;
+  await h.reset();
+});
+
+async function setup() {
+  await seedTenants(h.db, [{ id: TENANT_ID }]);
+  await seedPrincipal(h.db, {
+    id: ACTOR_PRINCIPAL_ID,
+    tenantId: TENANT_ID,
+    refId: ACTOR_USER_ID,
+  });
+
+  const app = createApp({
+    getSession: createMockGetSession(ACTOR_USER_ID),
+    authHandler: () => new Response("", { status: 404 }),
+    db: h.db,
+    grantStore: createInMemoryGrantStore([createGrant("manage")]),
+    sidecarRouter: createMockSidecarRouter(),
+    sessionService: createMockSessionService(),
+    eventCollectors: createMockEventCollectors(),
+    credentialCipher: createTestCredentialCipher(),
+    assetService: null,
+    repoStore: null,
+    maxTarballBytes: 10_000_000,
+  });
+  return app;
+}
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "DELETE /api/tenants/:tenantId/wallets/:walletId",
+  () => {
+    test("returns 409 and preserves the wallet when a model provider references it", async () => {
+      const app = await setup();
+      await seedWallet(h.db, { id: "wlt_bound", tenantId: TENANT_ID });
+      await seedModelProvider(h.db, {
+        id: "mp_wallet",
+        tenantId: TENANT_ID,
+        name: "wallet-provider",
+        plugin: "openai",
+        baseURL: "https://api.openai.com",
+        walletId: "wlt_bound",
+      });
+
+      const res = await app.request(
+        `/api/tenants/${TENANT_ID}/wallets/wlt_bound`,
+        { method: "DELETE" },
+      );
+      expect(res.status).toBe(409);
+      const body: unknown = await res.json();
+      if (!isObject(body)) throw new Error("expected object body");
+      const error = body["error"];
+      if (!isObject(error)) throw new Error("expected error object");
+      expect(error["code"]).toBe("conflict");
+
+      const [row] = await h.db
+        .select()
+        .from(wallet)
+        .where(eq(wallet.id, "wlt_bound"));
+      expect(row).toBeDefined();
+    });
+
+    test("deletes a wallet that no model provider references", async () => {
+      const app = await setup();
+      await seedWallet(h.db, { id: "wlt_free", tenantId: TENANT_ID });
+
+      const res = await app.request(
+        `/api/tenants/${TENANT_ID}/wallets/wlt_free`,
+        { method: "DELETE" },
+      );
+      expect(res.status).toBe(204);
+
+      const rows = await h.db
+        .select()
+        .from(wallet)
+        .where(eq(wallet.id, "wlt_free"));
+      expect(rows).toHaveLength(0);
+    });
+
+    test("returns 404 when the wallet does not exist", async () => {
+      const app = await setup();
+      const res = await app.request(
+        `/api/tenants/${TENANT_ID}/wallets/wlt_missing`,
+        { method: "DELETE" },
+      );
+      expect(res.status).toBe(404);
+    });
+
+    test("returns 404 without disclosing a referenced wallet in another tenant", async () => {
+      const app = await setup();
+
+      // A wallet in a different tenant, referenced by a model provider there.
+      // The acting principal holds a wildcard `wallet:*` grant, so requireGrant
+      // admits the request; tenant isolation is owned by the delete's WHERE
+      // clause. A pre-check that queried the referencing row globally would leak
+      // the wallet's existence as a 409.
+      const OTHER_TENANT_ID = "tnt_other";
+      await seedTenants(h.db, [{ id: OTHER_TENANT_ID }]);
+      await seedWallet(h.db, { id: "wlt_foreign", tenantId: OTHER_TENANT_ID });
+      await seedModelProvider(h.db, {
+        id: "mp_foreign",
+        tenantId: OTHER_TENANT_ID,
+        name: "foreign-provider",
+        plugin: "openai",
+        baseURL: "https://api.openai.com",
+        walletId: "wlt_foreign",
+      });
+
+      const res = await app.request(
+        `/api/tenants/${TENANT_ID}/wallets/wlt_foreign`,
+        { method: "DELETE" },
+      );
+      expect(res.status).toBe(404);
+
+      const rows = await h.db
+        .select()
+        .from(wallet)
+        .where(eq(wallet.id, "wlt_foreign"));
+      expect(rows).toHaveLength(1);
+    });
+  },
+);


### PR DESCRIPTION
## Summary

- Credential deletion removes the credential and its per-credential
  `credential:{id}` grants in one transaction, so grants no longer outlive
  the credential they authorize.
- Deleting a credential or wallet still referenced by a model provider
  returns 409 Conflict instead of a raw 500 (the `model_provider` foreign
  keys are `onDelete: restrict`); a foreign-tenant id returns 404.
- A one-time migration removes `credential:{id}` grants already orphaned by
  pre-fix deletes, sparing the coarse `credential:*` role grant.
- `buildCredentialDelivery` no longer builds the unused `bindingGrants`.

## Verification

The build passes (`make all` exits 0). Credential and wallet deletion, the
409 in-use paths, tenant-scoped 404s (including a cross-tenant probe), and
the cleanup migration are covered by tests against a real migrated Postgres
schema.

Closes INTR-411