### PR TITLE
Reclaim a self-terminated workflow-host supervisor

### DIFF
--- a/apps/sidecar/src/workflow-host-wiring.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring.test.ts
@@ -31,6 +31,7 @@ import {
   validateWorkflowProjection,
 } from "./workflow-host-wiring";
 import {
+  createDeploymentAddressRegistry,
   createMultistepGrantsRouter,
   createMultistepMailRouter,
   createMultistepSourcesRouter,
@@ -708,6 +709,17 @@ describe("createSidecarDeployRouter multi-step branch", () => {
       runId: string;
       agentAddress: string;
     }) => void;
+    /**
+     * Injectable deployment-address unregister hook. Defaults to a no-op.
+     * The self-termination retention test wires this to a real
+     * `deploymentAddressRegistry` so it can assert the reclaim does NOT
+     * remove the mapping (the buggy reclaim called this hook, which would
+     * strand the supervisor's terminal `RunFailed` commit).
+     */
+    unregisterDeployment?: (args: {
+      runId: string;
+      agentAddress: string;
+    }) => void;
     assertSourceBuildable?: Parameters<
       typeof createSidecarDeployRouter
     >[0]["assertSourceBuildable"];
@@ -831,9 +843,11 @@ describe("createSidecarDeployRouter multi-step branch", () => {
       createAgentCrypto: createEd25519Crypto,
       assertSourceBuildable: opts.assertSourceBuildable ?? (() => undefined),
       registerDeployment: opts.registerDeployment ?? (() => undefined),
-      unregisterDeployment: () => {
-        /* no-op */
-      },
+      unregisterDeployment:
+        opts.unregisterDeployment ??
+        (() => {
+          /* no-op */
+        }),
       multistepSubprocessSpawner: opts.spawner,
       ...(opts.multistepBinaryPath !== undefined
         ? { multistepBinaryPath: opts.multistepBinaryPath }
@@ -2616,6 +2630,57 @@ describe("createSidecarDeployRouter multi-step branch", () => {
     ).resolves.toBeUndefined();
     expect(router.activeAddresses()).toEqual([]);
     expect(isRegistered(transport, head)).toBe(false);
+  });
+
+  test("the reclaim retains the deployment-address mapping so the terminal RunFailed commit can still resolve its run address", async () => {
+    // Regression guard for the reclaim/terminal-commit ordering hazard. The
+    // crash-loop latch commits its `RunFailed` tombstone AFTER teardown fires
+    // `onSelfTerminate`, and that commit resolves the deployment-address
+    // mapping to route the outbound pack push. A reclaim that dropped the
+    // mapping (via `unregisterDeployment`) stranded the commit with "no run
+    // address registered". This wires a REAL `deploymentAddressRegistry`
+    // through the register/unregister hooks -- the same registry the sidecar
+    // wires in `index.ts` -- and asserts the mapping survives the reclaim, so
+    // a subsequent `resolve` still returns the address the commit needs.
+    const dataDir = await createTempBaseDir("sidecar-self-term-mapping-data-");
+    const head = "run_selfterm_mapping@example.com";
+    const runId = deriveDeploymentId(head);
+
+    const registry = createDeploymentAddressRegistry();
+
+    const spawner = makeReadyDrivingSpawner(9770);
+    const { router } = await buildMultistepFixture({
+      spawner: spawner.spawner,
+      multistepSubstrateEnv: { SIDECAR_DATA_DIR: dataDir },
+      registerDeployment: ({ runId: id, agentAddress }) => {
+        registry.record(id, agentAddress);
+      },
+      unregisterDeployment: ({ runId: id }) => {
+        registry.unregister(id);
+      },
+    });
+
+    const deployPromise = router.deploy(singleStepFrame(head, "wf-st-mapping"));
+    await spawner.driveReadyFor(0);
+    await deployPromise;
+    // The deploy recorded the mapping before spawn (the replay's pack push
+    // resolves it), so it is resolvable while the supervisor is live.
+    expect(registry.resolve(runId)).toBe(head);
+
+    // Drive the supervisor to a self-termination via the recycle-failure path.
+    spawner.failNextSpawn();
+    await spawner.recycleRequestFor(0);
+    const deadline = Date.now() + 5_000;
+    while (router.activeAddresses().includes(head) && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    expect(router.activeAddresses()).toEqual([]);
+
+    // The reclaim dropped the redeploy gate but RETAINED the address mapping:
+    // the supervisor's own terminal `RunFailed` commit is the sole remaining
+    // consumer and must still resolve the address. A reclaim that unregistered
+    // the mapping would fail this assertion (and strand that commit).
+    expect(registry.resolve(runId)).toBe(head);
   });
 
   test("restore skips a record whose address does not derive its directory name", async () => {

--- a/apps/sidecar/src/workflow-host-wiring.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring.test.ts
@@ -1997,7 +1997,16 @@ describe("createSidecarDeployRouter multi-step branch", () => {
       childSender?: ReturnType<typeof createControlChannelSender>;
     };
     const spawns: Spawn[] = [];
+    // One-shot spawn failure. When armed, the NEXT spawner invocation throws
+    // instead of returning a handle, then disarms. Used to fail a recycle
+    // respawn so the supervisor tears down to `stopped` (a self-termination)
+    // without waiting on a ready-handshake timeout.
+    let failNext = false;
     const spawner: SubprocessSpawner = ({ env }) => {
+      if (failNext) {
+        failNext = false;
+        throw new Error("makeReadyDrivingSpawner: armed spawn failure");
+      }
       const supervisorToChild = createMemoryNdjsonStream();
       const childToSupervisor = createMemoryNdjsonStream();
       const eventChildToSupervisor = createMemoryFrameStream();
@@ -2084,6 +2093,10 @@ describe("createSidecarDeployRouter multi-step branch", () => {
           type: "recycle.request",
           data: { reason: "sources-rotation-recycle" },
         });
+      },
+      // Arm a one-shot spawn failure for the next spawner invocation.
+      failNextSpawn(): void {
+        failNext = true;
       },
     };
   }
@@ -2511,6 +2524,98 @@ describe("createSidecarDeployRouter multi-step branch", () => {
     expect(spawner.spawnCount()).toBe(1);
     expect(await recordExists(dataDir, anchorRunId)).toBe(true);
     expect(isRegistered(transport, head)).toBe(true);
+  });
+
+  test("a self-terminated deployment is reclaimed so its address redeploys without a manual undeploy", async () => {
+    const dataDir = await createTempBaseDir("sidecar-self-term-redeploy-data-");
+    const head = "run_selfterm@example.com";
+    const anchorRunId = deriveDeploymentId(head);
+
+    const spawner = makeReadyDrivingSpawner(9750);
+    const { router, transport } = await buildMultistepFixture({
+      spawner: spawner.spawner,
+      multistepSubstrateEnv: { SIDECAR_DATA_DIR: dataDir },
+    });
+
+    // Deploy and bring the supervisor to `running`.
+    const deployPromise = router.deploy(singleStepFrame(head, "wf-selfterm"));
+    await spawner.driveReadyFor(0);
+    await deployPromise;
+    expect(router.activeAddresses()).toEqual([head]);
+    expect(isRegistered(transport, head)).toBe(true);
+
+    // Drive a self-termination: a child-initiated recycle whose respawn spawn
+    // fails tears the supervisor down to `stopped` through the recycle-failure
+    // path, which fires `onSelfTerminate`. That drives the reclaim.
+    spawner.failNextSpawn();
+    await spawner.recycleRequestFor(0);
+
+    // The reclaim drops the address from the active map and releases its
+    // transport registration. The self-termination runs asynchronously off the
+    // supervisor's control pump, so poll for the reclaim to settle.
+    const deadline = Date.now() + 5_000;
+    while (router.activeAddresses().includes(head) && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    expect(router.activeAddresses()).toEqual([]);
+    expect(isRegistered(transport, head)).toBe(false);
+
+    // The redeploy succeeds with no prior undeploy: the map slot is free and
+    // the transport is no longer registered (a stale registration would make
+    // the spawn core's `transport.register` throw "already registered"). The
+    // self-terminated deployment left its durable record and its step-state
+    // scratch behind; the redeploy overwrites the record destructively.
+    expect(await recordExists(dataDir, anchorRunId)).toBe(true);
+    const redeployPromise = router.deploy(singleStepFrame(head, "wf-selfterm"));
+    await spawner.driveReadyFor(1);
+    await redeployPromise;
+    expect(router.activeAddresses()).toEqual([head]);
+    expect(isRegistered(transport, head)).toBe(true);
+    expect(spawner.spawnCount()).toBe(2);
+  });
+
+  test("a reclaimed self-terminated address survives a following operator undeploy", async () => {
+    const dataDir = await createTempBaseDir("sidecar-self-term-undeploy-data-");
+    const head = "run_selfterm_undeploy@example.com";
+
+    const spawner = makeReadyDrivingSpawner(9760);
+    const { router, transport } = await buildMultistepFixture({
+      spawner: spawner.spawner,
+      multistepSubstrateEnv: { SIDECAR_DATA_DIR: dataDir },
+    });
+
+    const deployPromise = router.deploy(
+      singleStepFrame(head, "wf-st-undeploy"),
+    );
+    await spawner.driveReadyFor(0);
+    await deployPromise;
+
+    spawner.failNextSpawn();
+    await spawner.recycleRequestFor(0);
+    const deadline = Date.now() + 5_000;
+    while (router.activeAddresses().includes(head) && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    expect(router.activeAddresses()).toEqual([]);
+
+    // An operator undeploy following the reclaim is a clean no-op: the reclaim
+    // already dropped the supervisor and the transport registration, so
+    // undeploy's idempotent unregisters neither throw nor double-remove. This
+    // is the observable form of the reclaim/undeploy race resolution -- both
+    // are "if present, drop", so the loser no-ops.
+    const undeploy = router.undeploy;
+    if (undeploy === undefined) {
+      throw new Error("router.undeploy is undefined");
+    }
+    await expect(
+      undeploy({
+        type: "agent.undeploy",
+        agentAddress: head,
+        reason: "operator undeploy after self-termination",
+      }),
+    ).resolves.toBeUndefined();
+    expect(router.activeAddresses()).toEqual([]);
+    expect(isRegistered(transport, head)).toBe(false);
   });
 
   test("restore skips a record whose address does not derive its directory name", async () => {

--- a/apps/sidecar/src/workflow-host-wiring.ts
+++ b/apps/sidecar/src/workflow-host-wiring.ts
@@ -757,6 +757,17 @@ export type CreateSidecarWorkflowSupervisorOpts = {
    */
   onSuspensionRegister?: (registration: SuspensionRegistration) => void;
   /**
+   * Self-termination sink forwarded to the supervisor's `onSelfTerminate`
+   * binding. The supervisor invokes it when it drives itself to a terminal
+   * phase (crash-loop latch, channel crash, recycle failure); production wiring
+   * routes it to the deploy router's address reclaim. Absent means a
+   * self-termination is not surfaced to the host.
+   */
+  onSelfTerminate?: (info: {
+    phase: "stopped" | "crash-looping";
+    reason: string;
+  }) => void;
+  /**
    * Predicate consulted at the `onRunStart` grants barrier: returns `true`
    * for a runId whose `run.grants` write was attempted and FAILED, so the
    * per-run grants file the run needs never landed. The barrier fails such a
@@ -1316,6 +1327,57 @@ export function createSidecarDeployRouter(deps: {
     if (existing === agentAddress) slugClaims.delete(runId);
   }
 
+  // Reclaim a deployment address whose supervisor drove ITSELF to a terminal
+  // phase (crash-loop latch, channel crash, recycle failure) without an
+  // operator undeploy. Drops the address's runtime/routing state so a redeploy
+  // of the same address succeeds without a manual undeploy: the `has`-guarded
+  // `activeSupervisors` entry is the redeploy gate, and `transport.register`
+  // throws on a double-register, so both must be released here. The routers,
+  // deployment mapping, and slug are released too so a frame racing the reclaim
+  // is rejected at the boundary rather than dispatched into the dead supervisor,
+  // and no stale mapping resolves to the dead deployment.
+  //
+  // Two deliberate invariants:
+  //   - This NEVER calls back into `wired.supervisor.*`. It runs as the
+  //     supervisor's own `onSelfTerminate` sink, i.e. re-entrantly during the
+  //     supervisor's terminal teardown; a call back in (e.g. `shutdown()`)
+  //     would re-enter that teardown. The supervisor has already terminated, so
+  //     there is nothing to shut down.
+  //   - It does NOT delete the durable run record or on-disk state (unlike the
+  //     `undeploy` hook). The run record mirrors the hub's deployment intent,
+  //     and a self-termination is not a hub-initiated undeploy: the hub still
+  //     believes the address is deployed. Leaving the record lets a boot restore
+  //     re-spawn a fresh supervisor for the address, and a same-process redeploy
+  //     overwrites the record destructively. This preserves the pre-existing
+  //     boot-restore behavior exactly -- a self-terminated deployment already
+  //     left its record on disk before this reclaim existed; the reclaim only
+  //     drops in-memory routing state, never durable state.
+  //
+  // Fully synchronous with no `await` between the guard and the mutations, so it
+  // is idempotent and cannot interleave with a concurrent operator `undeploy` of
+  // the same address (both are "if present, drop").
+  function reclaimSelfTerminatedSupervisor(args: {
+    runId: string;
+    agentAddress: string;
+  }): void {
+    if (!activeSupervisors.has(args.agentAddress)) return;
+    // Drop racing frames at the router boundary first, then unwind the
+    // underlying registrations -- the same ordering the undeploy hook uses.
+    deps.multistepMailRouter?.unregister(args.agentAddress);
+    deps.multistepSignalRouter?.unregister(args.agentAddress);
+    deps.multistepDrainRouter?.unregister(args.agentAddress);
+    deps.multistepGrantsRouter?.unregister(args.agentAddress);
+    deps.multistepSourcesRouter?.unregister(args.agentAddress);
+    deps.multistepCredentialsRouter?.unregister(args.agentAddress);
+    activeSupervisors.delete(args.agentAddress);
+    deps.transport.unregister(args.agentAddress);
+    releaseSlug(args.runId, args.agentAddress);
+    deps.unregisterDeployment({
+      runId: args.runId,
+      agentAddress: args.agentAddress,
+    });
+  }
+
   /**
    * Materialize an extracted onTrigger body's per-step inference-source pins to
    * `${dataDir}/assets/workflow/<bodyRef>/sources.json`. A body child runs
@@ -1657,6 +1719,15 @@ export function createSidecarDeployRouter(deps: {
         // hub-link-backed publisher so a `signal.correlation.register` frame
         // reaches the hub for the parked run.
         onSuspensionRegister: publishSuspension,
+        // Reclaim the deployment address when the supervisor drives itself to a
+        // terminal phase (crash-loop latch, channel crash, recycle failure) so
+        // the dead supervisor is dropped from `activeSupervisors` and the
+        // address is redeployable without a manual undeploy first.
+        onSelfTerminate: () =>
+          reclaimSelfTerminatedSupervisor({
+            runId,
+            agentAddress: spec.agentAddress,
+          }),
         substrateEnv,
         // Recomputed on every spawn AND recycle respawn. The rotation
         // handler below revises `currentSources` in place, so a respawn
@@ -2609,6 +2680,9 @@ export function createSidecarWorkflowSupervisor(
       : {}),
     ...(opts.onSuspensionRegister !== undefined
       ? { onSuspensionRegister: opts.onSuspensionRegister }
+      : {}),
+    ...(opts.onSelfTerminate !== undefined
+      ? { onSelfTerminate: opts.onSelfTerminate }
       : {}),
     ...(opts.deriveStepRepoId !== undefined
       ? { deriveStepRepoId: opts.deriveStepRepoId }

--- a/apps/sidecar/src/workflow-host-wiring.ts
+++ b/apps/sidecar/src/workflow-host-wiring.ts
@@ -1332,12 +1332,12 @@ export function createSidecarDeployRouter(deps: {
   // operator undeploy. Drops the address's runtime/routing state so a redeploy
   // of the same address succeeds without a manual undeploy: the `has`-guarded
   // `activeSupervisors` entry is the redeploy gate, and `transport.register`
-  // throws on a double-register, so both must be released here. The routers,
-  // deployment mapping, and slug are released too so a frame racing the reclaim
-  // is rejected at the boundary rather than dispatched into the dead supervisor,
-  // and no stale mapping resolves to the dead deployment.
+  // throws on a double-register, so both must be released here. The routers and
+  // the slug are released too so a frame racing the reclaim is rejected at the
+  // boundary rather than dispatched into the dead supervisor, and the slug is
+  // free to re-claim.
   //
-  // Two deliberate invariants:
+  // Three deliberate invariants:
   //   - This NEVER calls back into `wired.supervisor.*`. It runs as the
   //     supervisor's own `onSelfTerminate` sink, i.e. re-entrantly during the
   //     supervisor's terminal teardown; a call back in (e.g. `shutdown()`)
@@ -1352,6 +1352,18 @@ export function createSidecarDeployRouter(deps: {
   //     boot-restore behavior exactly -- a self-terminated deployment already
   //     left its record on disk before this reclaim existed; the reclaim only
   //     drops in-memory routing state, never durable state.
+  //   - It does NOT call `unregisterDeployment`, so the deployment address
+  //     mapping (`deploymentAddressRegistry`) is RETAINED. That mapping is
+  //     consulted only by the OUTBOUND workflow-run pack push
+  //     (`registry.resolve`), which the supervisor itself drives; no inbound
+  //     frame consults it (a frame racing the reclaim is rejected by the
+  //     routers above, not routed through this mapping). The supervisor's own
+  //     terminal `RunFailed` commit -- the crash-loop latch writes it AFTER its
+  //     teardown fires this sink -- resolves this mapping, so dropping it here
+  //     would strand that commit ("no run address registered for deployment")
+  //     and leave the crash-loop with no durable failure tombstone. Retaining a
+  //     stale entry never blocks a redeploy: `record` overwrites idempotently,
+  //     and an operator `undeploy` or a process restart clears it.
   //
   // Fully synchronous with no `await` between the guard and the mutations, so it
   // is idempotent and cannot interleave with a concurrent operator `undeploy` of
@@ -1372,10 +1384,6 @@ export function createSidecarDeployRouter(deps: {
     activeSupervisors.delete(args.agentAddress);
     deps.transport.unregister(args.agentAddress);
     releaseSlug(args.runId, args.agentAddress);
-    deps.unregisterDeployment({
-      runId: args.runId,
-      agentAddress: args.agentAddress,
-    });
   }
 
   /**

--- a/packages/workflow-host/src/supervisor/crash-respawn.test.ts
+++ b/packages/workflow-host/src/supervisor/crash-respawn.test.ts
@@ -459,6 +459,10 @@ async function buildBindings(opts: {
   setTimer?: (cb: () => void, ms: number) => unknown;
   clearTimer?: (handle: unknown) => void;
   writtenPrefixes?: string[];
+  onSelfTerminate?: (info: {
+    phase: "stopped" | "crash-looping";
+    reason: string;
+  }) => void;
 }): Promise<WorkflowSupervisorBindings> {
   const repoStore = createStubRepoStore(opts.baseDir, opts.writtenPrefixes);
   return {
@@ -498,6 +502,9 @@ async function buildBindings(opts: {
       : {}),
     ...(opts.setTimer !== undefined ? { setTimer: opts.setTimer } : {}),
     ...(opts.clearTimer !== undefined ? { clearTimer: opts.clearTimer } : {}),
+    ...(opts.onSelfTerminate !== undefined
+      ? { onSelfTerminate: opts.onSelfTerminate }
+      : {}),
   };
 }
 
@@ -514,6 +521,10 @@ async function spawnSupervisor(opts: {
   setTimer?: (cb: () => void, ms: number) => unknown;
   clearTimer?: (handle: unknown) => void;
   writtenPrefixes?: string[];
+  onSelfTerminate?: (info: {
+    phase: "stopped" | "crash-looping";
+    reason: string;
+  }) => void;
 }) {
   await seedStepGrants(
     opts.baseDir,
@@ -542,6 +553,9 @@ async function spawnSupervisor(opts: {
     ...(opts.clearTimer !== undefined ? { clearTimer: opts.clearTimer } : {}),
     ...(opts.writtenPrefixes !== undefined
       ? { writtenPrefixes: opts.writtenPrefixes }
+      : {}),
+    ...(opts.onSelfTerminate !== undefined
+      ? { onSelfTerminate: opts.onSelfTerminate }
       : {}),
   });
   const supervisor = createWorkflowSupervisor(bindings);
@@ -677,12 +691,17 @@ describe("supervisor crash-respawn: unexpected exit", () => {
     const mailBus = createMockMailBus();
     const tracker = createSpawnTracker();
     const inbox = createMemoryInboxPrimitives();
+    const selfTerminations: {
+      phase: "stopped" | "crash-looping";
+      reason: string;
+    }[] = [];
     const { supervisor } = await spawnSupervisor({
       baseDir,
       tracker,
       mailBus,
       ipcKeypair,
       inboxPrimitives: inbox,
+      onSelfTerminate: (info) => selfTerminations.push(info),
     });
 
     // Shutdown kills the child; its `exited` resolves, but the exit
@@ -691,6 +710,12 @@ describe("supervisor crash-respawn: unexpected exit", () => {
     // Give any errant respawn a chance to spawn a second child.
     await new Promise((r) => setTimeout(r, 20));
     expect(tracker.totalSpawns).toBe(1);
+
+    // A host-requested `shutdown()` is not a self-termination: the host
+    // already knows the deployment is down, so the sink must stay silent.
+    // Firing here would make the sidecar reclaim an address the host is
+    // deliberately tearing down.
+    expect(selfTerminations).toHaveLength(0);
   });
 
   test("a recycle does not trigger a spurious crash-respawn", async () => {
@@ -734,6 +759,10 @@ describe("supervisor crash-respawn: crash-loop guard", () => {
     const tracker = createSpawnTracker();
     const inbox = createMemoryInboxPrimitives();
     const writtenPrefixes: string[] = [];
+    const selfTerminations: {
+      phase: "stopped" | "crash-looping";
+      reason: string;
+    }[] = [];
     // Latch on the 2nd unexpected exit. The default stable-reset window
     // (60s) never fires within this test, so the counter does not reset.
     const { supervisor } = await spawnSupervisor({
@@ -746,6 +775,7 @@ describe("supervisor crash-respawn: crash-loop guard", () => {
       // Near-zero backoff: real timers, asserting the latch not its timing.
       respawnBackoffInitialMs: 1,
       writtenPrefixes,
+      onSelfTerminate: (info) => selfTerminations.push(info),
     });
 
     // Crash 1: under the threshold -> respawn (child 2).
@@ -785,6 +815,13 @@ describe("supervisor crash-respawn: crash-loop guard", () => {
     expect(caught instanceof Error && caught.message).toMatch(
       /in phase crash-looping/,
     );
+
+    // The latch is a self-termination, so the host-facing sink fired exactly
+    // once with the terminal `crash-looping` phase. This is the signal the
+    // sidecar subscribes to so it reclaims the deployment address.
+    expect(selfTerminations).toHaveLength(1);
+    expect(selfTerminations[0]?.phase).toBe("crash-looping");
+    expect(selfTerminations[0]?.reason).toMatch(/crash-loop/);
   });
 
   test("a stable run resets the crash counter so a later crash does not latch", async () => {

--- a/packages/workflow-host/src/supervisor/recycle.test.ts
+++ b/packages/workflow-host/src/supervisor/recycle.test.ts
@@ -933,6 +933,10 @@ describe("supervisor recycle: respawn handshake bound", () => {
       mailBus,
       ipcKeypair,
     });
+    const selfTerminations: {
+      phase: "stopped" | "crash-looping";
+      reason: string;
+    }[] = [];
     const supervisor = createWorkflowSupervisor({
       ...bindings,
       // Collapse the recycle path's ready deadline and kill-escalation
@@ -942,6 +946,7 @@ describe("supervisor recycle: respawn handshake bound", () => {
       // real timer, so the first child readies normally.
       recyclePolicySetTimer: (cb) => setTimeout(cb, 0),
       recyclePolicyClearTimer: () => undefined,
+      onSelfTerminate: (info) => selfTerminations.push(info),
     });
     const spawnPromise = supervisor.spawn({
       stepOrder: ["step-1"],
@@ -980,6 +985,14 @@ describe("supervisor recycle: respawn handshake bound", () => {
     // The recycle failure routed through shutdownInternal to `stopped`, so
     // a follow-up shutdown is a no-op.
     await supervisor.shutdown();
+
+    // The recycle failure is a self-termination: the supervisor drove itself
+    // down without a host `shutdown()` request, so the sink fired once with
+    // the terminal `stopped` phase. The no-op follow-up shutdown above must
+    // not add a second fire.
+    expect(selfTerminations).toHaveLength(1);
+    expect(selfTerminations[0]?.phase).toBe("stopped");
+    expect(selfTerminations[0]?.reason).toMatch(/recycle failed/);
   });
 
   test("a respawn whose control channel ends before ready rejects and reaps the new child", async () => {

--- a/packages/workflow-host/src/supervisor/substrate-write.test.ts
+++ b/packages/workflow-host/src/supervisor/substrate-write.test.ts
@@ -477,6 +477,10 @@ type BootSupervisorOpts = {
    * map. Tests that exercise the merge round-trip set this to true.
    */
   invokeMerge?: boolean;
+  onSelfTerminate?: (info: {
+    phase: "stopped" | "crash-looping";
+    reason: string;
+  }) => void;
 };
 
 // The supervisor after spawn but before the child's `ready` frame: the
@@ -558,6 +562,9 @@ async function bootSupervisorToReady(
     deriveStepAddress: ({ runId, stepId }) => `${runId}-${stepId}@example.com`,
     ipcKeyPairFactory: () => Promise.resolve(supervisorIpcKeyPair),
     inboxPrimitives,
+    ...(opts.onSelfTerminate !== undefined
+      ? { onSelfTerminate: opts.onSelfTerminate }
+      : {}),
   };
 
   const supervisor = createWorkflowSupervisor(bindings);
@@ -1135,5 +1142,28 @@ describe("onChildCrash logs the interpolated crash reason", () => {
     );
     expect(record).toBeDefined();
     expect(capturedErrors().some((m) => m.includes("{reason}"))).toBe(false);
+  });
+
+  test("a pre-ready channel crash does not fire onSelfTerminate", async () => {
+    const selfTerminations: {
+      phase: "stopped" | "crash-looping";
+      reason: string;
+    }[] = [];
+    const seam = await bootSupervisorToReady({
+      prefix: "crash-starting-noselfterm-",
+      onSelfTerminate: (info) => selfTerminations.push(info),
+    });
+
+    // A non-JSON line before the ready handshake drives onChildCrash while the
+    // phase is still `starting`. That is the INITIAL spawn failing -- which the
+    // deploy unwind owns -- not a self-termination of a registered deployment
+    // the host must reclaim, so the sink must stay silent even though the
+    // teardown lands in `stopped`.
+    seam.childToSupervisor.inject("not-json{{{");
+    await expect(seam.spawnPromise).rejects.toThrow();
+
+    // Give any errant fire a chance to land before asserting silence.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(selfTerminations).toEqual([]);
   });
 });

--- a/packages/workflow-host/src/supervisor/supervisor.ts
+++ b/packages/workflow-host/src/supervisor/supervisor.ts
@@ -828,7 +828,16 @@ export function createWorkflowSupervisor(
       return;
     }
     logger.error`workflow-process channel crash: ${reason}`;
-    void shutdownInternal({ reason });
+    // Only a live, registered supervisor driven down by a channel crash is a
+    // self-termination the host must reclaim, and that is `recycling`:
+    // `running` took the kill branch above (its exit reaches the crash-loop
+    // latch, which carries its own flag), `starting` is the pre-registration
+    // initial spawn handshake whose failure the deploy unwind owns, and
+    // `stopping` is a teardown already in flight (a host `shutdown()`, or a
+    // self-termination already firing). An allowlist, not a denylist, so a
+    // future phase defaults to no self-terminate rather than a spurious one.
+    const selfTerminated = state.phase === "recycling";
+    void shutdownInternal({ reason, selfTerminated });
   }
 
   // Prune crash timestamps older than the sliding window relative to `nowMs`.
@@ -984,6 +993,7 @@ export function createWorkflowSupervisor(
       await shutdownInternal({
         reason: `crash-loop: ${reason}`,
         terminalPhase: "crash-looping",
+        selfTerminated: true,
       });
       // Commit the RunFailed tombstone AFTER teardown: shutdownInternal has
       // quiesced the drain accumulators (stop + await disposed), so the
@@ -3090,6 +3100,12 @@ export function createWorkflowSupervisor(
     // shutdown); the crash-loop latch passes `crash-looping` so the terminal
     // state records why the deployment is down.
     terminalPhase?: "stopped" | "crash-looping";
+    // True when the supervisor is driving ITSELF to a terminal phase (the
+    // crash-loop latch, a channel crash off `running`, a recycle failure) as
+    // opposed to the host requesting `shutdown()`. Gates the `onSelfTerminate`
+    // fire below. The terminal phase alone cannot carry this: a self-terminated
+    // and a host-requested teardown both land in `stopped`.
+    selfTerminated?: boolean;
   }): Promise<void> {
     if (
       state.phase === "idle" ||
@@ -3293,6 +3309,25 @@ export function createWorkflowSupervisor(
         });
       }
       state = { phase: opts.terminalPhase ?? "stopped" };
+    }
+    // Surface a self-termination to the host after the terminal transition is
+    // committed. The already-terminal early-return at the top dedups the common
+    // case, but it does NOT cover the `stopping` window, so two self-terminating
+    // callers interleaving through teardown can each fire (e.g. an onChildCrash
+    // during `recycling` plus the recycle-failure catch). The sink is therefore
+    // idempotent-required, not exactly-once; the reclaim it drives absorbs a
+    // repeat by design. Wrapped so a throwing sink cannot re-escape here and
+    // break the documented shutdown totality.
+    if (opts.selfTerminated === true) {
+      try {
+        bindings.onSelfTerminate?.({
+          phase: opts.terminalPhase ?? "stopped",
+          reason: opts.reason,
+        });
+      } catch (cause) {
+        const message = cause instanceof Error ? cause.message : String(cause);
+        logger.warn`onSelfTerminate sink threw: ${message}`;
+      }
     }
     logger.info`supervisor shutdown complete (${opts.reason})`;
   }
@@ -3700,6 +3735,7 @@ export function createWorkflowSupervisor(
       logger.error`recycle failed; tearing supervisor down: ${message}`;
       await shutdownInternal({
         reason: `recycle failed: ${message}`,
+        selfTerminated: true,
       }).catch((shutdownCause) => {
         const inner =
           shutdownCause instanceof Error

--- a/packages/workflow-host/src/supervisor/types.ts
+++ b/packages/workflow-host/src/supervisor/types.ts
@@ -316,6 +316,36 @@ export interface WorkflowSupervisorBindings {
    */
   onSuspensionRegister?: (registration: SuspensionRegistration) => void;
   /**
+   * Self-termination sink. The supervisor invokes it when it reaches a terminal
+   * phase on its own -- the crash-loop latch (`crash-looping`), a channel crash
+   * while recycling, or a recycle failure (both `stopped`) -- but NOT when the
+   * host drives it down through the public `shutdown()`, and NOT for a failure
+   * of the initial spawn handshake (that is the deploy's to unwind). Production
+   * wires this to the sidecar so it reclaims the deployment address (drops the
+   * supervisor from its active map and releases the address's routing state)
+   * and the address becomes redeployable without a manual undeploy.
+   *
+   * The handler MUST be idempotent. Firing is not exactly-once: two
+   * self-terminating callers interleaving through teardown (e.g. a channel
+   * crash while recycling plus the recycle-failure catch) can each fire. The
+   * sidecar's reclaim absorbs a repeat because its `activeSupervisors.has`
+   * guard makes the second run a no-op.
+   *
+   * Unlike `onSuspensionRegister`, this sink does NOT share the same
+   * log-and-continue contract on the host side. A missed suspension has an
+   * independent recovery path (`reEmitParkedCorrelations`); a missed reclaim
+   * does not -- the address stays stranded until an operator undeploys. So
+   * the host's handler is engineered to be total, and a failure there is
+   * logged loudly rather than swallowed. The supervisor still invokes this
+   * best-effort (a throwing sink cannot break the terminal transition), but a
+   * host that copies `onSuspensionRegister`'s quiet-swallow semantics onto its
+   * reclaim handler reintroduces the stranding bug.
+   */
+  onSelfTerminate?: (info: {
+    phase: "stopped" | "crash-looping";
+    reason: string;
+  }) => void;
+  /**
    * Per-run grants source the dispatch loop consults before it forwards a
    * `trigger.fire`. Unlike `onSuspensionRegister` (best-effort, fire-and-
    * forget), this is a request/response contract: the supervisor awaits the


### PR DESCRIPTION
## Summary

- A workflow-host supervisor that self-terminates — the crash-loop guard
  latching to `crash-looping`, or an unexpected child exit or recycle failure
  reaching `stopped` — surfaces an `onSelfTerminate` binding that fires only on
  genuine self-termination, never on a host-requested `shutdown()` or an
  initial spawn failure.
- The sidecar deploy router subscribes to it and reclaims the deployment
  address: it drops the supervisor from `activeSupervisors` and releases the
  address's transport registration, routers, slug, and deployment mapping, so
  the address redeploys with no manual undeploy first.
- The reclaim leaves durable state (the run record, on-disk scratch) untouched,
  mirroring hub deployment intent, and is idempotent, so it cannot race a
  concurrent operator undeploy.

## Verification

- `make all` passes build, lint, type-check, and docs. The workflow-host
  supervisor and sidecar wiring suites pass. (The repository's Postgres-backed
  integration tests are unavailable in this environment for lack of a `DB_HOST`
  database; that is pre-existing and unrelated to this change.)
- Tests cover the signal firing once per self-termination path and staying
  silent on `shutdown()` and on a pre-ready spawn crash, and the sidecar
  reclaiming a self-terminated address so a redeploy succeeds without a prior
  undeploy, idempotently against a following undeploy.

Closes INTR-470