### PR TITLE
Recover interrupted run-event compactions at supervisor boot

### DIFF
--- a/packages/hub-sessions/src/index.ts
+++ b/packages/hub-sessions/src/index.ts
@@ -156,6 +156,7 @@ export {
   dequeueToProcessing,
   readProcessingEntry,
   markConsumed,
+  scanRunsForBoot,
   readOwnedMessageIds,
   readCommittedWorkflowRunLifecycle,
   readWorkflowRunLifecycle,

--- a/packages/hub-sessions/src/index.ts
+++ b/packages/hub-sessions/src/index.ts
@@ -156,6 +156,7 @@ export {
   dequeueToProcessing,
   readProcessingEntry,
   markConsumed,
+  classifyTerminalEvent,
   scanRunsForBoot,
   readOwnedMessageIds,
   readCommittedWorkflowRunLifecycle,

--- a/packages/hub-sessions/src/index.ts
+++ b/packages/hub-sessions/src/index.ts
@@ -158,7 +158,6 @@ export {
   markConsumed,
   classifyTerminalEvent,
   scanRunsForBoot,
-  readOwnedMessageIds,
   readCommittedWorkflowRunLifecycle,
   readWorkflowRunLifecycle,
   replayProcessingToInbox,

--- a/packages/hub-sessions/src/substrate.ts
+++ b/packages/hub-sessions/src/substrate.ts
@@ -23,7 +23,6 @@ export {
   markConsumed,
   parseEventSeq,
   scanRunsForBoot,
-  readOwnedMessageIds,
   readCommittedWorkflowRunLifecycle,
   readWorkflowRunLifecycle,
   readProcessingEntry,

--- a/packages/hub-sessions/src/substrate.ts
+++ b/packages/hub-sessions/src/substrate.ts
@@ -21,6 +21,7 @@ export {
   enqueueInbox,
   markConsumed,
   parseEventSeq,
+  scanRunsForBoot,
   readOwnedMessageIds,
   readCommittedWorkflowRunLifecycle,
   readWorkflowRunLifecycle,

--- a/packages/hub-sessions/src/substrate.ts
+++ b/packages/hub-sessions/src/substrate.ts
@@ -16,6 +16,7 @@
 // module. The barrel still re-exports all of these for hub-side consumers.
 
 export {
+  classifyTerminalEvent,
   DEFAULT_CONSUMED_RETENTION_MS,
   dequeueToProcessing,
   enqueueInbox,

--- a/packages/hub-sessions/src/workflow-run-kind.test.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.test.ts
@@ -16,6 +16,7 @@ import {
   parseEventSeq,
   readCommittedWorkflowRunLifecycle,
   readOwnedMessageIds,
+  scanRunsForBoot,
   readWorkflowRunLifecycle,
   replayProcessingToInbox,
   WORKFLOW_RUN_GITIGNORE_PATH,
@@ -2548,6 +2549,49 @@ describe("claim-check API — resume-owned processing entries survive replay", (
     const owned = await readOwnedMessageIds(store, repoId);
     expect(owned.has("live")).toBe(true);
     expect(owned.has("done")).toBe(false);
+  });
+
+  test("scanRunsForBoot proposes a terminal per-event run for sealing and drops it from owned", async () => {
+    const { store, repoId, principal } = await makeClaimCheckStore("cc-scan-");
+    // `live` is parked (RunStarted only). `done` reached RunCompleted but is
+    // still in per-event form -- the crash window an interrupted fold leaves
+    // behind. A single terminal run must appear in `pendingSealRunIds` and be
+    // absent from `ownedMessageIds`: the same event that ends a run stops it
+    // owning its message and makes it a seal candidate.
+    await store.writeTree(principal, repoId, "refs/heads/main", {
+      files: {
+        [`${WORKFLOW_RUN_RUNS_PREFIX}/live/events/0.json`]:
+          runStartedBody("live"),
+        [`${WORKFLOW_RUN_RUNS_PREFIX}/done/events/0.json`]:
+          runStartedBody("done"),
+        [`${WORKFLOW_RUN_RUNS_PREFIX}/done/events/1.json`]: runCompletedBody(1),
+      },
+      message: "seed one live and one terminal per-event run",
+    });
+    const { ownedMessageIds, pendingSealRunIds } = await scanRunsForBoot(
+      store,
+      repoId,
+    );
+    expect(pendingSealRunIds).toEqual(["done"]);
+    expect(ownedMessageIds.has("done")).toBe(false);
+    expect(ownedMessageIds.has("live")).toBe(true);
+  });
+
+  test("scanRunsForBoot excludes an already-sealed run from pendingSealRunIds", async () => {
+    const { store, repoId, principal } =
+      await makeClaimCheckStore("cc-scan-sealed-");
+    // A sealed run (combined events.jsonl, no per-event directory) is already
+    // folded, so it is not a seal candidate.
+    const sealed =
+      [runStartedBody("sealed"), runCompletedBody(1)].join("\n") + "\n";
+    await store.writeTree(principal, repoId, "refs/heads/main", {
+      files: {
+        [`${WORKFLOW_RUN_RUNS_PREFIX}/sealed/events.jsonl`]: sealed,
+      },
+      message: "seed a sealed (terminated, compacted) run",
+    });
+    const { pendingSealRunIds } = await scanRunsForBoot(store, repoId);
+    expect(pendingSealRunIds).toEqual([]);
   });
 
   test("readWorkflowRunLifecycle distinguishes grants-only, live, and terminal logs", async () => {

--- a/packages/hub-sessions/src/workflow-run-kind.test.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.test.ts
@@ -15,7 +15,6 @@ import {
   markConsumed,
   parseEventSeq,
   readCommittedWorkflowRunLifecycle,
-  readOwnedMessageIds,
   scanRunsForBoot,
   readWorkflowRunLifecycle,
   replayProcessingToInbox,
@@ -2505,7 +2504,7 @@ describe("claim-check substrate FIFO invariant", () => {
 
 // A `processing/` entry whose run is still live (non-terminal durable
 // log) is owned by the recovery re-drive of that run after a crash.
-// `readOwnedMessageIds` finds those runs' messageIds so the spawn-time
+// `scanRunsForBoot` finds those runs' messageIds so the spawn-time
 // replay leaves them in `processing/` rather than re-admitting them to
 // `inbox/` and dispatching a colliding second run on the same runId. The
 // run logs live on the run-event ref (`refs/heads/main`); the claim-check
@@ -2532,7 +2531,7 @@ describe("claim-check API — resume-owned processing entries survive replay", (
     });
   }
 
-  test("readOwnedMessageIds returns non-terminal run messageIds and excludes terminal ones", async () => {
+  test("scanRunsForBoot returns non-terminal run messageIds and excludes terminal ones", async () => {
     const { store, repoId, principal } = await makeClaimCheckStore("cc-owned-");
     // A mail-triggered run's runId is its messageId. `live` is parked
     // (RunStarted only); `done` reached RunCompleted.
@@ -2546,7 +2545,7 @@ describe("claim-check API — resume-owned processing entries survive replay", (
       },
       message: "seed one live and one terminal run",
     });
-    const owned = await readOwnedMessageIds(store, repoId);
+    const { ownedMessageIds: owned } = await scanRunsForBoot(store, repoId);
     expect(owned.has("live")).toBe(true);
     expect(owned.has("done")).toBe(false);
   });
@@ -2685,7 +2684,7 @@ describe("claim-check API — resume-owned processing entries survive replay", (
       },
       message: "seed a run with a pending cancel but no finalizer",
     });
-    const owned = await readOwnedMessageIds(store, repoId);
+    const { ownedMessageIds: owned } = await scanRunsForBoot(store, repoId);
     expect(owned.has("cancelling")).toBe(true);
   });
 
@@ -2694,7 +2693,7 @@ describe("claim-check API — resume-owned processing entries survive replay", (
       await makeClaimCheckStore("cc-owned-no-msgid-");
     // A child run (e.g. a spawned sub-run) starts without a
     // consumedMessageId: it was not triggered by an inbound claim-check
-    // message. readOwnedMessageIds only adds when consumedMessageId is a
+    // message. scanRunsForBoot only adds when consumedMessageId is a
     // string, so this live run contributes no messageId to suppress.
     await store.writeTree(principal, repoId, "refs/heads/main", {
       files: {
@@ -2709,7 +2708,7 @@ describe("claim-check API — resume-owned processing entries survive replay", (
       },
       message: "seed a live child run with no consumedMessageId",
     });
-    const owned = await readOwnedMessageIds(store, repoId);
+    const { ownedMessageIds: owned } = await scanRunsForBoot(store, repoId);
     expect(owned.size).toBe(0);
   });
 
@@ -2719,7 +2718,7 @@ describe("claim-check API — resume-owned processing entries survive replay", (
     // A terminated run is sealed: its per-event `events/<seq>.json` blobs
     // are folded into one combined `events.jsonl` file. Only a terminated
     // run may be sealed, so a sealed run owns nothing even though its
-    // RunStarted still carries a consumedMessageId. readOwnedMessageIds
+    // RunStarted still carries a consumedMessageId. scanRunsForBoot
     // detects the sealed run by the combined file's presence and skips it
     // without reading the (absent) per-event directory.
     const sealed =
@@ -2730,7 +2729,7 @@ describe("claim-check API — resume-owned processing entries survive replay", (
       },
       message: "seed a sealed (terminated, compacted) run",
     });
-    const owned = await readOwnedMessageIds(store, repoId);
+    const { ownedMessageIds: owned } = await scanRunsForBoot(store, repoId);
     expect(owned.has("sealed")).toBe(false);
     expect(owned.size).toBe(0);
   });
@@ -2739,9 +2738,9 @@ describe("claim-check API — resume-owned processing entries survive replay", (
     const { store, repoId } = await makeClaimCheckStore("cc-owned-no-runs-");
     // A freshly-initialised repo has only a `.gitignore` genesis tree and
     // no `runs/` directory. readdir on the missing directory surfaces
-    // ENOENT, which readOwnedMessageIds treats as an empty owned set
+    // ENOENT, which scanRunsForBoot treats as an empty owned set
     // rather than throwing.
-    const owned = await readOwnedMessageIds(store, repoId);
+    const { ownedMessageIds: owned } = await scanRunsForBoot(store, repoId);
     expect(owned.size).toBe(0);
   });
 
@@ -2774,7 +2773,7 @@ describe("claim-check API — resume-owned processing entries survive replay", (
       message: "seed the live run for the owned entry",
     });
 
-    const owned = await readOwnedMessageIds(store, repoId);
+    const { ownedMessageIds: owned } = await scanRunsForBoot(store, repoId);
     expect(owned).toEqual(new Set(["live"]));
 
     const replay = await replayProcessingToInbox(

--- a/packages/hub-sessions/src/workflow-run-kind.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.ts
@@ -3504,30 +3504,40 @@ export type ReplayProcessingToInboxResult = {
   replayedKeys: string[];
 };
 
+export type ScanRunsForBootResult = {
+  ownedMessageIds: Set<string>;
+  pendingSealRunIds: string[];
+};
+
 /**
- * Read the run event logs under `runs/` and return the set of
- * `consumedMessageId`s belonging to NON-terminal runs -- the messages a
- * live run still owns. The caller (the supervisor's spawn-time replay)
- * feeds this into `replayProcessingToInbox`'s `ownedMessageIds` so a
- * parked run's message is not re-admitted to inbox and dispatched a
- * second time while the run is recovered by re-driving its durable log.
- * Without this, the re-drive AND the re-triggered fresh run both re-park
- * the same awaitSignal gate on the same runId, and the two concurrent
- * runtime bodies race to a corrupt terminal.
+ * Walk `runs/` once and return the two boot-recovery inputs the supervisor's
+ * spawn needs, from a single traversal of the working tree via `getRepoDir`:
  *
- * Reads the substrate's working tree via `getRepoDir`, mirroring the
- * child's `discoverInFlightRuns`. The working tree tracks the run-event
- * ref (`refs/heads/main`); the claim-check ref (`refs/heads/events`)
- * cannot see it, which is why this lives at the caller rather than inside
- * `replayProcessingToInbox`'s single-ref delta. A run whose log is sealed
- * (combined `events.json`, only permitted for a terminated run) or
- * carries a terminal event is excluded; an absent `runs/` directory
- * yields an empty set.
+ * - `ownedMessageIds`: the `consumedMessageId`s of NON-terminal runs -- the
+ *   messages a live run still owns. Spawn feeds this into
+ *   `replayProcessingToInbox`'s `ownedMessageIds` so a parked run's message is
+ *   not re-admitted to inbox and dispatched a second time while the run is
+ *   recovered by re-driving its durable log. Without this, the re-drive AND the
+ *   re-triggered fresh run both re-park the same awaitSignal gate on the same
+ *   runId, and the two concurrent runtime bodies race to a corrupt terminal.
+ * - `pendingSealRunIds`: runs that are terminal but still in per-event form --
+ *   an interrupted fold left them unsealed. Spawn hands these to the recovery
+ *   sweep, which re-runs the idempotent fold. A terminal event is a *proposal*:
+ *   the authoritative decision is `compactRunEvents`, which independently
+ *   re-checks the run's max-seq event and no-ops a run that is not actually
+ *   terminal, so this scan may be loose.
+ *
+ * The working tree tracks the run-event ref (`refs/heads/main`); the
+ * claim-check ref (`refs/heads/events`) cannot see it, which is why this lives
+ * at the caller rather than inside `replayProcessingToInbox`'s single-ref
+ * delta. A run whose log is sealed (combined `events.jsonl`, only permitted for
+ * a terminated run) contributes to neither set; an absent `runs/` directory
+ * yields empty results.
  */
-export async function readOwnedMessageIds(
+export async function scanRunsForBoot(
   store: RepoStore,
   repoId: RepoId,
-): Promise<Set<string>> {
+): Promise<ScanRunsForBootResult> {
   const fs = await import("node:fs/promises");
   const path = await import("node:path");
   const repoDir = store.getRepoDir(repoId);
@@ -3537,21 +3547,33 @@ export async function readOwnedMessageIds(
     runIds = await fs.readdir(runsDir);
   } catch (cause) {
     if (cause instanceof Error && "code" in cause && cause.code === "ENOENT") {
-      return new Set();
+      return { ownedMessageIds: new Set(), pendingSealRunIds: [] };
     }
     throw cause;
   }
   const owned = new Set<string>();
+  const pendingSealRunIds: string[] = [];
   for (const runId of runIds) {
     const runDir = path.join(runsDir, runId);
     // A sealed run (combined events file) is terminal by the handler's
     // own invariant -- only a terminated run is sealed -- so it owns
-    // nothing. Its presence also means the per-event directory is absent.
+    // nothing and is already folded. Its presence also means the per-event
+    // directory is absent.
     let sealed = false;
     try {
       await fs.access(path.join(runDir, WORKFLOW_RUN_EVENTS_FILE));
       sealed = true;
-    } catch {
+    } catch (cause) {
+      // ENOENT is the normal "not sealed" case. Any other stat error leaves
+      // the run to fall through to the events-dir read below, which resolves
+      // it, so this catch is benign; warn so the anomaly is still visible.
+      if (
+        !(cause instanceof Error) ||
+        !("code" in cause) ||
+        cause.code !== "ENOENT"
+      ) {
+        logger.warn`scanRunsForBoot: stat of the sealed-log file for run ${runId} failed: ${cause instanceof Error ? cause.message : String(cause)}`;
+      }
       sealed = false;
     }
     if (sealed) continue;
@@ -3559,7 +3581,21 @@ export async function readOwnedMessageIds(
     let files: string[];
     try {
       files = await fs.readdir(eventsDir);
-    } catch {
+    } catch (cause) {
+      // ENOENT means the run has neither a sealed log nor a per-event
+      // directory (grants may be staged before the first event); skip it.
+      // A non-ENOENT error drops the run from BOTH result sets, and a live
+      // run dropped from ownedMessageIds gets its message re-admitted and
+      // dispatched a second time on the same runId -- the double-driver
+      // corruption this scan exists to prevent. Surface it, but still skip:
+      // aborting the whole boot scan over one run is worse.
+      if (
+        !(cause instanceof Error) ||
+        !("code" in cause) ||
+        cause.code !== "ENOENT"
+      ) {
+        logger.error`scanRunsForBoot: reading events for run ${runId} failed; skipping it may re-admit its message and start a second run on the same runId: ${cause instanceof Error ? cause.message : String(cause)}`;
+      }
       continue;
     }
     let terminal = false;
@@ -3571,7 +3607,19 @@ export async function readOwnedMessageIds(
         parsed = JSON.parse(
           await fs.readFile(path.join(eventsDir, file), "utf8"),
         );
-      } catch {
+      } catch (cause) {
+        // A corrupt or unreadable event file drops this run's
+        // classification: a missed RunStarted re-admits its message (a
+        // second run on the same runId), a missed terminal event skips a
+        // needed seal. Surface it, but skip the file rather than abort the
+        // scan. ENOENT here is a benign race (the file vanished mid-scan).
+        if (
+          !(cause instanceof Error) ||
+          !("code" in cause) ||
+          cause.code !== "ENOENT"
+        ) {
+          logger.error`scanRunsForBoot: reading event ${file} for run ${runId} failed; skipping it may re-admit its message and start a second run on the same runId: ${cause instanceof Error ? cause.message : String(cause)}`;
+        }
         continue;
       }
       if (
@@ -3592,10 +3640,24 @@ export async function readOwnedMessageIds(
         if (typeof mid === "string") consumedMessageId = mid;
       }
     }
-    if (terminal) continue;
+    if (terminal) {
+      pendingSealRunIds.push(runId);
+      continue;
+    }
     if (consumedMessageId !== undefined) owned.add(consumedMessageId);
   }
-  return owned;
+  return { ownedMessageIds: owned, pendingSealRunIds };
+}
+
+/**
+ * The owned-message-id half of {@link scanRunsForBoot}. Retained for callers
+ * that need only the owned set; see `scanRunsForBoot` for the semantics.
+ */
+export async function readOwnedMessageIds(
+  store: RepoStore,
+  repoId: RepoId,
+): Promise<Set<string>> {
+  return (await scanRunsForBoot(store, repoId)).ownedMessageIds;
 }
 
 export type WorkflowRunLifecycle = "absent" | "live" | "terminal";

--- a/packages/hub-sessions/src/workflow-run-kind.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.ts
@@ -510,7 +510,7 @@ export type WatermarkEnvelope = typeof WatermarkEnvelope.infer;
  * stay in sync with the canonical runtime definition:
  * if the runtime adds or removes a terminal run phase, update this map too.
  * Drift silently reopens the restore-time double-driver collision that
- * `readOwnedMessageIds` (below) exists to prevent.
+ * `scanRunsForBoot` (below) exists to prevent.
  */
 type TerminalRunStatus = "completed" | "failed" | "cancelled";
 
@@ -3647,17 +3647,6 @@ export async function scanRunsForBoot(
     if (consumedMessageId !== undefined) owned.add(consumedMessageId);
   }
   return { ownedMessageIds: owned, pendingSealRunIds };
-}
-
-/**
- * The owned-message-id half of {@link scanRunsForBoot}. Retained for callers
- * that need only the owned set; see `scanRunsForBoot` for the semantics.
- */
-export async function readOwnedMessageIds(
-  store: RepoStore,
-  repoId: RepoId,
-): Promise<Set<string>> {
-  return (await scanRunsForBoot(store, repoId)).ownedMessageIds;
 }
 
 export type WorkflowRunLifecycle = "absent" | "live" | "terminal";

--- a/packages/workflow-host/src/supervisor/run-event-compaction.ts
+++ b/packages/workflow-host/src/supervisor/run-event-compaction.ts
@@ -47,8 +47,8 @@ export type CompactRunEventsOpts = {
  * Idempotent and terminal-only: a run already sealed (no `events/` subtree)
  * or one whose latest event is not terminal is left untouched, so the call
  * is safe to repeat. The live caller invokes it once per run, right after the
- * run terminates; a bounded recovery sweep that would retry the fold for a run
- * whose compaction a crash interrupted is not yet implemented.
+ * run terminates; `recoverInterruptedCompactions` re-runs it for a run whose
+ * fold a crash interrupted before it could seal.
  *
  * The combined file is the verbatim byte concatenation of the per-event
  * blobs in seq order (`encodeCombinedEventLog`), the exact shape the

--- a/packages/workflow-host/src/supervisor/run-event-compaction.ts
+++ b/packages/workflow-host/src/supervisor/run-event-compaction.ts
@@ -14,6 +14,7 @@ import type {
   WorkflowRunSupervisorPrincipal,
 } from "@intx/hub-sessions/substrate";
 import {
+  classifyTerminalEvent,
   WORKFLOW_RUN_EVENTS_FILE,
   encodeCombinedEventLog,
 } from "@intx/hub-sessions/substrate";
@@ -23,11 +24,6 @@ import { SUPERVISOR_PRINCIPAL_KIND } from "./cancel-signing";
 const RUNS_PREFIX = "runs";
 const EVENTS_DIR = "events";
 const EVENT_FILENAME_RE = /^(0|[1-9][0-9]*)\.json$/;
-const TERMINAL_EVENT_TYPES = new Set<string>([
-  "RunCompleted",
-  "RunFailed",
-  "RunCancelled",
-]);
 
 export type CompactRunEventsOpts = {
   /** Substrate handle the supervisor writes through. */
@@ -100,7 +96,10 @@ export async function compactRunEvents(
     return { compacted: false };
   }
   const lastType = (parsed as { type?: unknown }).type;
-  if (typeof lastType !== "string" || !TERMINAL_EVENT_TYPES.has(lastType)) {
+  if (
+    typeof lastType !== "string" ||
+    !classifyTerminalEvent(lastType).terminal
+  ) {
     return { compacted: false };
   }
 

--- a/packages/workflow-host/src/supervisor/run-event-recovery.test.ts
+++ b/packages/workflow-host/src/supervisor/run-event-recovery.test.ts
@@ -1,0 +1,260 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { generateKeyPair } from "@intx/crypto";
+import type { KeyPair } from "@intx/types/runtime";
+import {
+  createRepoStore,
+  workflowRunKindHandler,
+  WORKFLOW_RUN_GITIGNORE_PATH,
+} from "@intx/hub-sessions";
+import type {
+  AuthorizeFn,
+  RepoId,
+  WorkflowRunSupervisorPrincipal,
+} from "@intx/hub-sessions";
+
+import { compactRunEvents } from "./run-event-compaction";
+import { recoverInterruptedCompactions } from "./run-event-recovery";
+
+// The sweep's harness is a deliberate local mirror of the helpers in
+// run-event-compaction.test.ts. The sweep operates over MULTIPLE runs, so it
+// seeds per-run event trees by id, where that file's `setup`/`ev` assume the
+// single fixed `run-1`.
+
+const REF = "refs/heads/main";
+const allowAll: AuthorizeFn = () => ({ allowed: true });
+
+const tempDirs: string[] = [];
+let signingKey: KeyPair;
+
+beforeAll(async () => {
+  signingKey = await generateKeyPair();
+});
+afterAll(async () => {
+  for (const d of tempDirs.splice(0)) {
+    await fs.promises.rm(d, { recursive: true, force: true }).catch(() => {
+      /* best effort */
+    });
+  }
+});
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const d = await fs.promises.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(d);
+  return d;
+}
+
+function ev(runId: string, seq: number, type: string): string {
+  return JSON.stringify({ seq, type, runId });
+}
+
+async function setup(anchorRunId: string) {
+  const dataDir = await makeTempDir("recover-");
+  const repoId: RepoId = { kind: "workflow-run", id: anchorRunId };
+  const substrate = createRepoStore({
+    dataDir,
+    signingKey,
+    handlers: { "workflow-run": workflowRunKindHandler },
+    authorize: allowAll,
+  });
+  await substrate.writeTree({ kind: "hub" }, repoId, REF, {
+    files: { [WORKFLOW_RUN_GITIGNORE_PATH]: "" },
+    message: "genesis",
+  });
+  const supervisor: WorkflowRunSupervisorPrincipal = {
+    kind: "supervisor",
+    anchorRunId,
+  };
+  const runDir = (runId: string) =>
+    path.join(substrate.getRepoDir(repoId), "runs", runId);
+  // Seed a run's per-event `events/<seq>.json` blobs: the on-disk shape a
+  // crash leaves behind when the fold never runs.
+  const seedPerEvent = (runId: string, events: [number, string][]) =>
+    substrate.writeTreePreservingPrefix(supervisor, repoId, REF, {
+      preservePrefix: `runs/${runId}/events/`,
+      merge: async () =>
+        Object.fromEntries(
+          events.map(([seq, type]) => [
+            `runs/${runId}/events/${seq}.json`,
+            ev(runId, seq, type),
+          ]),
+        ),
+      message: `seed per-event ${runId}`,
+    });
+  // Seed an already-sealed run: the combined `events.jsonl`, no `events/`.
+  const seedSealed = (runId: string, events: [number, string][]) =>
+    substrate.writeTreePreservingPrefix(supervisor, repoId, REF, {
+      preservePrefix: `runs/${runId}/events/`,
+      merge: async () => ({
+        [`runs/${runId}/events.jsonl`]:
+          events.map(([seq, type]) => ev(runId, seq, type)).join("\n") + "\n",
+      }),
+      message: `seed sealed ${runId}`,
+    });
+  return { repoId, substrate, anchorRunId, runDir, seedPerEvent, seedSealed };
+}
+
+describe("recoverInterruptedCompactions", () => {
+  test("seals a run left terminal-but-per-event by an interrupted fold", async () => {
+    const { repoId, substrate, anchorRunId, runDir, seedPerEvent } =
+      await setup("dep-crash-window");
+    // The exact crash window: the terminal event committed, the fold did not.
+    await seedPerEvent("run-1", [
+      [0, "RunStarted"],
+      [1, "RunCompleted"],
+    ]);
+    expect(
+      (await fs.promises.readdir(path.join(runDir("run-1"), "events"))).sort(),
+    ).toEqual(["0.json", "1.json"]);
+
+    const result = await recoverInterruptedCompactions({
+      substrate,
+      repoId,
+      ref: REF,
+      anchorRunId,
+      pendingSealRunIds: ["run-1"],
+    });
+    expect(result).toEqual({ sealed: 1, failed: [] });
+
+    // The per-event directory is gone; the combined file is the verbatim fold.
+    await expect(
+      fs.promises.readdir(path.join(runDir("run-1"), "events")),
+    ).rejects.toThrow();
+    const combined = await fs.promises.readFile(
+      path.join(runDir("run-1"), "events.jsonl"),
+      "utf8",
+    );
+    expect(combined).toBe(
+      `${ev("run-1", 0, "RunStarted")}\n${ev("run-1", 1, "RunCompleted")}\n`,
+    );
+  });
+
+  test("leaves live and already-sealed proposals untouched", async () => {
+    const { repoId, substrate, anchorRunId, runDir, seedPerEvent, seedSealed } =
+      await setup("dep-noop");
+    // `live` is non-terminal (RunStarted only); `sealed` is already folded.
+    // Neither should be mutated even when handed to the sweep.
+    await seedPerEvent("live", [[0, "RunStarted"]]);
+    await seedSealed("sealed", [
+      [0, "RunStarted"],
+      [1, "RunCompleted"],
+    ]);
+
+    const result = await recoverInterruptedCompactions({
+      substrate,
+      repoId,
+      ref: REF,
+      anchorRunId,
+      pendingSealRunIds: ["live", "sealed"],
+    });
+    expect(result).toEqual({ sealed: 0, failed: [] });
+
+    // `live` keeps its per-event directory; `sealed` keeps its combined file.
+    expect(
+      (await fs.promises.readdir(path.join(runDir("live"), "events"))).sort(),
+    ).toEqual(["0.json"]);
+    await expect(
+      fs.promises.readdir(path.join(runDir("sealed"), "events")),
+    ).rejects.toThrow();
+    expect(
+      await fs.promises.readFile(
+        path.join(runDir("sealed"), "events.jsonl"),
+        "utf8",
+      ),
+    ).toBe(
+      `${ev("sealed", 0, "RunStarted")}\n${ev("sealed", 1, "RunCompleted")}\n`,
+    );
+  });
+
+  test("is safe when a live fold folds the same run concurrently", async () => {
+    // A sweep can race the live fire-and-forget fold for the same run. This
+    // composes the two; the exactly-once guarantee itself lives in
+    // compactRunEvents' own "two concurrent seals" test. Here we only assert
+    // the sweep participates safely: exactly one path seals, and the combined
+    // file survives intact.
+    const { repoId, substrate, anchorRunId, runDir, seedPerEvent } =
+      await setup("dep-concurrent");
+    await seedPerEvent("run-1", [
+      [0, "RunStarted"],
+      [1, "RunCompleted"],
+    ]);
+
+    const [sweep, direct] = await Promise.all([
+      recoverInterruptedCompactions({
+        substrate,
+        repoId,
+        ref: REF,
+        anchorRunId,
+        pendingSealRunIds: ["run-1"],
+      }),
+      compactRunEvents({
+        substrate,
+        repoId,
+        ref: REF,
+        anchorRunId,
+        runId: "run-1",
+      }),
+    ]);
+    expect(sweep.sealed + (direct.compacted ? 1 : 0)).toBe(1);
+    expect(sweep.failed).toEqual([]);
+
+    const combined = await fs.promises.readFile(
+      path.join(runDir("run-1"), "events.jsonl"),
+      "utf8",
+    );
+    expect(combined).toBe(
+      `${ev("run-1", 0, "RunStarted")}\n${ev("run-1", 1, "RunCompleted")}\n`,
+    );
+  });
+
+  test("records a failed fold and still seals the remaining runs", async () => {
+    const { repoId, substrate, anchorRunId, runDir, seedPerEvent } =
+      await setup("dep-failure");
+    // Two terminal-but-per-event runs. The write for `bad` is injected to
+    // throw; `good` must still seal, and `bad` must be reported in `failed`.
+    await seedPerEvent("bad", [
+      [0, "RunStarted"],
+      [1, "RunCompleted"],
+    ]);
+    await seedPerEvent("good", [
+      [0, "RunStarted"],
+      [1, "RunCompleted"],
+    ]);
+
+    const failing: typeof substrate = {
+      ...substrate,
+      writeTreePreservingPrefix: (
+        ...args: Parameters<typeof substrate.writeTreePreservingPrefix>
+      ) => {
+        const [, , , writeOpts] = args;
+        if (writeOpts.preservePrefix.includes("/bad/")) {
+          return Promise.reject(new Error("injected fold failure for bad"));
+        }
+        return substrate.writeTreePreservingPrefix(...args);
+      },
+    };
+
+    const result = await recoverInterruptedCompactions({
+      substrate: failing,
+      repoId,
+      ref: REF,
+      anchorRunId,
+      pendingSealRunIds: ["bad", "good"],
+    });
+    expect(result).toEqual({
+      sealed: 1,
+      failed: [{ runId: "bad", message: "injected fold failure for bad" }],
+    });
+
+    // `good` sealed; `bad` stays per-event, ready to retry on the next boot.
+    await expect(
+      fs.promises.readdir(path.join(runDir("good"), "events")),
+    ).rejects.toThrow();
+    expect(
+      (await fs.promises.readdir(path.join(runDir("bad"), "events"))).sort(),
+    ).toEqual(["0.json", "1.json"]);
+  });
+});

--- a/packages/workflow-host/src/supervisor/run-event-recovery.ts
+++ b/packages/workflow-host/src/supervisor/run-event-recovery.ts
@@ -1,0 +1,68 @@
+// Bounded recovery for run-event compaction folds a crash interrupted.
+//
+// When a run terminates, the supervisor fires `compactRunEvents` in the
+// background. A crash between the terminal commit and that fold leaves the
+// run terminal but still in per-event form, and the terminal signal never
+// fires again for it. At the next spawn the boot scan proposes those runs;
+// this sweep re-runs the idempotent fold for each so the leaked per-event
+// file count is reclaimed.
+
+import type {
+  RepoId,
+  RepoStore as SubstrateRepoStore,
+} from "@intx/hub-sessions/substrate";
+
+import { compactRunEvents } from "./run-event-compaction";
+
+export type RecoverInterruptedCompactionsOpts = {
+  /** Substrate handle the supervisor writes through. */
+  substrate: SubstrateRepoStore;
+  /** Workflow-run repo for this deployment. */
+  repoId: RepoId;
+  /** Events ref the workflow-run repo writes to. */
+  ref: string;
+  /** Anchor run id used to construct the supervisor principal. */
+  anchorRunId: string;
+  /** Runs the boot scan proposes as terminal-but-per-event. */
+  pendingSealRunIds: readonly string[];
+};
+
+/** A run whose recovery fold threw, paired with the failure cause. */
+export type RecoveryFoldFailure = { runId: string; message: string };
+
+/**
+ * Re-seal runs a crash left terminal but still in per-event form, by re-running
+ * the idempotent `compactRunEvents` for each proposed run. `compactRunEvents`
+ * is authoritative: it no-ops a run that is already sealed or whose latest
+ * event is not terminal, so a stale or mistaken proposal is a harmless no-op.
+ *
+ * Folds run serially. Every fold contends the same per-repo write lock that
+ * live dispatch also takes, so folding one run at a time drains the backlog
+ * without a thundering herd on that lock. One run's failure is caught so it
+ * cannot abort the rest; the failed run id and its cause are returned -- not
+ * logged here -- so the caller owns how to surface the aggregate.
+ */
+export async function recoverInterruptedCompactions(
+  opts: RecoverInterruptedCompactionsOpts,
+): Promise<{ sealed: number; failed: RecoveryFoldFailure[] }> {
+  let sealed = 0;
+  const failed: RecoveryFoldFailure[] = [];
+  for (const runId of opts.pendingSealRunIds) {
+    try {
+      const { compacted } = await compactRunEvents({
+        substrate: opts.substrate,
+        repoId: opts.repoId,
+        ref: opts.ref,
+        anchorRunId: opts.anchorRunId,
+        runId,
+      });
+      if (compacted) sealed += 1;
+    } catch (cause) {
+      failed.push({
+        runId,
+        message: cause instanceof Error ? cause.message : String(cause),
+      });
+    }
+  }
+  return { sealed, failed };
+}

--- a/packages/workflow-host/src/supervisor/supervisor.ts
+++ b/packages/workflow-host/src/supervisor/supervisor.ts
@@ -55,7 +55,7 @@ import {
   enqueueInbox as defaultEnqueueInbox,
   dequeueToProcessing as defaultDequeueToProcessing,
   markConsumed as defaultMarkConsumed,
-  readOwnedMessageIds,
+  scanRunsForBoot,
   readWorkflowRunLifecycle,
   replayProcessingToInbox as defaultReplayProcessingToInbox,
   StaleInboxEnqueueError,
@@ -100,6 +100,7 @@ import { commitCancelRequested } from "./cancel-signing";
 import { commitRunFailed } from "./terminal-commit";
 import { buildChildSpawnEnv } from "./spawn-env";
 import { compactRunEvents } from "./run-event-compaction";
+import { recoverInterruptedCompactions } from "./run-event-recovery";
 import { decodeMail } from "@intx/mime";
 import { commitMail, InvalidMailError } from "../adapters/mail-part-store";
 import {
@@ -1951,6 +1952,7 @@ export function createWorkflowSupervisor(
       terminalBroadcaster: createTerminalBroadcaster(),
       dispatchLoop: null,
       replayDone: null,
+      sweepDone: null,
     };
 
     // Everything from here to the successful `return` runs with the state
@@ -1985,11 +1987,16 @@ export function createWorkflowSupervisor(
       // first `dequeueToProcessing` so a fresh inbound mail that lands
       // during the replay window cannot ship ahead of the orphan once
       // the replay completes.
-      const replayDone = readOwnedMessageIds(
+      // One scan of `runs/` feeds both spawn-time recovery consumers: the
+      // orphan replay (which gates dispatch) and the compaction sweep (which
+      // does not). Sharing the walk keeps recovery off a second O(total-runs)
+      // scan.
+      const scanDone = scanRunsForBoot(
         bindings.repoStore,
         bindings.workflowRunRepoId,
-      )
-        .then((ownedMessageIds) =>
+      );
+      const replayDone = scanDone
+        .then(({ ownedMessageIds }) =>
           inboxPrimitives.replayProcessingToInbox(
             bindings.repoStore,
             inboxWritePrincipal,
@@ -2016,7 +2023,7 @@ export function createWorkflowSupervisor(
           // best-effort until that lands.
           const message =
             cause instanceof Error ? cause.message : String(cause);
-          logger.warn`replayProcessingToInbox on spawn failed: ${message}`;
+          logger.warn`boot recovery scan or processing replay failed on spawn: ${message}`;
         });
       // Hold the replay promise on the active-state record so
       // `shutdownInternal` awaits its settlement before tearing the
@@ -2024,6 +2031,40 @@ export function createWorkflowSupervisor(
       // flight would otherwise leave the substrate write pending past
       // the supervisor's exit.
       state.replayDone = replayDone;
+
+      // Re-seal runs a crash left terminal-but-per-event when their
+      // fire-and-forget fold never ran. Unlike the replay above, this must
+      // NOT gate dispatch: reclaiming leaked per-event files is housekeeping
+      // and cannot be allowed to delay the first dequeue. Best-effort, held
+      // on the active-state record so shutdown awaits its settlement (see the
+      // `sweepDone` field docstring for the teardown-latency tradeoff).
+      const sweepDone = scanDone
+        .then(({ pendingSealRunIds }) =>
+          recoverInterruptedCompactions({
+            substrate: bindings.repoStore,
+            repoId: bindings.workflowRunRepoId,
+            ref: bindings.workflowRunRef,
+            anchorRunId: bindings.anchorRunId,
+            pendingSealRunIds,
+          }),
+        )
+        .then(({ sealed, failed }) => {
+          if (sealed > 0) {
+            logger.info`recovery sweep sealed ${String(sealed)} interrupted run(s)`;
+          }
+          if (failed.length > 0) {
+            const detail = failed
+              .map((f) => `${f.runId} (${f.message})`)
+              .join("; ");
+            logger.warn`recovery sweep left ${String(failed.length)} run(s) unsealed: ${detail}`;
+          }
+        })
+        .catch((cause) => {
+          const message =
+            cause instanceof Error ? cause.message : String(cause);
+          logger.warn`boot recovery scan or compaction sweep failed on spawn: ${message}`;
+        });
+      state.sweepDone = sweepDone;
 
       bindings.mailBus.registerAddress(bindings.deploymentMailAddress);
       const mailUnsubscribe = bindings.mailBus.subscribeMailForAddress(
@@ -2145,6 +2186,7 @@ export function createWorkflowSupervisor(
         terminalBroadcaster: startingPhaseBroadcaster,
         dispatchLoop,
         replayDone,
+        sweepDone,
       };
       // Bump the generation and arm the exit-watcher atomically with the
       // running transition (no await between the swap above and this call)
@@ -3155,6 +3197,23 @@ export function createWorkflowSupervisor(
              path only waits for the substrate write to settle. */
         });
       }
+      if (
+        (prior.phase === "starting" ||
+          prior.phase === "running" ||
+          prior.phase === "recycling") &&
+        prior.sweepDone !== null
+      ) {
+        // Await the spawn-time compaction sweep before teardown so an
+        // in-flight fold's substrate commit does not outlive the supervisor
+        // and interleave with the next incarnation's boot. Teardown latency
+        // is bounded by the recovery backlog (see the `sweepDone` field
+        // docstring); a normal boot has zero or one pending fold.
+        await prior.sweepDone.catch(() => {
+          /* swallowed: the sweep's own catch already surfaces failures to
+             the supervisor's warn channel; the shutdown path only waits for
+             the in-flight fold's substrate commit to settle. */
+        });
+      }
       if (recyclePolicy !== null) {
         try {
           recyclePolicy.stop();
@@ -3411,6 +3470,7 @@ export function createWorkflowSupervisor(
       terminalBroadcaster: prior.terminalBroadcaster,
       dispatchLoop: null,
       replayDone: null,
+      sweepDone: prior.sweepDone,
     };
     let attempt: RecycleAttempt;
     try {
@@ -3544,6 +3604,7 @@ export function createWorkflowSupervisor(
               terminalBroadcaster: newBroadcaster,
               dispatchLoop: newDispatchLoop,
               replayDone: null,
+              sweepDone: prior.sweepDone,
             };
             // Bump the generation and arm the exit-watcher for the
             // respawned child atomically with this running transition, so
@@ -3889,6 +3950,23 @@ type ActiveState = {
    * `installNewChild` transitions back to `running`.
    */
   replayDone: Promise<void> | null;
+  /**
+   * Settles when the spawn-time compaction recovery sweep resolves (or
+   * rejects, swallowed via the supervisor's warn log). Tracked on the
+   * active-state record so `shutdownInternal` awaits its settlement before
+   * tearing the bindings down. Unlike `replayDone`, the dispatch loop does
+   * NOT borrow this promise: re-sealing interrupted folds is housekeeping and
+   * must not gate the first dequeue. The recycle-path ActiveState carries
+   * `prior.sweepDone` forward -- the sweep runs only at spawn, never on
+   * recycle -- so the last incarnation still awaits the original sweep.
+   *
+   * Awaiting full settlement couples teardown latency to the recovery
+   * backlog: the sweep is O(pending) serial substrate commits. This is
+   * acceptable because each fold is an idempotent atomic commit, so a fold
+   * abandoned at shutdown is simply re-proposed on the next boot; a normal
+   * boot has zero or one pending run.
+   */
+  sweepDone: Promise<void> | null;
 };
 
 type SpawnContext = {


### PR DESCRIPTION
## Summary

- A single boot scan of `runs/` yields both the orphan replay's owned
  message ids and the pending-seal run ids, so recovery adds no second
  walk of the run tree.
- A serial, best-effort sweep re-seals runs left terminal-but-per-event
  when a crash interrupts the fire-and-forget compaction fold, reusing the
  idempotent `compactRunEvents` and reporting `{ sealed, failed }`.
- The supervisor runs the sweep at spawn off the dispatch path and awaits
  its settlement at shutdown; the compaction fold and the boot scan share
  one terminal-event authority so they cannot disagree on which runs are
  terminal.

## Verification

- `make all` passes: lint, `tsc -b --noEmit --force`, the admin-ui bundle,
  and tests (7026 unit + 820 integration, 0 failures).
- New unit tests exercise the crash window end-to-end on a real temp-dir
  substrate: a terminal-but-per-event run seals to a byte-exact combined
  file, live and already-sealed runs are no-ops, a sweep racing a live fold
  seals exactly once, and a failed fold is reported without aborting the
  sweep.

Closes INTR-229