### PR TITLE
Upstream fixes from INTR-472: collector serialization, usage hook, deploy-frame signal, and cleanups

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -356,6 +356,7 @@
       },
       "devDependencies": {
         "@intx/workflow": "workspace:*",
+        "@types/ssri": "catalog:",
         "openapi-types": "^12.1.3",
         "tar": "catalog:",
       },
@@ -541,7 +542,7 @@
       "devDependencies": {
         "@types/npm-package-arg": "^6.1.4",
         "@types/semver": "catalog:",
-        "@types/ssri": "^7.1.5",
+        "@types/ssri": "catalog:",
       },
     },
     "packages/tools-lsp": {
@@ -658,6 +659,7 @@
   },
   "catalog": {
     "@types/semver": "^7.7.1",
+    "@types/ssri": "^7.1.5",
     "arktype": "^2.1.29",
     "better-auth": "^1.4.18",
     "drizzle-orm": "^0.45.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "catalog": {
     "@types/semver": "^7.7.1",
+    "@types/ssri": "^7.1.5",
     "arktype": "^2.1.29",
     "better-auth": "^1.4.18",
     "drizzle-orm": "^0.45.1",

--- a/packages/hub-api/package.json
+++ b/packages/hub-api/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@intx/workflow": "workspace:*",
+    "@types/ssri": "catalog:",
     "openapi-types": "^12.1.3",
     "tar": "catalog:"
   },

--- a/packages/hub-api/src/index.ts
+++ b/packages/hub-api/src/index.ts
@@ -33,3 +33,10 @@ export {
   resolveDefinitionSources,
   type DefinitionSourceResolution,
 } from "./run-source-resolution";
+export {
+  resolveApproval,
+  type ResolveApprovalRequest,
+  type ResolveApprovalOutcome,
+  type CreateApprovalRoutesDeps,
+  type ReadRunLifecycles,
+} from "./routes/approvals";

--- a/packages/hub-api/src/routes/approvals.ts
+++ b/packages/hub-api/src/routes/approvals.ts
@@ -80,7 +80,7 @@ export type ReadRunLifecycles = (
   target: WorkflowRunLifecycle;
 }>;
 
