### PR TITLE
Break runaway agent loops that repeat a tool call

### DIFF
--- a/docs/INFERENCE.md
+++ b/docs/INFERENCE.md
@@ -407,7 +407,7 @@ It returns one or more actions. Multiple actions execute concurrently where poss
 
 **If the director throws an exception**, the reactor catches it, emits `reactor.error` with the exception details, and initiates graceful shutdown. The director is user-provided code and must not be able to crash the reactor without a clean terminal event.
 
-**If the model drives a doom loop** — the same tool-call turn (identical tool names and, by exact match, arguments) executed `doomLoopThreshold` times in a row, default 3 — the reactor emits a fatal `reactor.error` and initiates graceful shutdown, ending the run with `message.run.ended` carrying `kind: "doom_loop"`. This guards against a runaway model that repeats an identical call: it makes no progress but keeps paying for an inference every turn.
+**If the model drives a doom loop** — the same tool-call turn (identical tool names and, by exact match, arguments) executed `doomLoopThreshold` times in a row, default 3 — the reactor emits a fatal `reactor.error` and initiates graceful shutdown, ending the run with `message.run.ended` carrying `kind: "doom_loop"`. This guards against a runaway model that repeats an identical call: it makes no progress but keeps paying for an inference every turn. Passing `doomLoopThreshold: false` disables the guard entirely.
 
 ### Action Validation
 

--- a/docs/INFERENCE.md
+++ b/docs/INFERENCE.md
@@ -407,6 +407,8 @@ It returns one or more actions. Multiple actions execute concurrently where poss
 
 **If the director throws an exception**, the reactor catches it, emits `reactor.error` with the exception details, and initiates graceful shutdown. The director is user-provided code and must not be able to crash the reactor without a clean terminal event.
 
+**If the model drives a doom loop** — the same tool-call turn (identical tool names and, by exact match, arguments) executed `doomLoopThreshold` times in a row, default 3 — the reactor emits a fatal `reactor.error` and initiates graceful shutdown, ending the run with `message.run.ended` carrying `kind: "doom_loop"`. This guards against a runaway model that repeats an identical call: it makes no progress but keeps paying for an inference every turn.
+
 ### Action Validation
 
 The reactor validates the action set returned by the director before executing:

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -706,6 +706,9 @@ export async function createAgent<EnvReq extends BaseEnv>(
       ...(env.sizeCapMaxChars !== undefined
         ? { sizeCapMaxChars: env.sizeCapMaxChars }
         : {}),
+      ...(env.doomLoopThreshold !== undefined
+        ? { doomLoopThreshold: env.doomLoopThreshold }
+        : {}),
       deps,
       ...(env.compactors !== undefined ? { compactors: env.compactors } : {}),
     });

