### PR TITLE
Fix and harden the deferred unified-host follow-up cleanups

### DIFF
--- a/apps/admin-ui/src/lib/api.test.ts
+++ b/apps/admin-ui/src/lib/api.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from "bun:test";
+
+import { api } from "./api";
+
+// The hub's async-accept routes return 202. A signal route returns 202 with
+// an empty body; a trigger route returns 202 with a JSON acknowledgement.
+// api() must resolve both without throwing "Unexpected end of JSON input",
+// which res.json() raises on an empty body. Driving a real Response through
+// a stubbed global fetch exercises the actual body-reading branch rather
+// than a mock that pre-decides the result.
+describe("api 202 handling", () => {
+  test("resolves undefined on a real 202 empty-body response without throwing", async () => {
+    const originalFetch = globalThis.fetch;
+    const seen: { url: string; method: string | undefined }[] = [];
+    globalThis.fetch = Object.assign(
+      (input: string | URL | Request, init?: RequestInit) => {
+        seen.push({ url: String(input), method: init?.method });
+        return Promise.resolve(new Response(null, { status: 202 }));
+      },
+      { preconnect: () => undefined },
+    );
+    try {
+      const result = await api("POST", "/api/workflows/run_1/signals");
+      expect(result).toBeUndefined();
+      expect(seen).toHaveLength(1);
+      expect(seen[0]?.method).toBe("POST");
+      expect(seen[0]?.url).toBe("/api/workflows/run_1/signals");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("returns the parsed acknowledgement from a real 202-with-body response", async () => {
+    const ack = {
+      runId: "run_1",
+      address: "wf@deployments.example.com",
+      messageId: "<msg_1@example.com>",
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = Object.assign(
+      () =>
+        Promise.resolve(
+          new Response(JSON.stringify(ack), {
+            status: 202,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+      { preconnect: () => undefined },
+    );
+    try {
+      const result = await api<typeof ack>(
+        "POST",
+        "/api/workflows/run_1/mail",
+        { content: "kick off" },
+      );
+      expect(result).toEqual(ack);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/apps/admin-ui/src/lib/api.ts
+++ b/apps/admin-ui/src/lib/api.ts
@@ -46,6 +46,18 @@ export async function api<T>(
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- T is a generic parameter; runtime validation is the caller's responsibility
   if (res.status === 204) return undefined as T;
+  // A 202 (Accepted) response may carry an empty body or a JSON
+  // acknowledgement body. Reading the raw text first distinguishes the two:
+  // an empty body resolves to undefined, a present body is JSON-parsed.
+  // Calling res.json() unconditionally on an empty body would throw
+  // "Unexpected end of JSON input".
+  if (res.status === 202) {
+    const text = await res.text();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- T is a generic parameter; runtime validation is the caller's responsibility
+    if (text.length === 0) return undefined as T;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- T is a generic parameter; runtime validation is the caller's responsibility
+    return JSON.parse(text) as T;
+  }
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- T is a generic parameter; runtime validation is the caller's responsibility
   return (await res.json()) as T;
 }

--- a/apps/sidecar/src/step-agent-tools.test.ts
+++ b/apps/sidecar/src/step-agent-tools.test.ts
@@ -274,6 +274,150 @@ describe("createToolBearingAgentFactory plugin/LSP lifecycle", () => {
     }
     expect(alive).toBe(false);
   });
+
+  test("agent.close() rejects with an AggregateError when a disposer fails, and still runs the rest", async () => {
+    // The underlying agent close succeeds; a plugin disposer (standing in
+    // for the LSP subprocess kill) then throws. That failure must surface
+    // through close() rather than be swallowed -- a leaked LSP subprocess
+    // is otherwise invisible -- and one failing disposer must not strand
+    // the others.
+    const disposeError = new Error("lsp dispose boom");
+    let survivorDisposed = 0;
+    const throwingPlugin = definePlugin({
+      id: "@intx/throwing-disposer/sidecar-bundle",
+      factory: () => ({
+        tools: [],
+        dispose: () => {
+          throw disposeError;
+        },
+      }),
+    });
+    const survivorPlugin = definePlugin({
+      id: "@intx/survivor-disposer/sidecar-bundle",
+      factory: () => ({
+        tools: [],
+        dispose: () => {
+          survivorDisposed += 1;
+        },
+      }),
+    });
+
+    const materialization: StepToolMaterialization = {
+      factories: [],
+      pluginFactories: [throwingPlugin, survivorPlugin],
+    };
+
+    const env = await buildStepEnv();
+    attachStepTools(env, materialization);
+
+    const agentFactory = createToolBearingAgentFactory();
+    const def = {
+      id: "agent-disposer-aggregate",
+      systemPrompt: "disposer aggregate test",
+      toolFactories: [],
+      capabilities: [],
+      inference: { sources: [{ provider: "anthropic", model: "mock-model" }] },
+    } as const;
+
+    const agent = await agentFactory(def, { ...env });
+
+    let thrown: unknown;
+    try {
+      await agent.close();
+    } catch (cause) {
+      thrown = cause;
+    }
+    expect(thrown).toBeInstanceOf(AggregateError);
+    if (!(thrown instanceof AggregateError)) {
+      throw new Error("expected an AggregateError from a failing teardown");
+    }
+    expect(thrown.errors).toContain(disposeError);
+    // The loop kept going after the first disposer threw: the other ran.
+    expect(survivorDisposed).toBe(1);
+  });
+
+  test("a disposer that throws during construction rollback does not mask the construction error", async () => {
+    // On a construction-failure rollback the pending construction error is
+    // the one worth surfacing; a disposer failure during that rollback is
+    // logged but must never replace it.
+    const firstPlugin = definePlugin({
+      id: "@intx/rollback-throwing-disposer/sidecar-bundle",
+      factory: () => ({
+        tools: [],
+        dispose: () => {
+          throw new Error("rollback dispose boom");
+        },
+      }),
+    });
+    const throwingPlugin = definePlugin({
+      id: "@intx/rollback-construction-throw/sidecar-bundle",
+      factory: () => {
+        throw new Error("plugin construction failure");
+      },
+    });
+
+    const materialization: StepToolMaterialization = {
+      factories: [],
+      pluginFactories: [firstPlugin, throwingPlugin],
+    };
+
+    const env = await buildStepEnv();
+    attachStepTools(env, materialization);
+
+    const agentFactory = createToolBearingAgentFactory();
+    const def = {
+      id: "agent-rollback-dispose-mask",
+      systemPrompt: "rollback dispose mask test",
+      toolFactories: [],
+      capabilities: [],
+      inference: { sources: [{ provider: "anthropic", model: "mock-model" }] },
+    } as const;
+
+    await expect(agentFactory(def, { ...env })).rejects.toThrow(
+      /plugin construction failure/,
+    );
+  });
+
+  test("a second close() after a failed teardown neither re-runs disposers nor rethrows", async () => {
+    let disposeCalls = 0;
+    const throwingPlugin = definePlugin({
+      id: "@intx/double-close-disposer/sidecar-bundle",
+      factory: () => ({
+        tools: [],
+        dispose: () => {
+          disposeCalls += 1;
+          throw new Error("dispose boom");
+        },
+      }),
+    });
+
+    const materialization: StepToolMaterialization = {
+      factories: [],
+      pluginFactories: [throwingPlugin],
+    };
+
+    const env = await buildStepEnv();
+    attachStepTools(env, materialization);
+
+    const agentFactory = createToolBearingAgentFactory();
+    const def = {
+      id: "agent-double-close",
+      systemPrompt: "double close test",
+      toolFactories: [],
+      capabilities: [],
+      inference: { sources: [{ provider: "anthropic", model: "mock-model" }] },
+    } as const;
+
+    const agent = await agentFactory(def, { ...env });
+
+    await expect(agent.close()).rejects.toBeInstanceOf(AggregateError);
+    expect(disposeCalls).toBe(1);
+    // wrapAgentClose guards teardown behind `tornDown`, so a second close
+    // is a no-op: it neither re-runs the disposer nor re-surfaces the
+    // failure.
+    await agent.close();
+    expect(disposeCalls).toBe(1);
+  });
 });
 
 describe("stepDeployTreeDir base-step resolution", () => {

--- a/apps/sidecar/src/step-agent-tools.ts
+++ b/apps/sidecar/src/step-agent-tools.ts
@@ -39,7 +39,7 @@ import {
   type BaseEnv,
   type ToolBundle,
 } from "@intx/agent";
-import { readDeployTree, sanitizeAddress } from "@intx/hub-agent/paths";
+import { readDeployTree, agentDir } from "@intx/hub-agent/paths";
 import { getLogger } from "@intx/log";
 import type { HostCredentialCapability } from "@intx/harness";
 import type { LoadedToolFactory } from "@intx/tool-packaging";
@@ -265,9 +265,9 @@ function requireCapabilitiesBag(env: BaseEnv): RuntimeCapabilities {
  * `deploy/asset-mounts.json`) is shipped to the sidecar per step by the
  * hub's `launchSession` deploy-pack push, which lands it in the LEGACY
  * per-agent directory keyed by the step's sanitized mail address (see
- * `@intx/hub-agent` `agentDir` / `sanitizeAddress`). It is NOT in the
- * substrate's `agent-state/<id>` layout -- the multi-step deploy path
- * never pushes step `agent-state` packs to the child's substrate.
+ * `@intx/hub-agent` `agentDir`). It is NOT in the substrate's
+ * `agent-state/<id>` layout -- the multi-step deploy path never pushes
+ * step `agent-state` packs to the child's substrate.
  *
  * The step's mail address is `resolveStepAddress(...)`, the single owner
  * of the head/step collapse: for a single-step deployment the lone step
@@ -302,7 +302,7 @@ export function stepDeployTreeDir(args: {
     domain: parsed.domain,
     stepCount: args.stepCount,
   });
-  return path.join(args.dataDir, sanitizeAddress(stepAddress));
+  return agentDir(args.dataDir, stepAddress);
 }
 
 /**

--- a/apps/sidecar/src/step-agent-tools.ts
+++ b/apps/sidecar/src/step-agent-tools.ts
@@ -523,14 +523,17 @@ export function createToolBearingAgentFactory(): <EnvReq extends BaseEnv>(
     // nothing, but a future key-file/socket handle would leak otherwise).
     // Bundle disposers are idempotent, so re-running one `createAgent` already
     // disposed on its own failure path is safe.
-    const runCapturedDisposers = async (): Promise<void> => {
+    const runCapturedDisposers = async (): Promise<unknown[]> => {
+      const failures: unknown[] = [];
       for (const dispose of capturedDisposers) {
         try {
           await dispose();
         } catch (cause) {
-          logger.warn`step tool bundle dispose failed: ${cause instanceof Error ? cause.message : String(cause)}`;
+          logger.error`step tool bundle dispose failed: ${cause instanceof Error ? cause.message : String(cause)}`;
+          failures.push(cause);
         }
       }
+      return failures;
     };
 
     // Rebuild the def with the materialized tool factories. The
@@ -603,8 +606,20 @@ export function createToolBearingAgentFactory(): <EnvReq extends BaseEnv>(
       // plugin twice is safe: `lsp.dispose()` clears its client set and the
       // posix bundle's dispose is idempotent. Running both guarantees the LSP
       // subprocess is torn down even for a plugin no tool bundle consumed.
-      await runCapturedDisposers();
-      await disposeAll(pluginInstances, "step teardown");
+      // Both loops run every disposer and collect failures rather than
+      // throwing mid-loop, so one failing disposer never strands the rest.
+      // A leaked or failing LSP subprocess must surface, not be swallowed:
+      // any collected failure fails the close, so the caller sees it.
+      const failures = [
+        ...(await runCapturedDisposers()),
+        ...(await disposeAll(pluginInstances, "step teardown")),
+      ];
+      if (failures.length > 0) {
+        throw new AggregateError(
+          failures,
+          `step agent close: ${String(failures.length)} disposer(s) failed during teardown; an LSP subprocess may be leaked`,
+        );
+      }
     });
   };
 }
@@ -641,7 +656,8 @@ function wrapAgentClose(agent: Agent, teardown: () => Promise<void>): Agent {
 async function disposeAll(
   instances: readonly unknown[],
   context: string,
-): Promise<void> {
+): Promise<unknown[]> {
+  const failures: unknown[] = [];
   for (const instance of instances) {
     const dispose = pluginDispose(instance);
     if (dispose === undefined) continue;
@@ -650,9 +666,11 @@ async function disposeAll(
       // whether the disposer is sync or async.
       await dispose();
     } catch (cause) {
-      logger.warn`step plugin dispose failed during ${context}: ${cause instanceof Error ? cause.message : String(cause)}`;
+      logger.error`step plugin dispose failed during ${context}: ${cause instanceof Error ? cause.message : String(cause)}`;
+      failures.push(cause);
     }
   }
+  return failures;
 }
 
 /**

--- a/apps/sidecar/src/workflow-substrate-factory-step-storage.test.ts
+++ b/apps/sidecar/src/workflow-substrate-factory-step-storage.test.ts
@@ -28,9 +28,12 @@ import type {
   AuditStore,
   ContextStore,
   InferenceSource,
+  PendingOperation,
+  ToolCall,
 } from "@intx/types/runtime";
 import type { RepoId } from "@intx/hub-sessions";
 import { createBuiltinRegistry } from "@intx/inference/providers";
+import { createIsogitStore } from "@intx/storage-isogit/node";
 import type {
   ChildOutboundMailBridge,
   SourcesSnapshotRef,
@@ -40,6 +43,7 @@ import { scopedStepId, type StepInvokeRequest } from "@intx/workflow";
 
 import {
   createSidecarStepBuildEnv,
+  stepStorageRoot,
   type SidecarStepBuildEnvDeps,
 } from "./workflow-substrate-factory";
 import type { DurableConversationRegistry } from "./conversation-state";
@@ -282,5 +286,121 @@ describe("createSidecarStepBuildEnv per-step scratch keying", () => {
     expect(env.defaultSource).toBe(SOURCE.id);
     // Per-iteration scratch stays keyed by the scoped id, not the base.
     expect(env.workdir).toContain(path.join("steps", scopedId));
+  });
+});
+
+// A re-dispatchable ask-rail approval gate always carries a `suspendedCall`
+// (the call to re-run on approval). An async-tool pending marker uses the
+// same `kind: "approval"` but never sets `suspendedCall`, and on resume the
+// reactor clears its gate WITHOUT re-dispatching. The cold-path resume
+// keying assertion must therefore find a `suspendedCall`-bearing op for the
+// resumed correlationId, mirroring the reactor's own discriminator.
+const SUSPENDED_CALL: ToolCall = {
+  id: "call-1",
+  name: "charge_card",
+  arguments: { amount: 100 },
+};
+
+function approvalOp(
+  correlationId: string,
+  opts: { suspendedCall?: ToolCall } = {},
+): PendingOperation {
+  return {
+    correlationId,
+    kind: "approval",
+    registeredAt: 0,
+    gateId: `gate-${correlationId}`,
+    ...(opts.suspendedCall !== undefined
+      ? { suspendedCall: opts.suspendedCall }
+      : {}),
+  };
+}
+
+async function seedColdStore(
+  dataDir: string,
+  runId: string,
+  pendingOperations: PendingOperation[],
+): Promise<void> {
+  const store = await createIsogitStore(
+    stepStorageRoot({
+      dataDir,
+      workflowRunRepoId: WORKFLOW_RUN_REPO_ID,
+      runId,
+      stepId: STEP_ID,
+      attempt: 1,
+    }),
+    (payload: string) => Promise.resolve(`sig:${payload.length}`),
+  );
+  await store.writeMetadata({
+    pendingOperations,
+    tokenUsage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      thinking: 0,
+    },
+  });
+}
+
+function approvalResumeRequest(
+  runId: string,
+  correlationId: string,
+): StepInvokeRequest {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- buildEnv reads only authzContext and resume; the agent definition is never consulted here
+    agent: {} as StepInvokeRequest["agent"],
+    input: null,
+    authzContext: { stepId: STEP_ID, runId, attempt: 1 },
+    resume: {
+      correlationId,
+      decision: { outcome: "approved" },
+      kind: "approval",
+    },
+    signal: new AbortController().signal,
+  };
+}
+
+describe("createSidecarStepBuildEnv cold-path approval-resume keying", () => {
+  test("rejects a resume whose matching pending op carries no suspendedCall", async () => {
+    const dataDir = await makeTempDir();
+    // A pending op that matches the correlationId but is not a
+    // re-dispatchable gate (no suspendedCall) -- an async-tool marker, not
+    // the ask-rail approval the resume must find.
+    await seedColdStore(dataDir, "run-1", [approvalOp("corr-1")]);
+    const buildEnv = createSidecarStepBuildEnv(buildDeps({ dataDir }));
+
+    await expect(
+      buildEnv(approvalResumeRequest("run-1", "corr-1"), sourcesRefFor()),
+    ).rejects.toThrow(/keying violation/);
+  });
+
+  test("accepts a resume that finds a suspendedCall-bearing approval gate", async () => {
+    const dataDir = await makeTempDir();
+    await seedColdStore(dataDir, "run-1", [
+      approvalOp("corr-1", { suspendedCall: SUSPENDED_CALL }),
+    ]);
+    const buildEnv = createSidecarStepBuildEnv(buildDeps({ dataDir }));
+
+    const env: StepEnvBase = await buildEnv(
+      approvalResumeRequest("run-1", "corr-1"),
+      sourcesRefFor(),
+    );
+
+    expect(env.workdir).toContain(path.join("runs", "run-1"));
+  });
+
+  test("rejects a resume whose correlationId has no pending op at all", async () => {
+    const dataDir = await makeTempDir();
+    // A real gate exists, but for a different correlationId: the resumed
+    // correlationId finds nothing -- the wrong-attempt forever-hang guard.
+    await seedColdStore(dataDir, "run-1", [
+      approvalOp("other", { suspendedCall: SUSPENDED_CALL }),
+    ]);
+    const buildEnv = createSidecarStepBuildEnv(buildDeps({ dataDir }));
+
+    await expect(
+      buildEnv(approvalResumeRequest("run-1", "corr-1"), sourcesRefFor()),
+    ).rejects.toThrow(/keying violation/);
   });
 });

--- a/apps/sidecar/src/workflow-substrate-factory.ts
+++ b/apps/sidecar/src/workflow-substrate-factory.ts
@@ -921,15 +921,21 @@ export function createSidecarStepBuildEnv(
     // the resume-attempt invariant documented on `stepStorageRoot`). An
     // APPROVAL resume re-invocation delivers the correlated decision to the
     // reactor, which rehydrates its gate from THIS store's pending
-    // operations. The store the runtime reopened is keyed by `attempt`
-    // (`stepStorageRoot` above); if that attempt does not match the attempt
-    // the step suspended on, the store carries no pending-op for the resumed
-    // correlationId, the reactor comes up gateless, and the delivered
-    // decision correlates against nothing -- a silent forever-hang. Make that
-    // keying violation loud here, at the single seam that both opened the
-    // store AND knows an approval resume must find its gate, rather than
-    // letting it surface as a hang. The warm path keys its durable store per
-    // agent (not per attempt) and rehydrates from a different lifecycle, so
+    // operations. A re-dispatchable ask-rail approval gate carries a
+    // `suspendedCall` (the call the approval re-runs); an async-tool pending
+    // marker shares `kind: "approval"` but has no `suspendedCall`, and on
+    // resume the reactor clears its gate WITHOUT re-running the approved
+    // call. So the resume must find a `suspendedCall`-bearing op for its
+    // correlationId, mirroring the reactor's own discriminator. Two failure
+    // modes make that false: the runtime reopened the wrong `attempt`'s
+    // store (`stepStorageRoot` above), so no pending op matches at all and
+    // the reactor comes up gateless -- a silent forever-hang; or the only
+    // match is an async marker, so the gate clears and the approved call is
+    // silently skipped. Make either loud here, at the single seam that both
+    // opened the store AND knows an approval resume must find its gate,
+    // rather than letting it surface as a hang or a skipped call. The
+    // warm path keys its durable store per agent (not per attempt) and
+    // rehydrates from a different lifecycle, so
     // this assertion is cold-path only. An `"input"` resume is exempt by
     // construction: its correlationId names the runtime-minted re-arm channel
     // awaiting the step's next trigger, not a reactor gate, so no pending
@@ -942,12 +948,14 @@ export function createSidecarStepBuildEnv(
     ) {
       const resumeCorrelationId = req.resume.correlationId;
       const loaded = await storage.load();
-      const hasPendingOp = loaded.pendingOperations.some(
-        (op) => op.correlationId === resumeCorrelationId,
+      const hasPendingGate = loaded.pendingOperations.some(
+        (op) =>
+          op.correlationId === resumeCorrelationId &&
+          op.suspendedCall !== undefined,
       );
-      if (!hasPendingOp) {
+      if (!hasPendingGate) {
         throw new Error(
-          `sidecar workflow-child step invoker buildEnv: resume of step ${JSON.stringify(stepId)} (run ${JSON.stringify(runId)}, attempt ${String(attempt)}) reopened a ContextStore with no pending operation for correlationId ${JSON.stringify(resumeCorrelationId)}. The cold-path store is keyed by attempt (${storeDir}); a resume that finds no gate here means it reopened the wrong attempt's store -- the reactor would rehydrate no gate and the delivered decision would correlate against nothing. This is a keying violation, not a recoverable state.`,
+          `sidecar workflow-child step invoker buildEnv: resume of step ${JSON.stringify(stepId)} (run ${JSON.stringify(runId)}, attempt ${String(attempt)}) reopened a ContextStore with no re-dispatchable approval gate for correlationId ${JSON.stringify(resumeCorrelationId)}. The cold-path store is keyed by attempt (${storeDir}); a resume that finds no suspendedCall-bearing pending operation here means it reopened the wrong attempt's store (the reactor would come up gateless and the decision would correlate against nothing) or matched only an async pending marker (the reactor would clear the gate without re-running the approved call). This is a keying violation, not a recoverable state.`,
         );
       }
     }

--- a/packages/hub-agent/src/paths.ts
+++ b/packages/hub-agent/src/paths.ts
@@ -12,4 +12,4 @@
 // orchestrator graph, so this entry exposes them without it.
 
 export { readDeployTree, type DeployTree } from "./deploy-tree";
-export { sanitizeAddress } from "./agent-paths";
+export { agentDir } from "./agent-paths";

--- a/packages/workflow-host/src/adapters/step-invoker.test.ts
+++ b/packages/workflow-host/src/adapters/step-invoker.test.ts
@@ -446,6 +446,59 @@ describe("workflow-host StepInvoker adapter - happy path", () => {
     await expect(sendPromise).rejects.toThrow(/no approval snapshot/);
   });
 
+  test("surfaces the send error, not the teardown close error, when both fail", async () => {
+    // The wrapped agent close now rejects when a plugin/LSP disposer fails.
+    // In the cold path that close runs in the adapter's teardown; a close
+    // failure must not mask a step error already unwinding from the send.
+    let closeCalls = 0;
+    const agent: Agent = {
+      send() {
+        return Promise.reject(new Error("send boom"));
+      },
+      stream() {
+        throw new Error("stub stream() not used");
+      },
+      deliver() {
+        throw new Error("stub deliver() not used");
+      },
+      close() {
+        closeCalls += 1;
+        return Promise.reject(new Error("close boom"));
+      },
+      setSource() {
+        throw new Error("stub setSource() not used");
+      },
+      setSources() {
+        throw new Error("stub setSources() not used");
+      },
+      history() {
+        return Promise.resolve([]);
+      },
+      checkpoints() {
+        return Promise.resolve([]);
+      },
+      readAt() {
+        return Promise.resolve([]);
+      },
+      blobReader: stubBlobReader(),
+    };
+    const invoker = createWorkflowStepInvoker({
+      workflowAuthorize: async () => ({
+        effect: "allow",
+        matchingGrants: [],
+        resolvedBy: null,
+      }),
+      buildEnv: async () => stubBuildEnv(),
+      agentFactory: async () => agent,
+    });
+
+    await expect(
+      invoker(buildRequest({ input: { goal: "ping" } })),
+    ).rejects.toThrow(/send boom/);
+    // The teardown close still ran; its failure was logged, not surfaced.
+    expect(closeCalls).toBe(1);
+  });
+
   test("passes a string input through verbatim instead of double-JSON-encoding", async () => {
     const stub = buildStubAgent();
     const invoker = createWorkflowStepInvoker({

--- a/packages/workflow-host/src/adapters/step-invoker.ts
+++ b/packages/workflow-host/src/adapters/step-invoker.ts
@@ -83,6 +83,7 @@ import type {
   WarmAgentCache,
   WarmEventSinkRef,
 } from "../child/warm-agent-cache";
+import { runBodyThenCleanup } from "../run-body-then-cleanup";
 
 const logger = getLogger(["workflow-host", "step-invoker"]);
 
@@ -262,27 +263,34 @@ async function invokeColdStep(
   // flow through by default.
   const eventForward = subscribeAgentEvents(agent, opts.onEvent);
 
-  try {
-    return stepResultFromSend(
-      await sendWithAbort(agent, req, {
-        closeOnAbort: true,
-        mailPartReader: opts.mailPartReader,
-      }),
-    );
-  } finally {
-    // `close` is idempotent: a second call after the send already
-    // resolved still releases the workdir lock and tears down stream
-    // consumers. We await so the lock is gone before the adapter
-    // returns -- a subsequent step on the same workdir must not race
-    // a still-closing agent.
-    await agent.close();
-    // `agent.close()` terminates every active `stream()` iterator, so
-    // the forwarder's for-await loop has ended (or is about to). Await
-    // it after close so the subscription is fully drained before the
-    // adapter returns and no listener outlives the step. Awaited last
-    // because the loop only ends once close has fired.
-    await eventForward;
-  }
+  // `agent.close()` is the wrapAgentClose-wrapped close: it runs the
+  // agent's own close (idempotent -- releases the workdir lock and tears
+  // down stream consumers) and then the plugin/tool-bundle disposers,
+  // which now reject the close if a disposer (e.g. the LSP subprocess
+  // kill) fails. Route the close through runBodyThenCleanup so a disposer
+  // failure surfaces on a clean step but never masks a step error already
+  // unwinding from `sendWithAbort`. `eventForward` is drained on every
+  // path -- `agent.close()` ends the forwarder's for-await loop, and it
+  // never rejects (subscribeAgentEvents swallows), so awaiting it in the
+  // cleanup cannot mask either error.
+  return runBodyThenCleanup(
+    async () =>
+      stepResultFromSend(
+        await sendWithAbort(agent, req, {
+          closeOnAbort: true,
+          mailPartReader: opts.mailPartReader,
+        }),
+      ),
+    async () => {
+      try {
+        await agent.close();
+      } finally {
+        await eventForward;
+      }
+    },
+    (cause) =>
+      logger.error`step invoker: agent.close failed while unwinding a step error; surfacing the step error, close failure: ${cause instanceof Error ? cause.message : String(cause)}`,
+  );
 }
 
 /**

--- a/packages/workflow-host/src/child/run-child.ts
+++ b/packages/workflow-host/src/child/run-child.ts
@@ -122,6 +122,7 @@ import {
   type NdjsonReader,
   type NdjsonWriter,
 } from "../ipc/index";
+import { runBodyThenCleanup } from "../run-body-then-cleanup";
 import { createWorkflowHostSignalChannel } from "../seams/signal-channel";
 import type { CredentialsSnapshot } from "../supervisor/credentials";
 import { hashGrants } from "../supervisor/credentials";
@@ -903,7 +904,7 @@ export async function runWorkflowChild(
     },
   });
 
-  try {
+  const runControlLoop = async (): Promise<void> => {
     for await (const payload of iter) {
       if (
         await handleControlPayload(payload, {
@@ -942,7 +943,9 @@ export async function runWorkflowChild(
         break;
       }
     }
-  } finally {
+  };
+
+  const cleanupControlLoop = async (): Promise<void> => {
     // Any exit path -- clean (iterator end), dirty (thrown error),
     // shutdown (already cancelled, repeat is a no-op on an empty map)
     // -- cancels every still-pending substrate write so the runtime
@@ -970,7 +973,18 @@ export async function runWorkflowChild(
     if (warmCache !== undefined) {
       await warmCache.evictAll("workflow-child control loop exited");
     }
-  }
+  };
+
+  // Run the control loop, then always run the cleanup above. A failing
+  // eviction (the wrapped agent close rejects when a plugin/LSP disposer
+  // fails) surfaces on a clean exit, but must not mask a control-loop
+  // error already unwinding -- so it is logged, not rethrown, in that case.
+  await runBodyThenCleanup(
+    runControlLoop,
+    cleanupControlLoop,
+    (cause) =>
+      logger.error`workflow-child: warm-agent eviction failed while unwinding a control-loop error; surfacing the control-loop error, eviction failure: ${cause instanceof Error ? cause.message : String(cause)}`,
+  );
 
   return {
     resumedRunIds,

--- a/packages/workflow-host/src/child/warm-agent-cache.test.ts
+++ b/packages/workflow-host/src/child/warm-agent-cache.test.ts
@@ -54,28 +54,115 @@ describe("warm-agent cache applySources", () => {
       cache.applySources([makeSource("primary")], "primary"),
     ).not.toThrow();
   });
+
+  test("applies to every agent even when one rejects the rotation", () => {
+    // One agent rejecting the rotation must not skip the rest; the
+    // failures surface together rather than stranding later agents.
+    const cache = createWarmAgentCache();
+    const rotateError = new Error("bad source");
+    let secondApplied = false;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub: applySources only calls setSources
+    const firstAgent = {
+      setSources() {
+        throw rotateError;
+      },
+    } as unknown as Agent;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub: applySources only calls setSources
+    const secondAgent = {
+      setSources() {
+        secondApplied = true;
+      },
+    } as unknown as Agent;
+    cache.store("step-1", firstAgent, { current: null }, Promise.resolve());
+    cache.store("step-2", secondAgent, { current: null }, Promise.resolve());
+
+    let thrown: unknown;
+    try {
+      cache.applySources([makeSource("primary")], "primary");
+    } catch (cause) {
+      thrown = cause;
+    }
+    // The first agent throwing did not skip the second.
+    expect(secondApplied).toBe(true);
+    expect(thrown).toBeInstanceOf(AggregateError);
+    if (!(thrown instanceof AggregateError)) {
+      throw new Error("expected an AggregateError from a failing rotation");
+    }
+    expect(thrown.errors).toContain(rotateError);
+  });
 });
 
+function closingAgent(onClose: () => Promise<void>): Agent {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub: evictAll only calls close on the entry's agent
+  return {
+    close: onClose,
+  } as unknown as Agent;
+}
+
 describe("warm-agent cache eviction", () => {
-  test("surfaces the AggregateError from a failing wrapped agent close", async () => {
-    // The wrapped step-agent close rejects with an AggregateError when a
-    // disposer (e.g. the LSP subprocess kill) fails. evictAll must
+  test("surfaces a failing wrapped agent close as an AggregateError", async () => {
+    // The wrapped step-agent close rejects (itself an AggregateError) when
+    // a disposer -- e.g. the LSP subprocess kill -- fails. evictAll must
     // propagate that so a leaked LSP subprocess is visible to the run-loop
     // rather than swallowed at the cache boundary.
     const cache = createWarmAgentCache();
-    const aggregate = new AggregateError(
-      [new Error("lsp dispose boom")],
-      "step agent close: 1 disposer(s) failed during teardown",
-    );
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub: evictAll only calls close on the entry's agent
-    const agent = {
-      close() {
-        return Promise.reject(aggregate);
-      },
-    } as unknown as Agent;
+    const closeError = new Error("lsp dispose boom");
     const sinkRef: WarmEventSinkRef = { current: null };
-    cache.store("step-1", agent, sinkRef, Promise.resolve());
+    cache.store(
+      "step-1",
+      closingAgent(() => Promise.reject(closeError)),
+      sinkRef,
+      Promise.resolve(),
+    );
 
-    await expect(cache.evictAll("test eviction")).rejects.toBe(aggregate);
+    let thrown: unknown;
+    try {
+      await cache.evictAll("test eviction");
+    } catch (cause) {
+      thrown = cause;
+    }
+    expect(thrown).toBeInstanceOf(AggregateError);
+    if (!(thrown instanceof AggregateError)) {
+      throw new Error("expected an AggregateError from a failing eviction");
+    }
+    expect(thrown.errors).toContain(closeError);
+  });
+
+  test("closes every warm agent even when an earlier close rejects", async () => {
+    // A first agent's close rejecting must not strand the remaining
+    // agents' teardown -- otherwise their LSP subprocesses leak. Every
+    // agent is closed and the failures surface together.
+    const cache = createWarmAgentCache();
+    const firstError = new Error("first close boom");
+    let secondClosed = false;
+    cache.store(
+      "step-1",
+      closingAgent(() => Promise.reject(firstError)),
+      { current: null },
+      Promise.resolve(),
+    );
+    cache.store(
+      "step-2",
+      closingAgent(() => {
+        secondClosed = true;
+        return Promise.resolve();
+      }),
+      { current: null },
+      Promise.resolve(),
+    );
+
+    let thrown: unknown;
+    try {
+      await cache.evictAll("test eviction");
+    } catch (cause) {
+      thrown = cause;
+    }
+    // The first failure did not strand the second: it was still closed.
+    expect(secondClosed).toBe(true);
+    expect(thrown).toBeInstanceOf(AggregateError);
+    if (!(thrown instanceof AggregateError)) {
+      throw new Error("expected an AggregateError from a failing eviction");
+    }
+    expect(thrown.errors).toContain(firstError);
   });
 });

--- a/packages/workflow-host/src/child/warm-agent-cache.test.ts
+++ b/packages/workflow-host/src/child/warm-agent-cache.test.ts
@@ -55,3 +55,27 @@ describe("warm-agent cache applySources", () => {
     ).not.toThrow();
   });
 });
+
+describe("warm-agent cache eviction", () => {
+  test("surfaces the AggregateError from a failing wrapped agent close", async () => {
+    // The wrapped step-agent close rejects with an AggregateError when a
+    // disposer (e.g. the LSP subprocess kill) fails. evictAll must
+    // propagate that so a leaked LSP subprocess is visible to the run-loop
+    // rather than swallowed at the cache boundary.
+    const cache = createWarmAgentCache();
+    const aggregate = new AggregateError(
+      [new Error("lsp dispose boom")],
+      "step agent close: 1 disposer(s) failed during teardown",
+    );
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub: evictAll only calls close on the entry's agent
+    const agent = {
+      close() {
+        return Promise.reject(aggregate);
+      },
+    } as unknown as Agent;
+    const sinkRef: WarmEventSinkRef = { current: null };
+    cache.store("step-1", agent, sinkRef, Promise.resolve());
+
+    await expect(cache.evictAll("test eviction")).rejects.toBe(aggregate);
+  });
+});

--- a/packages/workflow-host/src/child/warm-agent-cache.ts
+++ b/packages/workflow-host/src/child/warm-agent-cache.ts
@@ -177,8 +177,26 @@ export function createWarmAgentCache(): WarmAgentCache {
     sources: InferenceSource[],
     defaultSource: string,
   ): void {
+    // Rotate every retained agent before surfacing any failure: one agent
+    // rejecting the rotation (an invalid source, or a closed agent racing
+    // eviction) must not skip the rest. Collect failures and throw them
+    // together. (Warm-keep is single-step today, so the cache holds 0 or 1
+    // entry; this keeps the contract honest if warm-keep ever spans steps.)
+    const failures: unknown[] = [];
     for (const entry of entries.values()) {
-      entry.agent.setSources(sources, defaultSource);
+      try {
+        entry.agent.setSources(sources, defaultSource);
+      } catch (cause) {
+        const message = cause instanceof Error ? cause.message : String(cause);
+        logger.error`warm-agent rotation: setSources failed: ${message}`;
+        failures.push(cause);
+      }
+    }
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures,
+        `warm-agent rotation: ${String(failures.length)} agent(s) rejected the source rotation`,
+      );
     }
   }
 
@@ -186,29 +204,39 @@ export function createWarmAgentCache(): WarmAgentCache {
     if (entries.size === 0) return;
     const toEvict = [...entries.values()];
     entries.clear();
+    // Close every entry before surfacing any failure. The wrapped close
+    // (see `createToolBearingAgentFactory`) runs the agent's own close and
+    // then the plugin + tool-bundle disposers, killing the LSP subprocess,
+    // and it rejects when a disposer fails. One entry's close rejecting
+    // must not strand the remaining entries' teardown -- that would leak
+    // exactly the LSP subprocesses warm-keep risks. Collect failures and
+    // throw them together once every agent has been closed and drained.
+    // (Warm-keep is single-step today, so the cache holds 0 or 1 entry;
+    // this keeps the contract honest if warm-keep ever spans steps.)
+    const failures: unknown[] = [];
     for (const entry of toEvict) {
       // Clear the sink first so any event emitted during the agent's
       // shutdown window is dropped rather than delivered to a per-run
       // channel the run-loop is tearing down.
       entry.eventSinkRef.current = null;
       try {
-        // The wrapped close (see `createToolBearingAgentFactory`) runs
-        // the agent's own close and then the plugin + tool-bundle
-        // disposers, killing the LSP subprocess. A close failure must
-        // surface, not be swallowed -- a leaked LSP subprocess is
-        // exactly the failure warm-keep risks -- so it propagates after
-        // we have drained what we can.
         await entry.agent.close();
       } catch (cause) {
         const message = cause instanceof Error ? cause.message : String(cause);
         logger.error`warm-agent eviction (${reason}): agent.close failed: ${message}`;
-        throw cause instanceof Error ? cause : new Error(message);
+        failures.push(cause);
       } finally {
         // `agent.close()` terminates the stream iterator, so the
         // forwarder loop has ended (or is about to). Await it so no
         // forwarder outlives the eviction.
         await entry.eventForward;
       }
+    }
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures,
+        `warm-agent eviction (${reason}): ${String(failures.length)} agent(s) failed to close; an LSP subprocess may be leaked`,
+      );
     }
   }
 

--- a/packages/workflow-host/src/run-body-then-cleanup.test.ts
+++ b/packages/workflow-host/src/run-body-then-cleanup.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect } from "bun:test";
+
+import { runBodyThenCleanup } from "./run-body-then-cleanup";
+
+describe("runBodyThenCleanup", () => {
+  test("returns the body result and runs cleanup on the success path", async () => {
+    let cleaned = false;
+    const result = await runBodyThenCleanup(
+      () => Promise.resolve("value"),
+      () => {
+        cleaned = true;
+        return Promise.resolve();
+      },
+      () => {
+        throw new Error("onCleanupError must not be called on the ok path");
+      },
+    );
+    expect(result).toBe("value");
+    expect(cleaned).toBe(true);
+  });
+
+  test("surfaces a cleanup failure when the body succeeded", async () => {
+    const cleanupError = new Error("teardown failed");
+    let notified = false;
+    await expect(
+      runBodyThenCleanup(
+        () => Promise.resolve("value"),
+        () => Promise.reject(cleanupError),
+        () => {
+          notified = true;
+        },
+      ),
+    ).rejects.toBe(cleanupError);
+    // onCleanupErrorAfterBodyError is only for the body-already-threw path.
+    expect(notified).toBe(false);
+  });
+
+  test("surfaces the body error and still runs cleanup when the body threw", async () => {
+    const bodyError = new Error("body failed");
+    let cleaned = false;
+    await expect(
+      runBodyThenCleanup(
+        () => Promise.reject(bodyError),
+        () => {
+          cleaned = true;
+          return Promise.resolve();
+        },
+        () => {
+          throw new Error("onCleanupError must not fire when cleanup succeeds");
+        },
+      ),
+    ).rejects.toBe(bodyError);
+    expect(cleaned).toBe(true);
+  });
+
+  test("lets the body error win and reports the cleanup failure when both throw", async () => {
+    const bodyError = new Error("body failed");
+    const cleanupError = new Error("teardown failed");
+    const reported: unknown[] = [];
+    await expect(
+      runBodyThenCleanup(
+        () => Promise.reject(bodyError),
+        () => Promise.reject(cleanupError),
+        (cause) => {
+          reported.push(cause);
+        },
+      ),
+    ).rejects.toBe(bodyError);
+    // The cleanup failure is not lost -- it is reported for logging, just
+    // not allowed to mask the primary body error.
+    expect(reported).toEqual([cleanupError]);
+  });
+});

--- a/packages/workflow-host/src/run-body-then-cleanup.ts
+++ b/packages/workflow-host/src/run-body-then-cleanup.ts
@@ -1,0 +1,42 @@
+/**
+ * Run `body`, then always run `cleanup`, without letting a `cleanup`
+ * failure mask a `body` failure.
+ *
+ * When `body` throws, `cleanup` still runs and a `cleanup` failure is
+ * handed to `onCleanupErrorAfterBodyError` (to log) and then dropped, so
+ * the original `body` error is what propagates. When `body` succeeds, a
+ * `cleanup` failure propagates -- there is no primary error to protect, so
+ * a failing teardown is the error worth surfacing.
+ *
+ * This exists so teardown in a `finally` (agent close, warm-cache
+ * eviction) can surface its own failure without a `throw` inside a
+ * `finally` block, which `no-unsafe-finally` forbids precisely because it
+ * silently swallows the in-flight exception -- the masking bug this guards
+ * against.
+ */
+export async function runBodyThenCleanup<T>(
+  body: () => Promise<T>,
+  cleanup: () => Promise<void>,
+  onCleanupErrorAfterBodyError: (cause: unknown) => void,
+): Promise<T> {
+  let outcome: { ok: true; value: T } | { ok: false; error: unknown };
+  try {
+    outcome = { ok: true, value: await body() };
+  } catch (error) {
+    outcome = { ok: false, error };
+  }
+
+  try {
+    await cleanup();
+  } catch (cleanupError) {
+    if (outcome.ok) {
+      throw cleanupError;
+    }
+    onCleanupErrorAfterBodyError(cleanupError);
+  }
+
+  if (!outcome.ok) {
+    throw outcome.error;
+  }
+  return outcome.value;
+}

--- a/packages/workflow-host/src/supervisor/substrate-write.test.ts
+++ b/packages/workflow-host/src/supervisor/substrate-write.test.ts
@@ -1,6 +1,6 @@
 // Supervisor-level coverage for the substrate.write IPC layer.
 //
-// Three review concerns are pinned here:
+// Four review concerns are pinned here:
 //
 //   1. The terminal-write watchdog timeout. The supervisor holds the
 //      `substrate.write.response` back to the child until the
@@ -26,8 +26,22 @@
 //   3. A repoId.kind other than `workflow-run` -- the only kind the
 //      child's proxy is supposed to forward through this IPC -- must
 //      be rejected at the handler boundary. Pin that here.
+//
+//   4. The supervisor's crash handler must interpolate the crash reason
+//      into its log record. A malformed substrate.write.request reaches
+//      the crash handler on the live cohort; a non-JSON line during the
+//      pre-ready handshake reaches it in a non-running phase. Both log
+//      the reason, and both are pinned here because this file already
+//      owns the harness that drives a child through the IPC.
 
-import { describe, test, expect } from "bun:test";
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "bun:test";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -35,6 +49,7 @@ import path from "node:path";
 import { type } from "arktype";
 
 import { generateKeyPair } from "@intx/crypto";
+import { configureSync, getConfig, resetSync } from "@intx/log";
 import { hexEncode } from "@intx/types";
 import type { NewlyTerminalRun, RepoId, RepoStore } from "@intx/hub-sessions";
 
@@ -451,7 +466,7 @@ type SupervisorHarness = {
   spawnResult: { pid: number; channelId: string };
 };
 
-async function bootSupervisor(opts: {
+type BootSupervisorOpts = {
   prefix: string;
   inboxOpts?: Parameters<typeof createMemoryInboxPrimitives>[0];
   onWriteAttempt?: (cap: WriteCapture) => void;
@@ -462,7 +477,21 @@ async function bootSupervisor(opts: {
    * map. Tests that exercise the merge round-trip set this to true.
    */
   invokeMerge?: boolean;
-}): Promise<SupervisorHarness> {
+};
+
+// The supervisor after spawn but before the child's `ready` frame: the
+// receiver is already draining the child's control stream, yet the phase
+// is still `starting`. Tests that need to observe a pre-ready crash inject
+// into `childToSupervisor` and await `spawnPromise`; `sendReady` completes
+// the handshake for the running-phase harness below.
+type SupervisorSeam = Omit<SupervisorHarness, "spawnResult"> & {
+  spawnPromise: Promise<{ pid: number; channelId: string }>;
+  sendReady: () => Promise<void>;
+};
+
+async function bootSupervisorToReady(
+  opts: BootSupervisorOpts,
+): Promise<SupervisorSeam> {
   const baseDir = await makeTempDir(opts.prefix);
   await seedStepGrants(
     baseDir,
@@ -560,14 +589,14 @@ async function bootSupervisor(opts: {
   while (!mailBus.registered().includes("deployment-x@example.com")) {
     await new Promise((r) => setTimeout(r, 1));
   }
-  await childSender.send({
-    type: "ready",
-    data: {
-      childPid: 7777,
-      childPublicKey: hexEncode(childIpcKeyPair.publicKey),
-    },
-  });
-  const spawnResult = await spawnPromise;
+  const sendReady = (): Promise<void> =>
+    childSender.send({
+      type: "ready",
+      data: {
+        childPid: 7777,
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
+      },
+    });
   return {
     supervisor,
     channelId,
@@ -577,6 +606,26 @@ async function bootSupervisor(opts: {
     mailBus,
     inboxPrimitives,
     bindings,
+    spawnPromise,
+    sendReady,
+  };
+}
+
+async function bootSupervisor(
+  opts: BootSupervisorOpts,
+): Promise<SupervisorHarness> {
+  const seam = await bootSupervisorToReady(opts);
+  await seam.sendReady();
+  const spawnResult = await seam.spawnPromise;
+  return {
+    supervisor: seam.supervisor,
+    channelId: seam.channelId,
+    childToSupervisor: seam.childToSupervisor,
+    supervisorToChild: seam.supervisorToChild,
+    childSender: seam.childSender,
+    mailBus: seam.mailBus,
+    inboxPrimitives: seam.inboxPrimitives,
+    bindings: seam.bindings,
     spawnResult,
   };
 }
@@ -971,5 +1020,120 @@ describe("substrate-write malformed merge response", () => {
     expect(goodResponse.result.ok).toBe(true);
 
     await harness.supervisor.shutdown();
+  });
+});
+
+// Capture LogTape records file-wide so the crash-handler tests can assert
+// on the interpolated reason. configureSync is process-global, so the
+// prior config is saved and restored around this file.
+const captured: {
+  category: readonly string[];
+  level: string;
+  message: string;
+}[] = [];
+
+const savedConfig = getConfig();
+
+beforeAll(() => {
+  configureSync({
+    reset: true,
+    sinks: {
+      capture: (record) => {
+        const message = Array.isArray(record.message)
+          ? record.message
+              .map((part) =>
+                typeof part === "string" ? part : JSON.stringify(part),
+              )
+              .join("")
+          : String(record.message);
+        captured.push({
+          category: record.category,
+          level: record.level,
+          message,
+        });
+      },
+    },
+    loggers: [
+      { category: [], lowestLevel: "debug", sinks: ["capture"] },
+      {
+        category: ["logtape", "meta"],
+        lowestLevel: "warning",
+        sinks: ["capture"],
+      },
+    ],
+  });
+});
+
+afterAll(() => {
+  if (savedConfig) {
+    configureSync({ reset: true, ...savedConfig });
+  } else {
+    resetSync();
+  }
+});
+
+beforeEach(() => {
+  captured.length = 0;
+});
+
+function capturedErrors(): string[] {
+  return captured.filter((r) => r.level === "error").map((r) => r.message);
+}
+
+async function waitForCapturedError(
+  needle: string,
+): Promise<string | undefined> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const match = capturedErrors().find((m) => m.includes(needle));
+    if (match !== undefined) return match;
+    await new Promise((r) => setTimeout(r, 1));
+  }
+  return undefined;
+}
+
+describe("onChildCrash logs the interpolated crash reason", () => {
+  test("running-phase crash logs the reason, not a literal placeholder", async () => {
+    const harness = await bootSupervisor({ prefix: "crash-running-" });
+
+    // A repoId whose kind is outside RepoKind passes the permissive wire
+    // schema (kind: string) but fails the handler's RepoId() domain check,
+    // driving the direct onChildCrash call on the live cohort.
+    await harness.childSender.send({
+      type: "substrate.write.request",
+      data: {
+        requestId: "crash-req-1",
+        repoId: { kind: "bogus-kind", id: "deployment-x" },
+        ref: "refs/heads/main",
+        preservePrefix: "state/x/",
+        message: "malformed repoId",
+      },
+    });
+
+    const record = await waitForCapturedError(
+      "forcing child down to respawn: substrate.write.request repoId failed validation",
+    );
+    expect(record).toBeDefined();
+    expect(capturedErrors().some((m) => m.includes("{reason}"))).toBe(false);
+
+    // Cancel the respawn backoff the kill() scheduled.
+    await harness.supervisor.shutdown();
+  });
+
+  test("pre-ready crash logs the reason, not a literal placeholder", async () => {
+    const seam = await bootSupervisorToReady({ prefix: "crash-starting-" });
+
+    // A non-JSON line reaches the receiver before the ready handshake,
+    // while the phase is still `starting`, driving onChildCrash's
+    // non-running branch (shutdownInternal).
+    seam.childToSupervisor.inject("not-json{{{");
+
+    await expect(seam.spawnPromise).rejects.toThrow();
+
+    const record = await waitForCapturedError(
+      "channel crash: control channel received non-JSON line",
+    );
+    expect(record).toBeDefined();
+    expect(capturedErrors().some((m) => m.includes("{reason}"))).toBe(false);
   });
 });

--- a/packages/workflow-host/src/supervisor/supervisor.ts
+++ b/packages/workflow-host/src/supervisor/supervisor.ts
@@ -822,11 +822,11 @@ export function createWorkflowSupervisor(
   // (spawn handshake, recycle reap, shutdown) owns teardown.
   function onChildCrash(reason: string): void {
     if (state.phase === "running") {
-      logger.error`workflow-process channel crash on live cohort; forcing child down to respawn: {reason}`;
+      logger.error`workflow-process channel crash on live cohort; forcing child down to respawn: ${reason}`;
       state.handle.kill();
       return;
     }
-    logger.error`workflow-process channel crash: {reason}`;
+    logger.error`workflow-process channel crash: ${reason}`;
     void shutdownInternal({ reason });
   }
 


### PR DESCRIPTION
## Summary

- The supervisor crash log interpolates the crash reason on both crash
  branches instead of emitting a literal `{reason}` placeholder.
- The admin-ui API client handles 202 Accepted responses: an empty-body
  202 resolves to `undefined` and a body-bearing 202 is parsed, rather
  than throwing "Unexpected end of JSON input".
- The cold-path approval-resume assertion requires a re-dispatchable
  (`suspendedCall`-bearing) approval gate for the resumed correlationId,
  mirroring the reactor's discriminator, so a mis-keyed resume fails
  loudly instead of silently skipping the approved call.
- The sidecar computes the per-step deploy directory through the canonical
  `agentDir` helper, and the dependency-light `@intx/hub-agent/paths`
  entry drops its now-unused `sanitizeAddress` re-export.
- Step teardown surfaces plugin and tool-bundle disposer failures as an
  `AggregateError` instead of swallowing a leaked LSP subprocess to a
  warning, and the two teardown callers route their close through a shared
  `runBodyThenCleanup` helper so a rejecting close never masks an
  in-flight step or control-loop error.
- Warm-agent eviction and source rotation act on every entry and
  aggregate failures, so one agent's failure never strands the rest.

## Verification

`make all` exits 0 (lint, type-check, admin-ui bundle, and both test
passes, run against a provisioned local database). Every change ships
with tests; the crash-reason, 202-empty-body, approval-resume keying,
disposer-failure masking, and warm-agent stranding paths are covered by
mutation-verified regression tests.

Closes INTR-216