-type ResolveApprovalArgs = {
+export type ResolveApprovalRequest = {
   approvalId: string;
   tenantId: string;
   principalId: string;
@@ -89,7 +89,7 @@ type ResolveApprovalArgs = {
   decisionPayload: ApprovalDecision;
 };
 
-type ResolveApprovalResult =
+export type ResolveApprovalOutcome =
   | { kind: "resolved"; approval: ParsedApproval }
   | { kind: "not_found" }
   | { kind: "forbidden" }
@@ -99,7 +99,7 @@ type ResolveApprovalResult =
   | { kind: "dispatch_unavailable" };
 
 type PendingFailureKind = Extract<
-  ResolveApprovalResult["kind"],
+  ResolveApprovalOutcome["kind"],
   "deployment_unavailable" | "run_not_running" | "dispatch_unavailable"
 >;
 
@@ -119,10 +119,10 @@ type PendingFailureKind = Extract<
  * until workflow Git records the signal as received. Shared deployments retain
  * their direct sidecar delivery behavior.
  */
-async function resolveApproval(
+export async function resolveApproval(
   deps: CreateApprovalRoutesDeps,
-  args: ResolveApprovalArgs,
-): Promise<ResolveApprovalResult> {
+  args: ResolveApprovalRequest,
+): Promise<ResolveApprovalOutcome> {
   const {
     db,
     sidecarRouter,
@@ -610,7 +610,7 @@ export function createApprovalRoutes(
   return app;
 }
 
-function respond(c: Context<TenantEnv>, result: ResolveApprovalResult) {
+function respond(c: Context<TenantEnv>, result: ResolveApprovalOutcome) {
   switch (result.kind) {
     case "resolved":
       return c.json(formatApproval(result.approval), 200);

--- a/packages/hub-sessions/src/event-collector-registry.ts
+++ b/packages/hub-sessions/src/event-collector-registry.ts
@@ -67,6 +67,9 @@ export function createEventCollectorRegistry(
   const { db, onTurnFinalized } = config;
   const collectors = new Map<string, EventCollector>();
   const statuses = new Map<string, SessionStatus>();
+  // Per-address tail promise: serializes onEvent/abandon work for one run
+  // address so their DB writes cannot interleave. Reaped when it drains.
+  const tails = new Map<string, Promise<void>>();
 
   function create(
     agentAddress: string,
@@ -100,6 +103,31 @@ export function createEventCollectorRegistry(
     statuses.delete(agentAddress);
   }
 
+  // Chain `work` onto the address's tail so per-address work runs in order and
+  // never interleaves, while the caller stays non-blocking. `onError` swallows
+  // a failure so one bad event cannot wedge the chain; `onSettled` runs after
+  // the work settles. The tail entry is reaped once no later work is queued.
+  function enqueue(
+    agentAddress: string,
+    work: () => Promise<void>,
+    onError: (err: unknown) => void,
+    onSettled?: () => void,
+  ): void {
+    const prev = tails.get(agentAddress) ?? Promise.resolve();
+    const next = prev
+      .then(work)
+      .catch(onError)
+      .finally(() => {
+        if (onSettled !== undefined) {
+          onSettled();
+        }
+        if (tails.get(agentAddress) === next) {
+          tails.delete(agentAddress);
+        }
+      });
+    tails.set(agentAddress, next);
+  }
+
   function dispatch(agentAddress: string, event: InferenceEvent): void {
     const collector = collectors.get(agentAddress);
     if (collector === undefined) {
@@ -115,27 +143,38 @@ export function createEventCollectorRegistry(
       event.type === "reactor.done" ||
       (event.type === "reactor.error" && event.data.fatal);
 
-    collector
-      .onEvent(event)
-      .catch((err: unknown) => {
+    enqueue(
+      agentAddress,
+      () => collector.onEvent(event),
+      (err: unknown) => {
         log.warn`Failed to persist event ${event.type} seq=${String(event.seq)} for ${agentAddress}: ${err instanceof Error ? err.message : String(err)}`;
-      })
-      .finally(() => {
-        if (isTerminal) {
+      },
+      () => {
+        if (isTerminal && collectors.get(agentAddress) === collector) {
           removeCollector(agentAddress);
         }
-      });
+      },
+    );
   }
 
   function abandon(agentAddress: string): void {
     const collector = collectors.get(agentAddress);
     if (collector === undefined) return;
 
-    collector.abandon().catch((err: unknown) => {
-      log.warn`Failed to abandon collector for ${agentAddress}: ${err instanceof Error ? err.message : String(err)}`;
-    });
-
+    // Stop NEW dispatches immediately; the queued closures keep their own
+    // reference so already-queued events still drain before the abandon runs.
     removeCollector(agentAddress);
+
+    // Chain the abandon onto the tail so it runs AFTER any queued onEvents
+    // instead of racing them. Otherwise a queued beginTurn could create a
+    // fresh `running` turn row after the collector was finalized, orphaning it.
+    enqueue(
+      agentAddress,
+      () => collector.abandon(),
+      (err: unknown) => {
+        log.warn`Failed to abandon collector for ${agentAddress}: ${err instanceof Error ? err.message : String(err)}`;
+      },
+    );
   }
 
   function has(agentAddress: string): boolean {

--- a/packages/hub-sessions/src/event-collector-registry.ts
+++ b/packages/hub-sessions/src/event-collector-registry.ts
@@ -14,6 +14,7 @@ import {
   createEventCollector,
   type EventCollector,
   type TurnFinalized,
+  type TurnUsage,
 } from "./event-collector";
 
 const log = getLogger(["hub", "event-collector-registry"]);
@@ -37,6 +38,7 @@ export type EventCollectorRegistry = {
 export type EventCollectorRegistryConfig = {
   db: DB["db"];
   onTurnFinalized?: (agentAddress: string, turn: TurnFinalized) => void;
+  onUsage?: (agentAddress: string, usage: TurnUsage) => void;
 };
 
 export function deriveStatus(event: InferenceEvent): SessionStatus | null {
@@ -64,7 +66,7 @@ export function deriveStatus(event: InferenceEvent): SessionStatus | null {
 export function createEventCollectorRegistry(
   config: EventCollectorRegistryConfig,
 ): EventCollectorRegistry {
-  const { db, onTurnFinalized } = config;
+  const { db, onTurnFinalized, onUsage } = config;
   const collectors = new Map<string, EventCollector>();
   const statuses = new Map<string, SessionStatus>();
   // Per-address tail promise: serializes onEvent/abandon work for one run
@@ -91,6 +93,11 @@ export function createEventCollectorRegistry(
         ? {
             onTurnFinalized: (turn: TurnFinalized) =>
               onTurnFinalized(agentAddress, turn),
+          }
+        : {}),
+      ...(onUsage
+        ? {
+            onUsage: (usage: TurnUsage) => onUsage(agentAddress, usage),
           }
         : {}),
     });

--- a/packages/hub-sessions/src/event-collector.test.ts
+++ b/packages/hub-sessions/src/event-collector.test.ts
@@ -1072,9 +1072,6 @@ describe("EventCollectorRegistry getAccumulatedText", () => {
     registry.create(address, "tnt_test", "ses_test", "run_test");
 
     registry.dispatch(address, event("inference.start", 1, { model: "gpt-4" }));
-    // dispatch is fire-and-forget; wait for the microtask queue to flush
-    await Promise.resolve();
-
     registry.dispatch(
       address,
       event("inference.done", 5, {
@@ -1086,9 +1083,142 @@ describe("EventCollectorRegistry getAccumulatedText", () => {
         usage: { input: 10, output: 5 },
       }),
     );
-    await Promise.resolve();
+    // dispatch is non-blocking and serialized onto a per-address tail; yield to
+    // the macrotask queue so the queued onEvent work drains before asserting.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
     expect(registry.getAccumulatedText(address)).toBe("streaming text");
+  });
+});
+
+describe("EventCollectorRegistry dispatch serialization", () => {
+  // A fake DB that records every write and can gate them on a caller-held
+  // promise, so a test can hold one collector's onEvent mid-flight and observe
+  // whether a second dispatch interleaves.
+  function createRecordingRegistryDB() {
+    const ops: {
+      kind: "insert" | "update";
+      values: Record<string, unknown>;
+    }[] = [];
+    let gate: Promise<void> | null = null;
+    const db = {
+      insert(_table: unknown) {
+        return {
+          async values(vals: Record<string, unknown>) {
+            ops.push({ kind: "insert", values: vals });
+            if (gate !== null) await gate;
+          },
+        };
+      },
+      update(_table: unknown) {
+        return {
+          set(vals: Record<string, unknown>) {
+            return {
+              async where(_condition: unknown) {
+                ops.push({ kind: "update", values: vals });
+                if (gate !== null) await gate;
+              },
+            };
+          },
+        };
+      },
+    };
+    return {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- fake DB satisfies the shape required by event-collector-registry at runtime
+      db: db as never,
+      ops,
+      setGate(p: Promise<void>) {
+        gate = p;
+      },
+    };
+  }
+
+  // Yield to the macrotask queue so every pending microtask (the tail's chained
+  // continuations and the collector's awaits) settles.
+  function drain(): Promise<void> {
+    return new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+
+  test("queues a second event behind an in-flight one instead of interleaving", async () => {
+    const fake = createRecordingRegistryDB();
+    const registry = createEventCollectorRegistry({ db: fake.db });
+    const address = "agent://serialize";
+    registry.create(address, "tnt_test", "ses_test", "run_test");
+
+    let release!: () => void;
+    fake.setGate(new Promise<void>((r) => (release = r)));
+
+    registry.dispatch(address, event("inference.start", 1, { model: "gpt-4" }));
+    await drain();
+    // The first event's onEvent has begun a write and is now blocked on the gate.
+    const afterFirst = fake.ops.length;
+    expect(afterFirst).toBeGreaterThanOrEqual(1);
+
+    registry.dispatch(address, event("inference.start", 2, { model: "gpt-4" }));
+    await drain();
+    // The second event must wait for the first; no new writes yet.
+    expect(fake.ops.length).toBe(afterFirst);
+
+    release();
+    await drain();
+    // With the gate open both events drain, so more writes land.
+    expect(fake.ops.length).toBeGreaterThan(afterFirst);
+  });
+
+  test("a deferred terminal removal does not delete a replacement collector", async () => {
+    const fake = createRecordingRegistryDB();
+    const registry = createEventCollectorRegistry({ db: fake.db });
+    const address = "agent://replace";
+
+    registry.create(address, "tnt_test", "ses_test", "run_a");
+    // Start a turn so the terminal event issues a finalize write we can gate.
+    registry.dispatch(address, event("inference.start", 1, { model: "gpt-4" }));
+    await drain();
+
+    let release!: () => void;
+    fake.setGate(new Promise<void>((r) => (release = r)));
+    // The terminal event's finalize blocks, deferring its collector removal.
+    registry.dispatch(address, event("reactor.done", 2, {}));
+    await drain();
+
+    // Replace collector A with B while A's terminal removal is still pending.
+    registry.create(address, "tnt_test", "ses_test", "run_b");
+    expect(registry.has(address)).toBe(true);
+
+    release();
+    await drain();
+
+    // A's deferred terminal removal must not have deleted the replacement B.
+    expect(registry.has(address)).toBe(true);
+  });
+
+  test("abandon finalizes a turn a still-queued event started, not orphaning it", async () => {
+    const fake = createRecordingRegistryDB();
+    const registry = createEventCollectorRegistry({ db: fake.db });
+    const address = "agent://orphan";
+    registry.create(address, "tnt_test", "ses_test", "run_test");
+
+    // The inference.start onEvent is queued on the tail but has not run yet;
+    // teardown arrives before it. With serialization, abandon chains AFTER the
+    // queued beginTurn, so the `running` turn it creates is finalized. Without
+    // it, abandon would run first against no open turn and the later beginTurn
+    // would leave a `running` row nobody finalizes. The abandon MUST be issued
+    // before draining, or beginTurn has already set the open turn and even the
+    // unserialized path would finalize it -- masking the orphan.
+    registry.dispatch(address, event("inference.start", 1, { model: "gpt-4" }));
+    registry.abandon(address);
+
+    await drain();
+
+    const started = fake.ops.filter(
+      (o) => o.kind === "insert" && o.values["status"] === "running",
+    );
+    const finalizedFailed = fake.ops.filter(
+      (o) => o.kind === "update" && o.values["status"] === "failed",
+    );
+    expect(started).toHaveLength(1);
+    // The turn is finalized failed by the abandon, not left orphaned as running.
+    expect(finalizedFailed).toHaveLength(1);
   });
 });
 

--- a/packages/hub-sessions/src/event-collector.test.ts
+++ b/packages/hub-sessions/src/event-collector.test.ts
@@ -6,6 +6,7 @@ import {
   createEventCollector,
   type EventCollector,
   type TurnFinalized,
+  type TurnUsage,
 } from "./event-collector";
 import { createEventCollectorRegistry } from "./event-collector-registry";
 
@@ -1220,6 +1221,45 @@ describe("EventCollectorRegistry dispatch serialization", () => {
     // The turn is finalized failed by the abandon, not left orphaned as running.
     expect(finalizedFailed).toHaveLength(1);
   });
+
+  test("threads onUsage to the registry hook with the run address", async () => {
+    const fake = createRecordingRegistryDB();
+    const usages: { address: string; usage: TurnUsage }[] = [];
+    const registry = createEventCollectorRegistry({
+      db: fake.db,
+      onUsage: (address, usage) => usages.push({ address, usage }),
+    });
+    const address = "agent://usage";
+    registry.create(address, "tnt_test", "ses_test", "run_test");
+
+    registry.dispatch(address, event("inference.start", 1, { model: "gpt-4" }));
+    registry.dispatch(
+      address,
+      event("inference.usage", 2, {
+        usage: {
+          input: 42,
+          output: 7,
+          cacheRead: 0,
+          cacheWrite: 0,
+          thinking: 0,
+        },
+        source: { sourceId: "s1", provider: "anthropic", model: "gpt-4" },
+      }),
+    );
+    registry.dispatch(address, event("reactor.done", 3, {}));
+    await drain();
+
+    expect(usages).toHaveLength(1);
+    const u = at(usages, 0);
+    expect(u.address).toBe(address);
+    expect(u.usage.usage).toEqual({
+      input: 42,
+      output: 7,
+      cacheRead: 0,
+      cacheWrite: 0,
+      thinking: 0,
+    });
+  });
 });
 
 describe("EventCollector.getCurrentTurnId", () => {
@@ -1540,5 +1580,178 @@ describe("EventCollector.getLastTurnId", () => {
     await collector.onEvent(event("inference.start", 3, { model: "gpt-4" }));
 
     expect(collector.getLastTurnId()).not.toBe(firstTurnId);
+  });
+});
+
+describe("EventCollector onUsage", () => {
+  function fullUsage(input: number, output: number) {
+    return { input, output, cacheRead: 0, cacheWrite: 0, thinking: 0 };
+  }
+
+  function setup() {
+    const usages: TurnUsage[] = [];
+    const { db } = createFakeDB();
+    const collector = createEventCollector({
+      db,
+      sessionId: "ses_test",
+      runId: "run_test",
+      tenantId: "tnt_test",
+      onUsage: (u) => usages.push(u),
+    });
+    return { collector, usages };
+  }
+
+  test("emits per-turn usage once with the final cumulative total, not summed", async () => {
+    const { collector, usages } = setup();
+    await collector.onEvent(event("inference.start", 1, { model: "gpt-4" }));
+    // inference.usage carries a cumulative running total and fires repeatedly.
+    await collector.onEvent(
+      event("inference.usage", 2, {
+        usage: fullUsage(100, 0),
+        source: { sourceId: "s1", provider: "anthropic", model: "gpt-4" },
+      }),
+    );
+    await collector.onEvent(
+      event("inference.usage", 3, {
+        usage: fullUsage(100, 50),
+        source: { sourceId: "s1", provider: "anthropic", model: "gpt-4" },
+      }),
+    );
+    expect(usages).toHaveLength(0); // nothing emitted before the turn finalizes
+
+    await collector.onEvent(event("reactor.done", 4, {}));
+
+    expect(usages).toHaveLength(1);
+    const u = at(usages, 0);
+    // The last cumulative total, NOT the sum of the two events (200/50).
+    expect(u.usage).toEqual(fullUsage(100, 50));
+    expect(u.provider).toBe("anthropic");
+    expect(u.model).toBe("gpt-4");
+  });
+
+  test("carries full run identity and a non-null turnId", async () => {
+    const { collector, usages } = setup();
+    await collector.onEvent(event("inference.start", 1, { model: "gpt-4" }));
+    await collector.onEvent(
+      event("inference.usage", 2, {
+        usage: fullUsage(10, 5),
+        source: { sourceId: "s1", provider: "openai", model: "gpt-4" },
+      }),
+    );
+    await collector.onEvent(event("reactor.done", 3, {}));
+
+    expect(usages).toHaveLength(1);
+    const u = at(usages, 0);
+    expect(u.tenantId).toBe("tnt_test");
+    expect(u.sessionId).toBe("ses_test");
+    expect(u.runId).toBe("run_test");
+    expect(collector.getLastTurnId()).toBe(u.turnId);
+    expect(u.turnId.length).toBeGreaterThan(0);
+  });
+
+  test("reports usage even when the turn ends in an error", async () => {
+    const { collector, usages } = setup();
+    await collector.onEvent(event("inference.start", 1, { model: "gpt-4" }));
+    await collector.onEvent(
+      event("inference.usage", 2, {
+        usage: fullUsage(20, 0),
+        source: { sourceId: "s1", provider: "anthropic", model: "gpt-4" },
+      }),
+    );
+    await collector.onEvent(
+      event("inference.error", 3, {
+        error: { category: "fatal", message: "boom" },
+        partial: { role: "assistant", content: [] },
+      }),
+    );
+    await collector.onEvent(event("reactor.done", 4, {}));
+
+    expect(usages).toHaveLength(1);
+    expect(at(usages, 0).usage).toEqual(fullUsage(20, 0));
+  });
+
+  test("does not emit for a turn that ran no inference", async () => {
+    const { collector, usages } = setup();
+    // A fatal reactor.error with no preceding inference opens and finalizes a
+    // turn, but no usage was ever observed for it.
+    await collector.onEvent(
+      event("reactor.error", 1, { error: "boom", fatal: true }),
+    );
+    expect(usages).toHaveLength(0);
+  });
+
+  test("finalizing turn 1 via a bare inference.start emits its usage and does not carry it into turn 2", async () => {
+    const { collector, usages } = setup();
+    await collector.onEvent(event("inference.start", 1, { model: "m1" }));
+    await collector.onEvent(
+      event("inference.usage", 2, {
+        usage: fullUsage(100, 10),
+        source: { sourceId: "s1", provider: "anthropic", model: "m1" },
+      }),
+    );
+    const turn1Id = collector.getCurrentTurnId();
+
+    // Turn 2 starts with no intervening reactor.done: beginTurn must finalize
+    // turn 1 (emitting its usage) BEFORE it resets the accumulators.
+    await collector.onEvent(event("inference.start", 3, { model: "m2" }));
+
+    expect(usages).toHaveLength(1);
+    expect(turn1Id).toBe(at(usages, 0).turnId);
+    expect(at(usages, 0).usage).toEqual(fullUsage(100, 10));
+    expect(at(usages, 0).model).toBe("m1");
+
+    // Turn 2 carries only its own usage, never turn 1's.
+    await collector.onEvent(
+      event("inference.usage", 4, {
+        usage: fullUsage(5, 5),
+        source: { sourceId: "s2", provider: "openai", model: "m2" },
+      }),
+    );
+    await collector.onEvent(event("reactor.done", 5, {}));
+
+    expect(usages).toHaveLength(2);
+    expect(at(usages, 1).usage).toEqual(fullUsage(5, 5));
+    expect(at(usages, 1).model).toBe("m2");
+    expect(at(usages, 1).turnId).not.toBe(turn1Id ?? "");
+  });
+
+  test("a second turn with no usage does not re-emit the first turn's usage", async () => {
+    const { collector, usages } = setup();
+    await collector.onEvent(event("inference.start", 1, { model: "m1" }));
+    await collector.onEvent(
+      event("inference.usage", 2, {
+        usage: fullUsage(100, 10),
+        source: { sourceId: "s1", provider: "anthropic", model: "m1" },
+      }),
+    );
+    await collector.onEvent(event("reactor.done", 3, {}));
+    expect(usages).toHaveLength(1);
+
+    await collector.onEvent(event("inference.start", 4, { model: "m2" }));
+    await collector.onEvent(event("reactor.done", 5, {}));
+
+    expect(usages).toHaveLength(1);
+  });
+
+  test("inference.done usage overrides a prior inference.usage in the same turn", async () => {
+    const { collector, usages } = setup();
+    await collector.onEvent(event("inference.start", 1, { model: "m1" }));
+    await collector.onEvent(
+      event("inference.usage", 2, {
+        usage: fullUsage(100, 10),
+        source: { sourceId: "s1", provider: "anthropic", model: "m1" },
+      }),
+    );
+    await collector.onEvent(
+      event("inference.done", 3, {
+        turn: { role: "assistant", content: [], model: "m1" },
+        usage: fullUsage(100, 25),
+        source: { sourceId: "s1", provider: "anthropic", model: "m1" },
+      }),
+    );
+    await collector.onEvent(event("reactor.done", 4, {}));
+
+    expect(usages).toHaveLength(1);
+    expect(at(usages, 0).usage).toEqual(fullUsage(100, 25));
   });
 });

--- a/packages/hub-sessions/src/event-collector.ts
+++ b/packages/hub-sessions/src/event-collector.ts
@@ -8,7 +8,12 @@ import { eq } from "drizzle-orm";
 
 import { inferenceTurn, turnPart } from "@intx/db/schema";
 import { getLogger } from "@intx/log";
-import type { InferenceEvent, ContentBlock } from "@intx/types/runtime";
+import type {
+  InferenceEvent,
+  ContentBlock,
+  TokenUsage,
+  LastCycleSource,
+} from "@intx/types/runtime";
 import { type DB, parseTurnPartType } from "@intx/db";
 
 import { generateId } from "@intx/hub-common";
@@ -33,6 +38,19 @@ export type TurnFinalized = {
   toolErrors: { name: string; content: string }[];
 };
 
+// Per-turn token usage, emitted once when a turn finalizes. Carries full run
+// identity so a host accounting sink never has to join against a separate
+// address-to-tenant map (which would go stale at run teardown).
+export type TurnUsage = {
+  tenantId: string;
+  sessionId: string;
+  runId: string;
+  turnId: string;
+  provider: string;
+  model: string;
+  usage: TokenUsage;
+};
+
 export type EventCollector = {
   onEvent(event: InferenceEvent): Promise<void>;
   abandon(): Promise<void>;
@@ -47,12 +65,13 @@ export type EventCollectorConfig = {
   runId: string;
   tenantId: string;
   onTurnFinalized?: (turn: TurnFinalized) => void;
+  onUsage?: (usage: TurnUsage) => void;
 };
 
 export function createEventCollector(
   config: EventCollectorConfig,
 ): EventCollector {
-  const { db, sessionId, runId, tenantId, onTurnFinalized } = config;
+  const { db, sessionId, runId, tenantId, onTurnFinalized, onUsage } = config;
 
   // Current inference turn being accumulated. A new turn is created on each
   // inference.start. Finalized on connector.reply, reactor.done,
@@ -90,6 +109,12 @@ export function createEventCollector(
   let accumulatedToolCalls: TurnToolCall[] = [];
   // Tool results that reported isError, accumulated for TurnFinalized.
   let accumulatedToolErrors: { name: string; content: string }[] = [];
+  // Final cumulative token usage for the current turn. `inference.usage` events
+  // carry a running cumulative total and fire multiple times per step, so these
+  // are OVERWRITTEN (not summed); the last value before finalize is the
+  // authoritative per-turn total. Both reset on each new turn.
+  let turnUsage: TokenUsage | null = null;
+  let turnSource: LastCycleSource | null = null;
 
   async function onEvent(event: InferenceEvent): Promise<void> {
     switch (event.type) {
@@ -103,6 +128,8 @@ export function createEventCollector(
       case "inference.done":
         await handleInferenceDone(event.data.turn.content);
         streamingText = "";
+        turnUsage = event.data.usage;
+        turnSource = event.data.source;
         break;
       case "tool.done": {
         const callId = event.data.result.callId;
@@ -187,9 +214,15 @@ export function createEventCollector(
           });
         }
         break;
+      case "inference.usage":
+        // Cumulative running total that fires several times per step; overwrite
+        // so the last value before finalize is the authoritative per-turn
+        // usage, emitted once via onUsage from finalizeTurn.
+        turnUsage = event.data.usage;
+        turnSource = event.data.source;
+        break;
       default:
-        // reactor.start, streaming deltas, usage, and other events are
-        // not persisted.
+        // reactor.start, streaming deltas, and other events are not persisted.
         break;
     }
   }
@@ -214,6 +247,8 @@ export function createEventCollector(
     callArgs.clear();
     accumulatedToolCalls = [];
     accumulatedToolErrors = [];
+    turnUsage = null;
+    turnSource = null;
 
     await db.insert(inferenceTurn).values({
       id: currentTurnId,
@@ -367,6 +402,24 @@ export function createEventCollector(
         errors: [...accumulatedErrors],
         toolCalls: [...accumulatedToolCalls],
         toolErrors: [...accumulatedToolErrors],
+      });
+    }
+
+    // Report per-turn usage once, alongside the finalize notify. Gated on
+    // turnUsage being present so a turn that ran no inference emits nothing.
+    // NOTE: abandon() finalizes with notify=false, so a turn abandoned
+    // mid-step (e.g. a sidecar disconnect) reports no usage even if the
+    // provider already billed input tokens -- an accepted gap until durable
+    // usage persistence lands on the turn row.
+    if (notify && onUsage && turnUsage !== null && turnSource !== null) {
+      onUsage({
+        tenantId,
+        sessionId,
+        runId,
+        turnId,
+        provider: turnSource.provider,
+        model: turnSource.model,
+        usage: turnUsage,
       });
     }
 

--- a/packages/hub-sessions/src/workflow-run-kind.test.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.test.ts
@@ -9,6 +9,7 @@ import type { KeyPair } from "@intx/types/runtime";
 import {
   workflowRunKindHandler,
   workflowRunAuthorize,
+  classifyTerminalEvent,
   enqueueInbox,
   dequeueToProcessing,
   markConsumed,
@@ -4333,5 +4334,29 @@ describe("parseEventSeq", () => {
     ]) {
       expect(parseEventSeq(bad)).toBeNull();
     }
+  });
+});
+
+describe("classifyTerminalEvent", () => {
+  test("maps each terminal event type to its run status", () => {
+    expect(classifyTerminalEvent("RunCompleted")).toEqual({
+      terminal: true,
+      status: "completed",
+    });
+    expect(classifyTerminalEvent("RunFailed")).toEqual({
+      terminal: true,
+      status: "failed",
+    });
+    expect(classifyTerminalEvent("RunCancelled")).toEqual({
+      terminal: true,
+      status: "cancelled",
+    });
+  });
+
+  test("treats non-terminal and unknown event types as not terminal", () => {
+    expect(classifyTerminalEvent("RunStarted")).toEqual({ terminal: false });
+    expect(classifyTerminalEvent("unknown-event-type")).toEqual({
+      terminal: false,
+    });
   });
 });

--- a/packages/hub-sessions/src/workflow-run-kind.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.ts
@@ -543,6 +543,19 @@ export function classifyTerminalEvent(
 }
 
 /**
+ * True when a blob is absent from the prior tree -- i.e. this commit is the
+ * one that authored it. Consumers act only on a newly-added blob; a blob
+ * already present in the prior tree was carried forward unchanged by a
+ * compaction commit and must not be re-acted upon.
+ */
+async function blobIsNewlyAdded(
+  blobPath: string,
+  priorReadBlob: (path: string) => Promise<Uint8Array | null>,
+): Promise<boolean> {
+  return (await priorReadBlob(blobPath)) === null;
+}
+
+/**
  * Recognised CancelRequested origins. Mirrors the workflow package's
  * `CANCEL_ORIGINS` vocabulary; inlined here so the substrate does
  * not depend on `@intx/workflow`.
@@ -2460,7 +2473,7 @@ export const workflowRunKindHandler: KindHandler = {
           // checkPriorByteEquality rejects it first. Mirrors the newly-terminal
           // gate below, which likewise acts only on a blob absent from the
           // prior tree.
-          if ((await priorReadBlob(entry.blobPath)) === null) {
+          if (await blobIsNewlyAdded(entry.blobPath, priorReadBlob)) {
             const principalCheck = checkCancelOriginPrincipal(
               entry.blobPath,
               origin,
@@ -2490,7 +2503,7 @@ export const workflowRunKindHandler: KindHandler = {
           // terminal blob already present in the prior tree and emits no
           // signal, so a downstream consumer keyed on the signal does
           // not double-fire.
-          if ((await priorReadBlob(entry.blobPath)) === null) {
+          if (await blobIsNewlyAdded(entry.blobPath, priorReadBlob)) {
             const terminalBytes = await readBlob(entry.blobPath);
             newlyTerminalRuns.push({
               runId,

--- a/packages/hub-sessions/src/workflow-run-kind.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.ts
@@ -512,10 +512,9 @@ export type WatermarkEnvelope = typeof WatermarkEnvelope.infer;
  * Drift silently reopens the restore-time double-driver collision that
  * `readOwnedMessageIds` (below) exists to prevent.
  */
-const TERMINAL_EVENT_STATUS: ReadonlyMap<
-  string,
-  "completed" | "failed" | "cancelled"
-> = new Map([
+type TerminalRunStatus = "completed" | "failed" | "cancelled";
+
+const TERMINAL_EVENT_STATUS: ReadonlyMap<string, TerminalRunStatus> = new Map([
   ["RunCompleted", "completed"],
   ["RunFailed", "failed"],
   ["RunCancelled", "cancelled"],
@@ -527,6 +526,21 @@ const TERMINAL_EVENT_STATUS: ReadonlyMap<
  * the two cannot drift apart.
  */
 const TERMINAL_EVENT_TYPES = new Set<string>(TERMINAL_EVENT_STATUS.keys());
+
+/**
+ * Classify a workflow-run event type against the terminal-status vocabulary.
+ * `TERMINAL_EVENT_STATUS` is the sole authority (see above), so a type absent
+ * from it is by definition not terminal: no separate membership set is
+ * consulted and no "unmapped terminal type" case can arise.
+ */
+export function classifyTerminalEvent(
+  eventType: string,
+): { terminal: true; status: TerminalRunStatus } | { terminal: false } {
+  const status = TERMINAL_EVENT_STATUS.get(eventType);
+  return status === undefined
+    ? { terminal: false }
+    : { terminal: true, status };
+}
 
 /**
  * Recognised CancelRequested origins. Mirrors the workflow package's
@@ -2464,7 +2478,8 @@ export const workflowRunKindHandler: KindHandler = {
             reason: `run ${runId} has event at seq ${String(entry.filenameSeq)} after terminal ${terminalType} at seq ${String(terminalSeq)}`,
           };
         }
-        if (TERMINAL_EVENT_TYPES.has(parsed.parsed.body.type)) {
+        const classified = classifyTerminalEvent(parsed.parsed.body.type);
+        if (classified.terminal) {
           terminalSeq = entry.filenameSeq;
           terminalType = parsed.parsed.body.type;
           // Surface the run as newly terminal only when this commit is
@@ -2476,16 +2491,10 @@ export const workflowRunKindHandler: KindHandler = {
           // signal, so a downstream consumer keyed on the signal does
           // not double-fire.
           if ((await priorReadBlob(entry.blobPath)) === null) {
-            const status = TERMINAL_EVENT_STATUS.get(parsed.parsed.body.type);
-            if (status === undefined) {
-              throw new Error(
-                `terminal event type ${parsed.parsed.body.type} has no workflow_run.status mapping`,
-              );
-            }
             const terminalBytes = await readBlob(entry.blobPath);
             newlyTerminalRuns.push({
               runId,
-              status,
+              status: classified.status,
               terminalEventJson: new TextDecoder().decode(terminalBytes),
             });
           }

--- a/packages/hub-sessions/src/ws/sidecar-handler.test.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.test.ts
@@ -11,10 +11,30 @@ import type {
 } from "@intx/types/sidecar";
 import {
   createSidecarRouter,
+  isDeployFrameFailure,
   type SidecarAuthenticator,
   type SidecarRouterConfig,
   type WsHandle,
 } from "./sidecar-handler";
+
+// Assert a deploy rejection is tagged with whether the frame reached the wire.
+async function expectDeployFrameFailure(
+  promise: Promise<unknown>,
+  frameSent: boolean,
+  messagePattern: RegExp,
+): Promise<void> {
+  const err = await promise.then(
+    () => {
+      throw new Error("expected the deploy to reject");
+    },
+    (e: unknown) => e,
+  );
+  expect(isDeployFrameFailure(err)).toBe(true);
+  if (isDeployFrameFailure(err)) {
+    expect(err.frameSent).toBe(frameSent);
+    expect(err.message).toMatch(messagePattern);
+  }
+}
 
 // Test authenticator that accepts any presented token and echoes the
 // claimed id back as the verified identity. Tests that exercise routing
@@ -2170,9 +2190,61 @@ describe("SidecarRouter", () => {
         defaultSource: "anthropic:claude-sonnet-5",
       };
 
-      await expect(
+      await expectDeployFrameFailure(
         router.sendAgentDeploy("timeout@local", config),
-      ).rejects.toThrow(/timed out/);
+        true,
+        /timed out/,
+      );
+    });
+
+    test("a synchronous send failure rejects as not-sent", async () => {
+      const ws = createMockWs();
+      router.handleOpen(ws);
+      router.handleMessage(
+        ws,
+        JSON.stringify({
+          type: "register",
+          sidecarId: "sc-send-fail",
+          token: "tok",
+          agentAddresses: [],
+        }),
+      );
+      await tick();
+
+      // Make the underlying socket throw synchronously on the deploy frame.
+      ws.send = () => {
+        throw new Error("socket is closed");
+      };
+
+      const config = {
+        sessionId: "ses_test",
+        agentId: "a1",
+        tenantId: "t1",
+        principalId: "prin_test",
+        agentAddress: "send-fail@local",
+        systemPrompt: "test",
+        tools: [],
+        grants: [],
+        sources: [
+          {
+            id: "anthropic:claude-sonnet-5",
+            provider: "anthropic",
+            baseURL: "https://api.anthropic.com",
+            apiKey: "sk-test",
+            model: "claude-sonnet-5",
+          },
+        ],
+        defaultSource: "anthropic:claude-sonnet-5",
+      };
+
+      await expectDeployFrameFailure(
+        router.sendAgentDeploy("send-fail@local", config),
+        false,
+        /failed to send/,
+      );
+
+      // The failed send must leave no routing or pending-deploy residue.
+      expect(router.getRoutableAddresses()).not.toContain("send-fail@local");
     });
 
     test("undeploy to unknown agent rejects immediately", async () => {
@@ -2242,7 +2314,7 @@ describe("SidecarRouter", () => {
       const promise = router.sendAgentDeploy("dc-agent@local", config);
       router.handleClose(ws);
 
-      await expect(promise).rejects.toThrow(/disconnected/);
+      await expectDeployFrameFailure(promise, true, /disconnected/);
     });
 
     test("pack acknowledgement must come from the receiving connection", async () => {
@@ -4422,7 +4494,7 @@ describe("SidecarRouter", () => {
         }),
       );
 
-      await expect(
+      await expectDeployFrameFailure(
         router.sendAgentDeploy("new-agent@local", {
           agentId: "a1",
           agentAddress: "new-agent@local",
@@ -4443,7 +4515,9 @@ describe("SidecarRouter", () => {
           ],
           defaultSource: "test:m",
         }),
-      ).rejects.toThrow("Hub signing key is required");
+        false,
+        /Hub signing key is required/,
+      );
 
       expect(router.getRoutableAddresses()).not.toContain("new-agent@local");
     });

--- a/packages/hub-sessions/src/ws/sidecar-handler.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.ts
@@ -51,6 +51,33 @@ import {
 
 const logger = getLogger(["hub", "ws", "sidecar"]);
 
+/**
+ * A deploy-frame send failure, tagged with whether the `agent.deploy` frame
+ * reached the wire. `frameSent: false` means the send was refused before
+ * `conn.send` (a guard failed, or the send threw synchronously) -- the deploy
+ * provably never started, so a caller may safely roll back anything it staged.
+ * `frameSent: true` means the frame was sent and the failure came afterward (ack
+ * timeout, sidecar disconnect), so the sidecar may hold a live agent.
+ */
+export interface DeployFrameFailure extends Error {
+  readonly frameSent: boolean;
+}
+
+function deployFrameFailure(
+  message: string,
+  frameSent: boolean,
+): DeployFrameFailure {
+  return Object.assign(new Error(message), { frameSent });
+}
+
+export function isDeployFrameFailure(err: unknown): err is DeployFrameFailure {
+  return (
+    err instanceof Error &&
+    "frameSent" in err &&
+    typeof err.frameSent === "boolean"
+  );
+}
+
 export type SidecarConnection = {
   sidecarId: string;
   identity: SidecarAuthIdentity;
@@ -3088,20 +3115,30 @@ export function createSidecarRouter(
     workflow?: AgentDeployFrame["workflow"],
   ): Promise<{ publicKey: string }> {
     if (hubPublicKeyHex === undefined) {
-      throw new Error("Hub signing key is required for agent deployment");
+      throw deployFrameFailure(
+        "Hub signing key is required for agent deployment",
+        false,
+      );
     }
     const ws =
       addressIndex.get(agentAddress) ?? findSidecarForNewAgent(agentAddress);
     if (ws === undefined) {
-      throw new Error(`No sidecar available for agent "${agentAddress}"`);
+      throw deployFrameFailure(
+        `No sidecar available for agent "${agentAddress}"`,
+        false,
+      );
     }
     const conn = connections.get(ws);
     if (conn === undefined) {
-      throw new Error(`No sidecar connected for agent "${agentAddress}"`);
+      throw deployFrameFailure(
+        `No sidecar connected for agent "${agentAddress}"`,
+        false,
+      );
     }
     if (conn.identity.kind !== "shared") {
-      throw new Error(
+      throw deployFrameFailure(
         `Allocated sidecar ${conn.sidecarId} requires allocation-bound deploy routing`,
+        false,
       );
     }
     return sendAgentDeployOnConnection(
@@ -3121,11 +3158,17 @@ export function createSidecarRouter(
     workflow?: AgentDeployFrame["workflow"],
   ): Promise<{ publicKey: string }> {
     if (hubPublicKeyHex === undefined) {
-      throw new Error("Hub signing key is required for agent deployment");
+      throw deployFrameFailure(
+        "Hub signing key is required for agent deployment",
+        false,
+      );
     }
 
     if (pendingDeploys.has(agentAddress)) {
-      throw new Error(`Deploy already in progress for agent "${agentAddress}"`);
+      throw deployFrameFailure(
+        `Deploy already in progress for agent "${agentAddress}"`,
+        false,
+      );
     }
 
     const addressSet =
@@ -3143,8 +3186,9 @@ export function createSidecarRouter(
           addressIndex.delete(agentAddress);
         }
         reject(
-          new Error(
+          deployFrameFailure(
             `Deploy of "${agentAddress}" timed out after ${requestTimeoutMs}ms`,
+            true,
           ),
         );
       }, requestTimeoutMs);
@@ -3160,19 +3204,37 @@ export function createSidecarRouter(
             addressSet.delete(agentAddress);
             addressIndex.delete(agentAddress);
           }
-          reject(new Error(error));
+          reject(deployFrameFailure(error, true));
         },
         timer,
       });
 
-      conn.send({
-        type: "agent.deploy",
-        agentAddress,
-        agentId: harnessConfig.agentId,
-        config: harnessConfig,
-        hubPublicKey: hubPublicKeyHex,
-        ...(workflow !== undefined ? { workflow } : {}),
-      });
+      try {
+        conn.send({
+          type: "agent.deploy",
+          agentAddress,
+          agentId: harnessConfig.agentId,
+          config: harnessConfig,
+          hubPublicKey: hubPublicKeyHex,
+          ...(workflow !== undefined ? { workflow } : {}),
+        });
+      } catch (err) {
+        // A synchronous send failure means the frame never reached the wire.
+        // Tear down the pending entry and timer we just registered, and reject
+        // as not-sent so a caller may safely roll back what it staged.
+        clearTimeout(timer);
+        pendingDeploys.delete(agentAddress);
+        if (addressIndex.get(agentAddress) === ws) {
+          addressSet.delete(agentAddress);
+          addressIndex.delete(agentAddress);
+        }
+        reject(
+          deployFrameFailure(
+            `Deploy of "${agentAddress}" failed to send: ${err instanceof Error ? err.message : String(err)}`,
+            false,
+          ),
+        );
+      }
     });
   }
 

--- a/packages/tool-packaging/package.json
+++ b/packages/tool-packaging/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@types/npm-package-arg": "^6.1.4",
     "@types/semver": "catalog:",
-    "@types/ssri": "^7.1.5"
+    "@types/ssri": "catalog:"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Seven independently-shippable fixes from INTR-472 (the Workbench vendored-deltas brief). Each went through per-commit design review, the full `make all` gate, and adversarial critique (several confirmed by mutation testing).

## Commits
- **Extract a pure `classifyTerminalEvent` classifier** (P1) — isolates the terminal-run-flip status vocabulary as a testable pure kernel; drops a dead defensive throw.
- **Export `resolveApproval`** for programmatic callers (P1/P2) — from the hub-api barrel; renames its arg/result types to avoid a same-name collision with `@intx/db`.
- **Add `@types/ssri` to hub-api via the shared catalog** (P3) — declares the types hub-api relied on hoisting for; breaks under an isolated linker otherwise.
- **Extract a `blobIsNewlyAdded` helper** — dedups the "absent from prior tree" idiom used at two gates.
- **Serialize per-address event-collector dispatch** (P0) — fixes interleaved turn-state writes that dropped parts and mismarked turns; guards the replace-path removal; routes `abandon` through the same tail so a queued `beginTurn` can't orphan a `running` turn.
- **Add an optional per-turn `onUsage` accounting hook** (P2) — accumulates the cumulative `inference.usage` total and emits once at finalize (summing the raw events would double-count); self-contained identity payload.
- **Tag deploy-frame send failures with `frameSent`** (P1) — lets a caller distinguish a deploy that provably never started from one that may have left a live agent.

## Not included
The anchor-before-frame reorder (item 8a) that consumes `frameSent` is designed and checkpointed on INTR-472; it needs its fail-first integration guard run on a healthy CI machine.

Refs INTR-472.