### PR TITLE
Describe authorization in workflow-run principal terms

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -283,7 +283,7 @@ Revoke federation trust
 ### GET /api/tenants/:tenantId/principals
 List principals in the tenant
 
-Lists all principals (users, agents, and workflow deployments) in the tenant. Filterable by kind and status.
+Lists all principals (users, agents, and workflow runs) in the tenant. Filterable by kind and status.
 
 Query: kind?: user|agent|workflow, status?: active|suspended|invited|deactivated, cursor?, limit?
 
@@ -310,7 +310,7 @@ Body: UpdatePrincipal
 ### DELETE /api/tenants/:tenantId/principals/:principalId
 Remove principal from tenant
 
-Removes a user or agent principal from the tenant. For agents, use agent deletion instead.
+Removes a principal from the tenant.
 
 204: (no content) -- Principal removed
 403: ErrorResponse -- Insufficient grants

--- a/docs/API.md
+++ b/docs/API.md
@@ -1282,7 +1282,7 @@ Source: packages/types/src/tenants.ts
 Source: packages/types/src/grants.ts
 
 **effect**: Outcome when this grant is the one resolved for a request: `allow` permits the action, `deny` blocks it, `ask` requires interactive approval before proceeding. When several grants match, the most specific wins, and at equal specificity the strongest effect wins (`deny` over `ask` over `allow`).
-**origin**: Records where the grant came from: `system` (built-in), `role` (granted via a role), `creator` (from the agent definition author), or `invoker` (delegated by whoever launched the agent). Origin is provenance only; it does not affect evaluation precedence.
+**origin**: Records where the grant came from: `system` (built-in), `role` (granted via a role), `creator` (from the workflow definition author), or `invoker` (delegated by whoever launched the workflow run). Origin is provenance only; it does not affect evaluation precedence.
 **conditions**: Optional map of named conditions that must all pass for the grant to apply, evaluated against a condition registry at authorization time. A grant with conditions is skipped (fails closed) when no registry is available to evaluate them.
 
 ### CreateModel
@@ -1399,7 +1399,7 @@ Source: packages/types/src/agent-data.ts
 Source: packages/types/src/grants.ts
 
 **effect**: Outcome when this grant is the one resolved for a request: `allow` permits the action, `deny` blocks it, `ask` requires interactive approval before proceeding. When several grants match, the most specific wins, and at equal specificity the strongest effect wins (`deny` over `ask` over `allow`).
-**origin**: Records where the grant came from: `system` (built-in), `role` (granted via a role), `creator` (from the agent definition author), or `invoker` (delegated by whoever launched the agent). Origin is provenance only; it does not affect evaluation precedence.
+**origin**: Records where the grant came from: `system` (built-in), `role` (granted via a role), `creator` (from the workflow definition author), or `invoker` (delegated by whoever launched the workflow run). Origin is provenance only; it does not affect evaluation precedence.
 **conditions**: Optional map of named conditions that must all pass for the grant to apply, evaluated against a condition registry at authorization time. A grant with conditions is skipped (fails closed) when no registry is available to evaluate them.
 
 ### HistoryEntry

--- a/docs/API.md
+++ b/docs/API.md
@@ -1474,8 +1474,8 @@ Source: packages/types/src/catalog.ts
 `{ createdAt: string, displayName: string, id: string, kind: "agent" | "user" | "workflow", refId: string, roles: { id: string, name: string }[], status: "active" | "deactivated" | "invited" | "suspended", tenantId: string, updatedAt: string, email?: string }`
 Source: packages/types/src/principals.ts
 