--- a/packages/agent/src/env.ts
+++ b/packages/agent/src/env.ts
@@ -142,6 +142,13 @@ export interface BaseEnv {
   sizeCapMaxChars?: number;
 
   /**
+   * Override for the default doom-loop detection threshold: the number of
+   * identical consecutive tool-call turns that ends the run (default 3).
+   * Forwarded to the reactor. Must be a positive integer.
+   */
+  doomLoopThreshold?: number;
+
+  /**
    * Maximum number of pending sends (active + queued). Beyond this,
    * `send()` rejects with `SendQueueFullError`. Defaults to 16.
    */

--- a/packages/agent/src/env.ts
+++ b/packages/agent/src/env.ts
@@ -144,9 +144,10 @@ export interface BaseEnv {
   /**
    * Override for the default doom-loop detection threshold: the number of
    * identical consecutive tool-call turns that ends the run (default 3).
-   * Forwarded to the reactor. Must be a positive integer.
+   * Forwarded to the reactor. Must be a positive integer, or `false` to
+   * disable doom-loop detection entirely.
    */
-  doomLoopThreshold?: number;
+  doomLoopThreshold?: number | false;
 
   /**
    * Maximum number of pending sends (active + queued). Beyond this,

--- a/packages/inference/src/assembly.test.ts
+++ b/packages/inference/src/assembly.test.ts
@@ -745,4 +745,64 @@ describe("createReactorAssembly", () => {
     expect(toolDone.data.result.isError).toBe(true);
     expect(toolDone.data.result.content).toBe("blocked-by-caller");
   });
+
+  test("forwards doomLoopThreshold to the reactor", async () => {
+    // The forward is a conditional spread: a broken forward silently drops the
+    // value and the reactor falls back to its default of 3. This test runs
+    // exactly two identical tool turns, so it trips only if the supplied
+    // threshold of 2 actually reached the reactor -- the default of 3 would
+    // not trip in two turns. Reactor-level tests inject ReactorConfig directly
+    // and cannot cover this seam.
+    const events = collectEvents();
+
+    // Loops the same tool call, capped at two executions so a dropped
+    // threshold (default 3) completes without tripping.
+    let executions = 0;
+    const director: ReactorDirector = {
+      async decide(
+        event: { type: string },
+        _state: ReactorState,
+        caps: ReactorCapabilities,
+      ) {
+        if (event.type === "message.received" || event.type === "tool.done") {
+          if (executions >= 2) return caps.done();
+          executions += 1;
+          return caps.executeTools([
+            { id: `c${executions}`, name: "spin", arguments: {} },
+          ]);
+        }
+        return caps.done();
+      },
+    };
+
+    const { reactor } = createReactorAssembly({
+      deps: defaultDeps,
+      sessionId: "s-doom",
+      director,
+      source: source(),
+      toolRunner: makeToolRunner("ok"),
+      contextStore: makeContextStore(),
+      onEvent: events.onEvent,
+      doomLoopThreshold: 2,
+      shutdownTimeoutMs: 100,
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitForDone(events.events);
+
+    const error = events.events.find(
+      (e): e is Extract<ReactorEmittedEvent, { type: "reactor.error" }> =>
+        e.type === "reactor.error",
+    );
+    if (error === undefined) throw new Error("expected reactor.error");
+    expect(error.data.fatal).toBe(true);
+
+    const ended = events.events.find(
+      (e): e is Extract<ReactorEmittedEvent, { type: "message.run.ended" }> =>
+        e.type === "message.run.ended",
+    );
+    if (ended === undefined) throw new Error("expected message.run.ended");
+    expect(ended.data.error?.kind).toBe("doom_loop");
+  });
 });

--- a/packages/inference/src/assembly.ts
+++ b/packages/inference/src/assembly.ts
@@ -93,7 +93,7 @@ export type ReactorAssemblyConfig = {
   inferenceRunner?: ReactorConfig["inferenceRunner"];
   gateTimeout?: number;
   shutdownTimeoutMs?: number;
-  doomLoopThreshold?: number;
+  doomLoopThreshold?: number | false;
 };
 
 /**

--- a/packages/inference/src/assembly.ts
+++ b/packages/inference/src/assembly.ts
@@ -93,6 +93,7 @@ export type ReactorAssemblyConfig = {
   inferenceRunner?: ReactorConfig["inferenceRunner"];
   gateTimeout?: number;
   shutdownTimeoutMs?: number;
+  doomLoopThreshold?: number;
 };
 
 /**
@@ -143,6 +144,7 @@ export function createReactorAssembly(
     inferenceRunner,
     gateTimeout,
     shutdownTimeoutMs,
+    doomLoopThreshold,
   } = config;
 
   // Audit collector is created up-front so the authz extension can route its
@@ -259,6 +261,7 @@ export function createReactorAssembly(
     ...(inferenceRunner !== undefined ? { inferenceRunner } : {}),
     ...(gateTimeout !== undefined ? { gateTimeout } : {}),
     ...(shutdownTimeoutMs !== undefined ? { shutdownTimeoutMs } : {}),
+    ...(doomLoopThreshold !== undefined ? { doomLoopThreshold } : {}),
   };
 
   const reactor = createReactor(reactorConfig);

--- a/packages/inference/src/reactor.test.ts
+++ b/packages/inference/src/reactor.test.ts
@@ -251,7 +251,7 @@ type TestReactorOverrides = {
   sessionId?: string;
   gateTimeout?: number;
   shutdownTimeoutMs?: number;
-  doomLoopThreshold?: number;
+  doomLoopThreshold?: number | false;
   // Wire-level tests (see tests/inference/reactor-streaming.test.ts) supply
   // their own `Dependencies` (fetch stubbed by the harness) and may target a
   // non-Anthropic provider. Both override hooks are optional; omit them for
@@ -1607,6 +1607,29 @@ describe("createReactor — doom-loop detection", () => {
     expect(() => createTestReactor({ doomLoopThreshold: 2.5 })).toThrow(
       /positive integer/,
     );
+  });
+
+  test("does not trip when detection is disabled with false", async () => {
+    // With detection off, an identical batch repeated far past the default
+    // threshold must run to completion. This also guards the coercion trap: a
+    // stray `>= false` would read as `>= 0` and trip on the very first turn.
+    const { reactor, events, waitFor } = createTestReactor({
+      doomLoopThreshold: false,
+      director: createBatchLoopDirector((turn) =>
+        turn < 8
+          ? [{ id: `c${turn}`, name: "spin", arguments: { q: 1 } }]
+          : null,
+      ),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    expect(events.some((e) => e.type === "reactor.error")).toBe(false);
+    expect(getEvent(events, "message.run.ended").data.status).toBe("completed");
+    // All eight turns ran; nothing broke the loop early.
+    expect(events.filter((e) => e.type === "tool.start").length).toBe(8);
   });
 
   test("a threshold of 1 trips on the first executed tool turn", async () => {

--- a/packages/inference/src/reactor.test.ts
+++ b/packages/inference/src/reactor.test.ts
@@ -17,6 +17,7 @@ import type {
   ReactorState,
   ReactorCapabilities,
   ContextStore,
+  ToolCall,
   ToolRunner,
   InferenceEvent,
   InboundMessage,
@@ -250,6 +251,7 @@ type TestReactorOverrides = {
   sessionId?: string;
   gateTimeout?: number;
   shutdownTimeoutMs?: number;
+  doomLoopThreshold?: number;
   // Wire-level tests (see tests/inference/reactor-streaming.test.ts) supply
   // their own `Dependencies` (fetch stubbed by the harness) and may target a
   // non-Anthropic provider. Both override hooks are optional; omit them for
@@ -314,6 +316,9 @@ function createTestReactor(
       : {}),
     ...(overrides.gateTimeout !== undefined
       ? { gateTimeout: overrides.gateTimeout }
+      : {}),
+    ...(overrides.doomLoopThreshold !== undefined
+      ? { doomLoopThreshold: overrides.doomLoopThreshold }
       : {}),
     ...(overrides.compactors !== undefined
       ? { compactors: overrides.compactors }
@@ -1252,6 +1257,514 @@ describe("createReactor — tool execution", () => {
     const toolDones = events.filter((e) => e.type === "tool.done");
     expect(toolStarts.length).toBe(2);
     expect(toolDones.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7b. Doom-loop detection
+// ---------------------------------------------------------------------------
+
+// Drives one tool batch per turn. `nextBatch(turn)` supplies the batch to run
+// on each turn; returning null (or an empty batch) ends the run with `done`.
+// The director re-issues the next batch only once the current batch's results
+// are all in, mirroring the real director's pending-result accounting so a
+// parallel batch does not fan out into one re-issue per result.
+function createBatchLoopDirector(
+  nextBatch: (turn: number) => ToolCall[] | null,
+): ReactorDirector {
+  let turn = 0;
+  let pending = 0;
+
+  function issue(caps: ReactorCapabilities): ReactorAction | ReactorAction[] {
+    const batch = nextBatch(turn);
+    turn += 1;
+    if (batch === null || batch.length === 0) return caps.done();
+    pending = batch.length;
+    return caps.executeTools(batch, true);
+  }
+
+  return {
+    async decide(event, _state, caps) {
+      if (event.type === "message.received") return issue(caps);
+      if (event.type === "tool.done") {
+        pending -= 1;
+        if (pending > 0) return [];
+        return issue(caps);
+      }
+      return [];
+    },
+  };
+}
+
+// Drives the production-shaped agentic loop: each inference emits an assistant
+// turn carrying one tool_call, the director executes exactly that call, and the
+// tool result feeds the next inference. `argsFor(turn)` controls the arguments;
+// the loop ends after `maxTurns` inferences by issuing `done`. Unlike
+// `createBatchLoopDirector`, this interleaves an inference turn between tool
+// turns, matching the real reactor shape.
+function interleavedRunner(
+  argsFor: (turn: number) => Record<string, unknown>,
+  maxTurns: number,
+): {
+  inferenceRunner: (
+    opts: InferenceHarnessOptions,
+  ) => AsyncGenerator<InferenceEvent>;
+  director: ReactorDirector;
+} {
+  let turn = 0;
+  const inferenceRunner = async function* (opts: InferenceHarnessOptions) {
+    const t = turn;
+    yield {
+      type: "inference.done" as const,
+      seq: opts.nextSeq(),
+      data: {
+        turn: {
+          role: "assistant" as const,
+          content: [
+            {
+              type: "tool_call" as const,
+              id: `c${t}`,
+              name: "spin",
+              arguments: argsFor(t),
+            },
+          ],
+          model: "test-model",
+          timestamp: 1000,
+        },
+        usage: emptyUsage(),
+        source: TEST_SOURCE,
+      },
+    };
+  };
+  const director = directorFromTable(
+    {
+      "message.received": (_e, _s, caps) => caps.infer(),
+      "inference.done": (_e, _s, caps) => {
+        const t = turn;
+        turn += 1;
+        if (t >= maxTurns) return caps.done();
+        return caps.executeTools([
+          { id: `c${t}`, name: "spin", arguments: argsFor(t) },
+        ]);
+      },
+      "tool.done": (_e, _s, caps) => caps.infer(),
+    },
+    "wait",
+  );
+  return { inferenceRunner, director };
+}
+
+describe("createReactor — doom-loop detection", () => {
+  test("trips at the threshold on identical consecutive tool turns", async () => {
+    const { reactor, events, waitFor } = createTestReactor({
+      // Default threshold is 3; loop the same call well past it.
+      director: createBatchLoopDirector((turn) =>
+        turn < 8
+          ? [{ id: `c${turn}`, name: "spin", arguments: { q: 1 } }]
+          : null,
+      ),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    const error = getEvent(events, "reactor.error");
+    expect(error.data.fatal).toBe(true);
+    expect(error.data.error).toContain("spin");
+
+    const ended = getEvent(events, "message.run.ended");
+    expect(ended.data.status).toBe("failed");
+    expect(ended.data.error?.kind).toBe("doom_loop");
+
+    // The run broke before running the whole 8-turn loop.
+    const toolStarts = events.filter((e) => e.type === "tool.start");
+    expect(toolStarts.length).toBe(3);
+  });
+
+  test("does not trip on retries with different arguments", async () => {
+    const { reactor, events, waitFor } = createTestReactor({
+      director: createBatchLoopDirector((turn) =>
+        turn < 5
+          ? [{ id: `c${turn}`, name: "retry", arguments: { attempt: turn } }]
+          : null,
+      ),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    expect(events.some((e) => e.type === "reactor.error")).toBe(false);
+    expect(getEvent(events, "message.run.ended").data.status).toBe("completed");
+  });
+
+  test("treats key-reordered arguments as identical", async () => {
+    // Same logical arguments, keys emitted in different orders. Canonical
+    // serialization must collapse them to one signature, so three such turns
+    // trip the default threshold of 3.
+    const variants = [
+      { a: 1, b: 2 },
+      { b: 2, a: 1 },
+      { a: 1, b: 2 },
+    ];
+    const { reactor, events, waitFor } = createTestReactor({
+      director: createBatchLoopDirector((turn) => {
+        const args = variants[turn];
+        return args === undefined
+          ? null
+          : [{ id: `c${turn}`, name: "charge", arguments: args }];
+      }),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    expect(getEvent(events, "reactor.error").data.fatal).toBe(true);
+    expect(getEvent(events, "message.run.ended").data.error?.kind).toBe(
+      "doom_loop",
+    );
+  });
+
+  test("trips when an identical call errors every turn", async () => {
+    const { reactor, events, waitFor } = createTestReactor({
+      director: createBatchLoopDirector((turn) =>
+        turn < 8 ? [{ id: `c${turn}`, name: "flaky", arguments: {} }] : null,
+      ),
+      toolRunner: makeToolRunner(async (call) => ({
+        callId: call.id,
+        content: "boom",
+        isError: true,
+      })),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    expect(getEvent(events, "reactor.error").data.fatal).toBe(true);
+    expect(getEvent(events, "message.run.ended").data.error?.kind).toBe(
+      "doom_loop",
+    );
+  });
+
+  test("trips when an identical call succeeds every turn", async () => {
+    const { reactor, events, waitFor } = createTestReactor({
+      director: createBatchLoopDirector((turn) =>
+        turn < 8 ? [{ id: `c${turn}`, name: "reread", arguments: {} }] : null,
+      ),
+      toolRunner: makeToolRunner(async (call) => ({
+        callId: call.id,
+        content: "same file contents",
+      })),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    expect(getEvent(events, "reactor.error").data.fatal).toBe(true);
+    expect(getEvent(events, "message.run.ended").data.error?.kind).toBe(
+      "doom_loop",
+    );
+  });
+
+  test("a suspend and redispatch of one call does not double-count", async () => {
+    // A parked call is approved and re-dispatched: one real execution. With a
+    // threshold of 2, an implementation that counted the suspended request plus
+    // its redispatch would trip here; counting only executed turns must not.
+    const askExtension = createAuthzExtension({
+      authorize: async () => ({
+        effect: "ask" as const,
+        matchingGrants: [],
+        resolvedBy: null,
+      }),
+      approvalTimeoutMs: 60_000,
+    });
+    const toolsRun: string[] = [];
+
+    const { reactor, events, waitFor } = createTestReactor({
+      doomLoopThreshold: 2,
+      director: directorFromTable(
+        {
+          "message.received": (_e, _s, caps) => caps.infer(),
+          "inference.done": (_e, _s, caps) =>
+            caps.executeTools([
+              { id: "call-ask", name: "charge_card", arguments: {} },
+            ]),
+          "resume.execute_tools": (e, _s, caps) =>
+            caps.executeTools(e.calls, false, true),
+          "tool.done": (_e, _s, caps) => caps.done(),
+        },
+        "wait",
+      ),
+      inferenceRunner: makeInferenceRunner({
+        type: "done",
+        turn: suspendToolCallTurn,
+        usage: emptyUsage(),
+      }),
+      toolRunner: makeToolRunner(async (call) => {
+        toolsRun.push(call.name);
+        return { callId: call.id, content: "charged" };
+      }),
+      beforeToolExtensions: [askExtension],
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+
+    const blocked = await waitFor("reactor.gate.blocked");
+    if (blocked.type !== "reactor.gate.blocked") throw new Error("unreachable");
+    const correlationId = blocked.data.correlationId;
+    if (correlationId === undefined) throw new Error("expected correlationId");
+
+    reactor.deliver(makeApprovalMessage(correlationId));
+    await waitFor("reactor.done");
+
+    expect(toolsRun).toEqual(["charge_card"]);
+    expect(events.some((e) => e.type === "reactor.error")).toBe(false);
+  });
+
+  test("trips on a repeated parallel fan-out batch", async () => {
+    const batch: ToolCall[] = [
+      { id: "a", name: "read", arguments: { path: "a" } },
+      { id: "b", name: "read", arguments: { path: "b" } },
+      { id: "c", name: "read", arguments: { path: "c" } },
+    ];
+    const { reactor, events, waitFor } = createTestReactor({
+      director: createBatchLoopDirector((turn) =>
+        turn < 8
+          ? batch.map((call, i) => ({ ...call, id: `${call.id}-${turn}-${i}` }))
+          : null,
+      ),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    const error = getEvent(events, "reactor.error");
+    expect(error.data.fatal).toBe(true);
+    // The message reports every call in the batch, not a deduplicated name, so
+    // a three-call fan-out is not collapsed to one.
+    expect(error.data.error).toContain("read, read, read");
+    expect(getEvent(events, "message.run.ended").data.error?.kind).toBe(
+      "doom_loop",
+    );
+  });
+
+  test("does not trip on identical calls within a single batch", async () => {
+    // Three identical calls in one turn are one batch occurrence, not three
+    // consecutive turns.
+    const { reactor, events, waitFor } = createTestReactor({
+      director: createBatchLoopDirector((turn) =>
+        turn === 0
+          ? [
+              { id: "x1", name: "dup", arguments: {} },
+              { id: "x2", name: "dup", arguments: {} },
+              { id: "x3", name: "dup", arguments: {} },
+            ]
+          : null,
+      ),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    expect(events.some((e) => e.type === "reactor.error")).toBe(false);
+    expect(getEvent(events, "message.run.ended").data.status).toBe("completed");
+  });
+
+  test("a different batch between identical ones resets the counter", async () => {
+    const batches: ToolCall[][] = [
+      [{ id: "1", name: "spin", arguments: {} }],
+      [{ id: "2", name: "spin", arguments: {} }],
+      [{ id: "3", name: "other", arguments: {} }],
+      [{ id: "4", name: "spin", arguments: {} }],
+      [{ id: "5", name: "spin", arguments: {} }],
+    ];
+    const { reactor, events, waitFor } = createTestReactor({
+      director: createBatchLoopDirector((turn) => batches[turn] ?? null),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    expect(events.some((e) => e.type === "reactor.error")).toBe(false);
+    expect(getEvent(events, "message.run.ended").data.status).toBe("completed");
+  });
+
+  test("rejects a non-positive or non-integer threshold at construction", () => {
+    expect(() => createTestReactor({ doomLoopThreshold: 0 })).toThrow(
+      /positive integer/,
+    );
+    expect(() => createTestReactor({ doomLoopThreshold: -1 })).toThrow(
+      /positive integer/,
+    );
+    expect(() => createTestReactor({ doomLoopThreshold: 2.5 })).toThrow(
+      /positive integer/,
+    );
+  });
+
+  test("a threshold of 1 trips on the first executed tool turn", async () => {
+    const { reactor, events, waitFor } = createTestReactor({
+      doomLoopThreshold: 1,
+      director: createBatchLoopDirector((turn) =>
+        turn < 4 ? [{ id: `c${turn}`, name: "once", arguments: {} }] : null,
+      ),
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    expect(getEvent(events, "reactor.error").data.fatal).toBe(true);
+    expect(getEvent(events, "message.run.ended").data.error?.kind).toBe(
+      "doom_loop",
+    );
+    // Tripped on the very first turn: exactly one tool ran.
+    expect(events.filter((e) => e.type === "tool.start").length).toBe(1);
+  });
+
+  test("trips across inference-interleaved identical tool turns", async () => {
+    // The real reactor runs an inference between every tool turn. Detection
+    // must accumulate across those inference turns, not only across the
+    // back-to-back batches the other tests drive.
+    const { inferenceRunner, director } = interleavedRunner(
+      () => ({ q: 1 }),
+      8,
+    );
+    const { reactor, events, waitFor } = createTestReactor({
+      inferenceRunner,
+      director,
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    expect(getEvent(events, "reactor.error").data.fatal).toBe(true);
+    expect(getEvent(events, "message.run.ended").data.error?.kind).toBe(
+      "doom_loop",
+    );
+    expect(events.filter((e) => e.type === "tool.start").length).toBe(3);
+  });
+
+  test("does not trip on inference-interleaved differing arguments", async () => {
+    const { inferenceRunner, director } = interleavedRunner(
+      (t) => ({ q: t }),
+      5,
+    );
+    const { reactor, events, waitFor } = createTestReactor({
+      inferenceRunner,
+      director,
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+    await waitFor("reactor.done");
+
+    expect(events.some((e) => e.type === "reactor.error")).toBe(false);
+    expect(getEvent(events, "message.run.ended").data.status).toBe("completed");
+  });
+
+  test("accumulates across suspend, approval, and redispatch cycles", async () => {
+    // Each identical batch suspends for approval; approval re-dispatches the
+    // one parked call, and the reactor commits the cycle at every suspend. The
+    // run-scoped counter must survive that commit -- if it were reset there
+    // (e.g. added to resetCycleAccumulators), an approval-gated doom loop would
+    // never trip. Threshold 2, so the second redispatch trips.
+    let inferCount = 0;
+    const inferenceRunner = async function* (opts: InferenceHarnessOptions) {
+      const id = `spin-${inferCount}`;
+      inferCount += 1;
+      yield {
+        type: "inference.done" as const,
+        seq: opts.nextSeq(),
+        data: {
+          turn: {
+            role: "assistant" as const,
+            content: [
+              { type: "tool_call" as const, id, name: "spin", arguments: {} },
+            ],
+            model: "test-model",
+            timestamp: 1000,
+          },
+          usage: emptyUsage(),
+          source: TEST_SOURCE,
+        },
+      };
+    };
+
+    const askExtension = createAuthzExtension({
+      authorize: async () => ({
+        effect: "ask" as const,
+        matchingGrants: [],
+        resolvedBy: null,
+      }),
+      approvalTimeoutMs: 60_000,
+    });
+
+    const { reactor, events, waitFor } = createTestReactor({
+      doomLoopThreshold: 2,
+      inferenceRunner,
+      director: directorFromTable(
+        {
+          "message.received": (_e, _s, caps) => caps.infer(),
+          "inference.done": (e, _s, caps) => {
+            const block = e.turn.content.find((b) => b.type === "tool_call");
+            if (block === undefined || block.type !== "tool_call") {
+              return caps.done();
+            }
+            return caps.executeTools([
+              { id: block.id, name: block.name, arguments: block.arguments },
+            ]);
+          },
+          "resume.execute_tools": (e, _s, caps) =>
+            caps.executeTools(e.calls, false, true),
+          "tool.done": (_e, _s, caps) => caps.infer(),
+        },
+        "wait",
+      ),
+      toolRunner: makeToolRunner(async (call) => ({
+        callId: call.id,
+        content: "spun",
+      })),
+      beforeToolExtensions: [askExtension],
+    });
+
+    reactor.start();
+    reactor.deliver(makeInboundMessage());
+
+    // Approve each suspension as it arrives until the loop trips (or give up
+    // after a bounded number so a regression that never trips fails fast).
+    const approved = new Set<string>();
+    for (let i = 0; i < 6; i++) {
+      const ev = await waitForEvent(
+        events,
+        (e) =>
+          e.type === "reactor.done" ||
+          (e.type === "reactor.gate.blocked" &&
+            e.data.correlationId !== undefined &&
+            !approved.has(e.data.correlationId)),
+      );
+      if (ev.type === "reactor.done") break;
+      if (ev.type !== "reactor.gate.blocked") throw new Error("unreachable");
+      const cid = ev.data.correlationId;
+      if (cid === undefined) throw new Error("expected correlationId");
+      approved.add(cid);
+      reactor.deliver(makeApprovalMessage(cid));
+    }
+
+    await waitFor("reactor.done");
+
+    expect(getEvent(events, "reactor.error").data.fatal).toBe(true);
+    expect(getEvent(events, "message.run.ended").data.error?.kind).toBe(
+      "doom_loop",
+    );
   });
 });
 

--- a/packages/inference/src/reactor.ts
+++ b/packages/inference/src/reactor.ts
@@ -42,6 +42,7 @@ import type {
 
 import { getLogger } from "@intx/log";
 import { ApprovalDecision, signalKindToGateType } from "@intx/types";
+import { canonicalJsonStringify } from "@intx/types/wire-definition-hash";
 import { type } from "arktype";
 import { runInference } from "./harness";
 import type { Dependencies, InferenceHarnessOptions } from "./harness";
@@ -128,6 +129,15 @@ export type ReactorConfig = {
   onShutdown?: () => Promise<void>;
   gateTimeout?: number;
   shutdownTimeoutMs?: number;
+  /**
+   * Number of consecutive identical tool-call turns that trips doom-loop
+   * detection. A turn's identity is its batch of executed tool calls; a
+   * runaway model repeating the same call burns inference cost with no
+   * progress. On the Nth consecutive identical turn the reactor emits a fatal
+   * `reactor.error` and shuts the run down. Must be a positive integer.
+   * Defaults to `DEFAULT_DOOM_LOOP_THRESHOLD`.
+   */
+  doomLoopThreshold?: number;
 };
 
 export type Reactor = {
@@ -141,6 +151,23 @@ export type Reactor = {
 
 const DEFAULT_GATE_TIMEOUT_MS = 3_600_000;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 30_000;
+const DEFAULT_DOOM_LOOP_THRESHOLD = 3;
+
+/**
+ * Order-independent identity of a batch of executed tool calls. Each call
+ * canonicalizes to its name and arguments (the call `id` is excluded, since it
+ * differs on every request); sorting makes a parallel batch match regardless
+ * of the order the model emitted its calls. Two turns share a signature when
+ * they run the same multiset of `(name, arguments)` pairs.
+ */
+function toolBatchSignature(calls: ToolCall[]): string {
+  return calls
+    .map((call) =>
+      canonicalJsonStringify({ name: call.name, arguments: call.arguments }),
+    )
+    .sort()
+    .join("\n");
+}
 
 /**
  * Creates a reactor instance bound to the given configuration.
@@ -164,6 +191,7 @@ export function createReactor(config: ReactorConfig): Reactor {
     onShutdown,
     gateTimeout = DEFAULT_GATE_TIMEOUT_MS,
     shutdownTimeoutMs = DEFAULT_SHUTDOWN_TIMEOUT_MS,
+    doomLoopThreshold = DEFAULT_DOOM_LOOP_THRESHOLD,
     // Resolve the optional failover hooks once here, at the reactor's
     // construction edge. A reactor with no source list fails over to
     // nothing and resets to a no-op, so the inference loop below runs the
@@ -173,6 +201,12 @@ export function createReactor(config: ReactorConfig): Reactor {
       /* single-source: nothing to reset */
     },
   } = config;
+
+  if (!Number.isInteger(doomLoopThreshold) || doomLoopThreshold < 1) {
+    throw new Error(
+      `doomLoopThreshold must be a positive integer, got ${String(doomLoopThreshold)}`,
+    );
+  }
 
   // Monotonic sequence counter, scoped to this session.
   let seq = 0;
@@ -281,9 +315,23 @@ export function createReactor(config: ReactorConfig): Reactor {
   let currentMessageRunId: string | null = null;
   let currentMessageId: string | null = null;
 
+  // Doom-loop detection state, scoped to the current message run. Each executed
+  // tool-call turn is reduced to a batch signature; consecutive identical
+  // signatures accumulate here, and the run is broken when the count reaches
+  // `doomLoopThreshold`. This is run-scoped, not cycle-scoped: it resets only in
+  // `openMessageRun`, never in `resetCycleAccumulators`. It is also deliberately
+  // ephemeral (closure state, not persisted) -- a mid-run restart resets it to
+  // zero and the loop simply re-accumulates and trips a few turns later.
+  let lastToolBatchSignature: string | null = null;
+  let toolBatchRepeatCount = 0;
+  let lastToolBatchNames: string[] = [];
+
   function openMessageRun(messageId: string): void {
     currentMessageRunId = crypto.randomUUID();
     currentMessageId = messageId;
+    lastToolBatchSignature = null;
+    toolBatchRepeatCount = 0;
+    lastToolBatchNames = [];
     emit({
       type: "message.run.started",
       seq: nextSeq(),
@@ -859,6 +907,24 @@ export function createReactor(config: ReactorConfig): Reactor {
     // result to history and no tool.done continuation event.
     const results = outcomes.filter((o): o is ToolResult => o !== SUSPENDED);
 
+    // Doom-loop accounting keys off the calls that actually ran, aligned to
+    // their outcome by index (both the parallel and serial paths above keep
+    // `outcomes` in `calls` order). A parked call contributes nothing, so a
+    // suspend-then-redispatch cycle counts its one real execution once. The
+    // loop reads `toolBatchRepeatCount` after this returns and breaks the run
+    // when it reaches the threshold.
+    const ranCalls = calls.filter((_call, i) => outcomes[i] !== SUSPENDED);
+    if (ranCalls.length > 0) {
+      const signature = toolBatchSignature(ranCalls);
+      if (signature === lastToolBatchSignature) {
+        toolBatchRepeatCount += 1;
+      } else {
+        lastToolBatchSignature = signature;
+        toolBatchRepeatCount = 1;
+      }
+      lastToolBatchNames = ranCalls.map((call) => call.name);
+    }
+
     cycleToolCallsExecuted += results.length;
 
     if (addToHistory && stateManager !== null && results.length > 0) {
@@ -1407,6 +1473,17 @@ export function createReactor(config: ReactorConfig): Reactor {
         const parallel = toolsAction.parallel !== false;
         const addToHistory = toolsAction.addToHistory !== false;
         await executeTools(toolsAction.calls, parallel, addToHistory);
+        if (toolBatchRepeatCount >= doomLoopThreshold) {
+          const tools = lastToolBatchNames.join(", ");
+          const message =
+            `Doom loop detected: an identical tool batch (${tools}) executed ` +
+            `${String(doomLoopThreshold)} times consecutively`;
+          emitError(message, true);
+          closeMessageRun("failed", { message, kind: "doom_loop" });
+          done = true;
+          await initiateShutdown();
+          break;
+        }
         continue;
       }
 

--- a/packages/inference/src/reactor.ts
+++ b/packages/inference/src/reactor.ts
@@ -135,9 +135,10 @@ export type ReactorConfig = {
    * runaway model repeating the same call burns inference cost with no
    * progress. On the Nth consecutive identical turn the reactor emits a fatal
    * `reactor.error` and shuts the run down. Must be a positive integer.
-   * Defaults to `DEFAULT_DOOM_LOOP_THRESHOLD`.
+   * Pass `false` to disable doom-loop detection entirely. Defaults to
+   * `DEFAULT_DOOM_LOOP_THRESHOLD`.
    */
-  doomLoopThreshold?: number;
+  doomLoopThreshold?: number | false;
 };
 
 export type Reactor = {
@@ -152,6 +153,29 @@ export type Reactor = {
 const DEFAULT_GATE_TIMEOUT_MS = 3_600_000;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 30_000;
 const DEFAULT_DOOM_LOOP_THRESHOLD = 3;
+
+/**
+ * Resolve the caller-facing `doomLoopThreshold` into the reactor's internal
+ * form: a positive integer when detection is active, or `null` when it is
+ * disabled. `undefined` (omitted) takes the default; `false` disables; a
+ * number is validated here — the construction edge is the one place that owns
+ * the default and rejects a malformed value loudly, so a stray `0`, negative,
+ * or non-integer throws rather than silently disarming the guard. Downstream
+ * code compares against the returned `number | null` and never sees the raw
+ * `false`, whose numeric coercion would otherwise trip the loop immediately.
+ */
+function resolveDoomLoopThreshold(
+  raw: number | false | undefined,
+): number | null {
+  if (raw === false) return null;
+  if (raw === undefined) return DEFAULT_DOOM_LOOP_THRESHOLD;
+  if (!Number.isInteger(raw) || raw < 1) {
+    throw new Error(
+      `doomLoopThreshold must be a positive integer or false, got ${String(raw)}`,
+    );
+  }
+  return raw;
+}
 
 /**
  * Order-independent identity of a batch of executed tool calls. Each call
@@ -191,7 +215,6 @@ export function createReactor(config: ReactorConfig): Reactor {
     onShutdown,
     gateTimeout = DEFAULT_GATE_TIMEOUT_MS,
     shutdownTimeoutMs = DEFAULT_SHUTDOWN_TIMEOUT_MS,
-    doomLoopThreshold = DEFAULT_DOOM_LOOP_THRESHOLD,
     // Resolve the optional failover hooks once here, at the reactor's
     // construction edge. A reactor with no source list fails over to
     // nothing and resets to a no-op, so the inference loop below runs the
@@ -202,11 +225,10 @@ export function createReactor(config: ReactorConfig): Reactor {
     },
   } = config;
 
-  if (!Number.isInteger(doomLoopThreshold) || doomLoopThreshold < 1) {
-    throw new Error(
-      `doomLoopThreshold must be a positive integer, got ${String(doomLoopThreshold)}`,
-    );
-  }
+  // Resolved once at the construction edge: a positive integer while detection
+  // is active, or `null` when the caller disabled it with `false`. Every
+  // downstream comparison reads this binding, never the raw config value.
+  const doomLoopThreshold = resolveDoomLoopThreshold(config.doomLoopThreshold);
 
   // Monotonic sequence counter, scoped to this session.
   let seq = 0;
@@ -912,9 +934,10 @@ export function createReactor(config: ReactorConfig): Reactor {
     // `outcomes` in `calls` order). A parked call contributes nothing, so a
     // suspend-then-redispatch cycle counts its one real execution once. The
     // loop reads `toolBatchRepeatCount` after this returns and breaks the run
-    // when it reaches the threshold.
+    // when it reaches the threshold. A `null` threshold means detection is
+    // disabled, so the accounting is skipped entirely.
     const ranCalls = calls.filter((_call, i) => outcomes[i] !== SUSPENDED);
-    if (ranCalls.length > 0) {
+    if (doomLoopThreshold !== null && ranCalls.length > 0) {
       const signature = toolBatchSignature(ranCalls);
       if (signature === lastToolBatchSignature) {
         toolBatchRepeatCount += 1;
@@ -1473,7 +1496,10 @@ export function createReactor(config: ReactorConfig): Reactor {
         const parallel = toolsAction.parallel !== false;
         const addToHistory = toolsAction.addToHistory !== false;
         await executeTools(toolsAction.calls, parallel, addToHistory);
-        if (toolBatchRepeatCount >= doomLoopThreshold) {
+        if (
+          doomLoopThreshold !== null &&
+          toolBatchRepeatCount >= doomLoopThreshold
+        ) {
           const tools = lastToolBatchNames.join(", ");
           const message =
             `Doom loop detected: an identical tool batch (${tools}) executed ` +

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -1738,8 +1738,11 @@ export type InferenceEvent =
        *
        * `error.kind` is documented as one of
        * `"inference_error" | "tool_error" | "reactor_fatal" |
-       * "harness_aborted"` initially, extensible as new failure
-       * categories surface.
+       * "harness_aborted" | "doom_loop"` initially, extensible as new
+       * failure categories surface. `"doom_loop"` marks a protective
+       * break the reactor took on the agent's behalf when the agent
+       * repeated an identical tool batch past the configured threshold;
+       * unlike `"reactor_fatal"` it is not an internal fault.
        */
       type: "message.run.ended";
       seq: number;


### PR DESCRIPTION
## Summary

- The reactor detects when an agent repeats an identical tool-call turn N
  times in a row (N configurable, default 3) and ends the run with a fatal
  `reactor.error`, closing it as `message.run.ended` with `kind: "doom_loop"`.
  This guards against a runaway model that repeats an identical call: it makes
  no progress but keeps paying for an inference every turn.
- A turn's identity is the order-independent multiset of its executed calls'
  `(name, arguments)` pairs, canonicalized so reordered object keys and
  reordered parallel batches still match, while genuine retries with different
  arguments do not. Only calls that actually run count, so a suspended call that
  is approved and re-dispatched counts as the single execution it is.
- The threshold is operator-configurable through `createAgent` and reaches the
  reactor, which stays the single owner of the default and its validation.
  Passing `false` as the threshold disables detection entirely; a non-positive
  or non-integer value still throws, so only an explicit `false` disarms it.

## Verification

- `make all` passes: lint, type-check, the admin-ui bundle, and both test
  passes (unit and DB-backed integration) exit clean.
- The doom-loop suite exercises detection at threshold, no false positive on
  differing-argument retries, key-reordered equivalence, identical calls that
  error or succeed every turn, the suspend/approval/redispatch regression,
  repeated parallel fan-out, a single in-turn batch, counter reset on a
  different batch, threshold validation, and the disabled path. A seam test
  confirms the configured threshold reaches the reactor through the assembly.

Closes INTR-53