### PR TITLE
Add a concurrent-signal validator, share the run-lifecycle readers, extract a terminal-flip helper, and remove the dead deploy-test tarball wiring

### DIFF
--- a/packages/hub-sessions/src/workflow-run-kind.test.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.test.ts
@@ -2970,6 +2970,24 @@ describe("claim-check API — resume-owned processing entries survive replay", (
     ).rejects.toThrow(/workflow_run_event_unreadable/);
   });
 
+  test("readWorkflowRunLifecycle surfaces a non-ENOENT events-directory read error", async () => {
+    // An absent events directory (ENOENT) classifies as absent, but a
+    // non-ENOENT read error must surface rather than be swallowed as absent.
+    // Seed the per-event `events` path as a file so readdir fails with ENOTDIR.
+    const { store, repoId } = await makeClaimCheckStore("cc-enotdir-");
+    const runDir = path.join(
+      store.getRepoDir(repoId),
+      WORKFLOW_RUN_RUNS_PREFIX,
+      "notdir",
+    );
+    await fs.promises.mkdir(runDir, { recursive: true });
+    await fs.promises.writeFile(path.join(runDir, "events"), "not a directory");
+
+    await expect(
+      readWorkflowRunLifecycle(store, repoId, "notdir"),
+    ).rejects.toThrow();
+  });
+
   test("a CancelRequested-without-finalizer run is still owned (its message stays suppressed)", async () => {
     const { store, repoId, principal } = await makeClaimCheckStore(
       "cc-owned-cancelling-",

--- a/packages/hub-sessions/src/workflow-run-kind.test.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.test.ts
@@ -2871,6 +2871,54 @@ describe("claim-check API — resume-owned processing entries survive replay", (
     ).resolves.toBe("absent");
   });
 
+  test("readWorkflowRunLifecycle and readCommittedWorkflowRunLifecycle agree across states", async () => {
+    // Both readers run one shared classification core over different read
+    // surfaces (working-tree fs vs committed git objects). Seed one tree and
+    // read every run BOTH ways to prove the two surfaces classify identically.
+    const { store, repoId, principal } = await makeClaimCheckStore("cc-equiv-");
+    const sealedLog =
+      [runStartedBody("sealed"), runCompletedBody(1)].join("\n") + "\n";
+    await store.writeTree(principal, repoId, "refs/heads/main", {
+      files: {
+        [`${WORKFLOW_RUN_RUNS_PREFIX}/staged/grants.json`]: JSON.stringify({
+          stepGrants: [],
+        }),
+        [`${WORKFLOW_RUN_RUNS_PREFIX}/live/events/0.json`]:
+          runStartedBody("live-message"),
+        [`${WORKFLOW_RUN_RUNS_PREFIX}/done/events/0.json`]:
+          runStartedBody("done-message"),
+        [`${WORKFLOW_RUN_RUNS_PREFIX}/done/events/1.json`]: runCompletedBody(1),
+        [`${WORKFLOW_RUN_RUNS_PREFIX}/sealed/events.jsonl`]: sealedLog,
+      },
+      message: "seed lifecycle states for the equivalence check",
+    });
+
+    const reads = await store.openCommittedReads(
+      principal,
+      repoId,
+      "refs/heads/main",
+    );
+    expect(reads).not.toBeNull();
+
+    const cases = [
+      ["missing", "absent"],
+      ["staged", "absent"],
+      ["live", "live"],
+      ["done", "terminal"],
+      ["sealed", "terminal"],
+    ] as const;
+    for (const [runId, expected] of cases) {
+      const fsResult = await readWorkflowRunLifecycle(store, repoId, runId);
+      const committedResult = await readCommittedWorkflowRunLifecycle(
+        reads,
+        runId,
+      );
+      expect(fsResult).toBe(expected);
+      expect(committedResult).toBe(expected);
+      expect(committedResult).toBe(fsResult);
+    }
+  });
+
   test("a CancelRequested-without-finalizer run is still owned (its message stays suppressed)", async () => {
     const { store, repoId, principal } = await makeClaimCheckStore(
       "cc-owned-cancelling-",

--- a/packages/hub-sessions/src/workflow-run-kind.test.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.test.ts
@@ -2919,6 +2919,57 @@ describe("claim-check API — resume-owned processing entries survive replay", (
     }
   });
 
+  test("readWorkflowRunLifecycle wraps an unreadable latest event", async () => {
+    // A validated write cannot store a corrupt event, so seed a valid live run
+    // and then corrupt its latest event on disk -- the storage-corruption case
+    // the reader must surface as `workflow_run_event_unreadable` rather than
+    // misclassify.
+    const { store, repoId, principal } =
+      await makeClaimCheckStore("cc-corrupt-fs-");
+    await store.writeTree(principal, repoId, "refs/heads/main", {
+      files: {
+        [`${WORKFLOW_RUN_RUNS_PREFIX}/corrupt/events/0.json`]:
+          runStartedBody("corrupt"),
+      },
+      message: "seed a valid live run",
+    });
+    const eventPath = path.join(
+      store.getRepoDir(repoId),
+      WORKFLOW_RUN_RUNS_PREFIX,
+      "corrupt",
+      "events",
+      "0.json",
+    );
+    await fs.promises.writeFile(eventPath, "not valid json{");
+
+    await expect(
+      readWorkflowRunLifecycle(store, repoId, "corrupt"),
+    ).rejects.toThrow(/workflow_run_event_unreadable/);
+  });
+
+  test("readCommittedWorkflowRunLifecycle wraps an unreadable latest event", async () => {
+    // The committed reader reads git objects, so inject the corruption through
+    // a reads stub whose latest blob will not parse.
+    const reads = {
+      async treeOid() {
+        return null;
+      },
+      async listDir(dirPath: string) {
+        if (dirPath === "runs/corrupt/events") {
+          return [{ name: "0.json", oid: "corrupt", type: "blob" as const }];
+        }
+        return [];
+      },
+      async readBlobByOid(_oid: string) {
+        return new TextEncoder().encode("not valid json{");
+      },
+    };
+
+    await expect(
+      readCommittedWorkflowRunLifecycle(reads, "corrupt"),
+    ).rejects.toThrow(/workflow_run_event_unreadable/);
+  });
+
   test("a CancelRequested-without-finalizer run is still owned (its message stays suppressed)", async () => {
     const { store, repoId, principal } = await makeClaimCheckStore(
       "cc-owned-cancelling-",

--- a/packages/hub-sessions/src/workflow-run-kind.ts
+++ b/packages/hub-sessions/src/workflow-run-kind.ts
@@ -3874,50 +3874,31 @@ export async function scanRunsForBoot(
 
 export type WorkflowRunLifecycle = "absent" | "live" | "terminal";
 
-/** Read one run's lifecycle from a committed workflow-run tree. */
-export async function readCommittedWorkflowRunLifecycle(
-  reads: CommittedReads | null,
-  runId: string,
-): Promise<WorkflowRunLifecycle> {
-  if (reads === null) return "absent";
-  const runPath = `${WORKFLOW_RUN_RUNS_PREFIX}/${runId}`;
-  const runChildren = await reads.listDir(runPath);
-  if (
-    runChildren.some(
-      (entry) =>
-        entry.type === "blob" && entry.name === WORKFLOW_RUN_EVENTS_FILE,
-    )
-  ) {
-    return "terminal";
-  }
-
-  const eventsPath = `${runPath}/${WORKFLOW_RUN_EVENTS_DIR}`;
-  const eventEntries = (await reads.listDir(eventsPath)).filter(
-    (entry) => entry.type === "blob" && parseEventSeq(entry.name) !== null,
-  );
-  const latest = eventEntries.reduce<(typeof eventEntries)[number] | undefined>(
-    (candidate, entry) => {
-      if (candidate === undefined) return entry;
-      const candidateSeq = parseEventSeq(candidate.name);
-      const entrySeq = parseEventSeq(entry.name);
-      return entrySeq !== null &&
-        candidateSeq !== null &&
-        entrySeq > candidateSeq
-        ? entry
-        : candidate;
-    },
+/**
+ * Classify a run's lifecycle from a read surface. The committed (git-object)
+ * and working-tree (node:fs) readers share this core: a sealed combined log is
+ * terminal; otherwise the latest per-event file decides terminal-vs-live, and a
+ * run with no events is absent. The surface owns every read detail -- the
+ * absent/ENOENT discrimination, the per-surface entry filter, and wrapping an
+ * unreadable latest event as `workflow_run_event_unreadable` -- so this core
+ * never sees a raw read error.
+ */
+async function classifyRunLifecycle<
+  E extends { readonly seq: number },
+>(surface: {
+  sealedLogPresent(): Promise<boolean>;
+  listEventEntries(): Promise<readonly E[]>;
+  readEvent(entry: E): Promise<unknown>;
+}): Promise<WorkflowRunLifecycle> {
+  if (await surface.sealedLogPresent()) return "terminal";
+  const entries = await surface.listEventEntries();
+  const latest = entries.reduce<E | undefined>(
+    (candidate, entry) =>
+      candidate === undefined || entry.seq > candidate.seq ? entry : candidate,
     undefined,
   );
   if (latest !== undefined) {
-    const eventPath = `${eventsPath}/${latest.name}`;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(
-        new TextDecoder().decode(await reads.readBlobByOid(latest.oid)),
-      );
-    } catch (cause) {
-      throw new Error(`workflow_run_event_unreadable: ${eventPath}`, { cause });
-    }
+    const parsed = await surface.readEvent(latest);
     if (
       typeof parsed === "object" &&
       parsed !== null &&
@@ -3928,7 +3909,46 @@ export async function readCommittedWorkflowRunLifecycle(
       return "terminal";
     }
   }
-  return eventEntries.length === 0 ? "absent" : "live";
+  return entries.length === 0 ? "absent" : "live";
+}
+
+/** Read one run's lifecycle from a committed workflow-run tree. */
+export async function readCommittedWorkflowRunLifecycle(
+  reads: CommittedReads | null,
+  runId: string,
+): Promise<WorkflowRunLifecycle> {
+  if (reads === null) return "absent";
+  const runPath = `${WORKFLOW_RUN_RUNS_PREFIX}/${runId}`;
+  const eventsPath = `${runPath}/${WORKFLOW_RUN_EVENTS_DIR}`;
+  return classifyRunLifecycle<{ seq: number; name: string; oid: string }>({
+    async sealedLogPresent() {
+      const runChildren = await reads.listDir(runPath);
+      return runChildren.some(
+        (entry) =>
+          entry.type === "blob" && entry.name === WORKFLOW_RUN_EVENTS_FILE,
+      );
+    },
+    async listEventEntries() {
+      const eventEntries = await reads.listDir(eventsPath);
+      return eventEntries.flatMap((entry) => {
+        if (entry.type !== "blob") return [];
+        const seq = parseEventSeq(entry.name);
+        return seq === null ? [] : [{ seq, name: entry.name, oid: entry.oid }];
+      });
+    },
+    async readEvent(entry) {
+      const eventPath = `${eventsPath}/${entry.name}`;
+      try {
+        return JSON.parse(
+          new TextDecoder().decode(await reads.readBlobByOid(entry.oid)),
+        );
+      } catch (cause) {
+        throw new Error(`workflow_run_event_unreadable: ${eventPath}`, {
+          cause,
+        });
+      }
+    },
+  });
 }
 
 /**
@@ -3955,59 +3975,53 @@ export async function readWorkflowRunLifecycle(
     WORKFLOW_RUN_RUNS_PREFIX,
     runId,
   );
-
-  try {
-    await fs.access(path.join(runDir, WORKFLOW_RUN_EVENTS_FILE));
-    return "terminal";
-  } catch (cause) {
-    if (
-      !(cause instanceof Error) ||
-      !("code" in cause) ||
-      cause.code !== "ENOENT"
-    ) {
-      throw cause;
-    }
-  }
-
   const eventsDir = path.join(runDir, WORKFLOW_RUN_EVENTS_DIR);
-  let files: string[];
-  try {
-    files = await fs.readdir(eventsDir);
-  } catch (cause) {
-    if (cause instanceof Error && "code" in cause && cause.code === "ENOENT") {
-      return "absent";
-    }
-    throw cause;
-  }
-
-  const eventFiles = files.filter((file) => parseEventSeq(file) !== null);
-  const latest = eventFiles.reduce<string | undefined>((candidate, file) => {
-    if (candidate === undefined) return file;
-    const candidateSeq = parseEventSeq(candidate);
-    const fileSeq = parseEventSeq(file);
-    return fileSeq !== null && candidateSeq !== null && fileSeq > candidateSeq
-      ? file
-      : candidate;
-  }, undefined);
-  if (latest !== undefined) {
-    const eventPath = path.join(eventsDir, latest);
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(await fs.readFile(eventPath, "utf8"));
-    } catch (cause) {
-      throw new Error(`workflow_run_event_unreadable: ${eventPath}`, { cause });
-    }
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      "type" in parsed &&
-      typeof parsed.type === "string" &&
-      TERMINAL_EVENT_TYPES.has(parsed.type)
-    ) {
-      return "terminal";
-    }
-  }
-  return eventFiles.length === 0 ? "absent" : "live";
+  return classifyRunLifecycle<{ seq: number; name: string }>({
+    async sealedLogPresent() {
+      try {
+        await fs.access(path.join(runDir, WORKFLOW_RUN_EVENTS_FILE));
+        return true;
+      } catch (cause) {
+        if (
+          !(cause instanceof Error) ||
+          !("code" in cause) ||
+          cause.code !== "ENOENT"
+        ) {
+          throw cause;
+        }
+        return false;
+      }
+    },
+    async listEventEntries() {
+      let files: string[];
+      try {
+        files = await fs.readdir(eventsDir);
+      } catch (cause) {
+        if (
+          cause instanceof Error &&
+          "code" in cause &&
+          cause.code === "ENOENT"
+        ) {
+          return [];
+        }
+        throw cause;
+      }
+      return files.flatMap((file) => {
+        const seq = parseEventSeq(file);
+        return seq === null ? [] : [{ seq, name: file }];
+      });
+    },
+    async readEvent(entry) {
+      const eventPath = path.join(eventsDir, entry.name);
+      try {
+        return JSON.parse(await fs.readFile(eventPath, "utf8"));
+      } catch (cause) {
+        throw new Error(`workflow_run_event_unreadable: ${eventPath}`, {
+          cause,
+        });
+      }
+    },
+  });
 }
 
 export type ReplayProcessingToInboxOpts = {

--- a/packages/workflow/src/definition/workflow.test.ts
+++ b/packages/workflow/src/definition/workflow.test.ts
@@ -1122,6 +1122,228 @@ describe("awaitSignal onTimeout validation", () => {
   });
 });
 
+describe("concurrent awaitSignal name validation", () => {
+  test("rejects two dependency-free gates sharing a signal name", () => {
+    expect(() =>
+      defineWorkflow({
+        id: "wf",
+        trigger: { type: "manual" },
+        steps: {
+          gateA: awaitSignal({ name: "go" }),
+          gateB: awaitSignal({ name: "go" }),
+        },
+      }),
+    ).toThrow(/can concurrently await signal name go/);
+  });
+
+  test("accepts concurrent gates with distinct signal names", () => {
+    expect(() =>
+      defineWorkflow({
+        id: "wf",
+        trigger: { type: "manual" },
+        steps: {
+          gateA: awaitSignal({ name: "go" }),
+          gateB: awaitSignal({ name: "stop" }),
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  test("accepts same-name gates that are dependency-ordered", () => {
+    expect(() =>
+      defineWorkflow({
+        id: "wf",
+        trigger: { type: "manual" },
+        steps: {
+          first: awaitSignal({ name: "go" }),
+          second: awaitSignal({ name: "go", after: ["first"] }),
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  test("rejects a parent gate concurrent with a loop body awaiting the same name", () => {
+    expect(() =>
+      defineWorkflow({
+        id: "wf",
+        trigger: { type: "manual" },
+        steps: {
+          wait: awaitSignal({ name: "go" }),
+          rework: loop({
+            body: defineWorkflow({
+              id: "body",
+              trigger: { type: "manual" },
+              steps: { inner: awaitSignal({ name: "go" }) },
+            }),
+            while: "w",
+            carry: "c",
+            maxIterations: 2,
+            onExhausted: "esc",
+          }),
+          esc: step({ agent: makeAgent("e"), after: ["rework"] }),
+        },
+      }),
+    ).toThrow(/can concurrently await signal name go/);
+  });
+
+  test("accepts a loop body awaiting a name its parent gate is ordered before", () => {
+    expect(() =>
+      defineWorkflow({
+        id: "wf",
+        trigger: { type: "manual" },
+        steps: {
+          wait: awaitSignal({ name: "go" }),
+          rework: loop({
+            body: defineWorkflow({
+              id: "body",
+              trigger: { type: "manual" },
+              steps: { inner: awaitSignal({ name: "go" }) },
+            }),
+            while: "w",
+            carry: "c",
+            maxIterations: 2,
+            onExhausted: "esc",
+            after: ["wait"],
+          }),
+          esc: step({ agent: makeAgent("e"), after: ["rework"] }),
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  test("accepts a same-name awaiter across a childWorkflow boundary", () => {
+    expect(() =>
+      defineWorkflow({
+        id: "wf",
+        trigger: { type: "manual" },
+        steps: {
+          wait: awaitSignal({ name: "go" }),
+          child: childWorkflow({
+            definition: defineWorkflow({
+              id: "child",
+              trigger: { type: "manual" },
+              steps: { inner: awaitSignal({ name: "go" }) },
+            }),
+          }),
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  test("rejects a nested inner-loop body awaiting a name concurrent with a parent gate", () => {
+    expect(() =>
+      defineWorkflow({
+        id: "wf",
+        trigger: { type: "manual" },
+        steps: {
+          wait: awaitSignal({ name: "go" }),
+          outer: loop({
+            body: defineWorkflow({
+              id: "outer-body",
+              trigger: { type: "manual" },
+              steps: {
+                inner: loop({
+                  body: defineWorkflow({
+                    id: "inner-body",
+                    trigger: { type: "manual" },
+                    steps: { w: awaitSignal({ name: "go" }) },
+                  }),
+                  while: "w",
+                  carry: "c",
+                  maxIterations: 2,
+                  onExhausted: "innerEsc",
+                }),
+                innerEsc: step({ agent: makeAgent("ie"), after: ["inner"] }),
+              },
+            }),
+            while: "w",
+            carry: "c",
+            maxIterations: 2,
+            onExhausted: "esc",
+          }),
+          esc: step({ agent: makeAgent("e"), after: ["outer"] }),
+        },
+      }),
+    ).toThrow(/can concurrently await signal name go/);
+  });
+
+  test("rejects an inline onTrigger body awaiting a name concurrent with a parent gate", () => {
+    expect(() =>
+      defineWorkflow({
+        id: "wf",
+        trigger: { type: "manual" },
+        steps: {
+          wait: awaitSignal({ name: "go" }),
+          section: onTrigger({
+            on: { type: "manual" },
+            body: defineWorkflow({
+              id: "section-body",
+              trigger: { type: "manual" },
+              steps: { w: awaitSignal({ name: "go" }) },
+            }),
+          }),
+        },
+      }),
+    ).toThrow(/can concurrently await signal name go/);
+  });
+
+  test("accepts a childWorkflow nested in a loop body awaiting the parent's name", () => {
+    expect(() =>
+      defineWorkflow({
+        id: "wf",
+        trigger: { type: "manual" },
+        steps: {
+          wait: awaitSignal({ name: "go" }),
+          rework: loop({
+            body: defineWorkflow({
+              id: "body",
+              trigger: { type: "manual" },
+              steps: {
+                sub: childWorkflow({
+                  definition: defineWorkflow({
+                    id: "child",
+                    trigger: { type: "manual" },
+                    steps: { w: awaitSignal({ name: "go" }) },
+                  }),
+                }),
+              },
+            }),
+            while: "w",
+            carry: "c",
+            maxIterations: 2,
+            onExhausted: "esc",
+          }),
+          esc: step({ agent: makeAgent("e"), after: ["rework"] }),
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  test("rejects same-name awaiters on a gate's then and else branches (conservative)", () => {
+    // Documents the accepted over-reject: the two gates are mutually exclusive
+    // at runtime, but deciding that statically is a dominator analysis whose
+    // permissive-direction error would re-admit the hazard, so this is rejected
+    // and the runtime guard remains the backstop.
+    expect(() =>
+      defineWorkflow({
+        id: "wf",
+        trigger: { type: "manual" },
+        steps: {
+          p: step({ agent: makeAgent("p") }),
+          decide: gate({
+            when: { from: "steps.p.output" },
+            then: "left",
+            else: "right",
+            after: ["p"],
+          }),
+          left: awaitSignal({ name: "go", after: ["decide"] }),
+          right: awaitSignal({ name: "go", after: ["decide"] }),
+        },
+      }),
+    ).toThrow(/can concurrently await signal name go/);
+  });
+});
+
 describe("primitive defaults", () => {
   test("step defaults drainBehavior to cancel (batch)", () => {
     const s = step({ agent: makeAgent("a") });

--- a/packages/workflow/src/definition/workflow.ts
+++ b/packages/workflow/src/definition/workflow.ts
@@ -315,6 +315,9 @@ function validateSteps(steps: Record<string, Primitive>): void {
   // Runs after validateAfterRefs so every after/then/else endpoint is
   // already known to name a real step; this pass only rejects cycles.
   validateAcyclic(steps);
+  // Runs after validateAcyclic so the dependency graph is known acyclic and
+  // the reachability walk terminates.
+  validateConcurrentAwaitSignalNames(steps);
   validateLoopBody(steps);
   validateOnTriggerBody(steps);
   validateChildWorkflowBody(steps);
@@ -610,6 +613,126 @@ function buildDependencyAdjacency(
     }
   }
   return adjacency;
+}
+
+/**
+ * Reject a definition that lets two schedulable-concurrent `awaitSignal` steps
+ * await the same signal name. `handleSignalReceived` is a FIFO single-consumer
+ * scan keyed on the name, so two gates awaiting one name simultaneously make a
+ * delivery's binding order-dependent, and on resume the consumed signal cannot
+ * be durably re-bound to a specific gate. INTR-277 added a runtime fail-loud
+ * guard for this topology; rejecting it here makes it unauthorable.
+ *
+ * A loop or inline onTrigger body's awaitSignal park relays up into the parent
+ * run over the body's own author signal name, so a container step contributes
+ * its body's await names into the parent's concurrency set (recursively through
+ * nested loop / inline onTrigger bodies). A childWorkflow runs as a separate
+ * run with its own signal namespace, so its awaiters never collide with the
+ * parent's and are excluded.
+ *
+ * Two static-analysis limitations remain, both backstopped by the runtime
+ * guard:
+ *   - Conservative over-reject: two same-name awaiters on a gate's mutually
+ *     exclusive then/else branches are rejected, because deciding they can
+ *     never both be live is a dominator analysis whose permissive-direction
+ *     error would re-admit the hazard.
+ *   - Under-reject: a `{ ref }` onTrigger body is a separately-deployed asset
+ *     not visible here, so an await name it relays is not collected; a
+ *     collision with such a body is caught by the runtime guard, not here.
+ */
+function validateConcurrentAwaitSignalNames(
+  steps: Record<string, Primitive>,
+): void {
+  const reaches = makeReachability(buildDependencyAdjacency(steps));
+  const awaiters: { name: string; node: string; label: string }[] = [];
+  for (const [stepId, primitive] of Object.entries(steps)) {
+    if (primitive.kind === "awaitSignal") {
+      awaiters.push({ name: primitive.name, node: stepId, label: stepId });
+      continue;
+    }
+    for (const relayed of collectRelayedAwaitSignalNames(primitive)) {
+      awaiters.push({
+        name: relayed.name,
+        node: stepId,
+        label: `${stepId} (body awaitSignal ${relayed.bodyStepId})`,
+      });
+    }
+  }
+  for (let i = 0; i < awaiters.length; i++) {
+    const a = awaiters[i];
+    if (a === undefined) continue;
+    for (let j = i + 1; j < awaiters.length; j++) {
+      const b = awaiters[j];
+      if (b === undefined) continue;
+      if (a.name !== b.name || a.node === b.node) continue;
+      if (!reaches(a.node, b.node) && !reaches(b.node, a.node)) {
+        throw new Error(
+          `awaitSignal steps ${a.label} and ${b.label} can concurrently ` +
+            `await signal name ${a.name}; a signal name may have at most ` +
+            `one concurrent awaiter`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Collect the author signal names a loop or inline onTrigger body relays up to
+ * the parent run, recursing through nested loop and inline onTrigger bodies. A
+ * flat `steps` record keys gate branches and onTimeout targets as siblings, so
+ * enumerating the record covers them without a graph walk. A childWorkflow body
+ * runs in a separate signal namespace and is not relayed, so it is skipped.
+ */
+function collectRelayedAwaitSignalNames(
+  primitive: Primitive,
+): { name: string; bodyStepId: string }[] {
+  let body: Record<string, Primitive> | undefined;
+  if (primitive.kind === "loop") {
+    body = primitive.body.steps;
+  } else if (primitive.kind === "onTrigger" && "inline" in primitive.body) {
+    body = primitive.body.inline.steps;
+  }
+  if (body === undefined) return [];
+  const names: { name: string; bodyStepId: string }[] = [];
+  for (const [bodyStepId, bodyPrimitive] of Object.entries(body)) {
+    if (bodyPrimitive.kind === "awaitSignal") {
+      names.push({ name: bodyPrimitive.name, bodyStepId });
+    }
+    for (const nested of collectRelayedAwaitSignalNames(bodyPrimitive)) {
+      names.push({
+        name: nested.name,
+        bodyStepId: `${bodyStepId}/${nested.bodyStepId}`,
+      });
+    }
+  }
+  return names;
+}
+
+/**
+ * A memoized descendant-reachability predicate over the dependency adjacency.
+ * The graph is acyclic (validateAcyclic runs first), so the walk terminates.
+ */
+function makeReachability(
+  adjacency: Map<string, string[]>,
+): (from: string, to: string) => boolean {
+  const descendants = new Map<string, Set<string>>();
+  const descendantsOf = (start: string): Set<string> => {
+    const cached = descendants.get(start);
+    if (cached !== undefined) return cached;
+    const seen = new Set<string>();
+    const stack = [...(adjacency.get(start) ?? [])];
+    while (stack.length > 0) {
+      const node = stack.pop();
+      if (node === undefined || seen.has(node)) continue;
+      seen.add(node);
+      for (const next of adjacency.get(node) ?? []) {
+        stack.push(next);
+      }
+    }
+    descendants.set(start, seen);
+    return seen;
+  };
+  return (from, to) => descendantsOf(from).has(to);
 }
 
 /**

--- a/packages/workflow/src/runtime/env.ts
+++ b/packages/workflow/src/runtime/env.ts
@@ -15,7 +15,7 @@ import type {
   WorkflowAuthorizeFn,
 } from "../authorize-context";
 import type { Primitive } from "../definition/index";
-import type { WorkflowEvent } from "../state-machine/index";
+import type { TerminalRunPhase, WorkflowEvent } from "../state-machine/index";
 import type { DrainController } from "./drain";
 
 /**
@@ -647,7 +647,7 @@ export interface WorkflowRun {
 
 export interface RunResult {
   runId: string;
-  terminalStatus: "completed" | "failed" | "cancelled";
+  terminalStatus: TerminalRunPhase;
   /** Captured outputs of every step that reached `completed`. */
   outputs: Record<string, unknown>;
   /** The full event log as committed. */

--- a/packages/workflow/src/runtime/resume-awaiting-signal.test.ts
+++ b/packages/workflow/src/runtime/resume-awaiting-signal.test.ts
@@ -79,14 +79,27 @@ const timedGateWithHandler = defineWorkflow({
   },
 });
 
-const twoGatesSameName = defineWorkflow({
-  id: "wait-resume-two-gates",
-  trigger: { type: "manual" },
-  steps: {
-    gateA: awaitSignal({ name: "go" }),
-    gateB: awaitSignal({ name: "go" }),
-  },
-});
+// Two dependency-free gates awaiting the same signal name is the ambiguous
+// single-consumer topology the resume guard defends. defineWorkflow rejects it
+// at authoring time (INTR-281), so build it with distinct names and rewrite
+// gateB's name to reproduce the topology -- bypassing the load-time check that
+// the runtime guard exercised here is the backstop for.
+const twoGatesSameName = ((): WorkflowDefinition => {
+  const def = defineWorkflow({
+    id: "wait-resume-two-gates",
+    trigger: { type: "manual" },
+    steps: {
+      gateA: awaitSignal({ name: "go" }),
+      gateB: awaitSignal({ name: "goB" }),
+    },
+  });
+  const gateB = def.steps.gateB;
+  if (gateB === undefined || gateB.kind !== "awaitSignal") {
+    throw new Error("expected gateB to be an awaitSignal");
+  }
+  gateB.name = "go";
+  return def;
+})();
 
 const gateThenStep = defineWorkflow({
   id: "wait-resume-gate-then-step",

--- a/packages/workflow/src/runtime/run.ts
+++ b/packages/workflow/src/runtime/run.ts
@@ -69,6 +69,7 @@ import { loopBodyRunId, scopedStepId } from "./step-scope";
 import { inlineBodyRef } from "../ontrigger-bodies";
 import {
   controlParkKindOf,
+  decideTerminalRunFlip,
   isTerminalRunPhase,
   resumeFromLog,
   TransitionError,
@@ -862,12 +863,7 @@ async function executeRunBody(
   }
 
   const events = await env.repoStore.read(runId);
-  const terminalStatus =
-    state.phase === "completed"
-      ? "completed"
-      : state.phase === "failed"
-        ? "failed"
-        : "cancelled";
+  const terminalStatus = decideTerminalRunFlip(state.phase);
   return {
     runId,
     terminalStatus,
@@ -884,8 +880,9 @@ async function executeRunBody(
  * `RunStarted` (which would throw `terminal-phase`).
  *
  * The shape matches the live terminal path at the tail of
- * `executeRunBody` byte-for-byte: `terminalStatus` derived from the
- * (already terminal) `state.phase`, `events` read from the durable log
+ * `executeRunBody`: `terminalStatus` derived from the (already terminal)
+ * `state.phase` through the shared `decideTerminalRunFlip` helper,
+ * `events` read from the durable log
  * (so it carries the terminal event `emitTerminalEvent` and the child
  * entry point walk for), and `outputs` hydrated from the log's
  * `StepCompleted` refs (the live path threads in-process `stepOutputs`,
@@ -903,12 +900,7 @@ async function buildResultFromLog(
     if (event.kind !== "StepCompleted") continue;
     outputs[event.stepId] = await env.blobs.resolveRef(event.output.ref);
   }
-  const terminalStatus =
-    state.phase === "completed"
-      ? "completed"
-      : state.phase === "failed"
-        ? "failed"
-        : "cancelled";
+  const terminalStatus = decideTerminalRunFlip(state.phase);
   return { runId, terminalStatus, outputs, events };
 }
 

--- a/packages/workflow/src/state-machine/index.ts
+++ b/packages/workflow/src/state-machine/index.ts
@@ -29,6 +29,7 @@ export {
 
 export {
   controlParkKindOf,
+  decideTerminalRunFlip,
   emptyState,
   isTerminalRunPhase,
   isTerminalStepPhase,
@@ -39,6 +40,7 @@ export {
   type RunState,
   type StepPhase,
   type StepState,
+  type TerminalRunPhase,
 } from "./state";
 
 export {

--- a/packages/workflow/src/state-machine/state.test.ts
+++ b/packages/workflow/src/state-machine/state.test.ts
@@ -1,0 +1,20 @@
+import { describe, test, expect } from "bun:test";
+
+import { decideTerminalRunFlip, type RunPhase } from "./index";
+
+describe("decideTerminalRunFlip", () => {
+  test("maps each terminal phase to its status", () => {
+    expect(decideTerminalRunFlip("completed")).toBe("completed");
+    expect(decideTerminalRunFlip("failed")).toBe("failed");
+    expect(decideTerminalRunFlip("cancelled")).toBe("cancelled");
+  });
+
+  test("throws on a non-terminal phase", () => {
+    const nonTerminal: RunPhase[] = ["pending", "running", "cancelling"];
+    for (const phase of nonTerminal) {
+      expect(() => decideTerminalRunFlip(phase)).toThrow(
+        `decideTerminalRunFlip: non-terminal run phase ${phase}`,
+      );
+    }
+  });
+});

--- a/packages/workflow/src/state-machine/state.ts
+++ b/packages/workflow/src/state-machine/state.ts
@@ -23,6 +23,8 @@ export type RunPhase =
   | "failed"
   | "cancelled";
 
+export type TerminalRunPhase = "completed" | "failed" | "cancelled";
+
 export type StepPhase =
   | "in-flight"
   | "awaiting-signal"
@@ -132,6 +134,27 @@ export function emptyState(runId: RunId): RunState {
 
 export function isTerminalRunPhase(phase: RunPhase): boolean {
   return phase === "completed" || phase === "failed" || phase === "cancelled";
+}
+
+export function decideTerminalRunFlip(phase: RunPhase): TerminalRunPhase {
+  switch (phase) {
+    case "completed":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "cancelled":
+      return "cancelled";
+    case "pending":
+    case "running":
+    case "cancelling":
+      throw new Error(`decideTerminalRunFlip: non-terminal run phase ${phase}`);
+    default: {
+      const unexpected: never = phase;
+      throw new Error(
+        `decideTerminalRunFlip: unexpected run phase ${String(unexpected)}`,
+      );
+    }
+  }
 }
 
 export function isTerminalStepPhase(phase: StepPhase): boolean {

--- a/tests/hub-agent/lib/deploy-flow-env.ts
+++ b/tests/hub-agent/lib/deploy-flow-env.ts
@@ -57,7 +57,6 @@ import {
   DEFAULT_ASSET_REF,
   parseAgentId,
   type AgentRepoStore,
-  type AssetService,
   type InstallAndApproveResult,
   type RepoId,
   type SidecarLookups,
@@ -101,12 +100,6 @@ export const TOKEN = "test-token";
 // second via `startSidecarSubprocess` with these in `extraEnv`.
 export const SECOND_SIDECAR_ID = "sc-integration-2";
 export const SECOND_TOKEN = "test-token-2";
-
-const TENANT_ID = "tenant-1";
-const REGISTRY_NAME = "workspace-builtins";
-const ASSET_ID = `ast_${REGISTRY_NAME.replace(/-/g, "_")}`;
-
-export { TENANT_ID, REGISTRY_NAME, ASSET_ID };
 
 export async function waitFor(
   predicate: () => boolean | Promise<boolean>,
@@ -598,12 +591,8 @@ export type HubEnv = {
 };
 
 // Hub WebSocket server (in-process) wired against a real AgentRepoStore
-// and SessionService.
-//
-// The hub seeds an empty `package-registry` asset repo. Deploy tests carry
-// their tools inline in the workflow source closure, so no tool package is
-// seeded here; the resolver walk over a seeded registry is covered by the
-// tool-packaging end-to-end test instead.
+// and SessionService. It wires no tool-package registry surface; the DB stub
+// below explains why.
 export async function startHub(
   registerTempDir: (dir: string) => void,
   opts: {
@@ -803,84 +792,19 @@ export async function startHub(
     deployAcks.set(agentAddress, publicKey);
   });
 
-  // Seed the single package-registry asset. No tool package is seeded --
-  // deploy tests carry their tools inline in the workflow source closure --
-  // so the registry is empty. The AssetService below still serves it: the
-  // walker reads each tarball's own `package.json` to resolve a pin.
-  const tarballs: { filename: string; bytes: Uint8Array }[] = [];
-  const tarballByBlobPath = new Map(
-    tarballs.map((t) => [`tarballs/${t.filename}`, t.bytes]),
-  );
-  const seededFiles: Record<string, Uint8Array> = {};
-  for (const t of tarballs) {
-    seededFiles[`tarballs/${t.filename}`] = t.bytes;
-  }
-  await agentRepoStore.repoStore.initRepo({
-    kind: "package-registry",
-    id: ASSET_ID,
-  });
-  await agentRepoStore.repoStore.writeTree(
-    { kind: "hub" },
-    { kind: "package-registry", id: ASSET_ID },
-    DEFAULT_ASSET_REF,
-    {
-      files: seededFiles,
-      message: "Seed tool-package tarballs",
-    },
-  );
-
-  // The AssetService and DB stubs satisfy the narrow surface that the
-  // session-service tool-package path actually consults: blob reads for
-  // the resolver, tenant-walk and asset list for the registry map build,
-  // and a session_asset insert/delete for audit. The other members of the
-  // AssetService and DB interfaces throw on access so the test fails
-  // loudly if the production code drifts into a dependency the stub does
-  // not cover.
-  const assetRow = {
-    id: ASSET_ID,
-    tenantId: TENANT_ID,
-    kind: "package-registry" as const,
-    name: REGISTRY_NAME,
-    displayName: null,
-    creatorPrincipalId: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  };
-  const assetService: AssetService = {
-    createAsset: () => {
-      throw new Error("deploy-flow: AssetService.createAsset not used");
-    },
-    populateAsset: () => {
-      throw new Error("deploy-flow: AssetService.populateAsset not used");
-    },
-    readAssetBlob: async ({ assetId, path: p }) => {
-      if (assetId !== ASSET_ID) {
-        throw new Error(`deploy-flow: unexpected readAssetBlob ${assetId}`);
-      }
-      const bytes = tarballByBlobPath.get(p);
-      if (bytes === undefined) {
-        throw new Error(`deploy-flow: unexpected blob path ${p}`);
-      }
-      return bytes;
-    },
-    listAssetBlobs: async ({ assetId, dir: d }) => {
-      if (assetId !== ASSET_ID) {
-        throw new Error(`deploy-flow: unexpected listAssetBlobs ${assetId}`);
-      }
-      if (d !== "tarballs") {
-        throw new Error(`deploy-flow: unexpected list dir ${d}`);
-      }
-      return tarballs.map((t) => t.filename);
-    },
-  };
+  // The DB stub satisfies the narrow surface the session-service paths the
+  // deploy tests exercise actually consult: a tenant lookup and the
+  // session_asset insert/delete audit writes. Its other members throw on
+  // access so the test fails loudly if production code drifts into a
+  // dependency the stub does not cover. No package-registry asset or
+  // tool-package registry is wired: deploy tests carry their tools inline in
+  // the workflow source closure, so the session-service tool-package resolver
+  // path is never entered.
   const fakeDb = {
     query: {
       tenant: {
         findFirst: async (_args: unknown) =>
           ({ parentId: null }) as { parentId: string | null },
-      },
-      asset: {
-        findMany: async (_args: unknown) => [assetRow],
       },
     },
     insert(_table: unknown) {
@@ -902,16 +826,10 @@ export async function startHub(
   const sessionService = createSessionService({
     sidecarRouter: router,
     agentRepoStore,
-    assetService,
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the stub satisfies the narrow surface the session-service tool-package path actually calls (query.tenant.findFirst, query.asset.findMany, insert/delete), but cannot structurally satisfy the full drizzle PgDatabase type
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the stub satisfies the narrow surface the session-service paths the deploy tests exercise actually call (query.tenant.findFirst, insert/delete), but cannot structurally satisfy the full drizzle PgDatabase type
     db: fakeDb as unknown as NonNullable<
       Parameters<typeof createSessionService>[0]["db"]
     >,
-    toolPackageRegistries: {
-      httpRegistries: new Map(),
-      defaultRegistry: REGISTRY_NAME,
-      scopeRouting: [{ scope: "@intx", registry: REGISTRY_NAME }],
-    },
   });
 
   const app = new Hono();

--- a/tests/hub-agent/lib/deploy-flow-env.ts
+++ b/tests/hub-agent/lib/deploy-flow-env.ts
@@ -533,90 +533,6 @@ export async function buildSyntheticNpmPackageTarball(
   return new Uint8Array(bytes);
 }
 
-/**
- * Inputs for seeding the synthetic credential-consuming tool package. The
- * caller (the tests/workflow-deploy e2e, which owns the fixture) resolves
- * `entryPath` from its own project so this hub-agent-project helper never
- * imports the fixture across a project boundary.
- */
-export type SyntheticCredentialToolOpts = {
-  /** Absolute path to the fixture module compiled into the bundle entry. */
-  entryPath: string;
-  /** Package name stamped into `package.json` (the tool consumer identity). */
-  packageName: string;
-  /** Package version stamped into `package.json`. */
-  version: string;
-  /** The credential handle declared under `interchange.credentials`. */
-  handle: string;
-};
-
-// Synthetic credential-consuming tool tarball
-//
-// This compiles a REAL, type-checked fixture module
-// (`tests/workflow-deploy/fixtures/credential-tool-bundle.ts`) into the
-// package's `sidecar-bundle.js` with Bun.build, so the e2e drives the
-// production loader against a genuine ESM bundle. The caller passes the
-// fixture's absolute path (resolved from the tests/workflow-deploy project,
-// which owns the fixture) rather than importing it, so this hub-agent-project
-// helper carries no cross-project type edge.
-//
-// The written `package.json` declares BOTH `interchange.tools` (the bundle
-// entry) and `interchange.credentials` (the handle the tool resolves), so the
-// launch-time declared-vs-bound reconcile sees the handle the delivery binds.
-export async function buildSyntheticCredentialToolTarball(
-  registerTempDir: (dir: string) => void,
-  opts: SyntheticCredentialToolOpts,
-): Promise<Uint8Array> {
-  const stagingDir = await fs.promises.mkdtemp(
-    path.join(os.tmpdir(), "cred-tool-fixture-"),
-  );
-  registerTempDir(stagingDir);
-  const packageDir = path.join(stagingDir, "package");
-  await fs.promises.mkdir(packageDir, { recursive: true });
-
-  await fs.promises.writeFile(
-    path.join(packageDir, "package.json"),
-    JSON.stringify({
-      name: opts.packageName,
-      version: opts.version,
-      type: "module",
-      interchange: {
-        tools: "./sidecar-bundle.js",
-        credentials: [{ handle: opts.handle }],
-      },
-    }),
-  );
-
-  // Resolve `@intx/*` workspace deps to their TypeScript source via the
-  // `intx-src` export condition (mirroring bin/build-builtins.ts), so the
-  // packed bundle is a genuine module the production loader imports.
-  const result = await Bun.build({
-    entrypoints: [opts.entryPath],
-    outdir: packageDir,
-    naming: "sidecar-bundle.js",
-    target: "node",
-    format: "esm",
-    conditions: ["intx-src"],
-    minify: false,
-    sourcemap: "none",
-  });
-  if (!result.success) {
-    const messages = result.logs
-      .map((log) => (log instanceof Error ? log.message : String(log)))
-      .join("\n");
-    throw new Error(
-      `buildSyntheticCredentialToolTarball: Bun.build failed for ${opts.entryPath}:\n${messages || "(no diagnostics)"}`,
-    );
-  }
-
-  const tarballPath = path.join(stagingDir, "out.tgz");
-  await tar.create({ cwd: stagingDir, gzip: true, file: tarballPath }, [
-    "package",
-  ]);
-  const bytes = await fs.promises.readFile(tarballPath);
-  return new Uint8Array(bytes);
-}
-
 export type HubEnv = {
   server: ReturnType<typeof Bun.serve>;
   router: SidecarRouter;
@@ -684,22 +600,15 @@ export type HubEnv = {
 // Hub WebSocket server (in-process) wired against a real AgentRepoStore
 // and SessionService.
 //
-// The hub seeds a `package-registry` asset repo. It is empty unless the
-// caller opts a tool package in via `credentialTool`, in which case the
-// session-service tool-package resolver path exercises the real registry
-// walker end-to-end.
+// The hub seeds an empty `package-registry` asset repo. Deploy tests carry
+// their tools inline in the workflow source closure, so no tool package is
+// seeded here; the resolver walk over a seeded registry is covered by the
+// tool-packaging end-to-end test instead.
 export async function startHub(
   registerTempDir: (dir: string) => void,
   opts: {
     registerSignalCorrelation?: SidecarLookups["registerSignalCorrelation"];
     materializeMailTriggeredRunGrants?: SidecarLookups["materializeMailTriggeredRunGrants"];
-    /**
-     * When set, seed a tool package: a real credential-consuming bundle
-     * compiled from a fixture module, so the credential-delivery e2e drives
-     * the production loader + capability path against a genuine tool that
-     * resolves a mediated credential.
-     */
-    credentialTool?: SyntheticCredentialToolOpts;
   } = {},
 ): Promise<HubEnv> {
   const agentEvents: HubEnv["agentEvents"] = [];
@@ -894,26 +803,11 @@ export async function startHub(
     deployAcks.set(agentAddress, publicKey);
   });
 
-  // Seed one tarball per opted-in tool package into the single
-  // package-registry asset. The credential-consuming package joins the
-  // registry only when the caller opts in; otherwise the registry is empty.
-  // The registry walker reads each tarball's own `package.json` to resolve a
-  // pin, so the filename is arbitrary as long as it is both listed and
-  // readable through the AssetService below.
+  // Seed the single package-registry asset. No tool package is seeded --
+  // deploy tests carry their tools inline in the workflow source closure --
+  // so the registry is empty. The AssetService below still serves it: the
+  // walker reads each tarball's own `package.json` to resolve a pin.
   const tarballs: { filename: string; bytes: Uint8Array }[] = [];
-  if (opts.credentialTool !== undefined) {
-    const credentialTool = opts.credentialTool;
-    const filename = `${credentialTool.packageName
-      .replace(/^@intx\//, "")
-      .replace(/\//g, "-")}-${credentialTool.version}.tgz`;
-    tarballs.push({
-      filename,
-      bytes: await buildSyntheticCredentialToolTarball(
-        registerTempDir,
-        credentialTool,
-      ),
-    });
-  }
   const tarballByBlobPath = new Map(
     tarballs.map((t) => [`tarballs/${t.filename}`, t.bytes]),
   );
@@ -1230,12 +1124,6 @@ export type StartDeployFlowEnvOpts = {
    */
   inferenceEchoUserMessage?: boolean;
   /**
-   * When set, seed a tool package -- a real credential-consuming bundle
-   * compiled from a fixture module -- so a test can pin it and drive the
-   * credential-delivery + capability rail end-to-end.
-   */
-  credentialTool?: SyntheticCredentialToolOpts;
-  /**
    * Co-write hook for the `signal.correlation.register` frame a suspending
    * agent step emits. When set, the mock hub's sidecar router wires it as
    * the `registerSignalCorrelation` lookup, so a parked run's correlation +
@@ -1279,9 +1167,6 @@ export async function startDeployFlowEnv(
           materializeMailTriggeredRunGrants:
             opts.materializeMailTriggeredRunGrants,
         }
-      : {}),
-    ...(opts.credentialTool !== undefined
-      ? { credentialTool: opts.credentialTool }
       : {}),
   });
   const inference = startMockInference({

--- a/tests/hub-agent/lib/deploy-flow-env.ts
+++ b/tests/hub-agent/lib/deploy-flow-env.ts
@@ -105,9 +105,8 @@ export const SECOND_TOKEN = "test-token-2";
 const TENANT_ID = "tenant-1";
 const REGISTRY_NAME = "workspace-builtins";
 const ASSET_ID = `ast_${REGISTRY_NAME.replace(/-/g, "_")}`;
-const TARBALL_FILENAME = "tools-mail-0.1.2.tgz";
 
-export { TENANT_ID, REGISTRY_NAME, ASSET_ID, TARBALL_FILENAME };
+export { TENANT_ID, REGISTRY_NAME, ASSET_ID };
 
 export async function waitFor(
   predicate: () => boolean | Promise<boolean>,
@@ -498,149 +497,6 @@ function sse(event: string, data: unknown): string {
   return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
 }
 
-// Synthetic @intx/tools-mail tarball
-//
-// The integration test's loader path is unmodified production code; it
-// imports the tarball's `interchange.tools` entry as a real ESM module.
-// The tarball ships a minimal `sidecar-bundle.js` that exports an
-// AnnotatedToolFactory with the same `id` shape as the real bundle
-// (`@intx/tools-mail/sidecar-bundle`) and a single `mail_send` definition.
-// The loader prefixes the definition name with the bundle id to yield the
-// `@intx/tools-mail/sidecar-bundle:mail_send` tool the model ends up
-// seeing.
-export async function buildSyntheticToolsMailTarball(
-  registerTempDir: (dir: string) => void,
-  opts: { transportBacked?: boolean; approvalMarked?: boolean } = {},
-): Promise<Uint8Array> {
-  const stagingDir = await fs.promises.mkdtemp(
-    path.join(os.tmpdir(), "tools-mail-fixture-"),
-  );
-  registerTempDir(stagingDir);
-  const packageDir = path.join(stagingDir, "package");
-  await fs.promises.mkdir(packageDir, { recursive: true });
-
-  await fs.promises.writeFile(
-    path.join(packageDir, "package.json"),
-    JSON.stringify({
-      name: "@intx/tools-mail",
-      version: "0.1.2",
-      type: "module",
-      interchange: { tools: "./sidecar-bundle.js" },
-    }),
-  );
-
-  // Two bundle shapes, selected by `opts.transportBacked`:
-  //
-  // Default (filesystem-only): the tool's `run` writes a sentinel file
-  // into the agent's `env.workdir` so a spawned-child test can prove the
-  // tool executed IN THE CHILD by observing the file in the per-step
-  // workspace. It declares `requires: []` and never touches the agent's
-  // transport. Tests that never drive the model to call the tool never
-  // invoke `run`, so the write is inert for them.
-  //
-  // Transport-backed (the 4.6 milestone's OUTBOUND proof): the tool calls
-  // `env.transport.send(...)` -- the SAME supervisor-backed transport the
-  // unified child wires for a step agent -- so the call exercises the
-  // real OUTBOUND chain (mail tool -> supervisor-backed transport ->
-  // outbound bridge -> `outbound.message` IPC -> supervisor `sendOutbound`
-  // -> host transport signed send -> `SendReceipt`). It declares
-  // `requires: ["transport", "address"]` so the loader populates those
-  // env slots, sends to the `to` argument, and writes the sentinel ONLY
-  // after a successful receipt. A broken outbound path rejects inside
-  // `send`, so no sentinel is written and the run fails -- making the
-  // sentinel a load-bearing proof of the signed-outbound composition.
-  // The static `definitions` the loader exposes on the AnnotatedToolFactory
-  // is what the sidecar's tool-mark floor deriver reads to authorize a
-  // pinned tool. Stamping `approval: "ask"` here makes the derived floor
-  // `ask`, so a call suspends for approval WITHOUT any hand-injected ask
-  // grant -- the proof that the sidecar floor authorizes a pinned
-  // ask-marked tool on its own static mark.
-  const staticDefinitions =
-    opts.approvalMarked === true
-      ? `[{ name: "mail_send", approval: "ask" }]`
-      : `[{ name: "mail_send" }]`;
-  const bundleSource = opts.transportBacked
-    ? `
-import fs from "node:fs";
-import path from "node:path";
-const factory = (env) => ({
-  definitions: [
-    {
-      name: "mail_send",
-      description: "Send a mail message",
-      inputSchema: {
-        type: "object",
-        properties: { to: { type: "string" }, body: { type: "string" } },
-        required: ["to", "body"],
-      },
-    },
-  ],
-  run: async (call, signal) => {
-    const args = call.arguments ?? {};
-    const to = typeof args.to === "string" ? args.to : env.address;
-    const filename = typeof args.body === "string" ? args.body : "tool-ran.txt";
-    const receipt = await env.transport.send({
-      to,
-      type: "conversation.message",
-      content: "Reply produced by the unified-host step agent.",
-    }, signal);
-    await fs.promises.mkdir(env.workdir, { recursive: true });
-    await fs.promises.writeFile(
-      path.join(env.workdir, filename),
-      JSON.stringify({ messageId: receipt.messageId, status: receipt.status }),
-    );
-    return { callId: call.id, content: "sent " + receipt.messageId };
-  },
-});
-export const mail = Object.assign(factory, {
-  id: "@intx/tools-mail/sidecar-bundle",
-  requires: ["transport", "address"],
-  definitions: ${staticDefinitions},
-});
-`.trimStart()
-    : `
-import fs from "node:fs";
-import path from "node:path";
-const factory = (env) => ({
-  definitions: [
-    {
-      name: "mail_send",
-      description: "Send a mail message",
-      inputSchema: {
-        type: "object",
-        properties: { to: { type: "string" }, body: { type: "string" } },
-        required: ["to", "body"],
-      },
-    },
-  ],
-  run: async (call, signal) => {
-    const args = call.arguments ?? {};
-    const filename = typeof args.body === "string" ? args.body : "tool-ran.txt";
-    const content = typeof args.to === "string" ? args.to : "ok";
-    await fs.promises.mkdir(env.workdir, { recursive: true });
-    await fs.promises.writeFile(path.join(env.workdir, filename), content);
-    return { callId: call.id, content: "wrote " + filename };
-  },
-});
-export const mail = Object.assign(factory, {
-  id: "@intx/tools-mail/sidecar-bundle",
-  requires: [],
-  definitions: ${staticDefinitions},
-});
-`.trimStart();
-  await fs.promises.writeFile(
-    path.join(packageDir, "sidecar-bundle.js"),
-    bundleSource,
-  );
-
-  const tarballPath = path.join(stagingDir, "out.tgz");
-  await tar.create({ cwd: stagingDir, gzip: true, file: tarballPath }, [
-    "package",
-  ]);
-  const bytes = await fs.promises.readFile(tarballPath);
-  return new Uint8Array(bytes);
-}
-
 /**
  * Build a plain npm-package tarball (package.json + index.mjs), for serving as
  * a workflow's EXTERNAL dependency from an in-process registry. The registry
@@ -696,14 +552,13 @@ export type SyntheticCredentialToolOpts = {
 
 // Synthetic credential-consuming tool tarball
 //
-// Unlike `buildSyntheticToolsMailTarball` (which inlines its bundle as a
-// string), this compiles a REAL, type-checked fixture module
+// This compiles a REAL, type-checked fixture module
 // (`tests/workflow-deploy/fixtures/credential-tool-bundle.ts`) into the
-// package's `sidecar-bundle.js` with
-// Bun.build, so the e2e drives the production loader against a genuine ESM
-// bundle. The caller passes the fixture's absolute path (resolved from the
-// tests/workflow-deploy project, which owns the fixture) rather than importing
-// it, so this hub-agent-project helper carries no cross-project type edge.
+// package's `sidecar-bundle.js` with Bun.build, so the e2e drives the
+// production loader against a genuine ESM bundle. The caller passes the
+// fixture's absolute path (resolved from the tests/workflow-deploy project,
+// which owns the fixture) rather than importing it, so this hub-agent-project
+// helper carries no cross-project type edge.
 //
 // The written `package.json` declares BOTH `interchange.tools` (the bundle
 // entry) and `interchange.credentials` (the handle the tool resolves), so the
@@ -829,21 +684,20 @@ export type HubEnv = {
 // Hub WebSocket server (in-process) wired against a real AgentRepoStore
 // and SessionService.
 //
-// The hub seeds a `package-registry` asset repo with a synthetic
-// `@intx/tools-mail@0.1.2` tarball so the session-service tool-package
-// resolver path exercises the real registry walker end-to-end.
+// The hub seeds a `package-registry` asset repo. It is empty unless the
+// caller opts a tool package in via `credentialTool`, in which case the
+// session-service tool-package resolver path exercises the real registry
+// walker end-to-end.
 export async function startHub(
   registerTempDir: (dir: string) => void,
   opts: {
-    transportBackedMailTool?: boolean;
-    approvalMarkedMailTool?: boolean;
     registerSignalCorrelation?: SidecarLookups["registerSignalCorrelation"];
     materializeMailTriggeredRunGrants?: SidecarLookups["materializeMailTriggeredRunGrants"];
     /**
-     * When set, seed a second tool package alongside tools-mail: a real
-     * credential-consuming bundle compiled from a fixture module, so the
-     * credential-delivery e2e drives the production loader + capability path
-     * against a genuine tool that resolves a mediated credential.
+     * When set, seed a tool package: a real credential-consuming bundle
+     * compiled from a fixture module, so the credential-delivery e2e drives
+     * the production loader + capability path against a genuine tool that
+     * resolves a mediated credential.
      */
     credentialTool?: SyntheticCredentialToolOpts;
   } = {},
@@ -1040,24 +894,13 @@ export async function startHub(
     deployAcks.set(agentAddress, publicKey);
   });
 
-  // Seed one tarball per tool package into the single package-registry asset.
-  // tools-mail is always present; the credential-consuming package joins it
-  // only when the caller opts in. The registry walker reads each tarball's
-  // own `package.json` to resolve a pin, so the filename is arbitrary as long
-  // as it is both listed and readable through the AssetService below.
-  const tarballs: { filename: string; bytes: Uint8Array }[] = [
-    {
-      filename: TARBALL_FILENAME,
-      bytes: await buildSyntheticToolsMailTarball(registerTempDir, {
-        ...(opts.transportBackedMailTool === true
-          ? { transportBacked: true }
-          : {}),
-        ...(opts.approvalMarkedMailTool === true
-          ? { approvalMarked: true }
-          : {}),
-      }),
-    },
-  ];
+  // Seed one tarball per opted-in tool package into the single
+  // package-registry asset. The credential-consuming package joins the
+  // registry only when the caller opts in; otherwise the registry is empty.
+  // The registry walker reads each tarball's own `package.json` to resolve a
+  // pin, so the filename is arbitrary as long as it is both listed and
+  // readable through the AssetService below.
+  const tarballs: { filename: string; bytes: Uint8Array }[] = [];
   if (opts.credentialTool !== undefined) {
     const credentialTool = opts.credentialTool;
     const filename = `${credentialTool.packageName
@@ -1387,30 +1230,9 @@ export type StartDeployFlowEnvOpts = {
    */
   inferenceEchoUserMessage?: boolean;
   /**
-   * When true, the synthetic `@intx/tools-mail` tarball the hub seeds
-   * ships the transport-backed `mail_send` bundle: its `run` calls
-   * `env.transport.send(...)` (the supervisor-backed transport the
-   * unified child wires) and writes its workspace sentinel only after a
-   * successful `SendReceipt`. This drives the real OUTBOUND signed-send
-   * chain through the spawned child, proving the 4.3 path composes with
-   * the rest of the single-agent lifecycle. The default filesystem-only
-   * bundle is unchanged for tests that only assert in-child tool
-   * execution.
-   */
-  transportBackedMailTool?: boolean;
-  /**
-   * When true, the synthetic `@intx/tools-mail` tarball's static tool
-   * definition carries `approval: "ask"`. The sidecar derives the pinned
-   * tool's authorization floor from this static mark, so the tool
-   * suspends for approval on its own -- no hand-injected `ask` grant. Used
-   * to prove the sidecar-derived floor authorizes a pinned ask-marked tool
-   * end-to-end.
-   */
-  approvalMarkedMailTool?: boolean;
-  /**
-   * When set, seed a second tool package -- a real credential-consuming
-   * bundle compiled from a fixture module -- alongside tools-mail, so a test
-   * can pin it and drive the credential-delivery + capability rail end-to-end.
+   * When set, seed a tool package -- a real credential-consuming bundle
+   * compiled from a fixture module -- so a test can pin it and drive the
+   * credential-delivery + capability rail end-to-end.
    */
   credentialTool?: SyntheticCredentialToolOpts;
   /**
@@ -1449,12 +1271,6 @@ export async function startDeployFlowEnv(
   };
 
   const hub = await startHub(registerTempDir, {
-    ...(opts.transportBackedMailTool === true
-      ? { transportBackedMailTool: true }
-      : {}),
-    ...(opts.approvalMarkedMailTool === true
-      ? { approvalMarkedMailTool: true }
-      : {}),
     ...(opts.registerSignalCorrelation !== undefined
       ? { registerSignalCorrelation: opts.registerSignalCorrelation }
       : {}),

--- a/tests/workflow-deploy/approval-tracer-roundtrip.test.ts
+++ b/tests/workflow-deploy/approval-tracer-roundtrip.test.ts
@@ -161,13 +161,13 @@ const STEP_AGENT_ID = "agent-approval-capstone";
 // The sentinel the recording tool writes when (and only when) it actually runs
 // in the child. Absent before approval (the ask grant suspends the call);
 // written exactly once after approval (the re-dispatch runs the parked call).
-// The synthetic `mail_send` bundle writes `SENTINEL_CONTENT` (its `to`
+// The `mail_send` fixture tool writes `SENTINEL_CONTENT` (its `to`
 // argument) into the file named by its `body` argument, and returns
 // `"wrote " + <filename>` as the tool result, which the resumed reply echoes.
 const SENTINEL_FILENAME = "approval-tool-ran.txt";
 const SENTINEL_CONTENT = "tool-executed";
-// The tool's result string is `"wrote " + <body argument>`; see the synthetic
-// bundle in deploy-flow-env. The mock's resumed reply is
+// The tool's result string is `"wrote " + <body argument>`; see the
+// `mail-tool.ts` fixture. The mock's resumed reply is
 // `RESUME_REPLY_PREFIX + <that result>`, so a test can assert the run continued
 // with the tool's real output rather than a re-inference that skipped it.
 const TOOL_RESULT = `wrote ${SENTINEL_FILENAME}`;
@@ -603,11 +603,10 @@ describe.skipIf(!harnessDbEnvAvailable())(
       // (child -> sidecar -> hub -> co-write) intact. Every field the snapshot
       // carries is pinned verbatim: the name and arguments the model issued,
       // and the description and inputSchema of the resolved tool definition.
-      // All four are test-owned -- the tool is the synthetic `@intx/tools-mail`
-      // harness bundle whose `mail_send` definition is fixed in
-      // `deploy-flow-env.ts` (the loader namespaces its name to TOOL_NAME) --
-      // so a hop that dropped or mangled any field between the park and the
-      // co-write fails this assertion.
+      // All four are test-owned -- the tool is the `mail_send` definition from
+      // the `mail-tool.ts` fixture, whose model-facing name the test pins as
+      // TOOL_NAME (MAIL_TOOL_NAME) -- so a hop that dropped or mangled any
+      // field between the park and the co-write fails this assertion.
       expect(approvalRow.toolDefinition).toEqual({
         name: TOOL_NAME,
         description: "Send a mail message",

--- a/tests/workflow-deploy/fixtures/credential-tool-bundle.ts
+++ b/tests/workflow-deploy/fixtures/credential-tool-bundle.ts
@@ -1,8 +1,8 @@
 // A real, type-checked credential-consuming tool bundle for the single-step
-// credential-tool e2e. `buildSyntheticCredentialToolTarball` compiles THIS
-// module into the synthetic package's `sidecar-bundle.js` with Bun.build, so
-// the e2e drives the production tool-package loader against a genuine bundle
-// rather than a hand-written string blob.
+// credential-tool e2e. `credential-tool-workflow.ts` inlines THIS module into
+// the workflow's source closure via `bundleWorkflowEntry`, so the e2e drives
+// the production tool loader against a genuine bundle rather than a
+// hand-written string blob.
 //
 // The tool declares one credential handle and, at run, resolves it from the
 // host-assembled `credentials` capability into an http mediated credential,
@@ -19,10 +19,9 @@ import { defineTool, type BaseEnv } from "@intx/agent";
 import type { RuntimeCapabilities } from "@intx/types/runtime-capabilities";
 
 /**
- * The credential handle the tool declares and resolves. The package.json the
- * tarball builder writes MUST declare the same handle under
- * `interchange.credentials`, or the launch-time declared-vs-bound reconcile
- * fails the deploy closed.
+ * The credential handle the tool declares and resolves. The workflow's
+ * declared credential binding MUST bind this same handle, or the launch-time
+ * declared-vs-bound reconcile fails the deploy closed.
  */
 export const CREDENTIAL_HANDLE = "api-token";
 

--- a/tests/workflow-deploy/fixtures/mail-tool.ts
+++ b/tests/workflow-deploy/fixtures/mail-tool.ts
@@ -1,12 +1,11 @@
 // The `mail_send` tool as a real, type-checked `defineTool` source module.
 //
-// Reproduces the three variants of the ex-synthetic `@intx/tools-mail`
-// bundle (`buildSyntheticToolsMailTarball` in the deploy-flow env) as a real
+// Provides the three variants of the `@intx/tools-mail` bundle as a real
 // module so a code-sourced workflow carries the tool in its own source
 // closure. A fixture entry module imports `mailSendTool(variant)` and lists it
 // in a step agent's `tools`; `bundleWorkflowEntry` inlines this module into the
-// workflow bundle, so the tool evaluates in-child with the same filesystem /
-// transport side effect the synthetic bundle produced.
+// workflow bundle, so the tool evaluates in-child with a filesystem /
+// transport side effect.
 //
 // Three variants, selected by the `variant` parameter:
 //   - "fs":        writes the `body` arg as a filename under `env.workdir`

--- a/tests/workflow-deploy/reconnect-reemits-parked-correlation.test.ts
+++ b/tests/workflow-deploy/reconnect-reemits-parked-correlation.test.ts
@@ -140,7 +140,7 @@ const TOOL_NAME = MAIL_TOOL_NAME;
 const ASK_RESOURCE = `tool:${TOOL_NAME}`;
 const STEP_AGENT_ID = "agent-reconnect-reemit";
 
-// The `mail_send` arguments the mock issues. The synthetic bundle writes its
+// The `mail_send` arguments the mock issues. The fixture tool writes its
 // `to` argument into the file named by `body`; the run parks before the tool
 // ever runs, so these only travel as far as the approval snapshot's arguments.
 const CALL_TO = "correlation-recovery";


### PR DESCRIPTION
## Summary

- Reject at authoring time any workflow whose two schedulable-concurrent
  `awaitSignal` steps share a signal name, spanning the loop/onTrigger relay
  seam (childWorkflow excluded); the runtime fail-loud guard stays the backstop.
- Consolidate the two run-lifecycle readers (working-tree fs and committed git
  objects) behind one shared classification core fed by per-surface read
  adapters; `scanRunsForBoot` stays separate.
- Extract the duplicated run-phase→terminal-status mapping into a pure
  `decideTerminalRunFlip` helper and a named `TerminalRunPhase` type.
- Remove the vestigial synthetic tools-mail and credential tarball builders from
  the deploy test harness, along with the now-unused package-registry
  AssetService wiring; deploy tests carry their tools inline in the workflow
  source closure.

## Verification

Type-check and lint pass; the non-deploy suites pass (6500+ package tests, 0
failures). The DB-backed workflow-deploy suite passes except for four
pre-existing environmental timeout flakes (real-agent and mail-timing tests)
that reproduce identically on `origin/main`. The run-lifecycle change carries an
fs/committed equivalence test plus error-path coverage for the unreadable-event
and non-ENOENT read branches; the signal validator carries reject/accept tests
including cross-body and gate-branch cases; the tarball removals are verified
against the DB-backed deploy suite and the tool-packaging end-to-end test.

Closes INTR-281
Closes INTR-482
Closes INTR-500
Closes INTR-425