-**kind**: Whether this principal represents a `user` (a human account), an `agent`, or a `workflow` (a workflow deployment).
-**refId**: Identifier of the underlying entity this principal stands for: the auth user id when `kind` is `user`, the agent id when `kind` is `agent`, or the run id when `kind` is `workflow`. Unique per tenant and kind.
+**kind**: Whether this principal represents a `user` (a human account), an `agent`, or a `workflow` (a workflow run).
+**refId**: Identifier of the underlying entity this principal stands for: the auth user id when `kind` is `user`, an agent-instance id when `kind` is `agent`, or a workflow run (`run_...`) or workflow definition (`wfd_...`) id when `kind` is `workflow`. Unique per tenant and kind.
 **status**: Account state of the principal: `active`, `suspended`, `invited` (membership pending acceptance), or `deactivated`.
 
 ### ProviderResponse

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Interchange uses a unified principal model where users and agents share the same authorization system. Authentication establishes global identity. Authorization is tenant-scoped and evaluated through capability grants attached to principals.
+Interchange uses a unified principal model where users and workflow runs share the same authorization system. Authentication establishes global identity. Authorization is tenant-scoped and evaluated through capability grants attached to principals.
 
 ## Authentication
 
@@ -17,24 +17,24 @@ Supported auth methods:
 
 A user can belong to many tenants. Tenant context is always encoded in the URL path as `/api/tenants/:tenantId/...` -- no headers, no implicit context.
 
-| Path scope                 | Example                        | Behavior                                                                             |
-| -------------------------- | ------------------------------ | ------------------------------------------------------------------------------------ |
-| Tenant-scoped              | `/api/tenants/tnt_abc/agents`  | Principal resolved from `(user_id, tnt_abc)`, grants evaluated                       |
-| User-scoped (cross-tenant) | `/api/me/principals`           | All of the user's principals resolved, results aggregated and tagged with `tenantId` |
-| Global                     | `/api/tenants`, `/api/auth/**` | No tenant context needed                                                             |
+| Path scope                 | Example                          | Behavior                                                                             |
+| -------------------------- | -------------------------------- | ------------------------------------------------------------------------------------ |
+| Tenant-scoped              | `/api/tenants/tnt_abc/workflows` | Principal resolved from `(user_id, tnt_abc)`, grants evaluated                       |
+| User-scoped (cross-tenant) | `/api/me/principals`             | All of the user's principals resolved, results aggregated and tagged with `tenantId` |
+| Global                     | `/api/tenants`, `/api/auth/**`   | No tenant context needed                                                             |
 
 ## Principals
 
-A principal represents an identity within a tenant. It is the universal join between an entity (user or agent) and a tenant. A principal does not grant authorization by itself -- it establishes that an entity exists in a tenant and tracks their membership status.
+A principal represents an identity within a tenant. It is the universal join between an entity (user or workflow run) and a tenant. A principal does not grant authorization by itself -- it establishes that an entity exists in a tenant and tracks their membership status.
 
-A user in three tenants has three principal rows. An agent in a tenant has one principal row. Every authorization question starts by resolving the principal.
+A user in three tenants has three principal rows. A workflow run in a tenant has one principal row. Every authorization question starts by resolving the principal.
 
 ```
 principal
   id              text PK        -- prn_...
   tenant_id       text FK -> tenant
-  kind            text NOT NULL  -- 'user' | 'agent'
-  ref_id          text NOT NULL  -- user.id or agent id (run_...)
+  kind            text NOT NULL  -- 'user' | 'agent' | 'workflow'
+  ref_id          text NOT NULL  -- user.id, or a workflow_run (run_...) or workflow_definition (wfd_...) id
   status          text NOT NULL  -- 'active' | 'suspended' | 'invited' | 'deactivated'
   created_at      timestamptz
   updated_at      timestamptz
@@ -60,11 +60,11 @@ Request to /api/me/...
   -> aggregate results across tenants, each tagged with tenantId
 ```
 
-Agent requests follow the same flow. The principal is resolved by `(run_id, tenant_id)` rather than `(user_id, tenant_id)`. The agent's materialized grants are evaluated against the requested operation.
+Workflow-run requests follow the same flow. The principal is resolved by `(run_id, tenant_id)` rather than `(user_id, tenant_id)`. The run principal's materialized grants are evaluated against the requested operation.
 
 ## Roles
 
