### PR TITLE
Add a tolerate body-failure policy to onTrigger sections

### DIFF
--- a/packages/workflow/src/definition/index.ts
+++ b/packages/workflow/src/definition/index.ts
@@ -28,6 +28,7 @@ export {
   type ActionPrimitive,
   type AwaitSignalOpts,
   type AwaitSignalPrimitive,
+  type BodyFailurePolicy,
   type ChildWorkflowBody,
   type ChildWorkflowOpts,
   type ChildWorkflowPrimitive,

--- a/packages/workflow/src/definition/primitives.ts
+++ b/packages/workflow/src/definition/primitives.ts
@@ -229,6 +229,16 @@ export interface LoopPrimitive extends PrimitiveBase {
 }
 
 /**
+ * Section body-failure policy. Absent (or `"end"`) is terminal-is-final: a body
+ * run that ends non-`completed` ends the whole section (today's behavior). With
+ * `"tolerate"`, a body that ends `failed` re-arms the section for the next
+ * trigger instead of terminating; a cancelled body always terminates. The field
+ * is only present when an author opts in, so a default section's wire hash is
+ * unchanged.
+ */
+export type BodyFailurePolicy = "end" | "tolerate";
+
+/**
  * Long-lived, event-driven section. The workflow subscribes to `on` and
  * runs `body` -- a full sub-DAG -- once per occurrence of that trigger,
  * each occurrence a separate child run of `body` (own run id, own event
@@ -249,13 +259,14 @@ export interface LoopPrimitive extends PrimitiveBase {
  *
  * `drainBehavior` defaults to `"wait"`: a live interactive section is not
  * abandoned mid-conversation at redeploy unless the author opts into
- * `"cancel"`.
+ * `"cancel"`. `onBodyFailure` defaults to `"end"`; see `BodyFailurePolicy`.
  */
 export interface OnTriggerPrimitive extends PrimitiveBase {
   kind: "onTrigger";
   on: Trigger;
   body: OnTriggerBody;
   drainBehavior?: DrainBehavior;
+  onBodyFailure?: BodyFailurePolicy;
 }
 
 /**
@@ -575,6 +586,7 @@ export interface OnTriggerOpts {
   on: Trigger;
   body: WorkflowDefinition;
   drainBehavior?: DrainBehavior;
+  onBodyFailure?: BodyFailurePolicy;
   after?: readonly string[];
 }
 
@@ -587,6 +599,12 @@ export function onTrigger(opts: OnTriggerOpts): OnTriggerPrimitive {
     // Authored inline; the deploy step rewrites this to `{ ref }`.
     body: { inline: opts.body },
     drainBehavior,
+    // Conditional passthrough (NOT resolved to a default like drainBehavior):
+    // an absent policy must leave the field off so a default section's inert
+    // projection -- and therefore its approval hash -- is unchanged.
+    ...(opts.onBodyFailure !== undefined
+      ? { onBodyFailure: opts.onBodyFailure }
+      : {}),
     ...(opts.after !== undefined ? { after: opts.after } : {}),
   };
 }

--- a/packages/workflow/src/definition/workflow.test.ts
+++ b/packages/workflow/src/definition/workflow.test.ts
@@ -70,6 +70,25 @@ describe("onTrigger primitive", () => {
     expect(prim.after).toEqual(["setup"]);
   });
 
+  test("omits onBodyFailure when the author does not opt in", () => {
+    // Unlike drainBehavior, an absent policy is NOT resolved to a default: the
+    // field must stay off the primitive so a default section's inert projection
+    // -- and therefore its approval hash -- is byte-identical to before the
+    // policy existed. `in`, not `=== undefined`: a present-but-undefined key
+    // would still change the canonical bytes.
+    const prim = onTrigger({ on: { type: "manual" }, body: simpleBody() });
+    expect("onBodyFailure" in prim).toBe(false);
+  });
+
+  test("honors an explicit onBodyFailure", () => {
+    const prim = onTrigger({
+      on: { type: "manual" },
+      body: simpleBody(),
+      onBodyFailure: "tolerate",
+    });
+    expect(prim.onBodyFailure).toBe("tolerate");
+  });
+
   test("defineWorkflow populates the section id from its record key", () => {
     const def = defineWorkflow({
       id: "wf",

--- a/packages/workflow/src/live-inert-projector.test.ts
+++ b/packages/workflow/src/live-inert-projector.test.ts
@@ -21,6 +21,7 @@ import {
   onTrigger,
   sleep,
   step,
+  type BodyFailurePolicy,
   type Primitive,
   type WorkflowDefinition,
 } from "./definition/index";
@@ -743,5 +744,43 @@ describe("closed step schema accepts every real Primitive variant", () => {
       "step",
     ];
     expect([...seenKinds].sort()).toEqual(expectedKinds.sort());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onTrigger onBodyFailure: projection carries the policy through the hash, and
+// an absent policy leaves the projection (and hash) unchanged so existing
+// deployments never face forced re-approval.
+// ---------------------------------------------------------------------------
+
+describe("onTrigger onBodyFailure projection and hash", () => {
+  function sectionWorkflow(
+    onBodyFailure?: BodyFailurePolicy,
+  ): WorkflowDefinition {
+    const section: Primitive = {
+      kind: "onTrigger",
+      id: "",
+      on: { type: "mail", to: "run_sec@t.example" },
+      body: { ref: "body-ref" },
+      drainBehavior: "wait",
+      ...(onBodyFailure !== undefined ? { onBodyFailure } : {}),
+    };
+    return defineWorkflow({ id: "on-trigger-hash", steps: { section } });
+  }
+
+  test("a default section omits onBodyFailure from the inert projection", () => {
+    const json = canonicalJsonStringify(projectLiveToInert(sectionWorkflow()));
+    expect(json).not.toContain("onBodyFailure");
+  });
+
+  test("tolerate moves both the projection bytes and the hash", async () => {
+    const dflt = sectionWorkflow();
+    const tolerate = sectionWorkflow("tolerate");
+    expect(canonicalJsonStringify(projectLiveToInert(tolerate))).not.toBe(
+      canonicalJsonStringify(projectLiveToInert(dflt)),
+    );
+    expect(await computeLiveDefinitionHash(tolerate)).not.toBe(
+      await computeLiveDefinitionHash(dflt),
+    );
   });
 });

--- a/packages/workflow/src/live-inert-projector.ts
+++ b/packages/workflow/src/live-inert-projector.ts
@@ -41,6 +41,7 @@ import type { CredentialBinding } from "@intx/types";
 import type {
   ActionPrimitive,
   AwaitSignalPrimitive,
+  BodyFailurePolicy,
   ChildWorkflowPrimitive,
   DrainBehavior,
   EscalationPrimitive,
@@ -154,6 +155,7 @@ export interface InertOnTrigger {
   readonly on: Trigger;
   readonly body: InertOnTriggerBody;
   readonly drainBehavior?: DrainBehavior;
+  readonly onBodyFailure?: BodyFailurePolicy;
   readonly after?: readonly string[];
 }
 
@@ -379,6 +381,9 @@ function projectOnTrigger(primitive: OnTriggerPrimitive): InertOnTrigger {
     body,
     ...(primitive.drainBehavior !== undefined
       ? { drainBehavior: primitive.drainBehavior }
+      : {}),
+    ...(primitive.onBodyFailure !== undefined
+      ? { onBodyFailure: primitive.onBodyFailure }
       : {}),
     ...(primitive.after !== undefined ? { after: [...primitive.after] } : {}),
   };

--- a/packages/workflow/src/runtime/on-trigger-run.test.ts
+++ b/packages/workflow/src/runtime/on-trigger-run.test.ts
@@ -1086,3 +1086,189 @@ describe("runOnTrigger", () => {
     await run.complete.catch(() => undefined);
   });
 });
+
+describe("runOnTrigger onBodyFailure: tolerate", () => {
+  function toleratingSection(): WorkflowDefinition {
+    const section: Primitive = {
+      kind: "onTrigger",
+      id: "",
+      on: { type: "mail", to: "run_sec@t.example" },
+      body: { ref: "body-ref" },
+      drainBehavior: "wait",
+      onBodyFailure: "tolerate",
+    };
+    return defineWorkflow({ id: "on-trigger-tolerate", steps: { section } });
+  }
+
+  test("a failed body re-arms the section instead of ending it", async () => {
+    const runId = "sec-tolerate";
+    const repoStore = createInMemoryRepoStore();
+    const channel = createInMemorySignalChannel();
+    let spawn = 0;
+    const spawnSuspendableChild: SpawnSuspendableChild = async () => {
+      const terminalStatus = spawn++ === 0 ? "failed" : "completed";
+      let done = false;
+      return {
+        next: async () => {
+          if (done) throw new Error("next after terminal");
+          done = true;
+          return { kind: "terminal", terminalStatus };
+        },
+        resume: async () => undefined,
+        deliverSignal: async () => undefined,
+      };
+    };
+    const def = toleratingSection();
+    const run = runtimeRun(
+      def,
+      buildEnv({
+        def,
+        repoStore,
+        signalChannel: channel,
+        spawnSuspendableChild,
+      }),
+      { runId, triggerPayload: { text: "event-0" } },
+    );
+
+    // The first body failed, but under `tolerate` the section re-arms on an
+    // input park for the next trigger rather than ending.
+    const ch1 = await waitForPark(repoStore, runId, "input", 1);
+    await channel.deliver(ch1, { text: "event-1" }, "sig-1");
+    await waitForPark(repoStore, runId, "input", 2);
+
+    const log = await repoStore.read(runId);
+    expect(log.filter((e) => e.kind === "ChildSpawned").length).toBe(2);
+    // The failed occurrence still commits ChildCompleted{failed} for
+    // observability -- tolerate re-arms, it does not swallow the failure.
+    expect(
+      log.some(
+        (e) => e.kind === "ChildCompleted" && e.terminalStatus === "failed",
+      ),
+    ).toBe(true);
+    // The section itself did not end.
+    expect(
+      log.some((e) => e.kind === "RunCompleted" || e.kind === "RunFailed"),
+    ).toBe(false);
+
+    await run.cancel("supervisor-operator", "test done");
+    await run.complete.catch(() => undefined);
+  });
+
+  test("a cancelled body still ends the section even under tolerate", async () => {
+    const runId = "sec-tolerate-cancel";
+    const repoStore = createInMemoryRepoStore();
+    const channel = createInMemorySignalChannel();
+    const spawnSuspendableChild: SpawnSuspendableChild = async () => ({
+      next: async () => ({ kind: "terminal", terminalStatus: "cancelled" }),
+      resume: async () => undefined,
+      deliverSignal: async () => undefined,
+    });
+    const def = toleratingSection();
+    const run = runtimeRun(
+      def,
+      buildEnv({
+        def,
+        repoStore,
+        signalChannel: channel,
+        spawnSuspendableChild,
+      }),
+      { runId, triggerPayload: { text: "event-0" } },
+    );
+
+    const result = await run.complete;
+    expect(result.terminalStatus).toBe("failed");
+    const log = await repoStore.read(runId);
+    // Cancellation is never tolerated: no re-arm.
+    expect(log.filter((e) => e.kind === "ChildSpawned").length).toBe(1);
+    expect(
+      log.some((e) => e.kind === "SignalAwaited" && e.parkKind === "input"),
+    ).toBe(false);
+  });
+
+  test("resume: a failed body under tolerate re-parks rather than ending", async () => {
+    const runId = "sec-tolerate-resume";
+    const ch = signalName("corr-rearm");
+    // A section that failed event 0 and re-armed on an input park before the
+    // crash: byte-identical durable shape to a completed occurrence's re-arm.
+    const seed: WorkflowEvent[] = [
+      {
+        kind: "RunStarted",
+        seq: 1,
+        at,
+        runId,
+        definitionHash: "x",
+        trigger: { type: "manual", payload: { text: "event-0" } },
+      },
+      {
+        kind: "StepStarted",
+        seq: 2,
+        at,
+        stepId: "section",
+        attempt: 1,
+        input: { ref: "inline:null" },
+      },
+      {
+        kind: "ChildSpawned",
+        seq: 3,
+        at,
+        stepId: "section",
+        childRunId: "section__0",
+        childDefinitionRef: "body-ref",
+      },
+      {
+        kind: "ChildCompleted",
+        seq: 4,
+        at,
+        childRunId: "section__0",
+        terminalStatus: "failed",
+      },
+      {
+        kind: "SignalAwaited",
+        seq: 5,
+        at,
+        stepId: "section",
+        signalName: ch,
+        parkKind: "input",
+      },
+    ];
+    const repoStore = createInMemoryRepoStore();
+    const channel = createInMemorySignalChannel();
+    const spawnSuspendableChild: SpawnSuspendableChild = async () => {
+      let done = false;
+      return {
+        next: async () => {
+          if (done) throw new Error("next after terminal");
+          done = true;
+          return { kind: "terminal", terminalStatus: "completed" };
+        },
+        resume: async () => undefined,
+        deliverSignal: async () => undefined,
+      };
+    };
+    const def = toleratingSection();
+    const run = runtimeRun(
+      def,
+      buildEnv({
+        def,
+        repoStore,
+        signalChannel: channel,
+        spawnSuspendableChild,
+      }),
+      { runId, resumeFromEvents: seed },
+    );
+
+    // On resume the section re-adopts the SAME durable input park (it does not
+    // end); delivering the next trigger there advances to the next occurrence.
+    await channel.deliver(ch, { text: "event-1" }, "sig-resume");
+    await waitForPark(repoStore, runId, "input", 2);
+
+    const log = await repoStore.read(runId);
+    expect(log.some((e) => e.kind === "RunFailed")).toBe(false);
+    expect(
+      log.flatMap((e) => (e.kind === "ChildSpawned" ? [e.childRunId] : [])),
+    ).toContain("section__1");
+
+    await run.cancel("supervisor-operator", "test done");
+    await run.complete.catch(() => undefined);
+  });
+});

--- a/packages/workflow/src/runtime/run.ts
+++ b/packages/workflow/src/runtime/run.ts
@@ -14,6 +14,7 @@ import type { ApprovalSnapshot, ControlParkKind } from "@intx/types/runtime";
 import type {
   ActionPrimitive,
   AwaitSignalPrimitive,
+  BodyFailurePolicy,
   ChildWorkflowPrimitive,
   EscalationPrimitive,
   GatePrimitive,
@@ -2080,10 +2081,18 @@ async function runOnTrigger(
     }
     await flush(env, runId);
 
-    if (terminalStatus !== "completed") {
-      // Terminal-is-final: a body run that failed or was cancelled ends the
-      // whole section run. Throwing lands the parent terminal via
-      // `runPrimitiveSafe`; the run does not relaunch.
+    // Terminal-is-final unless the section tolerates a body failure. A cancelled
+    // body always ends the section (a drain/operator decision, never tolerated);
+    // a failed body ends it only under the default `end` policy. Under
+    // `tolerate`, a failed body falls through to the re-arm below -- the
+    // ChildCompleted{failed} committed above still records the occurrence.
+    if (
+      terminalStatus === "cancelled" ||
+      (terminalStatus === "failed" &&
+        bodyFailurePolicyOf(primitive) !== "tolerate")
+    ) {
+      // Throwing lands the parent terminal via `runPrimitiveSafe`; the run does
+      // not relaunch.
       throw new Error(
         `onTrigger ${primitive.id} body run ${childRunId} ended ` +
           `${terminalStatus}`,
@@ -2364,6 +2373,15 @@ type OnTriggerResumePlan =
       terminalStatus: "failed" | "cancelled";
     };
 
+/**
+ * The section's body-failure policy, defaulting an absent field to `"end"`
+ * (terminal-is-final). Single source for the default so the steady-state drive
+ * loop and the resume planner cannot drift.
+ */
+function bodyFailurePolicyOf(primitive: OnTriggerPrimitive): BodyFailurePolicy {
+  return primitive.onBodyFailure ?? "end";
+}
+
 function planOnTriggerResume(
   primitive: OnTriggerPrimitive,
   state: RunState,
@@ -2395,9 +2413,15 @@ function planOnTriggerResume(
   // is already owned -- a body that then completed is caught HERE (reawait-
   // input), not by the in-flight throw. Inverting the order would wrongly fail a
   // post-abandon-completed body.
+  // Terminal-is-final unless the section tolerates a body failure (mirrors the
+  // steady-state drive loop). A cancelled body always ends; a failed body ends
+  // only under the default `end` policy. A tolerated failure falls through to
+  // the completed block below, which re-adopts the SAME input park a completed
+  // body does -- never a bare new arm (which would wedge the section).
   if (
-    child.terminalStatus === "failed" ||
-    child.terminalStatus === "cancelled"
+    child.terminalStatus === "cancelled" ||
+    (child.terminalStatus === "failed" &&
+      bodyFailurePolicyOf(primitive) !== "tolerate")
   ) {
     return {
       kind: "terminal-is-final",
@@ -2406,9 +2430,14 @@ function planOnTriggerResume(
     };
   }
   const container = state.steps.get(primitive.id);
-  if (child.terminalStatus === "completed") {
-    // The event's body finished; the section is idle on its input re-arm. Re-
-    // adopt the durable input park if it was committed, else re-arm fresh.
+  if (
+    child.terminalStatus === "completed" ||
+    (child.terminalStatus === "failed" &&
+      bodyFailurePolicyOf(primitive) === "tolerate")
+  ) {
+    // The event's body finished (completed, or failed under a `tolerate`
+    // policy); the section is idle on its input re-arm. Re-adopt the durable
+    // input park if it was committed, else re-arm fresh.
     if (
       container !== undefined &&
       container.phase === "awaiting-signal" &&


### PR DESCRIPTION
## What

Adds an opt-in `onBodyFailure: "end" | "tolerate"` policy to onTrigger
sections (INTR-472, the flagship P1 item).

An onTrigger section is long-lived: it services one body child run per
trigger occurrence and re-arms on a snapshot-less input park between
occurrences. Today the runtime is terminal-is-final: any body run that
ends non-`completed` (failed OR cancelled) ends the whole section, so a
single failed occurrence kills a section meant to outlive it.

Under the new policy:

- Default (absent, or `"end"`): unchanged terminal-is-final behavior.
- `"tolerate"`: a body that ends `failed` re-arms the section for the
  next occurrence instead of ending it. The `ChildCompleted{failed}` is
  still committed, so the failed occurrence stays observable -- tolerate
  re-arms, it does not swallow the failure.
- A `cancelled` body always terminates, even under `tolerate`:
  cancellation is a drain or operator decision, never tolerated.

## Design constraints honored

- **Wire-hash stability.** The field is absent from the primitive and the
  inert projection when the author does not opt in (conditional spreads,
  not a resolved default like `drainBehavior`), so a default section's
  approval/wire hash is byte-identical to before this change.
- **Single source of the default.** The steady-state drive loop and the
  resume planner both read the policy through one `bodyFailurePolicyOf`
  helper, so they cannot drift on what an absent field means.
- **Resume re-adopts the same input park.** Under `tolerate`, a failed
  body on resume falls through to the completed/re-arm block (re-adopting
  the durable input park), never a bare new arm that would wedge the
  section, and never the terminal-is-final block.

## Tests

- Constructor: default omits `onBodyFailure` (asserted with `in`, not
  `=== undefined`, so the hash guarantee holds at the authoring boundary);
  explicit `tolerate` is carried through.
- Projection/hash: default section's canonical projection omits the field;
  opt-in moves the projection and hash.
- Runtime: a failed body under `tolerate` re-arms (two body spawns,
  `ChildCompleted{failed}` recorded, no run failure); a cancelled body
  still ends the section under `tolerate`; on resume a failed-then-armed
  section re-parks and advances to the next occurrence.

`make all` green: 6944 unit pass, 800 integration pass (2 skip).

## Relationship to other INTR-472 work

Independent of the quick-wins batch in the other INTR-472 PR (disjoint
files: workflow package vs hub-sessions/hub-api). Branched from `main`
directly so it reviews on its own.