### PR TITLE
Pass the credential cipher through shared workflow deploy

### DIFF
--- a/packages/hub-api/src/app.ts
+++ b/packages/hub-api/src/app.ts
@@ -116,7 +116,8 @@ export type MountHubRoutesDeps = {
   workflowDispatchService?: WorkflowDispatchService;
   eventCollectors: EventCollectorRegistry;
   /**
-   * Encrypts credential secrets at rest on the credential/oauth write paths.
+   * Encrypts credential secrets at rest on the credential/oauth write paths
+   * and decrypts tenant-owned credential bindings on workflow deploy.
    * Optional: when omitted, a noop cipher is used and a warning is logged.
    * Production supplies a real cipher; tests that do not exercise credential
    * secrets can omit it.
@@ -500,7 +501,8 @@ export type CreateAppOpts = {
   workflowDispatchService?: WorkflowDispatchService;
   eventCollectors: EventCollectorRegistry;
   /**
-   * Encrypts credential secrets at rest on the credential/oauth write paths.
+   * Encrypts credential secrets at rest on the credential/oauth write paths
+   * and decrypts tenant-owned credential bindings on workflow deploy.
    * Optional: when omitted, a noop cipher is used and a warning is logged.
    * Production supplies a real cipher; tests that do not exercise credential
    * secrets can omit it.

--- a/packages/hub-api/src/app.ts
+++ b/packages/hub-api/src/app.ts
@@ -327,6 +327,7 @@ export function mountHubRoutes(
         repoStore,
         grantStore,
         requireGrant,
+        credentialCipher,
       }),
     );
   }

--- a/packages/hub-api/src/routes/workflows.test.ts
+++ b/packages/hub-api/src/routes/workflows.test.ts
@@ -6,9 +6,14 @@ import git from "isomorphic-git";
 import { type, type Type } from "arktype";
 
 import { createInMemoryGrantStore, evaluateGrants } from "@intx/authz";
+import { createNoopCredentialCipher } from "@intx/crypto";
 import { WorkflowRunDispatchPayloadConflictError } from "@intx/db";
 import { base64Decode, ErrorResponse, signalName } from "@intx/types";
-import type { GrantWalkSnapshot, SidecarAllocationStatus } from "@intx/types";
+import type {
+  CredentialCipher,
+  GrantWalkSnapshot,
+  SidecarAllocationStatus,
+} from "@intx/types";
 import type { GrantRule } from "@intx/types/authz";
 import {
   asset as assetTable,
@@ -790,6 +795,7 @@ type TestAppOpts = {
   tenantConfig?: unknown;
   repoDirById?: Map<string, string>;
   runLifecycle?: WorkflowRunLifecycle | (() => WorkflowRunLifecycle);
+  credentialCipher?: CredentialCipher;
 };
 
 // Project a workflow envelope into the deploy-approved grant-walk snapshot the
@@ -884,6 +890,9 @@ function createTestApp(opts: TestAppOpts = {}) {
       opts.runLifecycle ?? "live",
     ),
     maxTarballBytes: 10_000_000,
+    ...(opts.credentialCipher !== undefined
+      ? { credentialCipher: opts.credentialCipher }
+      : {}),
   });
 }
 
@@ -1038,6 +1047,31 @@ describe("POST /workflows/deployments", () => {
         model: "m",
       },
     ]);
+  });
+
+  test("forwards the app credential cipher onto the shared deploy", async () => {
+    const deployCalls: DeployWorkflowFromSourceParams[] = [];
+    const credentialCipher = createNoopCredentialCipher();
+    const app = createTestApp({
+      grants: [makeGrant({ action: "create" })],
+      deployCalls,
+      deployResult: {
+        anchorRunId: DEPLOYMENT_ID,
+        deploymentAddress: `${DEPLOYMENT_ID}@${DOMAIN}`,
+        publicKey: "pubkey",
+      },
+      credentialCipher,
+    });
+
+    const res = await app.fetch(
+      authedPost(`${base()}/deployments`, sourceDeployBody()),
+    );
+
+    expect(res.status).toBe(201);
+    expect(deployCalls).toHaveLength(1);
+    const call = deployCalls[0];
+    if (call === undefined) throw new Error("missing deploy call");
+    expect(call.credentialCipher).toBe(credentialCipher);
   });
 
   test("prepares an exclusive deployment and returns a pending record", async () => {

--- a/packages/hub-api/src/routes/workflows.ts
+++ b/packages/hub-api/src/routes/workflows.ts
@@ -20,6 +20,7 @@ import {
   ErrorResponse,
   isSidecarAllocationDispatchable,
   SendMessage,
+  type CredentialCipher,
   type SidecarAllocationStatus,
 } from "@intx/types";
 import { InferenceSource } from "@intx/types/runtime";
@@ -191,6 +192,7 @@ export type CreateWorkflowRoutesDeps = {
   repoStore: RepoStore;
   grantStore: GrantStore;
   requireGrant: RequireGrant;
+  credentialCipher: CredentialCipher;
 };
 
 export function createWorkflowRoutes({
@@ -202,6 +204,7 @@ export function createWorkflowRoutes({
   repoStore,
   grantStore,
   requireGrant,
+  credentialCipher,
 }: CreateWorkflowRoutesDeps): Hono<TenantEnv> {
   const app = new Hono<TenantEnv>();
   const runReader = createWorkflowRunReader(repoStore);
@@ -438,6 +441,7 @@ export function createWorkflowRoutes({
             ...(body.pin !== undefined ? { pin: body.pin } : {}),
             definitionAssetId: assetRow.id,
             config,
+            credentialCipher,
           });
           deployedId = result.anchorRunId;
         } catch (err) {

--- a/packages/hub-sessions/src/session-service.ts
+++ b/packages/hub-sessions/src/session-service.ts
@@ -211,6 +211,8 @@ export type DeployWorkflowFromSourceParams = {
    * step to one approved source from it.
    */
   config: HarnessConfig;
+  /** Cipher for the definition's tenant-owned credential bindings, if any. */
+  credentialCipher?: CredentialCipher;
 };
 
 /**
@@ -1567,6 +1569,9 @@ export function createSessionService(
       tenantId: params.tenantId,
       anchorRunId: params.anchorRunId,
       deploymentDomain: params.deploymentDomain,
+      ...(params.credentialCipher !== undefined
+        ? { credentialCipher: params.credentialCipher }
+        : {}),
     };
     // Branch on the source discriminant so the deploy args match the
     // asset/registry arms of `DeployCodeSourcedWorkflowArgs`: an asset arm


### PR DESCRIPTION
## Summary

- HTTP workflow source-deploy passes the tenant credential cipher into the shared deploy path so definition bindings can decrypt.
- Shared deploy forwards an optional cipher onto code-sourced deploy when present; other callers stay cipher-less.

## Verification

- `make all` exits 0 in the worktree (7220 pass, 0 fail; then 399 pass, 590 skip).
- Route test asserts the same cipher object is forwarded onto the shared deploy call.

Closes INTR-484