-Roles are named bundles of capability grants scoped to a tenant. Both users and agents can be assigned roles.
+Roles are named bundles of capability grants scoped to a tenant. Both users and workflow runs can be assigned roles.
 
 ```
 role
@@ -90,7 +90,7 @@ principal_role
 
 ## Grant Requirements on Definitions
 
-Agent definitions declare grant requirements — the capabilities an agent needs to function. Requirements are not live grants. They are a manifest that the control plane resolves at launch time to produce materialized grants on the agent's principal. This mirrors the credential requirement model described in CREDENTIALS.md.
+Workflow definitions declare grant requirements — the capabilities a workflow run needs to function. Requirements are not live grants. They are a manifest that the control plane resolves at launch time to produce materialized grants on the run principal. This mirrors the credential requirement model described in CREDENTIALS.md.
 
 Each requirement specifies:
 
@@ -107,7 +107,7 @@ Each requirement specifies:
 The `source` field declares where the delegated authority should come from:
 
 - `source: "creator"` — The definition author must delegate this. Resolved at launch against the creator's own grants (identified by `creatorPrincipalId` on the definition). The control plane validates that the creator currently holds the authority being delegated — a creator cannot delegate what they don't have. Materializes as a `grant` with `origin = 'creator'`. This is the setuid model: the definition author's authority travels with the definition.
-- `source: "invoker"` — The person launching the agent must provide this. Resolved at launch against the invoker's grants. Materializes as a `grant` with `origin = 'invoker'` and a fixed 24-hour `expires_at` (`INVOKER_GRANT_TTL_MS`).
+- `source: "invoker"` — The person launching the workflow run must provide this. Resolved at launch against the invoker's grants. Materializes as a `grant` with `origin = 'invoker'` and a fixed 24-hour `expires_at` (`INVOKER_GRANT_TTL_MS`).
 
 Tenant-owned credential use is not a `source` on a grant requirement: it is authorized by ownership at resolution, and its consumer-scoping `credential:{id}` / `use` grant (`origin = 'system'`) is stamped directly rather than materialized from a requirement. See CREDENTIALS.md.
 
@@ -117,15 +117,15 @@ The definition stores a `creatorPrincipalId` field identifying the definition au
 
 ### Resolution at Launch
 
-When an agent is launched, the control plane processes each grant requirement:
+When a workflow run is launched, the control plane processes each grant requirement:
 
 1. Look at the `source` field
 2. Resolve the authority against the requirement's `source`: the creator's or the invoker's own grants
 3. Confirm the delegating principal holds the capability being delegated
-4. Create a `grant` row on the agent's new principal with the appropriate `origin` value
+4. Create a `grant` row on the run's new principal with the appropriate `origin` value
 5. Ship the effective grant set to the harness in the deploy frame
 
-The `initialGrants` field on `CreateAgent` is a grant requirements manifest — it specifies requirements with source annotations, not live grants. Each launch resolves these requirements against the current state of creator, tenant, and invoker authority.
+The `grantRequirements` field on a workflow definition is a grant requirements manifest — it specifies `GrantRequirement` entries with source annotations, not live grants. Each launch resolves these requirements against the current state of creator, tenant, and invoker authority.
 
 ## Definition Approval and Re-Verification
 
@@ -195,7 +195,7 @@ grant
   principal_id    text FK -> principal
 
   -- What is being authorized
-  resource        text NOT NULL  -- glob pattern: "agent:*", "wallet:wal_abc", "tool:bash"
+  resource        text NOT NULL  -- glob pattern: "workflow-run:*", "wallet:wal_abc", "tool:bash"
   action          text NOT NULL  -- glob pattern: "invoke", "read", "spend", "*"
   effect          text NOT NULL  -- 'allow' | 'deny' | 'ask'
 
@@ -214,8 +214,8 @@ grant
 
 Resources use a `type:identifier` format with glob support:
 
-- `agent:*` -- all agents
-- `agent:agt_abc123` -- a specific agent
+- `workflow-run:*` -- all workflow runs
+- `workflow-run:run_abc123` -- a specific workflow run
 - `wallet:wal_*` -- all wallets
 - `tool:bash` -- the bash tool
 - `tool:*` -- all tools
@@ -261,11 +261,11 @@ Conditions are evaluated at runtime by the authorization engine: a grant whose r
 
 Grant revocation is policy-driven with a default of fail-secure.
 
-**Creator grant revocation**: If the creator's authority is revoked after agents have been launched with creator-sourced grants, running agents must lose the affected grants. The harness authorizes each tool call against its live materialized grant set before the call executes, so a revoked capability is blocked once that set no longer contains it; a tool call already in flight is not interrupted. Propagating a revocation to an already-running deployment is not currently implemented — the earlier `grants.update` wire mechanism has been retired, and its supervised replacement is designed separately. Until then, the change takes effect when the deployment next loads its grants (the deploy pack at spawn and the supervisor's IPC credentials snapshot at recycle). Tenants can configure grace periods or notification-only behavior for specific grant types.
+**Creator grant revocation**: If the creator's authority is revoked after workflow runs have been launched with creator-sourced grants, those running workflow runs must lose the affected grants. The harness authorizes each tool call against its live materialized grant set before the call executes, so a revoked capability is blocked once that set no longer contains it; a tool call already in flight is not interrupted. Propagating a revocation to an already-running deployment is not currently implemented — the earlier `grants.update` wire mechanism has been retired, and its supervised replacement is designed separately. Until then, the change takes effect when the deployment next loads its grants (the deploy pack at spawn and the supervisor's IPC credentials snapshot at recycle). Tenants can configure grace periods or notification-only behavior for specific grant types.
 
-**Invoker grant revocation**: Invoker-granted capabilities carry a fixed 24-hour TTL from launch (`INVOKER_GRANT_TTL_MS`), not a lifetime tied to when the agent stops. A capability the user explicitly persists (approving with `always`) becomes a non-expiring grant.
+**Invoker grant revocation**: Invoker-granted capabilities carry a fixed 24-hour TTL from launch (`INVOKER_GRANT_TTL_MS`), not a lifetime tied to when the run stops. A capability the user explicitly persists (approving with `always`) becomes a non-expiring grant.
 
-**Tenant policy changes**: When tenant policies change (role modifications, system role updates), the control plane re-evaluates affected agents. Propagating the resulting grant changes to already-running deployments shares the retired-mechanism gap described above; a change takes effect when each deployment next loads its grants.
+**Tenant policy changes**: When tenant policies change (role modifications, system role updates), the control plane re-evaluates affected runs. Propagating the resulting grant changes to already-running deployments shares the retired-mechanism gap described above; a change takes effect when each deployment next loads its grants.
 
 This parallels the credential revocation model described in CREDENTIALS.md — both follow the same fail-secure default with configurable tenant policies.
 
@@ -288,7 +288,7 @@ git_token
   name                  text NOT NULL
   kind                  text NOT NULL   -- 'pat' | 'svc'
   token_hash_sha256     bytea NOT NULL UNIQUE
-  resource              text NOT NULL   -- 'asset:*', 'asset:def_xxx', 'agent-state:run_xxx', ...
+  resource              text NOT NULL   -- 'asset:*', 'asset:ast_xxx', 'agent-state:run_xxx', ...
   ref_pattern           text NOT NULL   -- simple-glob
   actions               text[] NOT NULL -- RepoActions
   expires_at            timestamptz NOT NULL
@@ -303,7 +303,7 @@ The partial unique on `(user_id, name)` filtered by `revoked_at IS NULL` lets a 
 
 Three columns bound a token's authority:
 
-- `resource` — a single substrate authz resource string, e.g. `asset:*`, `asset:def_xxx`, `agent-state:run_xxx`. Glob patterns are honored by the substrate; a token with `resource: "asset:*"` reaches every asset row in the tenant the token is bound to.
+- `resource` — a single substrate authz resource string, e.g. `asset:*`, `asset:ast_xxx`, `agent-state:run_xxx`. Glob patterns are honored by the substrate; a token with `resource: "asset:*"` reaches every asset row in the tenant the token is bound to.
 - `ref_pattern` — a glob restricting which refs within the resource the token may read or write. Grammar: `*` matches within a `/`-segment, `**` crosses segments. Worked examples appear in `docs/GIT_ACCESS.md`.
 - `actions` — the `RepoAction` vocabulary the token is allowed to invoke (`receivePack`, `createPack`, `resolveRef`, ...). The mint API accepts the user-facing aliases `can_read` (expands to `["createPack", "resolveRef"]`) and `can_push` (expands to `["receivePack"]`), and stores the canonical names so the lookup path never re-runs the alias table.
 - `expires_at` — required, server-enforced floor of one minute. The bearer middleware checks `expires_at > now()` on every request.
@@ -340,7 +340,7 @@ This table shows how Interchange authorization concepts map to materialized gran
 | Credential use               | A tenant-owned credential's use is authorized by ownership at resolution (no grant requirement); a consumer-scoping `credential:{id}` / `use` grant with `origin = 'system'` is stamped for the runtime gate. Principal-owned credential use is not yet supported. See CREDENTIALS.md |
 | User roles (RBAC)            | Grants attached to roles, roles assigned to user principals                                                                                                                                                                                                                           |
 | Human approval gates         | Grants with `effect = 'ask'`                                                                                                                                                                                                                                                          |
-| Agent delegation chain       | Child agent's grants are a subset of parent agent's grants, enforced at launch time                                                                                                                                                                                                   |
+| Delegation containment       | A delegator cannot delegate authority it does not currently hold — each creator/invoker requirement is validated at launch against that principal's own grants. Invoker grants are non-re-delegatable and expire in 24h                                                               |
 
 ## Personal Tenant
 
@@ -351,7 +351,7 @@ On user registration:
 3. Assign the system `owner` role.
 4. The owner role includes a broad default grant: `resource = "*", action = "*", effect = "allow"`.
 
-The personal tenant has the same authorization machinery as any other tenant. When the user creates agents there, those agents get principals and grants through the same system. The onboarding UX is simple, but the underlying model is uniform.
+The personal tenant has the same authorization machinery as any other tenant. When the user creates workflows there, those runs get principals and grants through the same system. The onboarding UX is simple, but the underlying model is uniform.
 
 ## Tenant Schema
 

--- a/packages/authz/src/patterns.ts
+++ b/packages/authz/src/patterns.ts
@@ -5,10 +5,10 @@
  * No other glob syntax is supported (no `?`, `**`, or character classes).
  *
  * Examples:
- *   matchPattern("*", "agent:agt_abc")          => true
- *   matchPattern("agent:*", "agent:agt_abc")    => true
- *   matchPattern("agent:agt_abc", "agent:agt_abc") => true
- *   matchPattern("agent:agt_abc", "agent:agt_xyz") => false
+ *   matchPattern("*", "workflow-run:run_abc")                   => true
+ *   matchPattern("workflow-run:*", "workflow-run:run_abc")      => true
+ *   matchPattern("workflow-run:run_abc", "workflow-run:run_abc") => true
+ *   matchPattern("workflow-run:run_abc", "workflow-run:run_xyz") => false
  *   matchPattern("wallet:wal_*", "wallet:wal_123") => true
  *   matchPattern("wallet:wal_*", "wallet:xyz")     => false
  */

--- a/packages/authz/src/specificity.ts
+++ b/packages/authz/src/specificity.ts
@@ -2,10 +2,10 @@
  * Compute a specificity score for a pattern.
  *
  * More specific patterns get higher scores:
- *   "*"              => 0  (matches everything)
- *   "agent:*"        => 6  (type-level wildcard, 6 literal chars)
- *   "wallet:wal_*"   => 11 (prefix match, 11 literal chars)
- *   "agent:agt_abc"  => 13 (exact match, 13 literal chars, no wildcards)
+ *   "*"                    => 0    (matches everything)
+ *   "wallet:wal_*"         => 11   (prefix match, 11 literal chars)
+ *   "workflow-run:*"       => 13   (type-level wildcard, 13 literal chars)
+ *   "workflow-run:run_abc" => 1020 (exact match, 20 literal chars, no wildcards)
  *
  * The score is the count of non-wildcard characters, plus a bonus
  * for patterns with no wildcards at all (exact matches).

--- a/packages/db/src/schema/git-tokens.ts
+++ b/packages/db/src/schema/git-tokens.ts
@@ -26,7 +26,7 @@ import { tenant } from "./tenants";
 // (`receivePack`, `createPack`, `resolveRef`, ...). The mint API
 // translates user-facing aliases to canonical names before insert.
 // `resource` is the single substrate authz resource string
-// (e.g. `agent-state:run_xxx`, `asset:def_yyy`) that the token grants
+// (e.g. `agent-state:run_xxx`, `asset:ast_yyy`) that the token grants
 // access to. `refPattern` is a glob restricting which refs within the
 // resource the token may read or write.
 //

--- a/packages/hub-api/src/middleware/grant.ts
+++ b/packages/hub-api/src/middleware/grant.ts
@@ -34,7 +34,7 @@ export type CreateRequireGrantDeps = {
  * grant store and condition registry. Usage:
  *
  *   const requireGrant = createRequireGrant({ grantStore, conditionRegistry });
- *   app.get("/", requireGrant("agent:*", "read"), handler);
+ *   app.get("/", requireGrant("workflow-run:*", "read"), handler);
  */
 export function createRequireGrant({
   grantStore,
@@ -92,8 +92,8 @@ export function createRequireGrant({
  * Helper that builds a resource string from a URL parameter.
  *
  * Usage:
- *   requireGrant(idResource("agent", "agentId"), "manage")
- *   // resolves to "agent:agt_abc123" from the URL
+ *   requireGrant(idResource("workflow-run", "runId"), "manage")
+ *   // resolves to "workflow-run:run_abc123" from the URL
  */
 export function idResource(
   resourceType: string,

--- a/packages/hub-api/src/routes/principals.ts
+++ b/packages/hub-api/src/routes/principals.ts
@@ -112,7 +112,7 @@ export function createPrincipalRoutes({
       tags: ["Principals"],
       summary: "List principals in the tenant",
       description:
-        "Lists all principals (users, agents, and workflow deployments) in the tenant. Filterable by kind and status.",
+        "Lists all principals (users, agents, and workflow runs) in the tenant. Filterable by kind and status.",
       parameters: [
         {
           name: "kind",
@@ -329,8 +329,7 @@ export function createPrincipalRoutes({
     describeRoute({
       tags: ["Principals"],
       summary: "Remove principal from tenant",
-      description:
-        "Removes a user or agent principal from the tenant. For agents, use agent deletion instead.",
+      description: "Removes a principal from the tenant.",
       responses: {
         204: {
           description: "Principal removed",

--- a/packages/types/src/credentials.ts
+++ b/packages/types/src/credentials.ts
@@ -126,7 +126,7 @@ export const CredentialRequirement = type({
   providerName: "string",
   "scopes?": "string[]",
   source: CredentialSourceType.describe(
-    "Whose credential satisfies this requirement at launch: `tenant` (a credential owned by the tenant), `creator` (the definition author's), or `invoker` (whoever launched the agent).",
+    "Whose credential satisfies this requirement at launch: `tenant` (a credential owned by the tenant), `creator` (the definition author's), or `invoker` (whoever launched the workflow run).",
   ),
   "name?": "string",
 });

--- a/packages/types/src/credentials.ts
+++ b/packages/types/src/credentials.ts
@@ -30,7 +30,7 @@ const CredType = type.enumerated(...credentialTypes);
 const CredStatus = type.enumerated(...credentialStatuses);
 const CredentialSourceType = type.enumerated(...credentialRequirementSources);
 
-// A credential binding on an agent definition maps a tool package's declared
+// A credential binding on a workflow definition maps a tool package's declared
 // credential handle -- keyed `(package, handle)` against the tool-package
 // declaration -- to a concrete credential resolved fresh at launch. `locator`
 // is which credential namespace the name is resolved in; today only `tenant`

--- a/packages/types/src/grants.ts
+++ b/packages/types/src/grants.ts
@@ -17,7 +17,7 @@ const effectDescription =
   "Outcome when this grant is the one resolved for a request: `allow` permits the action, `deny` blocks it, `ask` requires interactive approval before proceeding. When several grants match, the most specific wins, and at equal specificity the strongest effect wins (`deny` over `ask` over `allow`).";
 
 const originDescription =
-  "Records where the grant came from: `system` (built-in), `role` (granted via a role), `creator` (from the agent definition author), or `invoker` (delegated by whoever launched the agent). Origin is provenance only; it does not affect evaluation precedence.";
+  "Records where the grant came from: `system` (built-in), `role` (granted via a role), `creator` (from the workflow definition author), or `invoker` (delegated by whoever launched the workflow run). Origin is provenance only; it does not affect evaluation precedence.";
 
 const conditionsDescription =
   "Optional map of named conditions that must all pass for the grant to apply, evaluated against a condition registry at authorization time. A grant with conditions is skipped (fails closed) when no registry is available to evaluate them.";
@@ -107,7 +107,7 @@ export const GrantRequirement = type({
     "Effect to assign the materialized grant: `allow`, `deny`, or `ask`. Defaults to `allow` when omitted.",
   ),
   source: GrantSourceType.describe(
-    "Whose authority the grant is resolved against at launch: `creator` (the definition author) or `invoker` (whoever launched the agent) -- satisfied only if that party actually holds the requested capability. Tenant-owned credential use is not a grant requirement: it is authorized by ownership at resolution and its consumer-scoping grant is stamped directly (see CREDENTIALS.md).",
+    "Whose authority the grant is resolved against at launch: `creator` (the definition author) or `invoker` (whoever launched the workflow run) -- satisfied only if that party actually holds the requested capability. Tenant-owned credential use is not a grant requirement: it is authorized by ownership at resolution and its consumer-scoping grant is stamped directly (see CREDENTIALS.md).",
   ),
   "conditions?": "Record<string, unknown> | null",
 });

--- a/packages/types/src/package-json.ts
+++ b/packages/types/src/package-json.ts
@@ -15,7 +15,7 @@ import { type } from "arktype";
 /**
  * A tool package's static declaration of one provider-backed credential it
  * needs: an abstract handle plus optional scopes. Advisory only -- a request
- * the agent definition later binds to a concrete credential and the launch-time
+ * the workflow definition later binds to a concrete credential and the launch-time
  * grant gate authorizes; a declaration consents to nothing on its own. The
  * handle is the key the binding and the runtime delivery use.
  */

--- a/packages/types/src/principals.ts
+++ b/packages/types/src/principals.ts
@@ -27,10 +27,10 @@ export const PrincipalResponse = type({
   id: "string",
   tenantId: "string",
   kind: Kind.describe(
-    "Whether this principal represents a `user` (a human account), an `agent`, or a `workflow` (a workflow deployment).",
+    "Whether this principal represents a `user` (a human account), an `agent`, or a `workflow` (a workflow run).",
   ),
   refId: type("string").describe(
-    "Identifier of the underlying entity this principal stands for: the auth user id when `kind` is `user`, the agent id when `kind` is `agent`, or the run id when `kind` is `workflow`. Unique per tenant and kind.",
+    "Identifier of the underlying entity this principal stands for: the auth user id when `kind` is `user`, an agent-instance id when `kind` is `agent`, or a workflow run (`run_...`) or workflow definition (`wfd_...`) id when `kind` is `workflow`. Unique per tenant and kind.",
   ),
   displayName: "string",
   "email?": "string",

--- a/packages/types/src/workflows.ts
+++ b/packages/types/src/workflows.ts
@@ -1,6 +1,5 @@
 // Status vocabulary for the first-class workflow definition model, kept in its
-// own workflow-scoped module so no workflow table or validator depends on a
-// type from the agent surface.
+// own workflow-scoped module.
 export const workflowDefinitionStatuses = ["deployed", "stopped"] as const;
 export type WorkflowDefinitionStatus =
   (typeof workflowDefinitionStatuses)[number];
@@ -43,8 +42,7 @@ export const WorkflowDefinitionResponse = type({
   updatedAt: "string",
 });
 
-// Rollback a definition to a prior version. Kept separate from the agent
-// RollbackRequest so the workflow surface carries no agent-type dependency.
+// Rollback a definition to a prior version.
 export const WorkflowRollbackRequest = type({
   version: "string",
 });

--- a/packages/workflow/src/definition/workflow.ts
+++ b/packages/workflow/src/definition/workflow.ts
@@ -37,7 +37,6 @@ export interface WorkflowDefinition {
    * invoker's authority at trigger time. Each entry declares a resource,
    * action, and source (`creator` or `invoker`); the trigger route
    * materializes the satisfied ones as grants on the run principal.
-   * Mirrors an agent definition's `grantRequirements`.
    */
   grantRequirements?: readonly GrantRequirement[];
   /**
@@ -46,7 +45,7 @@ export interface WorkflowDefinition {
    * concrete provider and authorizing the delegation against the
    * binding's authority. The launch reads these from the folded body and
    * materializes a consumer-scoped `credential:{id}` / `use` grant per
-   * binding. Mirrors an agent definition's `credentialBindings`.
+   * binding.
    */
   credentialBindings?: readonly CredentialBinding[];
 }


### PR DESCRIPTION
## Summary

- AUTH.md describes authorization in the workflow-run principal model:
  run principals (`kind = 'workflow'`, `ref_id = run_...`), grant
  requirements via `grantRequirements`, and `workflow-run:` /
  `workflow-definition:` resource forms. The mapping table states the
  creator/invoker delegation containment the code enforces, replacing a
  retired "child agent ⊆ parent agent" launch check no code implements.
- Retired first-class-agent vocabulary becomes workflow-run /
  workflow-definition terms across the authz JSDoc and examples, the
  grant and principal API descriptions (`docs/API.md` regenerated), the
  workflow and credential field comments, and the principal route
  descriptions.
- Live vocabulary is preserved: the `@intx/agent` harness, wire-protocol
  frame types, the `agent-address` scheme, `agent-state`/`agent-data`
  resources, the workflow deployment resource, and the `kind='agent'`
  enum value.

## Verification

- `make lint` (Prettier, ESLint, API-docs freshness), `tsc -b --force`,
  and the admin-ui bundle pass; the unit suite passes (6896 tests). The
  e2e integration suite requires a running Postgres and sidecar stack
  and is unaffected by these documentation and comment changes.
- Every corrected fact is checked against the code (`packages/authz`,
  `hub-api`, `db`, `types`, `agent`); `docs/API.md` is regenerated from
  the edited type and route descriptions.

Closes INTR-289