### PR TITLE
Track the README version from the git tag and skip DB tests without a database

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/faremeter/interchange/actions/workflows/ci.yml/badge.svg)](https://github.com/faremeter/interchange/actions/workflows/ci.yml)
 [![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#project-status)
-[![Version: 0.2.x](https://img.shields.io/badge/version-0.2.x-blue.svg)](#project-status)
+[![Version](https://img.shields.io/github/v/tag/faremeter/interchange?sort=semver&label=version&color=blue)](https://github.com/faremeter/interchange/tags)
 [![License: LGPL-2.1](https://img.shields.io/badge/license-LGPL--2.1-green.svg)](./LICENSE)
 [![Runtimes: Bun | Node | Deno](https://img.shields.io/badge/runtimes-Bun%20%7C%20Node%20%7C%20Deno-black.svg)](#runtime-support)
 
@@ -32,7 +32,7 @@ What you build on top is up to you:
 - **A research harness** of agents that talk to each other
 
 > [!WARNING]
-> **Interchange is alpha (`0.2.x`).** The architecture is settled and
+> **Interchange is alpha.** The architecture is settled and
 > the stack runs real workloads, but public APIs and wire formats can
 > still change between releases. Pin your versions, and see
 > [Project status](#project-status) for what's solid and what's still
@@ -239,7 +239,7 @@ For the full package map and dependency rules, see
 
 ## Project status
 
-Interchange is **alpha (`0.2.x`)** — usable, running real workloads,
+Interchange is **alpha** — usable, running real workloads,
 with the architecture settled and public APIs still liable to change
 before 1.0. This section is the honest state of things, and the
 repository is the source of truth. The design docs in

--- a/tests/lib/db-harness.ts
+++ b/tests/lib/db-harness.ts
@@ -24,8 +24,23 @@ import { quoteIdent } from "./grants";
 /**
  * Returns true when the repo has the `.env` files this harness reads:
  * `.env` (connection host/port/database) and `.env.migrate` (the
- * migration role). Test suites use this with `describe.skipIf(...)` so a
- * fresh checkout without a configured database can still run `make all`.
+ * migration role). A suite uses this so a fresh checkout without a
+ * configured database can still run `make all`: the DB-dependent tests
+ * skip instead of failing.
+ *
+ * Apply it in one of two shapes. A skip must gate every place that
+ * reaches the database, and the two shapes cover the two places a hook
+ * can live:
+ *
+ *   1. Wrap the suite in `describe.skipIf(!harnessDbEnvAvailable())(...)`
+ *      and keep the DB-touching `beforeAll`/`beforeEach` inside that
+ *      `describe`. `skipIf` skips the hooks together with the bodies.
+ *
+ *   2. For a setup hook at file scope (column 0, outside any
+ *      `describe`), open the hook with
+ *      `if (!harnessDbEnvAvailable()) return;`. A file-scope `beforeAll`
+ *      runs even when `describe.skipIf` skips the bodies, so the
+ *      `describe` guard alone does not cover it; the early return does.
  *
  * Absence-only: a file that exists but lacks a required key still
  * surfaces a loud error from `loadHarnessDbConfig`. The gate is

--- a/tests/workflow-deploy/asset-source.e2e.test.ts
+++ b/tests/workflow-deploy/asset-source.e2e.test.ts
@@ -38,7 +38,11 @@ import type { WorkflowDefinitionAssetSource } from "@intx/types/workflow-sources
 import { generateId } from "@intx/hub-common";
 import { deriveRunAddress, type ApprovalSet } from "@intx/workflow-deploy";
 import { deriveDeploymentId } from "@intx/sidecar-app/src/workflow-host-wiring";
-import { createTestDb, type TestDb } from "@intx/test-harness/db-harness";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
 import { seedAsset, seedPrincipal } from "@intx/test-harness/seed";
 
 import {
@@ -188,7 +192,7 @@ let fixture: WorkflowPackageFixture;
 // synthesizing it from the asset's tarballs; no HTTP).
 let blobsByPath: Map<string, Uint8Array>;
 
-describe("asset-sourced workflow e2e", () => {
+describe.skipIf(!harnessDbEnvAvailable())("asset-sourced workflow e2e", () => {
   beforeAll(async () => {
     scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), "asset-skeleton-"));
     fixture = await buildWorkflowPackageFixture(scratchDir);

--- a/tests/workflow-deploy/child-workflow-inherited-grants-roundtrip.test.ts
+++ b/tests/workflow-deploy/child-workflow-inherited-grants-roundtrip.test.ts
@@ -111,6 +111,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/child-workflow-roundtrip.test.ts
+++ b/tests/workflow-deploy/child-workflow-roundtrip.test.ts
@@ -234,6 +234,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/child-workflow-tool-invoke-roundtrip.test.ts
+++ b/tests/workflow-deploy/child-workflow-tool-invoke-roundtrip.test.ts
@@ -65,6 +65,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/crash-loop-latch.test.ts
+++ b/tests/workflow-deploy/crash-loop-latch.test.ts
@@ -78,6 +78,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/crash-respawn-fifo.test.ts
+++ b/tests/workflow-deploy/crash-respawn-fifo.test.ts
@@ -80,6 +80,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/crash-restart-reconnect-resumes.test.ts
+++ b/tests/workflow-deploy/crash-restart-reconnect-resumes.test.ts
@@ -83,6 +83,7 @@ let restartedSidecar: SidecarHandle | undefined;
 const restartTempDirs: string[] = [];
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/cross-process-custom-adapter.test.ts
+++ b/tests/workflow-deploy/cross-process-custom-adapter.test.ts
@@ -91,6 +91,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/deploy-window-reconnect-recovery.test.ts
+++ b/tests/workflow-deploy/deploy-window-reconnect-recovery.test.ts
@@ -79,6 +79,7 @@ let h: TestDb;
 let deploymentMailAddress: string;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   deploymentMailAddress = deriveRunAddress({
     runId: DEPLOYMENT_ID,
     domain: DEPLOYMENT_DOMAIN,

--- a/tests/workflow-deploy/drain-roundtrip.test.ts
+++ b/tests/workflow-deploy/drain-roundtrip.test.ts
@@ -94,6 +94,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/fifo-mail-load.test.ts
+++ b/tests/workflow-deploy/fifo-mail-load.test.ts
@@ -116,6 +116,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/fifo-mail.test.ts
+++ b/tests/workflow-deploy/fifo-mail.test.ts
@@ -95,6 +95,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/folded-tools-failover-real-agent.test.ts
+++ b/tests/workflow-deploy/folded-tools-failover-real-agent.test.ts
@@ -96,6 +96,7 @@ let headRequests = 0;
 let deadHead: ReturnType<typeof Bun.serve>;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/hub-link-reconnect.test.ts
+++ b/tests/workflow-deploy/hub-link-reconnect.test.ts
@@ -71,6 +71,7 @@ let h: TestDb;
 let deploymentMailAddress: string;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   deploymentMailAddress = deriveRunAddress({
     runId: DEPLOYMENT_ID,
     domain: DEPLOYMENT_DOMAIN,

--- a/tests/workflow-deploy/interrupted-pack-reconnect-recovery.test.ts
+++ b/tests/workflow-deploy/interrupted-pack-reconnect-recovery.test.ts
@@ -81,6 +81,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/loop-action-roundtrip.test.ts
+++ b/tests/workflow-deploy/loop-action-roundtrip.test.ts
@@ -50,6 +50,7 @@ let h: TestDb;
 let deploymentMailAddress: string;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   deploymentMailAddress = deriveRunAddress({
     runId: DEPLOYMENT_ID,
     domain: DEPLOYMENT_DOMAIN,

--- a/tests/workflow-deploy/loop-roundtrip.test.ts
+++ b/tests/workflow-deploy/loop-roundtrip.test.ts
@@ -50,6 +50,7 @@ let h: TestDb;
 let deploymentMailAddress: string;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   deploymentMailAddress = deriveRunAddress({
     runId: DEPLOYMENT_ID,
     domain: DEPLOYMENT_DOMAIN,

--- a/tests/workflow-deploy/mail-edge-cases.test.ts
+++ b/tests/workflow-deploy/mail-edge-cases.test.ts
@@ -106,6 +106,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/map-fan-out-real-agent.test.ts
+++ b/tests/workflow-deploy/map-fan-out-real-agent.test.ts
@@ -92,6 +92,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/midrun-signal-survives-reconnect.test.ts
+++ b/tests/workflow-deploy/midrun-signal-survives-reconnect.test.ts
@@ -71,6 +71,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/multistep-perstep-reroute-reconnect.test.ts
+++ b/tests/workflow-deploy/multistep-perstep-reroute-reconnect.test.ts
@@ -91,6 +91,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/multistep-signal.test.ts
+++ b/tests/workflow-deploy/multistep-signal.test.ts
@@ -74,6 +74,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/multistep-signed-send.test.ts
+++ b/tests/workflow-deploy/multistep-signed-send.test.ts
@@ -90,6 +90,7 @@ let h: TestDb;
 let deploymentMailAddress: string;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   deploymentMailAddress = deriveRunAddress({
     runId: DEPLOYMENT_ID,
     domain: DEPLOYMENT_DOMAIN,

--- a/tests/workflow-deploy/on-trigger-agent-body.test.ts
+++ b/tests/workflow-deploy/on-trigger-agent-body.test.ts
@@ -75,6 +75,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/on-trigger-between-events-restart.test.ts
+++ b/tests/workflow-deploy/on-trigger-between-events-restart.test.ts
@@ -97,6 +97,7 @@ let restartedSidecar: SidecarHandle | undefined;
 const restartTempDirs: string[] = [];
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/on-trigger-childworkflow-roundtrip.test.ts
+++ b/tests/workflow-deploy/on-trigger-childworkflow-roundtrip.test.ts
@@ -125,6 +125,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/on-trigger-signal-delivery.test.ts
+++ b/tests/workflow-deploy/on-trigger-signal-delivery.test.ts
@@ -93,6 +93,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/single-step-credential-tool.test.ts
+++ b/tests/workflow-deploy/single-step-credential-tool.test.ts
@@ -169,6 +169,7 @@ let origin: ReturnType<typeof Bun.serve>;
 const originRequests: { path: string; authorization: string | null }[] = [];
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   origin = Bun.serve({
     port: 0,
     fetch(req) {

--- a/tests/workflow-deploy/single-step-full-lifecycle.test.ts
+++ b/tests/workflow-deploy/single-step-full-lifecycle.test.ts
@@ -147,6 +147,7 @@ let h: TestDb;
 let deploymentMailAddress: string;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   // The inline `mail_send` tool in its transport variant calls
   // `env.transport.send` (the supervisor-backed transport) and sentinels only
   // on a successful receipt -- the OUTBOUND signed-send proof.

--- a/tests/workflow-deploy/single-step-grants-bridge.test.ts
+++ b/tests/workflow-deploy/single-step-grants-bridge.test.ts
@@ -123,6 +123,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/single-step-mail-flag-expunge.test.ts
+++ b/tests/workflow-deploy/single-step-mail-flag-expunge.test.ts
@@ -106,6 +106,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/single-step-mail-in-reply-to.test.ts
+++ b/tests/workflow-deploy/single-step-mail-in-reply-to.test.ts
@@ -84,6 +84,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/single-step-mail-interactive-turns.test.ts
+++ b/tests/workflow-deploy/single-step-mail-interactive-turns.test.ts
@@ -118,6 +118,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/single-step-mail-loop.test.ts
+++ b/tests/workflow-deploy/single-step-mail-loop.test.ts
@@ -103,6 +103,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/single-step-mail-two-turn-thread.test.ts
+++ b/tests/workflow-deploy/single-step-mail-two-turn-thread.test.ts
@@ -106,6 +106,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/single-step-mail-wait-wake.test.ts
+++ b/tests/workflow-deploy/single-step-mail-wait-wake.test.ts
@@ -92,6 +92,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/single-step-message-input.test.ts
+++ b/tests/workflow-deploy/single-step-message-input.test.ts
@@ -98,6 +98,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/single-step-per-run-grants.test.ts
+++ b/tests/workflow-deploy/single-step-per-run-grants.test.ts
@@ -87,6 +87,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/single-step-pinned-ask-tool.test.ts
+++ b/tests/workflow-deploy/single-step-pinned-ask-tool.test.ts
@@ -72,6 +72,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/single-step-posix-tool.test.ts
+++ b/tests/workflow-deploy/single-step-posix-tool.test.ts
@@ -93,6 +93,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/single-step-real-agent.test.ts
+++ b/tests/workflow-deploy/single-step-real-agent.test.ts
@@ -75,6 +75,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/source-catalog.e2e.test.ts
+++ b/tests/workflow-deploy/source-catalog.e2e.test.ts
@@ -29,7 +29,11 @@ import type { WorkflowDefinitionAssetSource } from "@intx/types/workflow-sources
 import { generateId } from "@intx/hub-common";
 import { deriveRunAddress, type ApprovalSet } from "@intx/workflow-deploy";
 import { deriveDeploymentId } from "@intx/sidecar-app/src/workflow-host-wiring";
-import { createTestDb, type TestDb } from "@intx/test-harness/db-harness";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
 import { seedAsset, seedPrincipal } from "@intx/test-harness/seed";
 
 import {
@@ -159,211 +163,216 @@ const resolveAttachment = async (
   return { pack, ref, commitSha };
 };
 
-describe("catalog: source-workflow e2e", () => {
-  beforeAll(async () => {
-    scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), "source-catalog-"));
-    const workflowJs = await bundleWorkflowEntry(scratchDir);
+describe.skipIf(!harnessDbEnvAvailable())(
+  "catalog: source-workflow e2e",
+  () => {
+    beforeAll(async () => {
+      scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), "source-catalog-"));
+      const workflowJs = await bundleWorkflowEntry(scratchDir);
 
-    h = await createTestDb();
-    await h.db.insert(tenantTable).values({
-      id: TENANT_ID,
-      name: TENANT_ID,
-      slug: TENANT_ID,
-      domain: DEPLOYMENT_DOMAIN,
-      parentId: null,
-    });
-    await seedPrincipal(h.db, {
-      id: CALLER_PRINCIPAL_ID,
-      tenantId: TENANT_ID,
-      kind: "user",
-    });
+      h = await createTestDb();
+      await h.db.insert(tenantTable).values({
+        id: TENANT_ID,
+        name: TENANT_ID,
+        slug: TENANT_ID,
+        domain: DEPLOYMENT_DOMAIN,
+        parentId: null,
+      });
+      await seedPrincipal(h.db, {
+        id: CALLER_PRINCIPAL_ID,
+        tenantId: TENANT_ID,
+        kind: "user",
+      });
 
-    env = await startDeployFlowEnv({});
+      env = await startDeployFlowEnv({});
 
-    // Seed the monorepo: a private root declaring a `catalog` for @wf/lib, the
-    // workflow member @wf/app depending on @wf/lib via `catalog:`, and @wf/lib.
-    await env.hub.agentRepoStore.repoStore.initRepo(sourceRepoId);
-    const writeResult = await env.hub.agentRepoStore.repoStore.writeTree(
-      HUB_PRINCIPAL,
-      sourceRepoId,
-      DEFAULT_ASSET_REF,
-      {
-        files: {
-          "package.json": JSON.stringify({
-            name: "@wf/catalog-root",
-            private: true,
-            workspaces: ["packages/*"],
-            catalog: { [LIB_PACKAGE_NAME]: "*" },
-          }),
-          "packages/app/package.json": JSON.stringify({
-            name: APP_PACKAGE_NAME,
-            version: PACKAGE_VERSION,
-            type: "module",
-            interchange: { workflow: WORKFLOW_ENTRY },
-            dependencies: { [LIB_PACKAGE_NAME]: "catalog:" },
-          }),
-          "packages/app/workflow.mjs": workflowJs,
-          "packages/lib/package.json": JSON.stringify({
-            name: LIB_PACKAGE_NAME,
-            version: PACKAGE_VERSION,
-            type: "module",
-            exports: "./index.mjs",
-          }),
-          "packages/lib/index.mjs": libSource,
-        },
-        message: "Seed catalog-resolved monorepo source",
-      },
-    );
-    sourceCommitSha = writeResult.commitSha;
-  });
-
-  afterAll(async () => {
-    if (env !== undefined) await env.teardown();
-    if (h !== undefined) await h.close();
-    if (scratchDir !== undefined) {
-      await fs.rm(scratchDir, { recursive: true, force: true });
-    }
-  });
-
-  test("resolves a catalog: dependency and runs the workflow to completion", async () => {
-    await seedAsset(h.db, {
-      id: DEFINITION_ASSET_ID,
-      tenantId: TENANT_ID,
-      kind: "workflow",
-      name: "source-catalog-wf",
-      creatorPrincipalId: CALLER_PRINCIPAL_ID,
-    });
-
-    const source: WorkflowDefinitionAssetSource = {
-      kind: "asset",
-      assetId: SOURCE_ASSET_ID,
-      package: {
-        format: "source",
-        commitSha: sourceCommitSha,
-        packageName: APP_PACKAGE_NAME,
-      },
-    };
-
-    const committed =
-      await env.hub.agentRepoStore.repoStore.openCommittedReadsAtCommit(
+      // Seed the monorepo: a private root declaring a `catalog` for @wf/lib, the
+      // workflow member @wf/app depending on @wf/lib via `catalog:`, and @wf/lib.
+      await env.hub.agentRepoStore.repoStore.initRepo(sourceRepoId);
+      const writeResult = await env.hub.agentRepoStore.repoStore.writeTree(
         HUB_PRINCIPAL,
         sourceRepoId,
-        sourceCommitSha,
+        DEFAULT_ASSET_REF,
+        {
+          files: {
+            "package.json": JSON.stringify({
+              name: "@wf/catalog-root",
+              private: true,
+              workspaces: ["packages/*"],
+              catalog: { [LIB_PACKAGE_NAME]: "*" },
+            }),
+            "packages/app/package.json": JSON.stringify({
+              name: APP_PACKAGE_NAME,
+              version: PACKAGE_VERSION,
+              type: "module",
+              interchange: { workflow: WORKFLOW_ENTRY },
+              dependencies: { [LIB_PACKAGE_NAME]: "catalog:" },
+            }),
+            "packages/app/workflow.mjs": workflowJs,
+            "packages/lib/package.json": JSON.stringify({
+              name: LIB_PACKAGE_NAME,
+              version: PACKAGE_VERSION,
+              type: "module",
+              exports: "./index.mjs",
+            }),
+            "packages/lib/index.mjs": libSource,
+          },
+          message: "Seed catalog-resolved monorepo source",
+        },
       );
-    if (committed === null) {
-      throw new Error("catalog e2e: could not open committed reads at commit");
-    }
-
-    const approvals: ApprovalSet = new Set<string>([
-      "inference.source:anthropic:mock-model",
-      "director:@intx/agent/default",
-      `mail.address:${deploymentMailAddress}`,
-      `mail.send:${DEPLOYMENT_DOMAIN}`,
-    ]);
-
-    const approved = await installAndApproveWorkflowDefinition({
-      source,
-      entry: WORKFLOW_ENTRY,
-      assetId: DEFINITION_ASSET_ID,
-      approvals,
-      router: env.hub.router,
-      db: h.db,
-      reads: committedReadsToSourceTree(committed),
-      registryName: "npmjs",
-      registryConfig: { url: "https://registry.test" },
-      resolveAttachment,
+      sourceCommitSha = writeResult.commitSha;
     });
-    if (!approved.approval.ok) {
-      throw new Error(
-        `catalog e2e: install did not approve (reason: ${approved.approval.reason}): ${JSON.stringify(approved.approval)}\n${env.sidecarDiagnostics()}`,
-      );
-    }
-    expect(approved.projection.id).toBe("wf_catalog");
-    // Both members are source entries: @wf/lib resolved through `catalog:`.
-    const byName = new Map(approved.closure.entries.map((e) => [e.name, e]));
-    for (const memberName of [APP_PACKAGE_NAME, LIB_PACKAGE_NAME]) {
-      const entry = byName.get(memberName);
-      if (entry?.source.kind !== "asset") {
-        throw new Error(`catalog e2e: ${memberName} is not asset-sourced`);
+
+    afterAll(async () => {
+      if (env !== undefined) await env.teardown();
+      if (h !== undefined) await h.close();
+      if (scratchDir !== undefined) {
+        await fs.rm(scratchDir, { recursive: true, force: true });
       }
-      expect(entry.source.package.format).toBe("source");
-    }
-
-    const inferenceSource = {
-      id: "anthropic:mock-model",
-      provider: "anthropic",
-      baseURL: `http://localhost:${String(env.inference.server.port)}`,
-      apiKey: "sk-mock",
-      model: "mock-model",
-    };
-    const config: HarnessConfig = {
-      sessionId: SESSION_ID,
-      agentId: DEPLOYMENT_ID,
-      tenantId: "tenant-1",
-      principalId: "prin_integration-1",
-      agentAddress: deploymentMailAddress,
-      systemPrompt: "Fallback prompt (overridden per step by the definition)",
-      tools: [],
-      grants: [],
-      sources: [inferenceSource],
-      defaultSource: "anthropic:mock-model",
-    };
-
-    await deployCodeSourcedWorkflow({
-      approved,
-      source,
-      resolveAttachment,
-      sidecarRouter: env.hub.router,
-      agentAddress: deploymentMailAddress,
-      config,
-      sources: { [STEP_ID]: [inferenceSource] },
-      db: h.db,
-      tenantId: TENANT_ID,
-      anchorRunId: DEPLOYMENT_ID,
-      deploymentDomain: DEPLOYMENT_DOMAIN,
     });
 
-    const workflowRunRepoId: RepoId = {
-      kind: "workflow-run",
-      id: deriveDeploymentId(deploymentMailAddress),
-    };
-    env.registerDeployment({
-      anchorRunId: DEPLOYMENT_ID,
-      workflowDefinition: {
-        id: approved.projection.id,
-        triggers: [{ type: "mail", to: deploymentMailAddress }],
-        steps: {},
-        stepOrder: [...approved.projection.stepOrder],
-      },
-      workflowRunRepoId,
-      workflowRunRef: WORKFLOW_RUN_REF,
-      mailAddress: deploymentMailAddress,
-    });
+    test("resolves a catalog: dependency and runs the workflow to completion", async () => {
+      await seedAsset(h.db, {
+        id: DEFINITION_ASSET_ID,
+        tenantId: TENANT_ID,
+        kind: "workflow",
+        name: "source-catalog-wf",
+        creatorPrincipalId: CALLER_PRINCIPAL_ID,
+      });
 
-    await waitFor(
-      () =>
-        env.hub.router.getRoutableAddresses().includes(deploymentMailAddress),
-      { timeoutMs: 20_000, diagnostics: env.sidecarDiagnostics },
-    );
+      const source: WorkflowDefinitionAssetSource = {
+        kind: "asset",
+        assetId: SOURCE_ASSET_ID,
+        package: {
+          format: "source",
+          commitSha: sourceCommitSha,
+          packageName: APP_PACKAGE_NAME,
+        },
+      };
 
-    await fireMailTrigger(env, deploymentMailAddress, {
-      messageId: "<source-catalog-e2e@integration.interchange>",
-    });
-    const runId = await waitForFirstRunId(env, workflowRunRepoId, {
-      timeoutMs: 30_000,
-      diagnostics: env.sidecarDiagnostics,
-    });
-    const terminal = await waitForWorkflowRunComplete(
-      env,
-      DEPLOYMENT_ID,
-      runId,
-      { timeoutMs: 30_000, diagnostics: env.sidecarDiagnostics },
-    );
-    if (terminal.type !== "RunCompleted") {
-      throw new Error(
-        `catalog e2e: expected RunCompleted, got ${terminal.type}: ${JSON.stringify(terminal.body)}\n${env.sidecarDiagnostics()}`,
+      const committed =
+        await env.hub.agentRepoStore.repoStore.openCommittedReadsAtCommit(
+          HUB_PRINCIPAL,
+          sourceRepoId,
+          sourceCommitSha,
+        );
+      if (committed === null) {
+        throw new Error(
+          "catalog e2e: could not open committed reads at commit",
+        );
+      }
+
+      const approvals: ApprovalSet = new Set<string>([
+        "inference.source:anthropic:mock-model",
+        "director:@intx/agent/default",
+        `mail.address:${deploymentMailAddress}`,
+        `mail.send:${DEPLOYMENT_DOMAIN}`,
+      ]);
+
+      const approved = await installAndApproveWorkflowDefinition({
+        source,
+        entry: WORKFLOW_ENTRY,
+        assetId: DEFINITION_ASSET_ID,
+        approvals,
+        router: env.hub.router,
+        db: h.db,
+        reads: committedReadsToSourceTree(committed),
+        registryName: "npmjs",
+        registryConfig: { url: "https://registry.test" },
+        resolveAttachment,
+      });
+      if (!approved.approval.ok) {
+        throw new Error(
+          `catalog e2e: install did not approve (reason: ${approved.approval.reason}): ${JSON.stringify(approved.approval)}\n${env.sidecarDiagnostics()}`,
+        );
+      }
+      expect(approved.projection.id).toBe("wf_catalog");
+      // Both members are source entries: @wf/lib resolved through `catalog:`.
+      const byName = new Map(approved.closure.entries.map((e) => [e.name, e]));
+      for (const memberName of [APP_PACKAGE_NAME, LIB_PACKAGE_NAME]) {
+        const entry = byName.get(memberName);
+        if (entry?.source.kind !== "asset") {
+          throw new Error(`catalog e2e: ${memberName} is not asset-sourced`);
+        }
+        expect(entry.source.package.format).toBe("source");
+      }
+
+      const inferenceSource = {
+        id: "anthropic:mock-model",
+        provider: "anthropic",
+        baseURL: `http://localhost:${String(env.inference.server.port)}`,
+        apiKey: "sk-mock",
+        model: "mock-model",
+      };
+      const config: HarnessConfig = {
+        sessionId: SESSION_ID,
+        agentId: DEPLOYMENT_ID,
+        tenantId: "tenant-1",
+        principalId: "prin_integration-1",
+        agentAddress: deploymentMailAddress,
+        systemPrompt: "Fallback prompt (overridden per step by the definition)",
+        tools: [],
+        grants: [],
+        sources: [inferenceSource],
+        defaultSource: "anthropic:mock-model",
+      };
+
+      await deployCodeSourcedWorkflow({
+        approved,
+        source,
+        resolveAttachment,
+        sidecarRouter: env.hub.router,
+        agentAddress: deploymentMailAddress,
+        config,
+        sources: { [STEP_ID]: [inferenceSource] },
+        db: h.db,
+        tenantId: TENANT_ID,
+        anchorRunId: DEPLOYMENT_ID,
+        deploymentDomain: DEPLOYMENT_DOMAIN,
+      });
+
+      const workflowRunRepoId: RepoId = {
+        kind: "workflow-run",
+        id: deriveDeploymentId(deploymentMailAddress),
+      };
+      env.registerDeployment({
+        anchorRunId: DEPLOYMENT_ID,
+        workflowDefinition: {
+          id: approved.projection.id,
+          triggers: [{ type: "mail", to: deploymentMailAddress }],
+          steps: {},
+          stepOrder: [...approved.projection.stepOrder],
+        },
+        workflowRunRepoId,
+        workflowRunRef: WORKFLOW_RUN_REF,
+        mailAddress: deploymentMailAddress,
+      });
+
+      await waitFor(
+        () =>
+          env.hub.router.getRoutableAddresses().includes(deploymentMailAddress),
+        { timeoutMs: 20_000, diagnostics: env.sidecarDiagnostics },
       );
-    }
-    expect(terminal.type).toBe("RunCompleted");
-  }, 180_000);
-});
+
+      await fireMailTrigger(env, deploymentMailAddress, {
+        messageId: "<source-catalog-e2e@integration.interchange>",
+      });
+      const runId = await waitForFirstRunId(env, workflowRunRepoId, {
+        timeoutMs: 30_000,
+        diagnostics: env.sidecarDiagnostics,
+      });
+      const terminal = await waitForWorkflowRunComplete(
+        env,
+        DEPLOYMENT_ID,
+        runId,
+        { timeoutMs: 30_000, diagnostics: env.sidecarDiagnostics },
+      );
+      if (terminal.type !== "RunCompleted") {
+        throw new Error(
+          `catalog e2e: expected RunCompleted, got ${terminal.type}: ${JSON.stringify(terminal.body)}\n${env.sidecarDiagnostics()}`,
+        );
+      }
+      expect(terminal.type).toBe("RunCompleted");
+    }, 180_000);
+  },
+);

--- a/tests/workflow-deploy/source-credential.e2e.test.ts
+++ b/tests/workflow-deploy/source-credential.e2e.test.ts
@@ -32,7 +32,11 @@ import { createNoopCredentialCipher } from "@intx/crypto";
 import { generateId } from "@intx/hub-common";
 import { deriveRunAddress, type ApprovalSet } from "@intx/workflow-deploy";
 import { deriveDeploymentId } from "@intx/sidecar-app/src/workflow-host-wiring";
-import { createTestDb, type TestDb } from "@intx/test-harness/db-harness";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
 import {
   seedAsset,
   seedCredential,
@@ -169,200 +173,205 @@ const resolveAttachment = async (
   return { pack, ref, commitSha };
 };
 
-describe("credential-bound source-workflow e2e", () => {
-  beforeAll(async () => {
-    scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), "source-credential-"));
-    const workflowJs = await bundleWorkflowEntry(scratchDir);
+describe.skipIf(!harnessDbEnvAvailable())(
+  "credential-bound source-workflow e2e",
+  () => {
+    beforeAll(async () => {
+      scratchDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), "source-credential-"),
+      );
+      const workflowJs = await bundleWorkflowEntry(scratchDir);
 
-    h = await createTestDb();
-    await h.db.insert(tenantTable).values({
-      id: TENANT_ID,
-      name: TENANT_ID,
-      slug: TENANT_ID,
-      domain: DEPLOYMENT_DOMAIN,
-      parentId: null,
-    });
-    await seedPrincipal(h.db, {
-      id: CALLER_PRINCIPAL_ID,
-      tenantId: TENANT_ID,
-      kind: "user",
-    });
-    // The tenant-owned provider + credential the binding resolves against.
-    await seedProvider(h.db, {
-      id: PROVIDER_ID,
-      tenantId: TENANT_ID,
-      name: PROVIDER_NAME,
-      // Origin-pinned delivery needs the provider's API base URL.
-      apiBaseUrl: "https://api.test-provider.example",
-    });
-    await seedCredential(h.db, {
-      id: CREDENTIAL_ID,
-      tenantId: TENANT_ID,
-      providerId: PROVIDER_ID,
-      name: CREDENTIAL_NAME,
-    });
+      h = await createTestDb();
+      await h.db.insert(tenantTable).values({
+        id: TENANT_ID,
+        name: TENANT_ID,
+        slug: TENANT_ID,
+        domain: DEPLOYMENT_DOMAIN,
+        parentId: null,
+      });
+      await seedPrincipal(h.db, {
+        id: CALLER_PRINCIPAL_ID,
+        tenantId: TENANT_ID,
+        kind: "user",
+      });
+      // The tenant-owned provider + credential the binding resolves against.
+      await seedProvider(h.db, {
+        id: PROVIDER_ID,
+        tenantId: TENANT_ID,
+        name: PROVIDER_NAME,
+        // Origin-pinned delivery needs the provider's API base URL.
+        apiBaseUrl: "https://api.test-provider.example",
+      });
+      await seedCredential(h.db, {
+        id: CREDENTIAL_ID,
+        tenantId: TENANT_ID,
+        providerId: PROVIDER_ID,
+        name: CREDENTIAL_NAME,
+      });
 
-    env = await startDeployFlowEnv({});
+      env = await startDeployFlowEnv({});
 
-    await env.hub.agentRepoStore.repoStore.initRepo(sourceRepoId);
-    const writeResult = await env.hub.agentRepoStore.repoStore.writeTree(
-      HUB_PRINCIPAL,
-      sourceRepoId,
-      DEFAULT_ASSET_REF,
-      {
-        files: {
-          "package.json": JSON.stringify({
-            name: PACKAGE_NAME,
-            version: PACKAGE_VERSION,
-            interchange: { workflow: WORKFLOW_ENTRY },
-          }),
-          "workflow.mjs": workflowJs,
-        },
-        message: "Seed credential-skeleton workflow package",
-      },
-    );
-    sourceCommitSha = writeResult.commitSha;
-  });
-
-  afterAll(async () => {
-    if (env !== undefined) await env.teardown();
-    if (h !== undefined) await h.close();
-    if (scratchDir !== undefined) {
-      await fs.rm(scratchDir, { recursive: true, force: true });
-    }
-  });
-
-  test("resolves and delivers a credential binding on a source deploy", async () => {
-    await seedAsset(h.db, {
-      id: DEFINITION_ASSET_ID,
-      tenantId: TENANT_ID,
-      kind: "workflow",
-      name: "source-credential-wf",
-      creatorPrincipalId: CALLER_PRINCIPAL_ID,
-    });
-
-    const source: WorkflowDefinitionAssetSource = {
-      kind: "asset",
-      assetId: SOURCE_ASSET_ID,
-      package: { format: "source", commitSha: sourceCommitSha },
-    };
-
-    const committed =
-      await env.hub.agentRepoStore.repoStore.openCommittedReadsAtCommit(
+      await env.hub.agentRepoStore.repoStore.initRepo(sourceRepoId);
+      const writeResult = await env.hub.agentRepoStore.repoStore.writeTree(
         HUB_PRINCIPAL,
         sourceRepoId,
-        sourceCommitSha,
+        DEFAULT_ASSET_REF,
+        {
+          files: {
+            "package.json": JSON.stringify({
+              name: PACKAGE_NAME,
+              version: PACKAGE_VERSION,
+              interchange: { workflow: WORKFLOW_ENTRY },
+            }),
+            "workflow.mjs": workflowJs,
+          },
+          message: "Seed credential-skeleton workflow package",
+        },
       );
-    if (committed === null) {
-      throw new Error("credential e2e: could not open committed reads");
-    }
-
-    const approvals: ApprovalSet = new Set<string>([
-      "inference.source:anthropic:mock-model",
-      "director:@intx/agent/default",
-      `mail.address:${deploymentMailAddress}`,
-      `mail.send:${DEPLOYMENT_DOMAIN}`,
-      `credential:${CREDENTIAL_HANDLE}`,
-    ]);
-
-    const approved = await installAndApproveWorkflowDefinition({
-      source,
-      entry: WORKFLOW_ENTRY,
-      assetId: DEFINITION_ASSET_ID,
-      approvals,
-      router: env.hub.router,
-      db: h.db,
-      reads: committedReadsToSourceTree(committed),
-      registryName: "npmjs",
-      registryConfig: { url: "https://registry.test" },
-      resolveAttachment,
+      sourceCommitSha = writeResult.commitSha;
     });
-    if (!approved.approval.ok) {
-      throw new Error(
-        `credential e2e: install did not approve (reason: ${approved.approval.reason}): ${JSON.stringify(approved.approval)}\n${env.sidecarDiagnostics()}`,
+
+    afterAll(async () => {
+      if (env !== undefined) await env.teardown();
+      if (h !== undefined) await h.close();
+      if (scratchDir !== undefined) {
+        await fs.rm(scratchDir, { recursive: true, force: true });
+      }
+    });
+
+    test("resolves and delivers a credential binding on a source deploy", async () => {
+      await seedAsset(h.db, {
+        id: DEFINITION_ASSET_ID,
+        tenantId: TENANT_ID,
+        kind: "workflow",
+        name: "source-credential-wf",
+        creatorPrincipalId: CALLER_PRINCIPAL_ID,
+      });
+
+      const source: WorkflowDefinitionAssetSource = {
+        kind: "asset",
+        assetId: SOURCE_ASSET_ID,
+        package: { format: "source", commitSha: sourceCommitSha },
+      };
+
+      const committed =
+        await env.hub.agentRepoStore.repoStore.openCommittedReadsAtCommit(
+          HUB_PRINCIPAL,
+          sourceRepoId,
+          sourceCommitSha,
+        );
+      if (committed === null) {
+        throw new Error("credential e2e: could not open committed reads");
+      }
+
+      const approvals: ApprovalSet = new Set<string>([
+        "inference.source:anthropic:mock-model",
+        "director:@intx/agent/default",
+        `mail.address:${deploymentMailAddress}`,
+        `mail.send:${DEPLOYMENT_DOMAIN}`,
+        `credential:${CREDENTIAL_HANDLE}`,
+      ]);
+
+      const approved = await installAndApproveWorkflowDefinition({
+        source,
+        entry: WORKFLOW_ENTRY,
+        assetId: DEFINITION_ASSET_ID,
+        approvals,
+        router: env.hub.router,
+        db: h.db,
+        reads: committedReadsToSourceTree(committed),
+        registryName: "npmjs",
+        registryConfig: { url: "https://registry.test" },
+        resolveAttachment,
+      });
+      if (!approved.approval.ok) {
+        throw new Error(
+          `credential e2e: install did not approve (reason: ${approved.approval.reason}): ${JSON.stringify(approved.approval)}\n${env.sidecarDiagnostics()}`,
+        );
+      }
+      expect(approved.projection.id).toBe("wf_source_credential");
+      expect(approved.projection.credentialBindings?.length).toBe(1);
+
+      const inferenceSource = {
+        id: "anthropic:mock-model",
+        provider: "anthropic",
+        baseURL: `http://localhost:${String(env.inference.server.port)}`,
+        apiKey: "sk-mock",
+        model: "mock-model",
+      };
+      const config: HarnessConfig = {
+        sessionId: SESSION_ID,
+        agentId: DEPLOYMENT_ID,
+        tenantId: "tenant-1",
+        principalId: "prin_integration-1",
+        agentAddress: deploymentMailAddress,
+        systemPrompt: "Fallback prompt (overridden per step by the definition)",
+        tools: [],
+        grants: [],
+        sources: [inferenceSource],
+        defaultSource: "anthropic:mock-model",
+      };
+
+      // Deploy with a credential cipher: the binding is resolved from the DB and
+      // decrypted through it. A no-op cipher passes the seeded material verbatim.
+      await deployCodeSourcedWorkflow({
+        approved,
+        source,
+        resolveAttachment,
+        sidecarRouter: env.hub.router,
+        agentAddress: deploymentMailAddress,
+        config,
+        sources: { [STEP_ID]: [inferenceSource] },
+        db: h.db,
+        tenantId: TENANT_ID,
+        anchorRunId: DEPLOYMENT_ID,
+        deploymentDomain: DEPLOYMENT_DOMAIN,
+        credentialCipher: createNoopCredentialCipher(),
+      });
+
+      const workflowRunRepoId: RepoId = {
+        kind: "workflow-run",
+        id: deriveDeploymentId(deploymentMailAddress),
+      };
+      env.registerDeployment({
+        anchorRunId: DEPLOYMENT_ID,
+        workflowDefinition: {
+          id: approved.projection.id,
+          triggers: [{ type: "mail", to: deploymentMailAddress }],
+          steps: {},
+          stepOrder: [...approved.projection.stepOrder],
+        },
+        workflowRunRepoId,
+        workflowRunRef: WORKFLOW_RUN_REF,
+        mailAddress: deploymentMailAddress,
+      });
+
+      await waitFor(
+        () =>
+          env.hub.router.getRoutableAddresses().includes(deploymentMailAddress),
+        { timeoutMs: 20_000, diagnostics: env.sidecarDiagnostics },
       );
-    }
-    expect(approved.projection.id).toBe("wf_source_credential");
-    expect(approved.projection.credentialBindings?.length).toBe(1);
 
-    const inferenceSource = {
-      id: "anthropic:mock-model",
-      provider: "anthropic",
-      baseURL: `http://localhost:${String(env.inference.server.port)}`,
-      apiKey: "sk-mock",
-      model: "mock-model",
-    };
-    const config: HarnessConfig = {
-      sessionId: SESSION_ID,
-      agentId: DEPLOYMENT_ID,
-      tenantId: "tenant-1",
-      principalId: "prin_integration-1",
-      agentAddress: deploymentMailAddress,
-      systemPrompt: "Fallback prompt (overridden per step by the definition)",
-      tools: [],
-      grants: [],
-      sources: [inferenceSource],
-      defaultSource: "anthropic:mock-model",
-    };
-
-    // Deploy with a credential cipher: the binding is resolved from the DB and
-    // decrypted through it. A no-op cipher passes the seeded material verbatim.
-    await deployCodeSourcedWorkflow({
-      approved,
-      source,
-      resolveAttachment,
-      sidecarRouter: env.hub.router,
-      agentAddress: deploymentMailAddress,
-      config,
-      sources: { [STEP_ID]: [inferenceSource] },
-      db: h.db,
-      tenantId: TENANT_ID,
-      anchorRunId: DEPLOYMENT_ID,
-      deploymentDomain: DEPLOYMENT_DOMAIN,
-      credentialCipher: createNoopCredentialCipher(),
-    });
-
-    const workflowRunRepoId: RepoId = {
-      kind: "workflow-run",
-      id: deriveDeploymentId(deploymentMailAddress),
-    };
-    env.registerDeployment({
-      anchorRunId: DEPLOYMENT_ID,
-      workflowDefinition: {
-        id: approved.projection.id,
-        triggers: [{ type: "mail", to: deploymentMailAddress }],
-        steps: {},
-        stepOrder: [...approved.projection.stepOrder],
-      },
-      workflowRunRepoId,
-      workflowRunRef: WORKFLOW_RUN_REF,
-      mailAddress: deploymentMailAddress,
-    });
-
-    await waitFor(
-      () =>
-        env.hub.router.getRoutableAddresses().includes(deploymentMailAddress),
-      { timeoutMs: 20_000, diagnostics: env.sidecarDiagnostics },
-    );
-
-    await fireMailTrigger(env, deploymentMailAddress, {
-      messageId: "<source-credential-e2e@integration.interchange>",
-    });
-    const runId = await waitForFirstRunId(env, workflowRunRepoId, {
-      timeoutMs: 30_000,
-      diagnostics: env.sidecarDiagnostics,
-    });
-    const terminal = await waitForWorkflowRunComplete(
-      env,
-      DEPLOYMENT_ID,
-      runId,
-      { timeoutMs: 30_000, diagnostics: env.sidecarDiagnostics },
-    );
-    if (terminal.type !== "RunCompleted") {
-      throw new Error(
-        `credential e2e: expected RunCompleted, got ${terminal.type}: ${JSON.stringify(terminal.body)}\n${env.sidecarDiagnostics()}`,
+      await fireMailTrigger(env, deploymentMailAddress, {
+        messageId: "<source-credential-e2e@integration.interchange>",
+      });
+      const runId = await waitForFirstRunId(env, workflowRunRepoId, {
+        timeoutMs: 30_000,
+        diagnostics: env.sidecarDiagnostics,
+      });
+      const terminal = await waitForWorkflowRunComplete(
+        env,
+        DEPLOYMENT_ID,
+        runId,
+        { timeoutMs: 30_000, diagnostics: env.sidecarDiagnostics },
       );
-    }
-    expect(terminal.type).toBe("RunCompleted");
-  }, 180_000);
-});
+      if (terminal.type !== "RunCompleted") {
+        throw new Error(
+          `credential e2e: expected RunCompleted, got ${terminal.type}: ${JSON.stringify(terminal.body)}\n${env.sidecarDiagnostics()}`,
+        );
+      }
+      expect(terminal.type).toBe("RunCompleted");
+    }, 180_000);
+  },
+);

--- a/tests/workflow-deploy/source-inline-tool.e2e.test.ts
+++ b/tests/workflow-deploy/source-inline-tool.e2e.test.ts
@@ -128,6 +128,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/source-mixed-closure.e2e.test.ts
+++ b/tests/workflow-deploy/source-mixed-closure.e2e.test.ts
@@ -35,7 +35,11 @@ import type { Packument, PackumentFetcher } from "@intx/tool-packaging";
 import { generateId } from "@intx/hub-common";
 import { deriveRunAddress, type ApprovalSet } from "@intx/workflow-deploy";
 import { deriveDeploymentId } from "@intx/sidecar-app/src/workflow-host-wiring";
-import { createTestDb, type TestDb } from "@intx/test-harness/db-harness";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
 import { seedAsset, seedPrincipal } from "@intx/test-harness/seed";
 
 import {
@@ -187,279 +191,282 @@ const fetchPackument: PackumentFetcher = async (name) => {
   return packument;
 };
 
-describe("mixed-closure source-workflow e2e", () => {
-  beforeAll(async () => {
-    scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), "source-mixed-"));
-    const workflowJs = await bundleWorkflowEntry(scratchDir);
+describe.skipIf(!harnessDbEnvAvailable())(
+  "mixed-closure source-workflow e2e",
+  () => {
+    beforeAll(async () => {
+      scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), "source-mixed-"));
+      const workflowJs = await bundleWorkflowEntry(scratchDir);
 
-    // Build the external dep tarball, compute its SRI, and stand up an
-    // in-process npm registry that serves its packument + tarball.
-    const extBytes = await buildSyntheticNpmPackageTarball(
-      (dir) => tarballTempDirs.push(dir),
-      {
-        packageName: EXT_PACKAGE_NAME,
-        version: EXT_PACKAGE_VERSION,
-        moduleSource: extModuleSource,
-      },
-    );
-    const extIntegrity = sri(extBytes);
-
-    registryServer = Bun.serve({
-      port: 0,
-      fetch(req) {
-        const url = new URL(req.url);
-        if (url.pathname === `/${EXT_PACKAGE_NAME}`) {
-          return new Response(JSON.stringify(packument), {
-            headers: { "content-type": "application/json" },
-          });
-        }
-        if (url.pathname === EXT_TARBALL_PATH) {
-          return new Response(extBytes);
-        }
-        return new Response("not found", { status: 404 });
-      },
-    });
-    const registryUrl = `http://localhost:${String(registryServer.port)}`;
-    packument = {
-      name: EXT_PACKAGE_NAME,
-      "dist-tags": { latest: EXT_PACKAGE_VERSION },
-      versions: {
-        [EXT_PACKAGE_VERSION]: {
-          name: EXT_PACKAGE_NAME,
+      // Build the external dep tarball, compute its SRI, and stand up an
+      // in-process npm registry that serves its packument + tarball.
+      const extBytes = await buildSyntheticNpmPackageTarball(
+        (dir) => tarballTempDirs.push(dir),
+        {
+          packageName: EXT_PACKAGE_NAME,
           version: EXT_PACKAGE_VERSION,
-          dist: {
-            tarball: `${registryUrl}${EXT_TARBALL_PATH}`,
-            integrity: extIntegrity,
+          moduleSource: extModuleSource,
+        },
+      );
+      const extIntegrity = sri(extBytes);
+
+      registryServer = Bun.serve({
+        port: 0,
+        fetch(req) {
+          const url = new URL(req.url);
+          if (url.pathname === `/${EXT_PACKAGE_NAME}`) {
+            return new Response(JSON.stringify(packument), {
+              headers: { "content-type": "application/json" },
+            });
+          }
+          if (url.pathname === EXT_TARBALL_PATH) {
+            return new Response(extBytes);
+          }
+          return new Response("not found", { status: 404 });
+        },
+      });
+      const registryUrl = `http://localhost:${String(registryServer.port)}`;
+      packument = {
+        name: EXT_PACKAGE_NAME,
+        "dist-tags": { latest: EXT_PACKAGE_VERSION },
+        versions: {
+          [EXT_PACKAGE_VERSION]: {
+            name: EXT_PACKAGE_NAME,
+            version: EXT_PACKAGE_VERSION,
+            dist: {
+              tarball: `${registryUrl}${EXT_TARBALL_PATH}`,
+              integrity: extIntegrity,
+            },
           },
         },
-      },
-    };
+      };
 
-    h = await createTestDb();
-    await h.db.insert(tenantTable).values({
-      id: TENANT_ID,
-      name: TENANT_ID,
-      slug: TENANT_ID,
-      domain: DEPLOYMENT_DOMAIN,
-      parentId: null,
-    });
-    await seedPrincipal(h.db, {
-      id: CALLER_PRINCIPAL_ID,
-      tenantId: TENANT_ID,
-      kind: "user",
-    });
+      h = await createTestDb();
+      await h.db.insert(tenantTable).values({
+        id: TENANT_ID,
+        name: TENANT_ID,
+        slug: TENANT_ID,
+        domain: DEPLOYMENT_DOMAIN,
+        parentId: null,
+      });
+      await seedPrincipal(h.db, {
+        id: CALLER_PRINCIPAL_ID,
+        tenantId: TENANT_ID,
+        kind: "user",
+      });
 
-    // Point the sidecar's registry map at the in-process registry so it can
-    // fetch the external dep's tarball at probe + deploy.
-    env = await startDeployFlowEnv({
-      sidecarEnv: {
-        SIDECAR_TOOL_REGISTRIES: JSON.stringify([
-          { name: REGISTRY_NAME, url: registryUrl },
-        ]),
-      },
-    });
-
-    await env.hub.agentRepoStore.repoStore.initRepo(sourceRepoId);
-    const writeResult = await env.hub.agentRepoStore.repoStore.writeTree(
-      HUB_PRINCIPAL,
-      sourceRepoId,
-      DEFAULT_ASSET_REF,
-      {
-        files: {
-          "package.json": JSON.stringify({
-            name: "@wf/mixed-root",
-            private: true,
-            workspaces: ["packages/*"],
-          }),
-          "packages/app/package.json": JSON.stringify({
-            name: APP_PACKAGE_NAME,
-            version: PACKAGE_VERSION,
-            type: "module",
-            interchange: { workflow: WORKFLOW_ENTRY },
-            dependencies: {
-              [LIB_PACKAGE_NAME]: "workspace:*",
-              [EXT_PACKAGE_NAME]: `^${EXT_PACKAGE_VERSION}`,
-            },
-          }),
-          "packages/app/workflow.mjs": workflowJs,
-          "packages/lib/package.json": JSON.stringify({
-            name: LIB_PACKAGE_NAME,
-            version: PACKAGE_VERSION,
-            type: "module",
-            exports: "./index.mjs",
-          }),
-          "packages/lib/index.mjs": libSource,
+      // Point the sidecar's registry map at the in-process registry so it can
+      // fetch the external dep's tarball at probe + deploy.
+      env = await startDeployFlowEnv({
+        sidecarEnv: {
+          SIDECAR_TOOL_REGISTRIES: JSON.stringify([
+            { name: REGISTRY_NAME, url: registryUrl },
+          ]),
         },
-        message: "Seed mixed-closure monorepo source",
-      },
-    );
-    sourceCommitSha = writeResult.commitSha;
-  });
+      });
 
-  afterAll(async () => {
-    if (env !== undefined) await env.teardown();
-    if (h !== undefined) await h.close();
-    if (registryServer !== undefined) await registryServer.stop(true);
-    for (const dir of tarballTempDirs.splice(0)) {
-      await fs.rm(dir, { recursive: true, force: true });
-    }
-    if (scratchDir !== undefined) {
-      await fs.rm(scratchDir, { recursive: true, force: true });
-    }
-  });
-
-  test("resolves a workspace-local and an external dep in one closure and runs", async () => {
-    await seedAsset(h.db, {
-      id: DEFINITION_ASSET_ID,
-      tenantId: TENANT_ID,
-      kind: "workflow",
-      name: "source-mixed-wf",
-      creatorPrincipalId: CALLER_PRINCIPAL_ID,
-    });
-
-    const source: WorkflowDefinitionAssetSource = {
-      kind: "asset",
-      assetId: SOURCE_ASSET_ID,
-      package: {
-        format: "source",
-        commitSha: sourceCommitSha,
-        packageName: APP_PACKAGE_NAME,
-      },
-    };
-
-    const committed =
-      await env.hub.agentRepoStore.repoStore.openCommittedReadsAtCommit(
+      await env.hub.agentRepoStore.repoStore.initRepo(sourceRepoId);
+      const writeResult = await env.hub.agentRepoStore.repoStore.writeTree(
         HUB_PRINCIPAL,
         sourceRepoId,
-        sourceCommitSha,
+        DEFAULT_ASSET_REF,
+        {
+          files: {
+            "package.json": JSON.stringify({
+              name: "@wf/mixed-root",
+              private: true,
+              workspaces: ["packages/*"],
+            }),
+            "packages/app/package.json": JSON.stringify({
+              name: APP_PACKAGE_NAME,
+              version: PACKAGE_VERSION,
+              type: "module",
+              interchange: { workflow: WORKFLOW_ENTRY },
+              dependencies: {
+                [LIB_PACKAGE_NAME]: "workspace:*",
+                [EXT_PACKAGE_NAME]: `^${EXT_PACKAGE_VERSION}`,
+              },
+            }),
+            "packages/app/workflow.mjs": workflowJs,
+            "packages/lib/package.json": JSON.stringify({
+              name: LIB_PACKAGE_NAME,
+              version: PACKAGE_VERSION,
+              type: "module",
+              exports: "./index.mjs",
+            }),
+            "packages/lib/index.mjs": libSource,
+          },
+          message: "Seed mixed-closure monorepo source",
+        },
       );
-    if (committed === null) {
-      throw new Error("mixed e2e: could not open committed reads at commit");
-    }
-
-    const approvals: ApprovalSet = new Set<string>([
-      "inference.source:anthropic:mock-model",
-      "director:@intx/agent/default",
-      `mail.address:${deploymentMailAddress}`,
-      `mail.send:${DEPLOYMENT_DOMAIN}`,
-    ]);
-
-    const approved = await installAndApproveWorkflowDefinition({
-      source,
-      entry: WORKFLOW_ENTRY,
-      assetId: DEFINITION_ASSET_ID,
-      approvals,
-      router: env.hub.router,
-      db: h.db,
-      reads: committedReadsToSourceTree(committed),
-      registryName: REGISTRY_NAME,
-      registryConfig: {
-        url: `http://localhost:${String(registryServer?.port)}`,
-      },
-      fetchPackument,
-      resolveAttachment,
+      sourceCommitSha = writeResult.commitSha;
     });
-    if (!approved.approval.ok) {
-      throw new Error(
-        `mixed e2e: install did not approve (reason: ${approved.approval.reason}): ${JSON.stringify(approved.approval)}\n${env.sidecarDiagnostics()}`,
+
+    afterAll(async () => {
+      if (env !== undefined) await env.teardown();
+      if (h !== undefined) await h.close();
+      if (registryServer !== undefined) await registryServer.stop(true);
+      for (const dir of tarballTempDirs.splice(0)) {
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+      if (scratchDir !== undefined) {
+        await fs.rm(scratchDir, { recursive: true, force: true });
+      }
+    });
+
+    test("resolves a workspace-local and an external dep in one closure and runs", async () => {
+      await seedAsset(h.db, {
+        id: DEFINITION_ASSET_ID,
+        tenantId: TENANT_ID,
+        kind: "workflow",
+        name: "source-mixed-wf",
+        creatorPrincipalId: CALLER_PRINCIPAL_ID,
+      });
+
+      const source: WorkflowDefinitionAssetSource = {
+        kind: "asset",
+        assetId: SOURCE_ASSET_ID,
+        package: {
+          format: "source",
+          commitSha: sourceCommitSha,
+          packageName: APP_PACKAGE_NAME,
+        },
+      };
+
+      const committed =
+        await env.hub.agentRepoStore.repoStore.openCommittedReadsAtCommit(
+          HUB_PRINCIPAL,
+          sourceRepoId,
+          sourceCommitSha,
+        );
+      if (committed === null) {
+        throw new Error("mixed e2e: could not open committed reads at commit");
+      }
+
+      const approvals: ApprovalSet = new Set<string>([
+        "inference.source:anthropic:mock-model",
+        "director:@intx/agent/default",
+        `mail.address:${deploymentMailAddress}`,
+        `mail.send:${DEPLOYMENT_DOMAIN}`,
+      ]);
+
+      const approved = await installAndApproveWorkflowDefinition({
+        source,
+        entry: WORKFLOW_ENTRY,
+        assetId: DEFINITION_ASSET_ID,
+        approvals,
+        router: env.hub.router,
+        db: h.db,
+        reads: committedReadsToSourceTree(committed),
+        registryName: REGISTRY_NAME,
+        registryConfig: {
+          url: `http://localhost:${String(registryServer?.port)}`,
+        },
+        fetchPackument,
+        resolveAttachment,
+      });
+      if (!approved.approval.ok) {
+        throw new Error(
+          `mixed e2e: install did not approve (reason: ${approved.approval.reason}): ${JSON.stringify(approved.approval)}\n${env.sidecarDiagnostics()}`,
+        );
+      }
+      expect(approved.projection.id).toBe("wf_mixed");
+
+      // The closure carries three entries across two origins: @wf/app and @wf/lib
+      // as source, wf-ext-dep as a registry entry.
+      const byName = new Map(approved.closure.entries.map((e) => [e.name, e]));
+      const appEntry = byName.get(APP_PACKAGE_NAME);
+      const libEntry = byName.get(LIB_PACKAGE_NAME);
+      const extEntry = byName.get(EXT_PACKAGE_NAME);
+      if (
+        appEntry?.source.kind !== "asset" ||
+        libEntry?.source.kind !== "asset"
+      ) {
+        throw new Error("mixed e2e: workspace members are not asset-sourced");
+      }
+      expect(appEntry.source.package.format).toBe("source");
+      expect(libEntry.source.package.format).toBe("source");
+      if (extEntry?.source.kind !== "registry") {
+        throw new Error("mixed e2e: external dep is not a registry entry");
+      }
+      expect(extEntry.source.registry).toBe(REGISTRY_NAME);
+
+      const inferenceSource = {
+        id: "anthropic:mock-model",
+        provider: "anthropic",
+        baseURL: `http://localhost:${String(env.inference.server.port)}`,
+        apiKey: "sk-mock",
+        model: "mock-model",
+      };
+      const config: HarnessConfig = {
+        sessionId: SESSION_ID,
+        agentId: DEPLOYMENT_ID,
+        tenantId: "tenant-1",
+        principalId: "prin_integration-1",
+        agentAddress: deploymentMailAddress,
+        systemPrompt: "Fallback prompt (overridden per step by the definition)",
+        tools: [],
+        grants: [],
+        sources: [inferenceSource],
+        defaultSource: "anthropic:mock-model",
+      };
+
+      await deployCodeSourcedWorkflow({
+        approved,
+        source,
+        resolveAttachment,
+        sidecarRouter: env.hub.router,
+        agentAddress: deploymentMailAddress,
+        config,
+        sources: { [STEP_ID]: [inferenceSource] },
+        db: h.db,
+        tenantId: TENANT_ID,
+        anchorRunId: DEPLOYMENT_ID,
+        deploymentDomain: DEPLOYMENT_DOMAIN,
+      });
+
+      const workflowRunRepoId: RepoId = {
+        kind: "workflow-run",
+        id: deriveDeploymentId(deploymentMailAddress),
+      };
+      env.registerDeployment({
+        anchorRunId: DEPLOYMENT_ID,
+        workflowDefinition: {
+          id: approved.projection.id,
+          triggers: [{ type: "mail", to: deploymentMailAddress }],
+          steps: {},
+          stepOrder: [...approved.projection.stepOrder],
+        },
+        workflowRunRepoId,
+        workflowRunRef: WORKFLOW_RUN_REF,
+        mailAddress: deploymentMailAddress,
+      });
+
+      await waitFor(
+        () =>
+          env.hub.router.getRoutableAddresses().includes(deploymentMailAddress),
+        { timeoutMs: 20_000, diagnostics: env.sidecarDiagnostics },
       );
-    }
-    expect(approved.projection.id).toBe("wf_mixed");
 
-    // The closure carries three entries across two origins: @wf/app and @wf/lib
-    // as source, wf-ext-dep as a registry entry.
-    const byName = new Map(approved.closure.entries.map((e) => [e.name, e]));
-    const appEntry = byName.get(APP_PACKAGE_NAME);
-    const libEntry = byName.get(LIB_PACKAGE_NAME);
-    const extEntry = byName.get(EXT_PACKAGE_NAME);
-    if (
-      appEntry?.source.kind !== "asset" ||
-      libEntry?.source.kind !== "asset"
-    ) {
-      throw new Error("mixed e2e: workspace members are not asset-sourced");
-    }
-    expect(appEntry.source.package.format).toBe("source");
-    expect(libEntry.source.package.format).toBe("source");
-    if (extEntry?.source.kind !== "registry") {
-      throw new Error("mixed e2e: external dep is not a registry entry");
-    }
-    expect(extEntry.source.registry).toBe(REGISTRY_NAME);
-
-    const inferenceSource = {
-      id: "anthropic:mock-model",
-      provider: "anthropic",
-      baseURL: `http://localhost:${String(env.inference.server.port)}`,
-      apiKey: "sk-mock",
-      model: "mock-model",
-    };
-    const config: HarnessConfig = {
-      sessionId: SESSION_ID,
-      agentId: DEPLOYMENT_ID,
-      tenantId: "tenant-1",
-      principalId: "prin_integration-1",
-      agentAddress: deploymentMailAddress,
-      systemPrompt: "Fallback prompt (overridden per step by the definition)",
-      tools: [],
-      grants: [],
-      sources: [inferenceSource],
-      defaultSource: "anthropic:mock-model",
-    };
-
-    await deployCodeSourcedWorkflow({
-      approved,
-      source,
-      resolveAttachment,
-      sidecarRouter: env.hub.router,
-      agentAddress: deploymentMailAddress,
-      config,
-      sources: { [STEP_ID]: [inferenceSource] },
-      db: h.db,
-      tenantId: TENANT_ID,
-      anchorRunId: DEPLOYMENT_ID,
-      deploymentDomain: DEPLOYMENT_DOMAIN,
-    });
-
-    const workflowRunRepoId: RepoId = {
-      kind: "workflow-run",
-      id: deriveDeploymentId(deploymentMailAddress),
-    };
-    env.registerDeployment({
-      anchorRunId: DEPLOYMENT_ID,
-      workflowDefinition: {
-        id: approved.projection.id,
-        triggers: [{ type: "mail", to: deploymentMailAddress }],
-        steps: {},
-        stepOrder: [...approved.projection.stepOrder],
-      },
-      workflowRunRepoId,
-      workflowRunRef: WORKFLOW_RUN_REF,
-      mailAddress: deploymentMailAddress,
-    });
-
-    await waitFor(
-      () =>
-        env.hub.router.getRoutableAddresses().includes(deploymentMailAddress),
-      { timeoutMs: 20_000, diagnostics: env.sidecarDiagnostics },
-    );
-
-    await fireMailTrigger(env, deploymentMailAddress, {
-      messageId: "<source-mixed-e2e@integration.interchange>",
-    });
-    const runId = await waitForFirstRunId(env, workflowRunRepoId, {
-      timeoutMs: 30_000,
-      diagnostics: env.sidecarDiagnostics,
-    });
-    const terminal = await waitForWorkflowRunComplete(
-      env,
-      DEPLOYMENT_ID,
-      runId,
-      { timeoutMs: 30_000, diagnostics: env.sidecarDiagnostics },
-    );
-    if (terminal.type !== "RunCompleted") {
-      throw new Error(
-        `mixed e2e: expected RunCompleted, got ${terminal.type}: ${JSON.stringify(terminal.body)}\n${env.sidecarDiagnostics()}`,
+      await fireMailTrigger(env, deploymentMailAddress, {
+        messageId: "<source-mixed-e2e@integration.interchange>",
+      });
+      const runId = await waitForFirstRunId(env, workflowRunRepoId, {
+        timeoutMs: 30_000,
+        diagnostics: env.sidecarDiagnostics,
+      });
+      const terminal = await waitForWorkflowRunComplete(
+        env,
+        DEPLOYMENT_ID,
+        runId,
+        { timeoutMs: 30_000, diagnostics: env.sidecarDiagnostics },
       );
-    }
-    expect(terminal.type).toBe("RunCompleted");
-  }, 180_000);
-});
+      if (terminal.type !== "RunCompleted") {
+        throw new Error(
+          `mixed e2e: expected RunCompleted, got ${terminal.type}: ${JSON.stringify(terminal.body)}\n${env.sidecarDiagnostics()}`,
+        );
+      }
+      expect(terminal.type).toBe("RunCompleted");
+    }, 180_000);
+  },
+);

--- a/tests/workflow-deploy/source-monorepo-many.e2e.test.ts
+++ b/tests/workflow-deploy/source-monorepo-many.e2e.test.ts
@@ -57,7 +57,11 @@ import {
   type ApprovalSet,
 } from "@intx/workflow-deploy";
 import { deriveDeploymentId } from "@intx/sidecar-app/src/workflow-host-wiring";
-import { createTestDb, type TestDb } from "@intx/test-harness/db-harness";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
 import { seedAsset, seedPrincipal } from "@intx/test-harness/seed";
 
 import {
@@ -455,222 +459,225 @@ const collapseApprovals: ApprovalSet = new Set<string>([
   `mail.send:${DEPLOYMENT_DOMAIN}`,
 ]);
 
-describe("many-definitions-from-one-asset monorepo e2e", () => {
-  beforeAll(async () => {
-    scratchDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), "source-monorepo-many-"),
-    );
-    const oneJs = await bundleEntry(
-      scratchDir,
-      distinctEntrySource({
+describe.skipIf(!harnessDbEnvAvailable())(
+  "many-definitions-from-one-asset monorepo e2e",
+  () => {
+    beforeAll(async () => {
+      scratchDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), "source-monorepo-many-"),
+      );
+      const oneJs = await bundleEntry(
+        scratchDir,
+        distinctEntrySource({
+          workflowId: ONE_WORKFLOW_ID,
+          stepId: ONE_STEP_ID,
+          systemPrompt: ONE_SYSTEM_PROMPT,
+          address: oneAddress,
+        }),
+        "one",
+      );
+      const twoJs = await bundleEntry(
+        scratchDir,
+        distinctEntrySource({
+          workflowId: TWO_WORKFLOW_ID,
+          stepId: TWO_STEP_ID,
+          systemPrompt: TWO_SYSTEM_PROMPT,
+          address: twoAddress,
+        }),
+        "two",
+      );
+      // Both collapse members ship the SAME bundled workflow.mjs; only their
+      // package.json name differs.
+      const collapseJs = await bundleEntry(
+        scratchDir,
+        collapseEntrySource,
+        "collapse",
+      );
+
+      h = await createTestDb();
+      await h.db.insert(tenantTable).values({
+        id: TENANT_ID,
+        name: TENANT_ID,
+        slug: TENANT_ID,
+        domain: DEPLOYMENT_DOMAIN,
+        parentId: null,
+      });
+      await seedPrincipal(h.db, {
+        id: CALLER_PRINCIPAL_ID,
+        tenantId: TENANT_ID,
+        kind: "user",
+      });
+      await seedAsset(h.db, {
+        id: DEFINITION_ASSET_ID,
+        tenantId: TENANT_ID,
+        kind: "workflow",
+        name: "source-monorepo-many-wf",
+        creatorPrincipalId: CALLER_PRINCIPAL_ID,
+      });
+
+      env = await startDeployFlowEnv({});
+
+      // Seed the monorepo: a private workspaces root plus four members -- two
+      // distinct-surface workflows and two identical-surface collapse workflows.
+      await env.hub.agentRepoStore.repoStore.initRepo(sourceRepoId);
+      const mkPackageJson = (name: string): string =>
+        JSON.stringify({
+          name,
+          version: PACKAGE_VERSION,
+          type: "module",
+          interchange: { workflow: WORKFLOW_ENTRY },
+        });
+      const writeResult = await env.hub.agentRepoStore.repoStore.writeTree(
+        HUB_PRINCIPAL,
+        sourceRepoId,
+        DEFAULT_ASSET_REF,
+        {
+          files: {
+            "package.json": JSON.stringify({
+              name: "@wf/monorepo-many-root",
+              private: true,
+              workspaces: ["packages/*"],
+            }),
+            "packages/one/package.json": mkPackageJson(ONE_PACKAGE_NAME),
+            "packages/one/workflow.mjs": oneJs,
+            "packages/two/package.json": mkPackageJson(TWO_PACKAGE_NAME),
+            "packages/two/workflow.mjs": twoJs,
+            "packages/collapse-a/package.json": mkPackageJson(
+              COLLAPSE_A_PACKAGE_NAME,
+            ),
+            "packages/collapse-a/workflow.mjs": collapseJs,
+            "packages/collapse-b/package.json": mkPackageJson(
+              COLLAPSE_B_PACKAGE_NAME,
+            ),
+            "packages/collapse-b/workflow.mjs": collapseJs,
+          },
+          message: "Seed many-definitions monorepo source",
+        },
+      );
+      sourceCommitSha = writeResult.commitSha;
+    });
+
+    afterAll(async () => {
+      if (env !== undefined) await env.teardown();
+      if (h !== undefined) await h.close();
+      if (scratchDir !== undefined) {
+        await fs.rm(scratchDir, { recursive: true, force: true });
+      }
+    });
+
+    test("two distinct-surface members install to two rows and each deploys and runs", async () => {
+      const one = await installMember({
+        packageName: ONE_PACKAGE_NAME,
+        approvals: distinctApprovals(oneAddress),
+      });
+      const two = await installMember({
+        packageName: TWO_PACKAGE_NAME,
+        approvals: distinctApprovals(twoAddress),
+      });
+
+      // Distinct surfaces freeze to distinct definitions, each pinning its own
+      // member.
+      expect(one.projection.id).toBe(ONE_WORKFLOW_ID);
+      expect(two.projection.id).toBe(TWO_WORKFLOW_ID);
+      expect(two.approval.definitionId).not.toBe(one.approval.definitionId);
+      expect(one.closure.topLevel).toEqual([
+        { name: ONE_PACKAGE_NAME, version: PACKAGE_VERSION },
+      ]);
+      expect(two.closure.topLevel).toEqual([
+        { name: TWO_PACKAGE_NAME, version: PACKAGE_VERSION },
+      ]);
+
+      // One definition asset now backs both distinct rows. Assert membership of
+      // the two ids rather than a total count, so the check does not couple to
+      // whether the collapse test (which adds a third row to the same asset) has
+      // run yet.
+      const rowIds = new Set(
+        (
+          await h.db
+            .select({ id: workflowDefinitionTable.id })
+            .from(workflowDefinitionTable)
+            .where(eq(workflowDefinitionTable.assetId, DEFINITION_ASSET_ID))
+        ).map((r) => r.id),
+      );
+      expect(rowIds.has(one.approval.definitionId)).toBe(true);
+      expect(rowIds.has(two.approval.definitionId)).toBe(true);
+
+      // Deploy and run each independently; both reach RunCompleted from their own
+      // source-materialized closure.
+      await deployAndRun({
+        approved: one,
+        packageName: ONE_PACKAGE_NAME,
         workflowId: ONE_WORKFLOW_ID,
         stepId: ONE_STEP_ID,
-        systemPrompt: ONE_SYSTEM_PROMPT,
+        anchorRunId: ONE_DEPLOYMENT_ID,
         address: oneAddress,
-      }),
-      "one",
-    );
-    const twoJs = await bundleEntry(
-      scratchDir,
-      distinctEntrySource({
+      });
+      await deployAndRun({
+        approved: two,
+        packageName: TWO_PACKAGE_NAME,
         workflowId: TWO_WORKFLOW_ID,
         stepId: TWO_STEP_ID,
-        systemPrompt: TWO_SYSTEM_PROMPT,
+        anchorRunId: TWO_DEPLOYMENT_ID,
         address: twoAddress,
-      }),
-      "two",
-    );
-    // Both collapse members ship the SAME bundled workflow.mjs; only their
-    // package.json name differs.
-    const collapseJs = await bundleEntry(
-      scratchDir,
-      collapseEntrySource,
-      "collapse",
-    );
-
-    h = await createTestDb();
-    await h.db.insert(tenantTable).values({
-      id: TENANT_ID,
-      name: TENANT_ID,
-      slug: TENANT_ID,
-      domain: DEPLOYMENT_DOMAIN,
-      parentId: null,
-    });
-    await seedPrincipal(h.db, {
-      id: CALLER_PRINCIPAL_ID,
-      tenantId: TENANT_ID,
-      kind: "user",
-    });
-    await seedAsset(h.db, {
-      id: DEFINITION_ASSET_ID,
-      tenantId: TENANT_ID,
-      kind: "workflow",
-      name: "source-monorepo-many-wf",
-      creatorPrincipalId: CALLER_PRINCIPAL_ID,
-    });
-
-    env = await startDeployFlowEnv({});
-
-    // Seed the monorepo: a private workspaces root plus four members -- two
-    // distinct-surface workflows and two identical-surface collapse workflows.
-    await env.hub.agentRepoStore.repoStore.initRepo(sourceRepoId);
-    const mkPackageJson = (name: string): string =>
-      JSON.stringify({
-        name,
-        version: PACKAGE_VERSION,
-        type: "module",
-        interchange: { workflow: WORKFLOW_ENTRY },
       });
-    const writeResult = await env.hub.agentRepoStore.repoStore.writeTree(
-      HUB_PRINCIPAL,
-      sourceRepoId,
-      DEFAULT_ASSET_REF,
-      {
-        files: {
-          "package.json": JSON.stringify({
-            name: "@wf/monorepo-many-root",
-            private: true,
-            workspaces: ["packages/*"],
-          }),
-          "packages/one/package.json": mkPackageJson(ONE_PACKAGE_NAME),
-          "packages/one/workflow.mjs": oneJs,
-          "packages/two/package.json": mkPackageJson(TWO_PACKAGE_NAME),
-          "packages/two/workflow.mjs": twoJs,
-          "packages/collapse-a/package.json": mkPackageJson(
-            COLLAPSE_A_PACKAGE_NAME,
-          ),
-          "packages/collapse-a/workflow.mjs": collapseJs,
-          "packages/collapse-b/package.json": mkPackageJson(
-            COLLAPSE_B_PACKAGE_NAME,
-          ),
-          "packages/collapse-b/workflow.mjs": collapseJs,
-        },
-        message: "Seed many-definitions monorepo source",
-      },
-    );
-    sourceCommitSha = writeResult.commitSha;
-  });
 
-  afterAll(async () => {
-    if (env !== undefined) await env.teardown();
-    if (h !== undefined) await h.close();
-    if (scratchDir !== undefined) {
-      await fs.rm(scratchDir, { recursive: true, force: true });
-    }
-  });
+      // Each child evaluated its OWN member's source: both members' system prompts
+      // reached inference, proving the two runs did not share one definition's
+      // code (and that each step's agent prompt overrode the deploy fallback). The
+      // anthropic provider serializes the system prompt as a `system` array of
+      // text blocks on the wire.
+      const systemTexts = env.inference.requests.flatMap(systemBlockTexts);
+      expect(systemTexts.some((t) => t.includes(ONE_SYSTEM_PROMPT))).toBe(true);
+      expect(systemTexts.some((t) => t.includes(TWO_SYSTEM_PROMPT))).toBe(true);
+    }, 180_000);
 
-  test("two distinct-surface members install to two rows and each deploys and runs", async () => {
-    const one = await installMember({
-      packageName: ONE_PACKAGE_NAME,
-      approvals: distinctApprovals(oneAddress),
-    });
-    const two = await installMember({
-      packageName: TWO_PACKAGE_NAME,
-      approvals: distinctApprovals(twoAddress),
-    });
+    test("two identical-surface members collapse to one row that carries the second member's own source", async () => {
+      const a = await installMember({
+        packageName: COLLAPSE_A_PACKAGE_NAME,
+        approvals: collapseApprovals,
+      });
+      const b = await installMember({
+        packageName: COLLAPSE_B_PACKAGE_NAME,
+        approvals: collapseApprovals,
+      });
 
-    // Distinct surfaces freeze to distinct definitions, each pinning its own
-    // member.
-    expect(one.projection.id).toBe(ONE_WORKFLOW_ID);
-    expect(two.projection.id).toBe(TWO_WORKFLOW_ID);
-    expect(two.approval.definitionId).not.toBe(one.approval.definitionId);
-    expect(one.closure.topLevel).toEqual([
-      { name: ONE_PACKAGE_NAME, version: PACKAGE_VERSION },
-    ]);
-    expect(two.closure.topLevel).toEqual([
-      { name: TWO_PACKAGE_NAME, version: PACKAGE_VERSION },
-    ]);
+      // (a) The collapse itself: identical needs-surfaces yield an equal wire hash
+      // and the (assetId, wireHash) key resolves both installs to the SAME
+      // definition row. These two equalities are what discriminate the collapse --
+      // they fail if the second install forks a second row.
+      expect(a.projection.id).toBe(COLLAPSE_WORKFLOW_ID);
+      expect(b.projection.id).toBe(COLLAPSE_WORKFLOW_ID);
+      expect(b.approval.approvedWireHash).toBe(a.approval.approvedWireHash);
+      expect(b.approval.definitionId).toBe(a.approval.definitionId);
 
-    // One definition asset now backs both distinct rows. Assert membership of
-    // the two ids rather than a total count, so the check does not couple to
-    // whether the collapse test (which adds a third row to the same asset) has
-    // run yet.
-    const rowIds = new Set(
-      (
-        await h.db
-          .select({ id: workflowDefinitionTable.id })
-          .from(workflowDefinitionTable)
-          .where(eq(workflowDefinitionTable.assetId, DEFINITION_ASSET_ID))
-      ).map((r) => r.id),
-    );
-    expect(rowIds.has(one.approval.definitionId)).toBe(true);
-    expect(rowIds.has(two.approval.definitionId)).toBe(true);
+      // (b) Forward regression guard: the second install's carried closure is
+      // re-probed from the SECOND member's own source, independent of the row it
+      // collapses onto, so today it names @wf/collapse-b (its packageName) and
+      // never @wf/collapse-a. This cannot mis-carry the first member's source at
+      // present -- it pins that a future install short-circuit which resolved
+      // source from the shared row (returning A's cached projection) would break.
+      expect(b.closure.topLevel).toEqual([
+        { name: COLLAPSE_B_PACKAGE_NAME, version: PACKAGE_VERSION },
+      ]);
+      const bEntry = b.closure.entries.find(
+        (e) => e.name === COLLAPSE_B_PACKAGE_NAME,
+      );
+      if (bEntry?.source.kind !== "asset") {
+        throw new Error("many-defs e2e: collapse-b entry is not asset-sourced");
+      }
+      expect(bEntry.source.package.format).toBe("source");
+      // A must NOT appear in B's carried closure.
+      expect(
+        b.closure.entries.some((e) => e.name === COLLAPSE_A_PACKAGE_NAME),
+      ).toBe(false);
 
-    // Deploy and run each independently; both reach RunCompleted from their own
-    // source-materialized closure.
-    await deployAndRun({
-      approved: one,
-      packageName: ONE_PACKAGE_NAME,
-      workflowId: ONE_WORKFLOW_ID,
-      stepId: ONE_STEP_ID,
-      anchorRunId: ONE_DEPLOYMENT_ID,
-      address: oneAddress,
-    });
-    await deployAndRun({
-      approved: two,
-      packageName: TWO_PACKAGE_NAME,
-      workflowId: TWO_WORKFLOW_ID,
-      stepId: TWO_STEP_ID,
-      anchorRunId: TWO_DEPLOYMENT_ID,
-      address: twoAddress,
-    });
-
-    // Each child evaluated its OWN member's source: both members' system prompts
-    // reached inference, proving the two runs did not share one definition's
-    // code (and that each step's agent prompt overrode the deploy fallback). The
-    // anthropic provider serializes the system prompt as a `system` array of
-    // text blocks on the wire.
-    const systemTexts = env.inference.requests.flatMap(systemBlockTexts);
-    expect(systemTexts.some((t) => t.includes(ONE_SYSTEM_PROMPT))).toBe(true);
-    expect(systemTexts.some((t) => t.includes(TWO_SYSTEM_PROMPT))).toBe(true);
-  }, 180_000);
-
-  test("two identical-surface members collapse to one row that carries the second member's own source", async () => {
-    const a = await installMember({
-      packageName: COLLAPSE_A_PACKAGE_NAME,
-      approvals: collapseApprovals,
-    });
-    const b = await installMember({
-      packageName: COLLAPSE_B_PACKAGE_NAME,
-      approvals: collapseApprovals,
-    });
-
-    // (a) The collapse itself: identical needs-surfaces yield an equal wire hash
-    // and the (assetId, wireHash) key resolves both installs to the SAME
-    // definition row. These two equalities are what discriminate the collapse --
-    // they fail if the second install forks a second row.
-    expect(a.projection.id).toBe(COLLAPSE_WORKFLOW_ID);
-    expect(b.projection.id).toBe(COLLAPSE_WORKFLOW_ID);
-    expect(b.approval.approvedWireHash).toBe(a.approval.approvedWireHash);
-    expect(b.approval.definitionId).toBe(a.approval.definitionId);
-
-    // (b) Forward regression guard: the second install's carried closure is
-    // re-probed from the SECOND member's own source, independent of the row it
-    // collapses onto, so today it names @wf/collapse-b (its packageName) and
-    // never @wf/collapse-a. This cannot mis-carry the first member's source at
-    // present -- it pins that a future install short-circuit which resolved
-    // source from the shared row (returning A's cached projection) would break.
-    expect(b.closure.topLevel).toEqual([
-      { name: COLLAPSE_B_PACKAGE_NAME, version: PACKAGE_VERSION },
-    ]);
-    const bEntry = b.closure.entries.find(
-      (e) => e.name === COLLAPSE_B_PACKAGE_NAME,
-    );
-    if (bEntry?.source.kind !== "asset") {
-      throw new Error("many-defs e2e: collapse-b entry is not asset-sourced");
-    }
-    expect(bEntry.source.package.format).toBe("source");
-    // A must NOT appear in B's carried closure.
-    expect(
-      b.closure.entries.some((e) => e.name === COLLAPSE_A_PACKAGE_NAME),
-    ).toBe(false);
-
-    // The collapsed second install still enumerates a well-formed inline
-    // onTrigger body from its frozen projection (the same forward guard: a
-    // short-circuit returning a bodiless cached projection would drop it). The
-    // ref derives from the shared workflow id + section, so this checks
-    // well-formedness, not provenance -- provenance is pinned by topLevel above.
-    const bBodies = enumerateInertBodies(b.projection);
-    expect(bBodies.map((body) => body.ref)).toEqual([COLLAPSE_BODY_REF]);
-  }, 180_000);
-});
+      // The collapsed second install still enumerates a well-formed inline
+      // onTrigger body from its frozen projection (the same forward guard: a
+      // short-circuit returning a bodiless cached projection would drop it). The
+      // ref derives from the shared workflow id + section, so this checks
+      // well-formedness, not provenance -- provenance is pinned by topLevel above.
+      const bBodies = enumerateInertBodies(b.projection);
+      expect(bBodies.map((body) => body.ref)).toEqual([COLLAPSE_BODY_REF]);
+    }, 180_000);
+  },
+);

--- a/tests/workflow-deploy/source-monorepo.e2e.test.ts
+++ b/tests/workflow-deploy/source-monorepo.e2e.test.ts
@@ -40,7 +40,11 @@ import type { WorkflowDefinitionAssetSource } from "@intx/types/workflow-sources
 import { generateId } from "@intx/hub-common";
 import { deriveRunAddress, type ApprovalSet } from "@intx/workflow-deploy";
 import { deriveDeploymentId } from "@intx/sidecar-app/src/workflow-host-wiring";
-import { createTestDb, type TestDb } from "@intx/test-harness/db-harness";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
 import { seedAsset, seedPrincipal } from "@intx/test-harness/seed";
 
 import {
@@ -190,293 +194,300 @@ const resolveAttachment = async (
   return { pack, ref, commitSha };
 };
 
-describe("monorepo source-workflow e2e", () => {
-  beforeAll(async () => {
-    scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), "source-monorepo-"));
-    const workflowJs = await bundleWorkflowEntry(scratchDir);
+describe.skipIf(!harnessDbEnvAvailable())(
+  "monorepo source-workflow e2e",
+  () => {
+    beforeAll(async () => {
+      scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), "source-monorepo-"));
+      const workflowJs = await bundleWorkflowEntry(scratchDir);
 
-    h = await createTestDb();
-    await h.db.insert(tenantTable).values({
-      id: TENANT_ID,
-      name: TENANT_ID,
-      slug: TENANT_ID,
-      domain: DEPLOYMENT_DOMAIN,
-      parentId: null,
-    });
-    await seedPrincipal(h.db, {
-      id: CALLER_PRINCIPAL_ID,
-      tenantId: TENANT_ID,
-      kind: "user",
-    });
+      h = await createTestDb();
+      await h.db.insert(tenantTable).values({
+        id: TENANT_ID,
+        name: TENANT_ID,
+        slug: TENANT_ID,
+        domain: DEPLOYMENT_DOMAIN,
+        parentId: null,
+      });
+      await seedPrincipal(h.db, {
+        id: CALLER_PRINCIPAL_ID,
+        tenantId: TENANT_ID,
+        kind: "user",
+      });
 
-    env = await startDeployFlowEnv({});
+      env = await startDeployFlowEnv({});
 
-    // Seed the monorepo source: a private workspace root plus two members, one
-    // the workflow (`@wf/app`) and one its `workspace:*` dependency (`@wf/lib`).
-    // The `workflow`-kind push accepts the root; the resolver enumerates both
-    // members from `packages/*`.
-    await env.hub.agentRepoStore.repoStore.initRepo(sourceRepoId);
-    const writeResult = await env.hub.agentRepoStore.repoStore.writeTree(
-      HUB_PRINCIPAL,
-      sourceRepoId,
-      DEFAULT_ASSET_REF,
-      {
-        files: {
-          "package.json": JSON.stringify({
-            name: "@wf/monorepo-root",
-            private: true,
-            workspaces: ["packages/*"],
-          }),
-          "packages/app/package.json": JSON.stringify({
-            name: APP_PACKAGE_NAME,
-            version: APP_PACKAGE_VERSION,
-            type: "module",
-            interchange: { workflow: WORKFLOW_ENTRY },
-            dependencies: { [LIB_PACKAGE_NAME]: "workspace:*" },
-          }),
-          "packages/app/workflow.mjs": workflowJs,
-          "packages/lib/package.json": JSON.stringify({
-            name: LIB_PACKAGE_NAME,
-            version: LIB_PACKAGE_VERSION,
-            type: "module",
-            exports: "./index.mjs",
-          }),
-          "packages/lib/index.mjs": libSource,
-        },
-        message: "Seed monorepo source workflow",
-      },
-    );
-    sourceCommitSha = writeResult.commitSha;
-  });
-
-  afterAll(async () => {
-    if (restartedSidecar !== undefined) {
-      restartedSidecar.proc.kill();
-      await restartedSidecar.proc.exited;
-    }
-    for (const dir of restartTempDirs.splice(0)) {
-      await fs.rm(dir, { recursive: true, force: true });
-    }
-    if (env !== undefined) await env.teardown();
-    if (h !== undefined) await h.close();
-    if (scratchDir !== undefined) {
-      await fs.rm(scratchDir, { recursive: true, force: true });
-    }
-  });
-
-  test("install -> deploy-by-source-ref -> run, then restart restores from the durable git store", async () => {
-    await seedAsset(h.db, {
-      id: DEFINITION_ASSET_ID,
-      tenantId: TENANT_ID,
-      kind: "workflow",
-      name: "source-monorepo-wf",
-      creatorPrincipalId: CALLER_PRINCIPAL_ID,
-    });
-
-    const source: WorkflowDefinitionAssetSource = {
-      kind: "asset",
-      assetId: SOURCE_ASSET_ID,
-      // The workflow lives in one member of the monorepo; select it by name.
-      package: {
-        format: "source",
-        commitSha: sourceCommitSha,
-        packageName: APP_PACKAGE_NAME,
-      },
-    };
-
-    const committed =
-      await env.hub.agentRepoStore.repoStore.openCommittedReadsAtCommit(
+      // Seed the monorepo source: a private workspace root plus two members, one
+      // the workflow (`@wf/app`) and one its `workspace:*` dependency (`@wf/lib`).
+      // The `workflow`-kind push accepts the root; the resolver enumerates both
+      // members from `packages/*`.
+      await env.hub.agentRepoStore.repoStore.initRepo(sourceRepoId);
+      const writeResult = await env.hub.agentRepoStore.repoStore.writeTree(
         HUB_PRINCIPAL,
         sourceRepoId,
-        sourceCommitSha,
+        DEFAULT_ASSET_REF,
+        {
+          files: {
+            "package.json": JSON.stringify({
+              name: "@wf/monorepo-root",
+              private: true,
+              workspaces: ["packages/*"],
+            }),
+            "packages/app/package.json": JSON.stringify({
+              name: APP_PACKAGE_NAME,
+              version: APP_PACKAGE_VERSION,
+              type: "module",
+              interchange: { workflow: WORKFLOW_ENTRY },
+              dependencies: { [LIB_PACKAGE_NAME]: "workspace:*" },
+            }),
+            "packages/app/workflow.mjs": workflowJs,
+            "packages/lib/package.json": JSON.stringify({
+              name: LIB_PACKAGE_NAME,
+              version: LIB_PACKAGE_VERSION,
+              type: "module",
+              exports: "./index.mjs",
+            }),
+            "packages/lib/index.mjs": libSource,
+          },
+          message: "Seed monorepo source workflow",
+        },
       );
-    if (committed === null) {
-      throw new Error("monorepo e2e: could not open committed reads at commit");
-    }
-    const reads = committedReadsToSourceTree(committed);
-
-    const operatorApprovals: ApprovalSet = new Set<string>([
-      "inference.source:anthropic:mock-model",
-      "director:@intx/agent/default",
-      `mail.address:${deploymentMailAddress}`,
-      `mail.send:${DEPLOYMENT_DOMAIN}`,
-    ]);
-
-    // 1) Install: enumerate the monorepo members, probe, gate, freeze.
-    const approved = await installAndApproveWorkflowDefinition({
-      source,
-      entry: WORKFLOW_ENTRY,
-      assetId: DEFINITION_ASSET_ID,
-      approvals: operatorApprovals,
-      router: env.hub.router,
-      db: h.db,
-      reads,
-      registryName: "npmjs",
-      registryConfig: { url: "https://registry.test" },
-      resolveAttachment,
+      sourceCommitSha = writeResult.commitSha;
     });
 
-    if (!approved.approval.ok) {
-      throw new Error(
-        `install/approve gate did not approve (reason: ${approved.approval.reason}): ` +
-          `${JSON.stringify(approved.approval)}\n${env.sidecarDiagnostics()}`,
-      );
-    }
-    expect(approved.projection.id).toBe("wf_monorepo");
-    expect(approved.projection.stepOrder).toEqual([STEP_ID]);
-    // The top-level pin is the selected member; the closure carries BOTH members
-    // as source entries.
-    expect(approved.closure.topLevel).toEqual([
-      { name: APP_PACKAGE_NAME, version: APP_PACKAGE_VERSION },
-    ]);
-    const byName = new Map(approved.closure.entries.map((e) => [e.name, e]));
-    for (const memberName of [APP_PACKAGE_NAME, LIB_PACKAGE_NAME]) {
-      const entry = byName.get(memberName);
-      if (entry?.source.kind !== "asset") {
-        throw new Error(`monorepo e2e: ${memberName} is not asset-sourced`);
+    afterAll(async () => {
+      if (restartedSidecar !== undefined) {
+        restartedSidecar.proc.kill();
+        await restartedSidecar.proc.exited;
       }
-      expect(entry.source.package.format).toBe("source");
-    }
+      for (const dir of restartTempDirs.splice(0)) {
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+      if (env !== undefined) await env.teardown();
+      if (h !== undefined) await h.close();
+      if (scratchDir !== undefined) {
+        await fs.rm(scratchDir, { recursive: true, force: true });
+      }
+    });
 
-    const versionRow = await h.db
-      .select({
-        approvedWireHash: workflowDefinitionVersionTable.approvedWireHash,
-      })
-      .from(workflowDefinitionVersionTable)
-      .where(
-        and(
-          eq(
-            workflowDefinitionVersionTable.definitionId,
-            approved.approval.definitionId,
+    test("install -> deploy-by-source-ref -> run, then restart restores from the durable git store", async () => {
+      await seedAsset(h.db, {
+        id: DEFINITION_ASSET_ID,
+        tenantId: TENANT_ID,
+        kind: "workflow",
+        name: "source-monorepo-wf",
+        creatorPrincipalId: CALLER_PRINCIPAL_ID,
+      });
+
+      const source: WorkflowDefinitionAssetSource = {
+        kind: "asset",
+        assetId: SOURCE_ASSET_ID,
+        // The workflow lives in one member of the monorepo; select it by name.
+        package: {
+          format: "source",
+          commitSha: sourceCommitSha,
+          packageName: APP_PACKAGE_NAME,
+        },
+      };
+
+      const committed =
+        await env.hub.agentRepoStore.repoStore.openCommittedReadsAtCommit(
+          HUB_PRINCIPAL,
+          sourceRepoId,
+          sourceCommitSha,
+        );
+      if (committed === null) {
+        throw new Error(
+          "monorepo e2e: could not open committed reads at commit",
+        );
+      }
+      const reads = committedReadsToSourceTree(committed);
+
+      const operatorApprovals: ApprovalSet = new Set<string>([
+        "inference.source:anthropic:mock-model",
+        "director:@intx/agent/default",
+        `mail.address:${deploymentMailAddress}`,
+        `mail.send:${DEPLOYMENT_DOMAIN}`,
+      ]);
+
+      // 1) Install: enumerate the monorepo members, probe, gate, freeze.
+      const approved = await installAndApproveWorkflowDefinition({
+        source,
+        entry: WORKFLOW_ENTRY,
+        assetId: DEFINITION_ASSET_ID,
+        approvals: operatorApprovals,
+        router: env.hub.router,
+        db: h.db,
+        reads,
+        registryName: "npmjs",
+        registryConfig: { url: "https://registry.test" },
+        resolveAttachment,
+      });
+
+      if (!approved.approval.ok) {
+        throw new Error(
+          `install/approve gate did not approve (reason: ${approved.approval.reason}): ` +
+            `${JSON.stringify(approved.approval)}\n${env.sidecarDiagnostics()}`,
+        );
+      }
+      expect(approved.projection.id).toBe("wf_monorepo");
+      expect(approved.projection.stepOrder).toEqual([STEP_ID]);
+      // The top-level pin is the selected member; the closure carries BOTH members
+      // as source entries.
+      expect(approved.closure.topLevel).toEqual([
+        { name: APP_PACKAGE_NAME, version: APP_PACKAGE_VERSION },
+      ]);
+      const byName = new Map(approved.closure.entries.map((e) => [e.name, e]));
+      for (const memberName of [APP_PACKAGE_NAME, LIB_PACKAGE_NAME]) {
+        const entry = byName.get(memberName);
+        if (entry?.source.kind !== "asset") {
+          throw new Error(`monorepo e2e: ${memberName} is not asset-sourced`);
+        }
+        expect(entry.source.package.format).toBe("source");
+      }
+
+      const versionRow = await h.db
+        .select({
+          approvedWireHash: workflowDefinitionVersionTable.approvedWireHash,
+        })
+        .from(workflowDefinitionVersionTable)
+        .where(
+          and(
+            eq(
+              workflowDefinitionVersionTable.definitionId,
+              approved.approval.definitionId,
+            ),
+            eq(workflowDefinitionVersionTable.version, "1"),
           ),
-          eq(workflowDefinitionVersionTable.version, "1"),
-        ),
-      )
-      .limit(1)
-      .then((rows) => rows[0]);
-    expect(versionRow?.approvedWireHash).toBe(
-      approved.approval.approvedWireHash,
-    );
-
-    // 2) Deploy by source-ref: the frame carries the monorepo asset inline.
-    const inferenceSource = {
-      id: "anthropic:mock-model",
-      provider: "anthropic",
-      baseURL: `http://localhost:${String(env.inference.server.port)}`,
-      apiKey: "sk-mock",
-      model: "mock-model",
-    };
-    const config: HarnessConfig = {
-      sessionId: SESSION_ID,
-      agentId: DEPLOYMENT_ID,
-      tenantId: "tenant-1",
-      principalId: "prin_integration-1",
-      agentAddress: deploymentMailAddress,
-      systemPrompt: "Fallback prompt (overridden per step by the definition)",
-      tools: [],
-      grants: [],
-      sources: [inferenceSource],
-      defaultSource: "anthropic:mock-model",
-    };
-
-    const deployResult = await deployCodeSourcedWorkflow({
-      approved,
-      source,
-      resolveAttachment,
-      sidecarRouter: env.hub.router,
-      agentAddress: deploymentMailAddress,
-      config,
-      sources: { [STEP_ID]: [inferenceSource] },
-      db: h.db,
-      tenantId: TENANT_ID,
-      anchorRunId: DEPLOYMENT_ID,
-      deploymentDomain: DEPLOYMENT_DOMAIN,
-    });
-    expect(deployResult.publicKey.length).toBeGreaterThan(0);
-
-    const anchorRow = await h.db
-      .select({ address: workflowRunTable.address })
-      .from(workflowRunTable)
-      .where(eq(workflowRunTable.id, DEPLOYMENT_ID))
-      .limit(1)
-      .then((rows) => rows[0]);
-    expect(anchorRow?.address).toBe(deploymentMailAddress);
-
-    const workflowRunRepoId: RepoId = {
-      kind: "workflow-run",
-      id: deriveDeploymentId(deploymentMailAddress),
-    };
-    env.registerDeployment({
-      anchorRunId: DEPLOYMENT_ID,
-      workflowDefinition: {
-        id: approved.projection.id,
-        triggers: [{ type: "mail", to: deploymentMailAddress }],
-        steps: {},
-        stepOrder: [...approved.projection.stepOrder],
-      },
-      workflowRunRepoId,
-      workflowRunRef: WORKFLOW_RUN_REF,
-      mailAddress: deploymentMailAddress,
-    });
-
-    await waitFor(
-      () =>
-        env.hub.router.getRoutableAddresses().includes(deploymentMailAddress),
-      { timeoutMs: 20_000, diagnostics: env.sidecarDiagnostics },
-    );
-
-    // 3) Fire the trigger and assert the run completes. This proves the monorepo
-    // closure resolved BOTH members, the sidecar checked both subtrees out of
-    // the delivered pack, and `@wf/app`'s entry resolved its `@wf/lib`
-    // workspace-local import at evaluation time.
-    await fireMailTrigger(env, deploymentMailAddress, {
-      messageId: "<source-monorepo-e2e@integration.interchange>",
-    });
-    const runId = await waitForFirstRunId(env, workflowRunRepoId, {
-      timeoutMs: 30_000,
-      diagnostics: env.sidecarDiagnostics,
-    });
-    const terminal = await waitForWorkflowRunComplete(
-      env,
-      DEPLOYMENT_ID,
-      runId,
-      { timeoutMs: 30_000, diagnostics: env.sidecarDiagnostics },
-    );
-    if (terminal.type !== "RunCompleted") {
-      throw new Error(
-        `expected RunCompleted, got ${terminal.type}: ${JSON.stringify(terminal.body)}\n${env.sidecarDiagnostics()}`,
+        )
+        .limit(1)
+        .then((rows) => rows[0]);
+      expect(versionRow?.approvedWireHash).toBe(
+        approved.approval.approvedWireHash,
       );
-    }
-    expect(terminal.type).toBe("RunCompleted");
 
-    // 4) Restore leg: kill the sidecar and bring a fresh one up against the SAME
-    // data directory. Boot-time restore re-materializes BOTH monorepo members
-    // from the durable indexed-`.git` store alone, so the deployment re-routing
-    // is the load-bearing restore assertion.
-    const restoredDataDir = env.sidecar.dataDir;
-    const hubPort = env.hub.server.port;
-    if (hubPort === undefined) {
-      throw new Error("monorepo e2e: hub.server.port is undefined after kill");
-    }
-    env.sidecar.proc.kill();
-    await env.sidecar.proc.exited;
+      // 2) Deploy by source-ref: the frame carries the monorepo asset inline.
+      const inferenceSource = {
+        id: "anthropic:mock-model",
+        provider: "anthropic",
+        baseURL: `http://localhost:${String(env.inference.server.port)}`,
+        apiKey: "sk-mock",
+        model: "mock-model",
+      };
+      const config: HarnessConfig = {
+        sessionId: SESSION_ID,
+        agentId: DEPLOYMENT_ID,
+        tenantId: "tenant-1",
+        principalId: "prin_integration-1",
+        agentAddress: deploymentMailAddress,
+        systemPrompt: "Fallback prompt (overridden per step by the definition)",
+        tools: [],
+        grants: [],
+        sources: [inferenceSource],
+        defaultSource: "anthropic:mock-model",
+      };
 
-    restartedSidecar = await startSidecarSubprocess({
-      hubPort,
-      registerTempDir: (dir) => {
-        restartTempDirs.push(dir);
-      },
-      extraEnv: { SIDECAR_DATA_DIR: restoredDataDir },
-    });
+      const deployResult = await deployCodeSourcedWorkflow({
+        approved,
+        source,
+        resolveAttachment,
+        sidecarRouter: env.hub.router,
+        agentAddress: deploymentMailAddress,
+        config,
+        sources: { [STEP_ID]: [inferenceSource] },
+        db: h.db,
+        tenantId: TENANT_ID,
+        anchorRunId: DEPLOYMENT_ID,
+        deploymentDomain: DEPLOYMENT_DOMAIN,
+      });
+      expect(deployResult.publicKey.length).toBeGreaterThan(0);
 
-    await waitFor(
-      () =>
-        env.hub.router.getRoutableAddresses().includes(deploymentMailAddress),
-      {
+      const anchorRow = await h.db
+        .select({ address: workflowRunTable.address })
+        .from(workflowRunTable)
+        .where(eq(workflowRunTable.id, DEPLOYMENT_ID))
+        .limit(1)
+        .then((rows) => rows[0]);
+      expect(anchorRow?.address).toBe(deploymentMailAddress);
+
+      const workflowRunRepoId: RepoId = {
+        kind: "workflow-run",
+        id: deriveDeploymentId(deploymentMailAddress),
+      };
+      env.registerDeployment({
+        anchorRunId: DEPLOYMENT_ID,
+        workflowDefinition: {
+          id: approved.projection.id,
+          triggers: [{ type: "mail", to: deploymentMailAddress }],
+          steps: {},
+          stepOrder: [...approved.projection.stepOrder],
+        },
+        workflowRunRepoId,
+        workflowRunRef: WORKFLOW_RUN_REF,
+        mailAddress: deploymentMailAddress,
+      });
+
+      await waitFor(
+        () =>
+          env.hub.router.getRoutableAddresses().includes(deploymentMailAddress),
+        { timeoutMs: 20_000, diagnostics: env.sidecarDiagnostics },
+      );
+
+      // 3) Fire the trigger and assert the run completes. This proves the monorepo
+      // closure resolved BOTH members, the sidecar checked both subtrees out of
+      // the delivered pack, and `@wf/app`'s entry resolved its `@wf/lib`
+      // workspace-local import at evaluation time.
+      await fireMailTrigger(env, deploymentMailAddress, {
+        messageId: "<source-monorepo-e2e@integration.interchange>",
+      });
+      const runId = await waitForFirstRunId(env, workflowRunRepoId, {
         timeoutMs: 30_000,
-        diagnostics: () =>
-          `${env.sidecarDiagnostics()}\nrestored sidecar stderr:\n${restartedSidecar?.stderr.slice(-60).join("") ?? "<none>"}`,
-      },
-    );
-  }, 180_000);
-});
+        diagnostics: env.sidecarDiagnostics,
+      });
+      const terminal = await waitForWorkflowRunComplete(
+        env,
+        DEPLOYMENT_ID,
+        runId,
+        { timeoutMs: 30_000, diagnostics: env.sidecarDiagnostics },
+      );
+      if (terminal.type !== "RunCompleted") {
+        throw new Error(
+          `expected RunCompleted, got ${terminal.type}: ${JSON.stringify(terminal.body)}\n${env.sidecarDiagnostics()}`,
+        );
+      }
+      expect(terminal.type).toBe("RunCompleted");
+
+      // 4) Restore leg: kill the sidecar and bring a fresh one up against the SAME
+      // data directory. Boot-time restore re-materializes BOTH monorepo members
+      // from the durable indexed-`.git` store alone, so the deployment re-routing
+      // is the load-bearing restore assertion.
+      const restoredDataDir = env.sidecar.dataDir;
+      const hubPort = env.hub.server.port;
+      if (hubPort === undefined) {
+        throw new Error(
+          "monorepo e2e: hub.server.port is undefined after kill",
+        );
+      }
+      env.sidecar.proc.kill();
+      await env.sidecar.proc.exited;
+
+      restartedSidecar = await startSidecarSubprocess({
+        hubPort,
+        registerTempDir: (dir) => {
+          restartTempDirs.push(dir);
+        },
+        extraEnv: { SIDECAR_DATA_DIR: restoredDataDir },
+      });
+
+      await waitFor(
+        () =>
+          env.hub.router.getRoutableAddresses().includes(deploymentMailAddress),
+        {
+          timeoutMs: 30_000,
+          diagnostics: () =>
+            `${env.sidecarDiagnostics()}\nrestored sidecar stderr:\n${restartedSidecar?.stderr.slice(-60).join("") ?? "<none>"}`,
+        },
+      );
+    }, 180_000);
+  },
+);

--- a/tests/workflow-deploy/source-tamper-reject.e2e.test.ts
+++ b/tests/workflow-deploy/source-tamper-reject.e2e.test.ts
@@ -29,7 +29,11 @@ import type { HarnessConfig } from "@intx/types/runtime";
 import type { WorkflowDefinitionAssetSource } from "@intx/types/workflow-sources";
 import { generateId } from "@intx/hub-common";
 import { deriveRunAddress, type ApprovalSet } from "@intx/workflow-deploy";
-import { createTestDb, type TestDb } from "@intx/test-harness/db-harness";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
 import { seedAsset, seedPrincipal } from "@intx/test-harness/seed";
 
 import {
@@ -155,167 +159,172 @@ const resolveAttachment = async (
   return { pack, ref, commitSha };
 };
 
-describe("tampered source-workflow deploy is rejected", () => {
-  beforeAll(async () => {
-    scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), "source-tamper-"));
-    const workflowJs = await bundleWorkflowEntry(scratchDir);
+describe.skipIf(!harnessDbEnvAvailable())(
+  "tampered source-workflow deploy is rejected",
+  () => {
+    beforeAll(async () => {
+      scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), "source-tamper-"));
+      const workflowJs = await bundleWorkflowEntry(scratchDir);
 
-    h = await createTestDb();
-    await h.db.insert(tenantTable).values({
-      id: TENANT_ID,
-      name: TENANT_ID,
-      slug: TENANT_ID,
-      domain: DEPLOYMENT_DOMAIN,
-      parentId: null,
-    });
-    await seedPrincipal(h.db, {
-      id: CALLER_PRINCIPAL_ID,
-      tenantId: TENANT_ID,
-      kind: "user",
-    });
+      h = await createTestDb();
+      await h.db.insert(tenantTable).values({
+        id: TENANT_ID,
+        name: TENANT_ID,
+        slug: TENANT_ID,
+        domain: DEPLOYMENT_DOMAIN,
+        parentId: null,
+      });
+      await seedPrincipal(h.db, {
+        id: CALLER_PRINCIPAL_ID,
+        tenantId: TENANT_ID,
+        kind: "user",
+      });
 
-    env = await startDeployFlowEnv({});
+      env = await startDeployFlowEnv({});
 
-    await env.hub.agentRepoStore.repoStore.initRepo(sourceRepoId);
-    const writeResult = await env.hub.agentRepoStore.repoStore.writeTree(
-      HUB_PRINCIPAL,
-      sourceRepoId,
-      DEFAULT_ASSET_REF,
-      {
-        files: {
-          "package.json": JSON.stringify({
-            name: PACKAGE_NAME,
-            version: PACKAGE_VERSION,
-            interchange: { workflow: WORKFLOW_ENTRY },
-          }),
-          "workflow.mjs": workflowJs,
-        },
-        message: "Seed tamper-skeleton workflow package",
-      },
-    );
-    sourceCommitSha = writeResult.commitSha;
-  });
-
-  afterAll(async () => {
-    if (env !== undefined) await env.teardown();
-    if (h !== undefined) await h.close();
-    if (scratchDir !== undefined) {
-      await fs.rm(scratchDir, { recursive: true, force: true });
-    }
-  });
-
-  test("a byte-tampered delivery fails the deploy and never routes", async () => {
-    await seedAsset(h.db, {
-      id: DEFINITION_ASSET_ID,
-      tenantId: TENANT_ID,
-      kind: "workflow",
-      name: "source-tamper-wf",
-      creatorPrincipalId: CALLER_PRINCIPAL_ID,
-    });
-
-    const source: WorkflowDefinitionAssetSource = {
-      kind: "asset",
-      assetId: SOURCE_ASSET_ID,
-      package: { format: "source", commitSha: sourceCommitSha },
-    };
-
-    const committed =
-      await env.hub.agentRepoStore.repoStore.openCommittedReadsAtCommit(
+      await env.hub.agentRepoStore.repoStore.initRepo(sourceRepoId);
+      const writeResult = await env.hub.agentRepoStore.repoStore.writeTree(
         HUB_PRINCIPAL,
         sourceRepoId,
-        sourceCommitSha,
+        DEFAULT_ASSET_REF,
+        {
+          files: {
+            "package.json": JSON.stringify({
+              name: PACKAGE_NAME,
+              version: PACKAGE_VERSION,
+              interchange: { workflow: WORKFLOW_ENTRY },
+            }),
+            "workflow.mjs": workflowJs,
+          },
+          message: "Seed tamper-skeleton workflow package",
+        },
       );
-    if (committed === null) {
-      throw new Error("tamper e2e: could not open committed reads at commit");
-    }
-
-    const approvals: ApprovalSet = new Set<string>([
-      "inference.source:anthropic:mock-model",
-      "director:@intx/agent/default",
-      `mail.address:${deploymentMailAddress}`,
-      `mail.send:${DEPLOYMENT_DOMAIN}`,
-    ]);
-
-    // 1) Install cleanly: the genuine closure is resolved and frozen.
-    const approved = await installAndApproveWorkflowDefinition({
-      source,
-      entry: WORKFLOW_ENTRY,
-      assetId: DEFINITION_ASSET_ID,
-      approvals,
-      router: env.hub.router,
-      db: h.db,
-      reads: committedReadsToSourceTree(committed),
-      registryName: "npmjs",
-      registryConfig: { url: "https://registry.test" },
-      resolveAttachment,
+      sourceCommitSha = writeResult.commitSha;
     });
-    if (!approved.approval.ok) {
-      throw new Error(
-        `tamper e2e: install did not approve: ${JSON.stringify(approved.approval)}`,
-      );
-    }
 
-    // 2) Deploy with a TAMPERED delivery.
-    tamperDelivery = true;
-    const inferenceSource = {
-      id: "anthropic:mock-model",
-      provider: "anthropic",
-      baseURL: `http://localhost:${String(env.inference.server.port)}`,
-      apiKey: "sk-mock",
-      model: "mock-model",
-    };
-    const config: HarnessConfig = {
-      sessionId: SESSION_ID,
-      agentId: DEPLOYMENT_ID,
-      tenantId: "tenant-1",
-      principalId: "prin_integration-1",
-      agentAddress: deploymentMailAddress,
-      systemPrompt: "Fallback prompt (overridden per step by the definition)",
-      tools: [],
-      grants: [],
-      sources: [inferenceSource],
-      defaultSource: "anthropic:mock-model",
-    };
+    afterAll(async () => {
+      if (env !== undefined) await env.teardown();
+      if (h !== undefined) await h.close();
+      if (scratchDir !== undefined) {
+        await fs.rm(scratchDir, { recursive: true, force: true });
+      }
+    });
 
-    let deployRejected = false;
-    try {
-      await deployCodeSourcedWorkflow({
-        approved,
-        source,
-        resolveAttachment,
-        sidecarRouter: env.hub.router,
-        agentAddress: deploymentMailAddress,
-        config,
-        sources: { [STEP_ID]: [inferenceSource] },
-        db: h.db,
+    test("a byte-tampered delivery fails the deploy and never routes", async () => {
+      await seedAsset(h.db, {
+        id: DEFINITION_ASSET_ID,
         tenantId: TENANT_ID,
-        anchorRunId: DEPLOYMENT_ID,
-        deploymentDomain: DEPLOYMENT_DOMAIN,
+        kind: "workflow",
+        name: "source-tamper-wf",
+        creatorPrincipalId: CALLER_PRINCIPAL_ID,
       });
-    } catch {
-      deployRejected = true;
-    }
 
-    // Whether the deploy call rejected outright or acked, the tampered source
-    // must never become routable: materialization failed, so the sidecar never
-    // reported the address as deployed.
-    let becameRoutable = false;
-    try {
-      await waitFor(
-        () =>
-          env.hub.router.getRoutableAddresses().includes(deploymentMailAddress),
-        { timeoutMs: 8_000 },
-      );
-      becameRoutable = true;
-    } catch {
-      // Expected: the address never became routable within the window.
-    }
-    expect(becameRoutable).toBe(false);
+      const source: WorkflowDefinitionAssetSource = {
+        kind: "asset",
+        assetId: SOURCE_ASSET_ID,
+        package: { format: "source", commitSha: sourceCommitSha },
+      };
 
-    // Positive signal that the failure is the tamper, not a vacuously
-    // non-routing harness: the deploy call itself rejected when the sidecar's
-    // integrity check failed on the tampered pack. (A CLEAN source deploy on
-    // this same harness DOES become routable -- see source-workflow.e2e.)
-    expect(deployRejected).toBe(true);
-  }, 120_000);
-});
+      const committed =
+        await env.hub.agentRepoStore.repoStore.openCommittedReadsAtCommit(
+          HUB_PRINCIPAL,
+          sourceRepoId,
+          sourceCommitSha,
+        );
+      if (committed === null) {
+        throw new Error("tamper e2e: could not open committed reads at commit");
+      }
+
+      const approvals: ApprovalSet = new Set<string>([
+        "inference.source:anthropic:mock-model",
+        "director:@intx/agent/default",
+        `mail.address:${deploymentMailAddress}`,
+        `mail.send:${DEPLOYMENT_DOMAIN}`,
+      ]);
+
+      // 1) Install cleanly: the genuine closure is resolved and frozen.
+      const approved = await installAndApproveWorkflowDefinition({
+        source,
+        entry: WORKFLOW_ENTRY,
+        assetId: DEFINITION_ASSET_ID,
+        approvals,
+        router: env.hub.router,
+        db: h.db,
+        reads: committedReadsToSourceTree(committed),
+        registryName: "npmjs",
+        registryConfig: { url: "https://registry.test" },
+        resolveAttachment,
+      });
+      if (!approved.approval.ok) {
+        throw new Error(
+          `tamper e2e: install did not approve: ${JSON.stringify(approved.approval)}`,
+        );
+      }
+
+      // 2) Deploy with a TAMPERED delivery.
+      tamperDelivery = true;
+      const inferenceSource = {
+        id: "anthropic:mock-model",
+        provider: "anthropic",
+        baseURL: `http://localhost:${String(env.inference.server.port)}`,
+        apiKey: "sk-mock",
+        model: "mock-model",
+      };
+      const config: HarnessConfig = {
+        sessionId: SESSION_ID,
+        agentId: DEPLOYMENT_ID,
+        tenantId: "tenant-1",
+        principalId: "prin_integration-1",
+        agentAddress: deploymentMailAddress,
+        systemPrompt: "Fallback prompt (overridden per step by the definition)",
+        tools: [],
+        grants: [],
+        sources: [inferenceSource],
+        defaultSource: "anthropic:mock-model",
+      };
+
+      let deployRejected = false;
+      try {
+        await deployCodeSourcedWorkflow({
+          approved,
+          source,
+          resolveAttachment,
+          sidecarRouter: env.hub.router,
+          agentAddress: deploymentMailAddress,
+          config,
+          sources: { [STEP_ID]: [inferenceSource] },
+          db: h.db,
+          tenantId: TENANT_ID,
+          anchorRunId: DEPLOYMENT_ID,
+          deploymentDomain: DEPLOYMENT_DOMAIN,
+        });
+      } catch {
+        deployRejected = true;
+      }
+
+      // Whether the deploy call rejected outright or acked, the tampered source
+      // must never become routable: materialization failed, so the sidecar never
+      // reported the address as deployed.
+      let becameRoutable = false;
+      try {
+        await waitFor(
+          () =>
+            env.hub.router
+              .getRoutableAddresses()
+              .includes(deploymentMailAddress),
+          { timeoutMs: 8_000 },
+        );
+        becameRoutable = true;
+      } catch {
+        // Expected: the address never became routable within the window.
+      }
+      expect(becameRoutable).toBe(false);
+
+      // Positive signal that the failure is the tamper, not a vacuously
+      // non-routing harness: the deploy call itself rejected when the sidecar's
+      // integrity check failed on the tampered pack. (A CLEAN source deploy on
+      // this same harness DOES become routable -- see source-workflow.e2e.)
+      expect(deployRejected).toBe(true);
+    }, 120_000);
+  },
+);

--- a/tests/workflow-deploy/source-workflow.e2e.test.ts
+++ b/tests/workflow-deploy/source-workflow.e2e.test.ts
@@ -43,7 +43,11 @@ import type { WorkflowDefinitionAssetSource } from "@intx/types/workflow-sources
 import { generateId } from "@intx/hub-common";
 import { deriveRunAddress, type ApprovalSet } from "@intx/workflow-deploy";
 import { deriveDeploymentId } from "@intx/sidecar-app/src/workflow-host-wiring";
-import { createTestDb, type TestDb } from "@intx/test-harness/db-harness";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
 import { seedAsset, seedPrincipal } from "@intx/test-harness/seed";
 
 import {
@@ -149,7 +153,7 @@ const resolveAttachment = async (
   return { pack, ref, commitSha };
 };
 
-describe("source-sourced workflow e2e", () => {
+describe.skipIf(!harnessDbEnvAvailable())("source-sourced workflow e2e", () => {
   beforeAll(async () => {
     scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), "source-skeleton-"));
     const workflowJs = await bundleWorkflowEntry(

--- a/tests/workflow-deploy/unresolvable-director.test.ts
+++ b/tests/workflow-deploy/unresolvable-director.test.ts
@@ -52,6 +52,7 @@ let env: DeployFlowEnv;
 let h: TestDb;
 
 beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
   h = await createTestDb();
   await h.db.insert(tenantTable).values({
     id: TENANT_ID,

--- a/tests/workflow-deploy/walking-skeleton.e2e.test.ts
+++ b/tests/workflow-deploy/walking-skeleton.e2e.test.ts
@@ -66,7 +66,11 @@ import type { WorkflowDefinitionRegistrySource } from "@intx/types/workflow-sour
 import { generateId } from "@intx/hub-common";
 import { deriveRunAddress, type ApprovalSet } from "@intx/workflow-deploy";
 import { deriveDeploymentId } from "@intx/sidecar-app/src/workflow-host-wiring";
-import { createTestDb, type TestDb } from "@intx/test-harness/db-harness";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
 import { seedAsset, seedPrincipal } from "@intx/test-harness/seed";
 
 import {
@@ -318,7 +322,7 @@ let tarballUrl: string;
 let bodyFixture: WorkflowPackageFixture;
 let bodyTarballUrl: string;
 
-describe("walking skeleton e2e", () => {
+describe.skipIf(!harnessDbEnvAvailable())("walking skeleton e2e", () => {
   beforeAll(async () => {
     scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), "walking-skeleton-"));
     fixture = await buildWorkflowPackageFixture(scratchDir, {


### PR DESCRIPTION
## Summary

- The README version badge reads the latest release tag from GitHub (a
  dynamic shields.io tag badge) instead of a hardcoded series, and the two
  prose mentions drop the version number while keeping "alpha" — so the git
  tag is the single source of truth and nothing drifts.
- Database-dependent `tests/workflow-deploy/` suites skip instead of failing
  on a checkout with no configured database: a file-scope `beforeAll` returns
  early when the DB env is absent, and the e2e suites that lacked a guard wrap
  their `describe` in `skipIf`. The `harnessDbEnvAvailable` docstring now
  documents both shapes and the file-scope-hook trap that caused the drift.

## Verification

- `make all` passes with a database present (exits 0: lint, type check,
  admin-ui bundle, and full test suite green).
- `make test` passes on a checkout with the database env removed (exits 0; the
  previously-failing workflow-deploy suites now skip, 0 fail).

Closes INTR-486