### PR TITLE
Insert the shared deploy anchor row before emitting the frame

### DIFF
--- a/packages/hub-sessions/src/session-service.test.ts
+++ b/packages/hub-sessions/src/session-service.test.ts
@@ -1411,13 +1411,16 @@ describe("deployCodeSourcedWorkflow", () => {
   const SOURCE = { kind: "registry", registry: "npm" } as const;
   const TENANT = "tnt_test";
   // These unit tests assert FRAME logic plus the SHAPE of the anchor
-  // workflow_run row the composed entrypoint writes (status, self-ref) -- not
-  // its persistence (the real anchor-in-a-live-DB proof is the walking-skeleton
-  // e2e). A capturing db records the single anchor insert and answers the
-  // persisted-definition guard's existence query with a matching row; the
-  // fail-path tests throw before reaching the insert.
+  // workflow_run row the composed entrypoint writes (status, self-ref, born
+  // null-key) and its post-ack public-key stamp -- not its persistence (the
+  // real anchor-in-a-live-DB proof, including the anchor-before-frame ordering,
+  // is the tests/db regression test). A capturing db records the anchor insert
+  // and the success-path public-key update, and answers the persisted-definition
+  // guard's existence query with a matching row; the fail-path tests throw
+  // before reaching the insert.
   let capturedAnchorRow: Record<string, unknown> | undefined;
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub: only the definition existence query and .insert(...).values(...) are exercised
+  let capturedAnchorUpdate: Record<string, unknown> | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub: only the definition existence query, the anchor insert, and the success-path public-key update are exercised
   const CAPTURING_DB = {
     query: {
       workflowDefinition: {
@@ -1428,6 +1431,16 @@ describe("deployCodeSourcedWorkflow", () => {
       values: (row: Record<string, unknown>) => {
         capturedAnchorRow = row;
         return Promise.resolve();
+      },
+    }),
+    update: () => ({
+      set: (vals: Record<string, unknown>) => {
+        capturedAnchorUpdate = vals;
+        return {
+          where: () => ({
+            returning: () => Promise.resolve([{ id: ANCHOR_RUN_ID }]),
+          }),
+        };
       },
     }),
   } as unknown as DB["db"];
@@ -1483,12 +1496,18 @@ describe("deployCodeSourcedWorkflow", () => {
 
     // The anchor workflow_run row is born "deployed" (live but pre-trigger) and
     // self-referential (anchorRunId === id); its address is the run address
-    // derived from the anchor run id.
+    // derived from the anchor run id. It is inserted with a NULL public key --
+    // the row must exist before the frame, but the key is only known from the
+    // ack -- and the key is stamped by a follow-up update once the ack returns.
     expect(capturedAnchorRow).toBeDefined();
     expect(capturedAnchorRow?.status).toBe("deployed");
     expect(capturedAnchorRow?.id).toBe(ANCHOR_RUN_ID);
     expect(capturedAnchorRow?.anchorRunId).toBe(ANCHOR_RUN_ID);
     expect(capturedAnchorRow?.address).toBe(DEPLOY_ADDRESS);
+    expect(capturedAnchorRow?.publicKey).toBeNull();
+    expect(capturedAnchorUpdate).toEqual({
+      publicKey: "ed25519-supervisor-pubkey",
+    });
   });
 
   test("refuses to deploy when the gate did not approve", async () => {

--- a/packages/hub-sessions/src/session-service.ts
+++ b/packages/hub-sessions/src/session-service.ts
@@ -1,5 +1,5 @@
 import { type } from "arktype";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 
 import { getLogger } from "@intx/log";
 import {
@@ -74,6 +74,7 @@ import type {
   SidecarAllocationRouter,
   SidecarRouter,
 } from "./ws/sidecar-handler";
+import { isDeployFrameFailure } from "./ws/sidecar-handler";
 import type { Principal, RepoId, RepoKind } from "./repo-store";
 import {
   buildSourceAssetMounts,
@@ -635,19 +636,22 @@ function isAssetDeployArgs(
  * A gate outcome that did not approve cannot deploy: an unapproved `approval`
  * fails closed here rather than shipping an unfrozen definition.
  *
- * This emits the source-ref deploy frame ONLY -- it does NOT write the anchor
- * `workflow_run` row. `deployCodeSourcedWorkflow` wraps it with the shared-path
- * INSERT; the prepared exclusive path wraps it with an UPDATE-under-lock of the
- * anchor row that already exists from prepare time. It returns the frozen
- * definition id so each wrapper writes the same content-addressed identity the
- * gate persisted.
+ * This does the READ-ONLY preparation ONLY: it runs the guards, resolves
+ * credential material, pins the body sources, and builds the asset mounts, then
+ * returns the frozen definition id and the assembled send args. It emits NO
+ * frame and writes NO row, so it has no side effect to unwind. The shared path
+ * (`deployCodeSourcedWorkflow`) sequences prepare -> INSERT anchor -> emit so
+ * the anchor is visible before the frame spawns the child; `emitSourceRefDeployFrame`
+ * composes prepare -> emit for the prepared exclusive path, whose anchor row
+ * already exists from prepare time. It returns the frozen definition id so each
+ * caller writes the same content-addressed identity the gate persisted.
  */
-async function emitSourceRefDeployFrame(
+async function prepareSourceRefDeploy(
   args: DeployCodeSourcedWorkflowArgs & {
     allocationTarget?: AllocatedSidecarTarget;
     sidecarAllocationRouter?: SidecarAllocationRouter;
   },
-): Promise<{ publicKey: string; definitionId: string }> {
+): Promise<{ definitionId: string; sendArgs: SendMultiStepDeployFrameArgs }> {
   const { approval, projection, closure } = args.approved;
   if (!approval.ok) {
     throw new Error(
@@ -796,7 +800,7 @@ async function emitSourceRefDeployFrame(
     ? await buildSourceAssetMounts(closure, args.resolveAttachment)
     : [];
 
-  const result = await sendMultiStepDeployFrame({
+  const sendArgs: SendMultiStepDeployFrameArgs = {
     lineage: "source-ref",
     sidecarRouter: args.sidecarRouter,
     ...(args.sidecarAllocationRouter !== undefined
@@ -813,44 +817,170 @@ async function emitSourceRefDeployFrame(
     ...(credentials !== undefined ? { credentials } : {}),
     ...(referencedDefinitions.length > 0 ? { referencedDefinitions } : {}),
     ...(assets.length > 0 ? { assets } : {}),
-  });
+  };
 
-  return { publicKey: result.publicKey, definitionId: approval.definitionId };
+  return { definitionId: approval.definitionId, sendArgs };
+}
+
+/**
+ * Prepare then emit the source-ref deploy frame, for the prepared exclusive
+ * path whose anchor `workflow_run` row already exists (inserted at prepare
+ * time). It emits the frame but does NOT touch the anchor row: the caller
+ * (`deployPreparedCodeSourcedWorkflow`) stamps the acked key under the
+ * allocation-ownership lock. On emit failure it throws the raw
+ * `DeployFrameFailure` verbatim, which the caller's own error handling wraps.
+ * The shared path does NOT use this wrapper -- it must interleave the anchor
+ * INSERT between prepare and emit, so it drives `prepareSourceRefDeploy` and
+ * `sendMultiStepDeployFrame` directly.
+ */
+async function emitSourceRefDeployFrame(
+  args: DeployCodeSourcedWorkflowArgs & {
+    allocationTarget?: AllocatedSidecarTarget;
+    sidecarAllocationRouter?: SidecarAllocationRouter;
+  },
+): Promise<{ publicKey: string; definitionId: string }> {
+  const { definitionId, sendArgs } = await prepareSourceRefDeploy(args);
+  const result = await sendMultiStepDeployFrame(sendArgs);
+  return { publicKey: result.publicKey, definitionId };
 }
 
 /**
  * The single public composition entrypoint for a SHARED code-sourced (npm)
- * deploy: emit the source-ref frame, then INSERT the deployment's anchor
- * `workflow_run` row -- the deployment's first-class record that owns its
- * routing address and public key. Run-grant materialization keys off this row
- * (address + live status), so WITHOUT it no per-run grants (tool, capability, OR
- * credential) ever materialize for a source-ref deployment. Born "deployed"
- * (live but pre-trigger): the first trigger's materialization flips it to
- * "running" via `anchorWithPrincipal`'s guarded update, which a row born
- * "running" would skip. Its `anchorRunId` equals its own id, so the anchor
- * references itself. The deployer read grant is deferred to the production
- * route, which carries the authenticated deployer principal; this stays a
- * single insert with no grant row to pair atomically.
+ * deploy: prepare, INSERT the deployment's anchor `workflow_run` row, THEN emit
+ * the source-ref frame. The anchor row is the deployment's first-class record
+ * that owns its routing address and public key. Run-grant materialization keys
+ * off this row (address + live status), so WITHOUT it no per-run grants (tool,
+ * capability, OR credential) ever materialize for a source-ref deployment. Born
+ * "deployed" (live but pre-trigger) with a null public key: the first trigger's
+ * materialization flips it to "running" via `anchorWithPrincipal`'s guarded
+ * update, which a row born "running" would skip. Its `anchorRunId` equals its
+ * own id, so the anchor references itself. The deployer read grant is deferred
+ * to the production route, which carries the authenticated deployer principal.
  *
- * The prepared exclusive path does NOT use this wrapper: its anchor row already
- * exists from prepare time, so it wraps `emitSourceRefDeployFrame` with an
- * UPDATE-under-allocation-lock instead of this INSERT.
+ * ORDERING IS LOAD-BEARING. The anchor row must be committed and visible to the
+ * pack-receipt connection BEFORE the frame reaches the wire: the frame spawns
+ * the child, whose first events pack races the ack back, and
+ * `receiveWorkflowRunPack` fails closed on a missing live anchor. Emitting first
+ * (the previous order) rejected that first pack and never bootstrapped the log.
+ * This works because `args.db` is the autocommit handle (`DB["db"]`, which the
+ * type forbids from being a transaction) and the INSERT is NOT wrapped in a
+ * transaction with the emit -- so the row is durably visible the instant the
+ * INSERT statement returns. Do NOT relax `db` to a transaction executor or wrap
+ * anchor+emit in one transaction to make them atomic: that reopens the race.
+ *
+ * On emit failure the anchor row is rolled back or fenced by the `frameSent`
+ * evidence from the transport. `leakedAgent: false` (safe to fully roll back) is
+ * the STRONG claim and is made only on positive proof the frame never reached
+ * the wire (`isDeployFrameFailure && frameSent === false`); every other failure
+ * -- a sent-but-unacked frame OR any untagged error -- is treated as
+ * possibly-live: the anchor is fenced `deployed` -> `failed` and the error is
+ * `leakedAgent: true`.
+ *
+ * The prepared exclusive path does NOT use this composition: its anchor row
+ * already exists from prepare time, so it drives `emitSourceRefDeployFrame` and
+ * an UPDATE-under-allocation-lock instead.
  */
 export async function deployCodeSourcedWorkflow(
   args: DeployCodeSourcedWorkflowArgs,
 ): Promise<{ publicKey: string }> {
-  const { publicKey, definitionId } = await emitSourceRefDeployFrame(args);
+  const { definitionId, sendArgs } = await prepareSourceRefDeploy(args);
 
-  await args.db.insert(workflowRunTable).values({
-    id: args.anchorRunId,
-    tenantId: args.tenantId,
-    anchorRunId: args.anchorRunId,
-    definitionId,
-    address: args.agentAddress,
-    publicKey,
-    status: "deployed",
-    createdAt: new Date(),
-  });
+  // INSERT the anchor before the frame. A collision or DB error here spawned
+  // nothing (no frame went out), so it is a clean, non-leaking failure.
+  try {
+    await args.db.insert(workflowRunTable).values({
+      id: args.anchorRunId,
+      tenantId: args.tenantId,
+      anchorRunId: args.anchorRunId,
+      definitionId,
+      address: args.agentAddress,
+      publicKey: null,
+      status: "deployed",
+      createdAt: new Date(),
+    });
+  } catch (cause) {
+    throw new SessionLaunchError("start", cause, false);
+  }
+
+  let publicKey: string;
+  try {
+    const result = await sendMultiStepDeployFrame(sendArgs);
+    publicKey = result.publicKey;
+  } catch (cause) {
+    if (isDeployFrameFailure(cause) && cause.frameSent === false) {
+      // Positive proof the frame never reached the wire: nothing spawned, so
+      // fully roll the anchor back. The guard (`deployed`, null key) is a
+      // tripwire on the `frameSent: false` contract -- a 0-row delete means the
+      // row advanced or vanished, so the contract lied and a child may be live;
+      // surface that loudly and refuse to claim it is safe to roll back.
+      const deleted = await args.db
+        .delete(workflowRunTable)
+        .where(
+          and(
+            eq(workflowRunTable.id, args.anchorRunId),
+            eq(workflowRunTable.anchorRunId, args.anchorRunId),
+            eq(workflowRunTable.tenantId, args.tenantId),
+            eq(workflowRunTable.status, "deployed"),
+            isNull(workflowRunTable.publicKey),
+          ),
+        )
+        .returning({ id: workflowRunTable.id });
+      if (deleted.length === 0) {
+        logger.error`anchor-before-frame rollback found no deployed/null-key row for ${args.anchorRunId} after a frameSent:false failure; the never-sent contract was violated and a child may be live`;
+        throw new SessionLaunchError("start", cause, true);
+      }
+      throw new SessionLaunchError("start", cause, false);
+    }
+    // A sent-but-unacked frame, OR any untagged/unexpected error: no positive
+    // proof of a clean send, so treat the agent as possibly-live. Fence the
+    // anchor `deployed` -> `failed` (guarded so a self-flip to "running" by a
+    // trigger that already landed is left alone). Do NOT delete: a live child
+    // needs the anchor to bootstrap.
+    const flipped = await args.db
+      .update(workflowRunTable)
+      .set({ status: "failed" })
+      .where(
+        and(
+          eq(workflowRunTable.id, args.anchorRunId),
+          eq(workflowRunTable.anchorRunId, args.anchorRunId),
+          eq(workflowRunTable.tenantId, args.tenantId),
+          eq(workflowRunTable.status, "deployed"),
+          isNull(workflowRunTable.publicKey),
+        ),
+      )
+      .returning({ id: workflowRunTable.id });
+    if (flipped.length === 0) {
+      // The anchor already advanced past deployed -- a trigger flipped it to
+      // "running", so the deploy actually succeeded and the run is progressing
+      // despite the ack failure. Leave it; the leaked-agent disposition still
+      // holds because the frame was (or may have been) sent.
+      logger.warn`anchor-before-frame: anchor ${args.anchorRunId} already advanced past deployed on an unacked/failed emit; the agent is live and the run is progressing despite the ack failure`;
+    } else {
+      logger.warn`anchor-before-frame: fenced anchor ${args.anchorRunId} deployed->failed on an unacked/failed emit; the agent may be leaked but the run is dead`;
+    }
+    throw new SessionLaunchError("start", cause, true);
+  }
+
+  // Emit succeeded: stamp the acked key. No status guard -- the key is a fact
+  // regardless of whether the pack-ack race already flipped the row to
+  // "running", and skipping the stamp there would strand a live run with a null
+  // key. A 0-row update is an anomaly (nothing should remove a deployed anchor
+  // on the success path), but the deploy succeeded, so log it rather than
+  // failing a live run.
+  const stamped = await args.db
+    .update(workflowRunTable)
+    .set({ publicKey })
+    .where(
+      and(
+        eq(workflowRunTable.id, args.anchorRunId),
+        eq(workflowRunTable.anchorRunId, args.anchorRunId),
+        eq(workflowRunTable.tenantId, args.tenantId),
+      ),
+    )
+    .returning({ id: workflowRunTable.id });
+  if (stamped.length === 0) {
+    logger.error`anchor-before-frame: anchor ${args.anchorRunId} vanished before its public key could be stamped on a successful deploy`;
+  }
 
   return { publicKey };
 }

--- a/tests/db/anchor-before-frame.test.ts
+++ b/tests/db/anchor-before-frame.test.ts
@@ -1,0 +1,422 @@
+// Anchor-before-frame ordering for the SHARED source-ref deploy (real DB).
+//
+// `deployCodeSourcedWorkflow` must INSERT the deployment's anchor `workflow_run`
+// row -- committed on the autocommit handle, so visible to a separate
+// connection -- BEFORE it emits the deploy frame. The frame spawns the child,
+// whose first events pack races the ack back to the hub; `receiveWorkflowRunPack`
+// fails closed with `path_violation` on a missing live anchor. Emit-then-insert
+// (the previous order) rejected that first pack and never bootstrapped the log.
+//
+// The tripwire probes INSIDE the send: the fake `sendAgentDeploy`, at the moment
+// it is called (standing in for the child's first pack arriving while the frame
+// is on the wire), runs the REAL `receiveWorkflowRunPack` for the deployment
+// address and records whether it was accepted. A post-hoc assertion cannot tell
+// the two orderings apart -- the anchor exists under both once deploy returns --
+// so only an in-send probe distinguishes fail-before from pass-after. Under the
+// fixed insert-then-emit order the committed anchor is visible and the pack is
+// accepted; under the old order the probe sees no anchor and this test fails.
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { type } from "arktype";
+import { eq } from "drizzle-orm";
+
+import { defineAgent } from "@intx/agent";
+import { generateKeyPair } from "@intx/crypto";
+import { workflowDefinition, workflowRun } from "@intx/db/schema";
+import {
+  createAgentRepoStore,
+  createHubSessionLookups,
+  deployCodeSourcedWorkflow,
+  SessionLaunchError,
+  type AgentRepoStore,
+  type SidecarRouter,
+} from "@intx/hub-sessions";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import { seedTenants, seedWorkflowRun } from "@intx/test-harness/seed";
+import type {
+  HarnessConfig,
+  InferenceSource,
+  KeyPair,
+} from "@intx/types/runtime";
+import { WorkflowProjectionDefinition } from "@intx/types/sidecar";
+import type { ToolPackageManifest } from "@intx/types/tool-packages";
+import { computeWireDefinitionHash } from "@intx/types/wire-definition-hash";
+import { defineWorkflow, projectLiveToInert, step } from "@intx/workflow";
+import {
+  deriveRunAddress,
+  deriveWorkflowRunRepoId,
+} from "@intx/workflow-deploy";
+
+const TENANT_ID = "tnt_anchor_before_frame";
+const DEFINITION_ID = "def_anchor_before_frame";
+const DEPLOYMENT_DOMAIN = "workflow.interchange";
+const ANCHOR_RUN_ID = "run_abcdef0123456789abcdef0123456789";
+const DEPLOY_ADDRESS = deriveRunAddress({
+  runId: ANCHOR_RUN_ID,
+  domain: DEPLOYMENT_DOMAIN,
+});
+const WORKFLOW_RUN_REPO_ID = deriveWorkflowRunRepoId(DEPLOY_ADDRESS);
+const WORKFLOW_RUN_REF = "refs/heads/events";
+const ACKED_PUBLIC_KEY = "ed25519-anchor-before-frame-pubkey";
+
+const INFERENCE_SOURCE: InferenceSource = {
+  id: "src-only",
+  provider: "anthropic",
+  baseURL: "https://api.example/anthropic",
+  apiKey: "secret-only",
+  model: "mock-model",
+};
+const SOURCES = { only: [INFERENCE_SOURCE] };
+const CONFIG: HarnessConfig = {
+  sessionId: "ses-anchor-before-frame",
+  agentId: ANCHOR_RUN_ID,
+  tenantId: TENANT_ID,
+  principalId: "prin-anchor-before-frame",
+  agentAddress: DEPLOY_ADDRESS,
+  systemPrompt: "deployment-level",
+  tools: [],
+  grants: [],
+  sources: Object.values(SOURCES).flat(),
+  defaultSource: "src-only",
+};
+
+// Reproduce the approve output the shared entrypoint consumes, by hand: the
+// gate's ok-arm is a plain object, so a real gate/freeze run is unnecessary to
+// exercise the deploy ORDERING under test. Project a trivial single-step
+// definition to inert wire form, hash it, and pair it with an empty closure.
+async function makeApproveBundle(): Promise<{
+  approval: {
+    ok: true;
+    definitionId: string;
+    approvedWireHash: string;
+    approvedGrants: ReadonlySet<string>;
+    projection: WorkflowProjectionDefinition;
+  };
+  projection: WorkflowProjectionDefinition;
+  closure: ToolPackageManifest;
+}> {
+  const stubAgent = defineAgent({
+    id: "stub",
+    systemPrompt: "you stub",
+    tools: [],
+    capabilities: [],
+    inference: { sources: [{ provider: "anthropic", model: "mock-model" }] },
+  });
+  const definition = defineWorkflow({
+    id: "wf_anchor_before_frame",
+    trigger: { type: "manual" },
+    steps: { only: step({ agent: stubAgent, after: [] }) },
+  });
+  const roundTripped: unknown = JSON.parse(
+    JSON.stringify(projectLiveToInert(definition)),
+  );
+  const projection = WorkflowProjectionDefinition(roundTripped);
+  if (projection instanceof type.errors) {
+    throw new Error(
+      `inert projection failed WorkflowProjectionDefinition validation: ${projection.summary}`,
+    );
+  }
+  const approvedWireHash = await computeWireDefinitionHash(projection);
+  return {
+    approval: {
+      ok: true,
+      definitionId: DEFINITION_ID,
+      approvedWireHash,
+      approvedGrants: new Set<string>(),
+      projection,
+    },
+    projection,
+    closure: { schemaVersion: "1", topLevel: [], entries: [] },
+  };
+}
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "anchor-before-frame ordering (real DB)",
+  () => {
+    let h: TestDb;
+    let signingKey: KeyPair;
+    const tempDirs: string[] = [];
+
+    beforeAll(async () => {
+      h = await createTestDb();
+      signingKey = await generateKeyPair();
+    });
+
+    afterAll(async () => {
+      await h.close();
+    });
+
+    beforeEach(async () => {
+      await h.reset();
+      await seedTenants(h.db, [{ id: TENANT_ID }]);
+      // The persisted-definition guard and the anchor row's FK both need this.
+      await h.db.insert(workflowDefinition).values({
+        id: DEFINITION_ID,
+        tenantId: TENANT_ID,
+        name: "anchor-before-frame",
+      });
+    });
+
+    afterEach(async () => {
+      for (const dir of tempDirs.splice(0)) {
+        await fs.promises
+          .rm(dir, { recursive: true, force: true })
+          .catch(() => {
+            // Best-effort test cleanup.
+          });
+      }
+    });
+
+    // A real hub-session lookups over the real DB, with only the inner repo
+    // write stubbed: the anchor gate (status + self-anchor + address) runs for
+    // real; the pack bytes are never actually applied.
+    async function makeLookups() {
+      const dataDir = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), "anchor-before-frame-"),
+      );
+      tempDirs.push(dataDir);
+      const agentRepoStore: AgentRepoStore = {
+        ...createAgentRepoStore({ dataDir, signingKey }),
+        receiveWorkflowRunPack: async () => [],
+      };
+      return createHubSessionLookups({ db: h.db, agentRepoStore });
+    }
+
+    async function probePack(
+      lookups: ReturnType<typeof createHubSessionLookups>,
+    ) {
+      return lookups.receiveWorkflowRunPack(
+        { kind: "workflow-run", id: WORKFLOW_RUN_REPO_ID },
+        new Uint8Array(),
+        WORKFLOW_RUN_REF,
+        "pack-tip",
+        { kind: "shared", agentAddress: DEPLOY_ADDRESS },
+      );
+    }
+
+    async function deployWith(router: SidecarRouter): Promise<void> {
+      const { approval, projection, closure } = await makeApproveBundle();
+      await deployCodeSourcedWorkflow({
+        sidecarRouter: router,
+        agentAddress: DEPLOY_ADDRESS,
+        config: CONFIG,
+        sources: SOURCES,
+        approved: { approval, projection, closure },
+        source: { kind: "registry", registry: "npm" },
+        db: h.db,
+        tenantId: TENANT_ID,
+        anchorRunId: ANCHOR_RUN_ID,
+        deploymentDomain: DEPLOYMENT_DOMAIN,
+      });
+    }
+
+    async function readAnchor(): Promise<
+      { status: string; publicKey: string | null } | undefined
+    > {
+      const [row] = await h.db
+        .select({
+          status: workflowRun.status,
+          publicKey: workflowRun.publicKey,
+        })
+        .from(workflowRun)
+        .where(eq(workflowRun.id, ANCHOR_RUN_ID))
+        .limit(1);
+      return row;
+    }
+
+    // A router whose deploy frame emit throws `cause`, standing in for a send
+    // that failed. The `onSend` hook runs first, letting a test mutate the
+    // just-inserted anchor to exercise the 0-row tripwire branches.
+    function throwingRouter(
+      cause: unknown,
+      onSend?: () => Promise<void>,
+    ): SidecarRouter {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub: the shared deploy path only calls sendAgentDeploy
+      return {
+        sendAgentDeploy: async () => {
+          if (onSend !== undefined) await onSend();
+          throw cause;
+        },
+      } as unknown as SidecarRouter;
+    }
+
+    async function expectLeaked(
+      promise: Promise<void>,
+      leakedAgent: boolean,
+    ): Promise<void> {
+      let caught: unknown;
+      try {
+        await promise;
+      } catch (err) {
+        caught = err;
+      }
+      if (!(caught instanceof SessionLaunchError)) {
+        throw new Error(`expected a SessionLaunchError, got ${String(caught)}`);
+      }
+      expect(caught.leakedAgent).toBe(leakedAgent);
+    }
+
+    test("the child's first pack is accepted because the anchor exists before the frame", async () => {
+      const { approval, projection, closure } = await makeApproveBundle();
+      const lookups = await makeLookups();
+
+      // The probe stands in for the child's first events pack racing back while
+      // the deploy frame is on the wire.
+      let probeAccepted: boolean | undefined;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub: the shared deploy path only calls sendAgentDeploy
+      const router = {
+        sendAgentDeploy: async () => {
+          const result = await probePack(lookups);
+          probeAccepted = result.accepted;
+          return { publicKey: ACKED_PUBLIC_KEY };
+        },
+      } as unknown as SidecarRouter;
+
+      await deployCodeSourcedWorkflow({
+        sidecarRouter: router,
+        agentAddress: DEPLOY_ADDRESS,
+        config: CONFIG,
+        sources: SOURCES,
+        approved: { approval, projection, closure },
+        source: { kind: "registry", registry: "npm" },
+        db: h.db,
+        tenantId: TENANT_ID,
+        anchorRunId: ANCHOR_RUN_ID,
+        deploymentDomain: DEPLOYMENT_DOMAIN,
+      });
+
+      // Fails on the old emit-then-insert order: at probe time the anchor row
+      // did not exist yet, so the gate returned path_violation.
+      expect(probeAccepted).toBe(true);
+
+      // The successful ack stamped the key onto the now-live anchor.
+      const [row] = await h.db
+        .select({
+          status: workflowRun.status,
+          publicKey: workflowRun.publicKey,
+        })
+        .from(workflowRun)
+        .where(eq(workflowRun.id, ANCHOR_RUN_ID))
+        .limit(1);
+      expect(row?.status).toBe("deployed");
+      expect(row?.publicKey).toBe(ACKED_PUBLIC_KEY);
+    });
+
+    test("a never-sent frame (frameSent:false) rolls the anchor back and reports no leak", async () => {
+      const router = throwingRouter(
+        Object.assign(new Error("refused before the send"), {
+          frameSent: false,
+        }),
+      );
+      await expectLeaked(deployWith(router), false);
+      // Proven never on the wire: the anchor is fully rolled back.
+      expect(await readAnchor()).toBeUndefined();
+    });
+
+    test("a sent-but-unacked frame (frameSent:true) fences the anchor and reports a leak", async () => {
+      const router = throwingRouter(
+        Object.assign(new Error("ack timeout"), { frameSent: true }),
+      );
+      await expectLeaked(deployWith(router), true);
+      // A child may be live: the anchor is fenced to failed, not deleted.
+      const row = await readAnchor();
+      expect(row?.status).toBe("failed");
+      expect(row?.publicKey).toBeNull();
+    });
+
+    test("an untagged emit error is treated as possibly-live: fence and report a leak", async () => {
+      // No frameSent evidence at all -- must not claim a clean rollback.
+      const router = throwingRouter(new Error("router misconfiguration"));
+      await expectLeaked(deployWith(router), true);
+      const row = await readAnchor();
+      expect(row?.status).toBe("failed");
+    });
+
+    test("an anchor insert collision fails closed before the frame with no leak", async () => {
+      // A row already owns this anchor id, so the pre-emit INSERT collides. The
+      // frame never goes out; the pre-existing row must be left untouched.
+      await seedWorkflowRun(h.db, {
+        id: ANCHOR_RUN_ID,
+        anchorRunId: ANCHOR_RUN_ID,
+        tenantId: TENANT_ID,
+        address: DEPLOY_ADDRESS,
+        status: "running",
+      });
+      let sendCalled = false;
+      const router = throwingRouter(new Error("unused"), async () => {
+        sendCalled = true;
+      });
+      await expectLeaked(deployWith(router), false);
+      expect(sendCalled).toBe(false);
+      expect((await readAnchor())?.status).toBe("running");
+    });
+
+    test("a frameSent:false failure whose anchor already vanished refuses to claim safe", async () => {
+      // The guarded delete finds 0 rows: the frameSent:false contract lied, so
+      // a child may be live and the failure must NOT be reported as safe.
+      const router = throwingRouter(
+        Object.assign(new Error("refused before the send"), {
+          frameSent: false,
+        }),
+        async () => {
+          await h.db
+            .delete(workflowRun)
+            .where(eq(workflowRun.id, ANCHOR_RUN_ID));
+        },
+      );
+      await expectLeaked(deployWith(router), true);
+    });
+
+    test("a sent-but-unacked failure whose anchor already advanced leaves the live run alone", async () => {
+      // The guarded flip finds 0 rows because a trigger already flipped the
+      // anchor deployed->running: the deploy actually succeeded, so the live run
+      // is left as-is while the ack failure is still reported as a leak.
+      const router = throwingRouter(
+        Object.assign(new Error("ack timeout"), { frameSent: true }),
+        async () => {
+          await h.db
+            .update(workflowRun)
+            .set({ status: "running" })
+            .where(eq(workflowRun.id, ANCHOR_RUN_ID));
+        },
+      );
+      await expectLeaked(deployWith(router), true);
+      expect((await readAnchor())?.status).toBe("running");
+    });
+
+    test("receiveWorkflowRunPack accepts a deployed anchor whose public key is still null", async () => {
+      // Pins the gate's publicKey-agnosticism: the anchor-before-frame window is
+      // a live "deployed" row with a null key, and the gate must accept a pack
+      // against it. A future "require publicKey on the anchor" change turns this
+      // red rather than silently re-breaking deploy bootstrap.
+      await seedWorkflowRun(h.db, {
+        id: ANCHOR_RUN_ID,
+        anchorRunId: ANCHOR_RUN_ID,
+        tenantId: TENANT_ID,
+        address: DEPLOY_ADDRESS,
+        status: "deployed",
+      });
+      const lookups = await makeLookups();
+
+      const result = await probePack(lookups);
+      expect(result.accepted).toBe(true);
+    });
+  },
+);


### PR DESCRIPTION
## What

Closes the deploy-frame/anchor-row race on the SHARED source-ref deploy
path (INTR-472 item 8a). Stacked on `intr-472-quick-wins` (PR #142),
which carries the `frameSent` transport signal this consumes.

`deployCodeSourcedWorkflow` emitted the deploy frame first and inserted
the deployment's anchor `workflow_run` row afterward. The frame spawns
the child, whose first events pack races the deploy ack back to the hub;
`receiveWorkflowRunPack` fails closed on a missing live anchor, so that
first pack was rejected and the durable run log never bootstrapped.

## The fix

Insert the anchor row (`deployed`, null public key) BEFORE the frame and
stamp the acked key afterward, matching the prepared/exclusive path. The
row commits on the autocommit handle (`DB["db"]`, which the type forbids
from being a transaction) with no enclosing transaction, so it is visible
to the pack-receipt connection the instant the frame spawns the child --
this closes the race rather than narrowing it.

`emitSourceRefDeployFrame` is split into a read-only `prepareSourceRefDeploy`
(guards + credential resolution + source pinning + asset mounts; no frame,
no DB write) plus the send, so the anchor insert can sit between them; the
prepared/exclusive path keeps its `prepare -> emit` composition unchanged.

## Failure handling (evidence-gated)

On emit failure the anchor is rolled back or fenced by the transport's
`frameSent` evidence:

- `leakedAgent: false` (safe to fully roll back) is claimed ONLY on
  positive proof the frame never reached the wire
  (`isDeployFrameFailure && frameSent === false`): the anchor is deleted
  under a guarded WHERE. A 0-row delete means that contract lied (the row
  advanced or vanished), so it refuses to claim safe and reports a leak.
- Every other failure -- a sent-but-unacked frame OR any untagged error --
  is possibly-live: the anchor is fenced `deployed -> failed` under a
  guarded WHERE (a trigger that already flipped it to `running` is left
  alone) and the error is `leakedAgent: true`. It never deletes on this
  path, since a live child needs the anchor to bootstrap.
- The pre-emit INSERT is its own failure point (address collision, DB
  error): nothing was sent, so it fails closed with `leakedAgent: false`.

## Tests

`tests/db/anchor-before-frame.test.ts` (real DB):

- The regression guard drives the real `deployCodeSourcedWorkflow` with a
  fake router whose `sendAgentDeploy` probes the REAL
  `receiveWorkflowRunPack` mid-send (standing in for the child's first
  pack racing back). Mutation-verified: removing the pre-emit insert makes
  it fail with `path_violation`; it passes with the insert restored. A
  post-hoc assertion cannot distinguish the orderings, so the probe is
  inside the send.
- Six failure-path tests pin the classification matrix against the real
  delete/flip/stamp WHERE clauses: frameSent false/true, untagged error,
  insert collision, and both 0-row tripwires (vanished-anchor and
  already-advanced). Mutation-verified to gate the `leakedAgent` evidence
  and the WHERE columns.
- A characterization test pins that the gate accepts a `deployed` anchor
  with a null public key.

`make all` green (6951 unit, 808 integration, 2 skip).

## Follow-on (separate issue)

A sent-but-unacked deploy can leave a live child the hub can neither reach
nor undeploy (the supervisor key's only carrier is the ack). This fix
fences the stale anchor; true child recovery needs a versioned wire change
or an ownership-based reaper, tracked separately.