### PR TITLE
Flow the posix and LSP tool working directory through env-DI

### DIFF
--- a/apps/sidecar/src/workflow-substrate-factory.ts
+++ b/apps/sidecar/src/workflow-substrate-factory.ts
@@ -1098,14 +1098,16 @@ export function createSidecarStepBuildEnv(
     // ["capabilities", "address"]`) resolves `mail.transport` from it.
     const capabilities = createHarnessRuntimeCapabilities({ transport });
 
-    // The step env carries `transport`, `address`, and the assembled
-    // `capabilities` beyond `BaseEnv`. `capabilities` is what the mail bundle
+    // The step env carries `toolCwd`, `transport`, `address`, and the
+    // assembled `capabilities` beyond `BaseEnv`. `toolCwd` is the working
+    // tree the posix tools operate on; `capabilities` is what the mail bundle
     // reads; `transport` remains a raw env surface for tool packages that
     // read it directly. `address` is observability-only. These widen the
     // returned `StepEnvBase` structurally, which the buildEnv return type
     // (`StepEnvBase`) accepts (a wider object is assignable to the narrower
     // type).
     const env: StepEnvBase & {
+      toolCwd: string;
       transport: MessageTransport;
       address: string;
       capabilities: RuntimeCapabilities;
@@ -1118,6 +1120,10 @@ export function createSidecarStepBuildEnv(
       defaultSource: activeSource.id,
       storage,
       workdir,
+      // The per-step workspace is both the lock boundary and the tree the
+      // filesystem tools operate on; a deployed step gets a throwaway
+      // scratch dir, so the two coincide.
+      toolCwd: workdir,
       audit: storage,
       directors: createDefaultDirectorRegistry(),
       // Resolve inference adapters through the child's boot-built

--- a/bun.lock
+++ b/bun.lock
@@ -570,6 +570,7 @@
         "which": "^4.0.0",
       },
       "devDependencies": {
+        "@intx/storage-isogit": "workspace:*",
         "@types/which": "^3.0.0",
       },
     },

--- a/examples/coding-agent/README.md
+++ b/examples/coding-agent/README.md
@@ -13,11 +13,14 @@ end-to-end. Treat it as documentation that compiles.
 - Constructing an `AgentDefinition` via `defineAgent` and an env with an
   isogit-backed `ContextStore` at a real `contextDir`, then
   instantiating via `createAgent(def, env)`.
-- Bridging an existing `ToolRunner` (the bundle returned by
-  `createPosixTools` with the LSP plugin attached) into the agent via a
-  `defineTool` bundle factory that closes over the runner. Disposal
-  stays caller-owned; the example's `close()` awaits the agent then
-  invokes `posixTools.dispose()`.
+- Flowing the working directory through env-DI: `env.toolCwd` (the tree
+  the model reads and edits, from `--cwd`) is distinct from `env.workdir`
+  (the isogit lock and storage boundary, at `contextDir`). The shipped
+  `@intx/tools-posix` sidecar bundle and the `@intx/tools-lsp` plugin both
+  read `toolCwd` through their `requires` declarations, and the LSP plugin
+  is composed onto the env via `env.plugins`. Disposal stays caller-owned;
+  the example captures the tool bundle's disposer and `close()` awaits it
+  after the agent closes.
 - A single-shot `send()` that returns the model's reply.
 - Persistent history: re-running the example against the same `contextDir`
   picks up where the previous run left off — this is the resume-from-crash

--- a/examples/coding-agent/src/agent.ts
+++ b/examples/coding-agent/src/agent.ts
@@ -4,6 +4,12 @@
 // posix tools (with the LSP plugin attached) and a real workdir-backed
 // isogit store. The factory is separated from the CLI entry so tests
 // can construct the same agent with a stubbed inference source.
+//
+// The working directory flows through env-DI: `env.toolCwd` is the tree
+// the model reads and edits, distinct from `env.workdir` (the isogit
+// lock and storage boundary). The posix bundle and the LSP plugin both
+// read `toolCwd`, so the reference consumer demonstrates the env-DI
+// surface rather than bypassing it with constructor arguments.
 
 import { mkdirSync } from "node:fs";
 
@@ -13,13 +19,12 @@ import {
   defineAgent,
   defineTool,
   type Agent,
-  type BaseEnv,
   type Dependencies,
 } from "@intx/agent";
 import { noopAuditStore, permissiveAuthorize } from "@intx/agent/testing";
 import { createIsogitStore } from "@intx/storage-isogit/node";
-import { createLSPPlugin } from "@intx/tools-lsp";
-import { createPosixTools, type PosixTools } from "@intx/tools-posix";
+import { lsp } from "@intx/tools-lsp/sidecar-bundle";
+import { posix, type PosixToolEnv } from "@intx/tools-posix/sidecar-bundle";
 import type { InferenceSource } from "@intx/types/runtime";
 
 import { CODING_AGENT_SYSTEM_PROMPT } from "./prompt";
@@ -55,7 +60,6 @@ export type CodingAgentOptions = {
 
 export type CodingAgent = {
   agent: Agent;
-  posixTools: PosixTools;
   /**
    * Close the agent and dispose of the tool runner. Idempotent enough to
    * be called from a `finally` block.
@@ -66,19 +70,13 @@ export type CodingAgent = {
 export async function createCodingAgent(
   opts: CodingAgentOptions,
 ): Promise<CodingAgent> {
-  mkdirSync(opts.contextDir, { recursive: true });
-
-  const posixTools = createPosixTools({
-    cwd: opts.cwd,
-    plugins: [createLSPPlugin({ cwd: opts.cwd })],
-  });
-
+  // Resolve the inference source before building any tool resource, so a
+  // missing apiKey fails before there is anything to tear down.
   let source: InferenceSource;
   if (opts.sourceOverride !== undefined) {
     source = opts.sourceOverride;
   } else {
     if (opts.apiKey === undefined) {
-      await posixTools.dispose();
       throw new Error(
         "createCodingAgent: either apiKey or sourceOverride is required",
       );
@@ -93,20 +91,32 @@ export async function createCodingAgent(
     };
   }
 
-  // Wrap the already-constructed posix tool runner as a defineTool
-  // bundle factory. The bundle is closed over the runner; the caller
-  // owns the dispose lifetime (we invoke posixTools.dispose() from
-  // close()) since the env contract treats disposers as caller-owned.
-  const posixFactory = defineTool({
-    id: "@interchange-demo/coding-agent/posix",
-    definitions: posixTools.definitions.map((def) => ({ name: def.name })),
-    factory: () => ({
-      definitions: posixTools.definitions,
-      run: (call, signal) => posixTools.run(call, signal),
-    }),
-  });
-
+  mkdirSync(opts.contextDir, { recursive: true });
   const storage = await createIsogitStore(opts.contextDir);
+
+  // Wrap the shipped posix sidecar bundle to capture its disposer as the
+  // factory runs inside createAgent. Bundle lifetimes are caller-owned on
+  // the success path, and disposing the posix bundle chains through
+  // createPosixTools to the LSP subprocess. Forwarding posix.requires
+  // keeps the toolCwd env-DI contract enforced by validateEnv.
+  //
+  // This capture-dispose shape is duplicated in apps/sidecar
+  // (rewrapStepToolFactory); it is inlined here rather than shared
+  // because that helper carries a sidecar-specific credentials parameter
+  // and lives in an app that examples must not depend on. A shared helper
+  // belongs next to defineTool in @intx/agent, but only once a third
+  // consumer justifies touching that package's public surface.
+  let disposeTools: (() => Promise<void>) | undefined;
+  const posixFactory = defineTool<PosixToolEnv>({
+    id: posix.id,
+    requires: posix.requires,
+    definitions: posix.definitions,
+    factory: (env) => {
+      const bundle = posix(env);
+      disposeTools = bundle.dispose;
+      return bundle;
+    },
+  });
 
   const def = defineAgent({
     id: "coding-agent",
@@ -118,31 +128,42 @@ export async function createCodingAgent(
     },
   });
 
-  const env: BaseEnv = {
+  const env: PosixToolEnv = {
     sources: [source],
     defaultSource: source.id,
     storage,
     workdir: opts.contextDir,
+    toolCwd: opts.cwd,
     audit: noopAuditStore(),
     authorize: permissiveAuthorize(),
     directors: createDefaultDirectorRegistry(),
     ...(opts.deps !== undefined ? { deps: opts.deps } : {}),
   };
 
+  // The LSP plugin is a host responsibility: instantiate it (it reads
+  // env.toolCwd) and hand it to the agent through a fresh env carrying
+  // plugins, the same composition the deploy path performs. posix's
+  // factory reads it back off env.plugins and attaches it to its bundle.
+  const lspInstance = lsp(env);
+  const envWithPlugins: PosixToolEnv = { ...env, plugins: [lspInstance] };
+
   let agent: Agent;
   try {
-    agent = await createAgent(def, env);
+    agent = await createAgent(def, envWithPlugins);
   } catch (cause) {
-    await posixTools.dispose();
+    // Idempotent dual-dispose: the posix disposer if its factory ran
+    // (which chains to the LSP plugin), plus the LSP instance directly in
+    // case createAgent threw before the posix factory ran.
+    if (disposeTools !== undefined) await disposeTools();
+    if (lspInstance.dispose !== undefined) await lspInstance.dispose();
     throw cause;
   }
 
   return {
     agent,
-    posixTools,
     async close() {
       await agent.close();
-      await posixTools.dispose();
+      if (disposeTools !== undefined) await disposeTools();
     },
   };
 }

--- a/examples/posix-demo/src/cli.ts
+++ b/examples/posix-demo/src/cli.ts
@@ -13,7 +13,7 @@ import { setup, getLogger } from "@intx/log";
 import { createInMemoryTransport } from "@intx/mail-memory";
 import { generateKeyPair, createEd25519Crypto } from "@intx/crypto";
 import { createIsogitStore } from "@intx/storage-isogit/node";
-import { createPosixTools } from "@intx/tools-posix";
+import { posix, type PosixToolEnv } from "@intx/tools-posix/sidecar-bundle";
 import { createMailTools } from "@intx/tools-mail";
 import {
   createHarness,
@@ -164,32 +164,38 @@ const [storageAlpha, storageBeta] = await Promise.all([
 // Tools
 // ---------------------------------------------------------------------------
 
-// Keep per-package references so the shutdown path can dispose each
-// runner. Each per-agent createMailTools() is constructed against
-// that agent's transport; the harness wraps it as a defineTool bundle
-// factory via defineMailTools().
+// Keep per-package references so the shutdown path can dispose each mail
+// runner. Each per-agent createMailTools() is constructed against that
+// agent's transport; the harness wraps it as a defineTool bundle factory
+// via defineMailTools().
 const toolsAlphaMail = createMailTools({
   capabilities: createHarnessRuntimeCapabilities({
     transport: transportAlpha,
   }),
 });
-const toolsAlphaPosix = createPosixTools({ cwd: process.cwd() });
 
 const toolsBetaMail = createMailTools({
   capabilities: createHarnessRuntimeCapabilities({
     transport: transportBeta,
   }),
 });
-const toolsBetaPosix = createPosixTools({ cwd: process.cwd() });
 
-function posixFactoryFor(posixTools: typeof toolsAlphaPosix) {
-  return defineTool({
-    id: "@interchange-demo/posix-demo/posix",
-    definitions: posixTools.definitions.map((def) => ({ name: def.name })),
-    factory: () => ({
-      definitions: posixTools.definitions,
-      run: (call, signal) => posixTools.run(call, signal),
-    }),
+// The posix tools flow their working directory through env-DI: each
+// agent's factory reads env.toolCwd (both point at process.cwd() here,
+// distinct from the per-agent workdir lock boundary). Bundle lifetimes
+// are caller-owned, so the wrapper captures each bundle's disposer for
+// the shutdown path.
+const posixDisposers: (() => Promise<void>)[] = [];
+function posixFactory() {
+  return defineTool<PosixToolEnv>({
+    id: posix.id,
+    requires: posix.requires,
+    definitions: posix.definitions,
+    factory: (env) => {
+      const bundle = posix(env);
+      if (bundle.dispose !== undefined) posixDisposers.push(bundle.dispose);
+      return bundle;
+    },
   });
 }
 
@@ -321,7 +327,7 @@ const BETA_SYSTEM_PROMPT =
 const alphaDef = defineAgent({
   id: ALPHA_ADDRESS,
   systemPrompt: ALPHA_SYSTEM_PROMPT,
-  tools: [mailFactoryFor(toolsAlphaMail), posixFactoryFor(toolsAlphaPosix)],
+  tools: [mailFactoryFor(toolsAlphaMail), posixFactory()],
   capabilities: [],
   inference: {
     sources: [{ provider: alphaSource.provider, model: alphaSource.model }],
@@ -331,18 +337,19 @@ const alphaDef = defineAgent({
 const betaDef = defineAgent({
   id: BETA_ADDRESS,
   systemPrompt: BETA_SYSTEM_PROMPT,
-  tools: [mailFactoryFor(toolsBetaMail), posixFactoryFor(toolsBetaPosix)],
+  tools: [mailFactoryFor(toolsBetaMail), posixFactory()],
   capabilities: [],
   inference: {
     sources: [{ provider: betaSource.provider, model: betaSource.model }],
   },
 });
 
-const alphaEnv: MailEnv = {
+const alphaEnv: MailEnv & PosixToolEnv = {
   sources: [alphaSource],
   defaultSource: alphaSource.id,
   storage: storageAlpha,
   workdir: alphaDir,
+  toolCwd: process.cwd(),
   audit: noopAuditStore(),
   authorize: permissiveAuthorize(),
   directors: createDefaultDirectorRegistry(),
@@ -350,11 +357,12 @@ const alphaEnv: MailEnv = {
   address: ALPHA_ADDRESS,
 };
 
-const betaEnv: MailEnv = {
+const betaEnv: MailEnv & PosixToolEnv = {
   sources: [betaSource],
   defaultSource: betaSource.id,
   storage: storageBeta,
   workdir: betaDir,
+  toolCwd: process.cwd(),
   audit: noopAuditStore(),
   authorize: permissiveAuthorize(),
   directors: createDefaultDirectorRegistry(),
@@ -405,20 +413,18 @@ function shutdown(signal: string): void {
   stopAlphaLogger();
   stopBetaLogger();
   clearTimeout(safetyTimer);
-  // Each per-agent tool runner owns its own resources (LSP child
-  // processes via the posix tool runner's plugins, future per-package
-  // teardown via the mail tool runner). Dispose them so the demo exits
-  // cleanly. createHarness does not aggregate dispose -- the demo
-  // built the per-package runners and is responsible for disposing
-  // them after the harness closes.
+  // The demo owns the tool runners' lifetimes; createHarness does not
+  // aggregate dispose. Mail runners are built eagerly and disposed
+  // directly. Posix bundles are built inside their env-DI factories, so
+  // each factory captured its disposer at construction; dispose those
+  // after the harnesses close.
   void (async () => {
     await harnessAlpha.close();
     await harnessBeta.close();
     await Promise.all([
       toolsAlphaMail.dispose(),
-      toolsAlphaPosix.dispose(),
       toolsBetaMail.dispose(),
-      toolsBetaPosix.dispose(),
+      ...posixDisposers.map((dispose) => dispose()),
     ]);
   })();
 }

--- a/packages/agent/src/env.ts
+++ b/packages/agent/src/env.ts
@@ -82,6 +82,12 @@ export interface BaseEnv {
    * `workdir` values pointing at the same on-disk storage directory
    * will silently corrupt each other -- the invariant is the caller's
    * to maintain.
+   *
+   * This is the lock and storage boundary, not the working tree the
+   * filesystem tools operate on. A tool that needs a working directory
+   * (e.g. `@intx/tools-posix`) reads that from its own env-DI key
+   * declared through `defineTool({ requires })`, which the caller may
+   * point at a directory distinct from `workdir`.
    */
   workdir: string;
 

--- a/packages/tools-lsp/package.json
+++ b/packages/tools-lsp/package.json
@@ -29,6 +29,7 @@
     "which": "^4.0.0"
   },
   "devDependencies": {
+    "@intx/storage-isogit": "workspace:*",
     "@types/which": "^3.0.0"
   },
   "files": [

--- a/packages/tools-lsp/src/index.ts
+++ b/packages/tools-lsp/src/index.ts
@@ -13,13 +13,23 @@ export interface LSPPluginOptions {
   minSeverity?: number;
 }
 
-export function createLSPPlugin(opts: LSPPluginOptions): ToolPlugin {
+export interface LSPPlugin extends ToolPlugin {
+  /**
+   * The working directory the plugin's LSP roots its servers under,
+   * surfaced from the manager so a caller can confirm which tree the
+   * plugin is scoped to.
+   */
+  readonly cwd: string;
+}
+
+export function createLSPPlugin(opts: LSPPluginOptions): LSPPlugin {
   const lsp = createLSPManager({
     cwd: opts.cwd,
     ...(opts.worktree !== undefined ? { worktree: opts.worktree } : {}),
   });
 
   return {
+    cwd: lsp.cwd,
     tools: [
       {
         definition: LSP_TOOL_DEFINITION,

--- a/packages/tools-lsp/src/lsp.ts
+++ b/packages/tools-lsp/src/lsp.ts
@@ -38,6 +38,13 @@ export interface LSPStatus {
 }
 
 export interface LSPManager {
+  /**
+   * The working directory the manager roots its servers under. Every
+   * server's `root`/`spawn` receives this as `serverCtx.directory`, and
+   * `containsPath` gates file operations against it (together with an
+   * optional distinct `worktree`, when one is supplied).
+   */
+  readonly cwd: string;
   hasClients(file: string): Promise<boolean>;
   touchFile(file: string, mode?: "document" | "full"): Promise<void>;
   diagnostics(): Promise<Record<string, Diagnostic[]>>;
@@ -371,6 +378,7 @@ export function createLSPManager(opts: LSPManagerOptions): LSPManager {
   }
 
   return {
+    cwd: ctx.cwd,
     hasClients,
     touchFile,
     diagnostics,

--- a/packages/tools-lsp/src/sidecar-bundle.test.ts
+++ b/packages/tools-lsp/src/sidecar-bundle.test.ts
@@ -1,0 +1,76 @@
+// Behavior guard: the LSP sidecar bundle must scope its working directory
+// to `env.toolCwd` (the tool filesystem scope), not `env.workdir` (the lock
+// boundary). Every other test keeps the two equal, so a regression that
+// reads `env.workdir` again would pass the suite silently. This forces the
+// two apart and asserts the constructed plugin is rooted at `toolCwd`.
+//
+// `LSPPlugin.cwd` is surfaced straight from the manager's `ctx.cwd` — the
+// same directory `createLSPManager` hands every server as
+// `serverCtx.directory` and gates file operations against (proven in
+// lsp.test.ts). So this assertion tracks the value that actually drives the
+// LSP, not a copy that could drift from it.
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createDefaultDirectorRegistry } from "@intx/agent";
+import { noopAuditStore, permissiveAuthorize } from "@intx/agent/testing";
+import { createIsogitStore } from "@intx/storage-isogit/node";
+import type { PosixToolEnv } from "@intx/tools-posix/sidecar-bundle";
+import type { InferenceSource } from "@intx/types/runtime";
+
+import { lsp } from "./sidecar-bundle";
+
+const SOURCE: InferenceSource = {
+  id: "anthropic:mock-model",
+  provider: "anthropic",
+  baseURL: "https://api.anthropic.com",
+  apiKey: "sk-test",
+  model: "mock-model",
+};
+
+let toolDir: string;
+let workDir: string;
+let env: PosixToolEnv;
+
+beforeAll(async () => {
+  toolDir = await mkdtemp(join(tmpdir(), "tools-lsp-toolcwd-"));
+  workDir = await mkdtemp(join(tmpdir(), "tools-lsp-workdir-"));
+  const storage = await createIsogitStore(workDir);
+  env = {
+    sources: [SOURCE],
+    defaultSource: SOURCE.id,
+    storage,
+    workdir: workDir,
+    toolCwd: toolDir,
+    audit: noopAuditStore(),
+    authorize: permissiveAuthorize(),
+    directors: createDefaultDirectorRegistry(),
+  };
+});
+
+afterAll(async () => {
+  await Promise.all([
+    toolDir !== undefined
+      ? rm(toolDir, { recursive: true, force: true })
+      : undefined,
+    workDir !== undefined
+      ? rm(workDir, { recursive: true, force: true })
+      : undefined,
+  ]);
+});
+
+describe("lsp sidecar-bundle working directory", () => {
+  test("roots the LSP at env.toolCwd, not workdir", async () => {
+    const plugin = lsp(env);
+    try {
+      expect(plugin.cwd).toBe(toolDir);
+    } finally {
+      if (plugin.dispose !== undefined) {
+        await plugin.dispose();
+      }
+    }
+  });
+});

--- a/packages/tools-lsp/src/sidecar-bundle.ts
+++ b/packages/tools-lsp/src/sidecar-bundle.ts
@@ -10,6 +10,7 @@
 // `createPosixTools({ plugins })`.
 
 import { definePlugin } from "@intx/agent";
+import type { PosixToolEnv } from "@intx/tools-posix/sidecar-bundle";
 
 import { createLSPPlugin, LSP_TOOL_DEFINITION } from "./index";
 
@@ -37,6 +38,11 @@ export const lsp = definePlugin({
   // registers it under from `env.plugins` -- so the walked `tool:lsp` grant
   // matches the reactor's `tool:<call.name>` query. The tool is not
   // approval-gated, so it carries no `ask` mark.
+  requires: ["toolCwd"],
   definitions: [{ name: LSP_TOOL_DEFINITION.name }],
-  factory: (env) => createLSPPlugin({ cwd: env.workdir }),
+  // The env type is posix's: LSP contributes into posix's bundle via
+  // `env.plugins` and operates on the same working tree, so it reads the
+  // same `toolCwd` the posix tools scope to, not the lock-boundary
+  // `workdir`.
+  factory: (env: PosixToolEnv) => createLSPPlugin({ cwd: env.toolCwd }),
 });

--- a/packages/tools-posix/src/sidecar-bundle-toolcwd.test.ts
+++ b/packages/tools-posix/src/sidecar-bundle-toolcwd.test.ts
@@ -1,0 +1,86 @@
+// Behavior guard: the sidecar bundle must scope its filesystem tools to
+// `env.toolCwd`, not `env.workdir`. Every other test keeps the two keys
+// equal, so a regression that reads `env.workdir` again would pass the
+// suite silently. This test forces the two directories apart and proves a
+// relative write lands under `toolCwd` while `workdir` stays untouched.
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm, readFile, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createDefaultDirectorRegistry } from "@intx/agent";
+import { noopAuditStore, permissiveAuthorize } from "@intx/agent/testing";
+import { createIsogitStore } from "@intx/storage-isogit/node";
+import type { InferenceSource } from "@intx/types/runtime";
+
+import { posix, type PosixToolEnv } from "./sidecar-bundle";
+
+const SOURCE: InferenceSource = {
+  id: "anthropic:mock-model",
+  provider: "anthropic",
+  baseURL: "https://api.anthropic.com",
+  apiKey: "sk-test",
+  model: "mock-model",
+};
+
+function neverAbort(): AbortSignal {
+  return new AbortController().signal;
+}
+
+let toolDir: string;
+let workDir: string;
+let env: PosixToolEnv;
+
+beforeAll(async () => {
+  toolDir = await mkdtemp(join(tmpdir(), "tools-posix-toolcwd-"));
+  workDir = await mkdtemp(join(tmpdir(), "tools-posix-workdir-"));
+  const storage = await createIsogitStore(workDir);
+  env = {
+    sources: [SOURCE],
+    defaultSource: SOURCE.id,
+    storage,
+    workdir: workDir,
+    toolCwd: toolDir,
+    audit: noopAuditStore(),
+    authorize: permissiveAuthorize(),
+    directors: createDefaultDirectorRegistry(),
+  };
+});
+
+afterAll(async () => {
+  await Promise.all([
+    toolDir !== undefined
+      ? rm(toolDir, { recursive: true, force: true })
+      : undefined,
+    workDir !== undefined
+      ? rm(workDir, { recursive: true, force: true })
+      : undefined,
+  ]);
+});
+
+describe("posix sidecar-bundle working directory", () => {
+  test("resolves a relative write against toolCwd, not workdir", async () => {
+    const bundle = posix(env);
+    try {
+      const result = await bundle.run(
+        {
+          id: "w1",
+          name: "write_file",
+          arguments: { path: "sentinel.txt", content: "hello" },
+        },
+        neverAbort(),
+      );
+      expect(result.isError).toBeFalsy();
+
+      const written = await readFile(join(toolDir, "sentinel.txt"), "utf8");
+      expect(written).toBe("hello");
+
+      await expect(access(join(workDir, "sentinel.txt"))).rejects.toThrow();
+    } finally {
+      if (bundle.dispose !== undefined) {
+        await bundle.dispose();
+      }
+    }
+  });
+});

--- a/packages/tools-posix/src/sidecar-bundle.test.ts
+++ b/packages/tools-posix/src/sidecar-bundle.test.ts
@@ -14,12 +14,12 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { createDefaultDirectorRegistry, type BaseEnv } from "@intx/agent";
+import { createDefaultDirectorRegistry } from "@intx/agent";
 import { noopAuditStore, permissiveAuthorize } from "@intx/agent/testing";
 import { createIsogitStore } from "@intx/storage-isogit/node";
 import type { InferenceSource } from "@intx/types/runtime";
 
-import { posix } from "./sidecar-bundle";
+import { posix, type PosixToolEnv } from "./sidecar-bundle";
 import { TOOL_NAMES } from "./registry";
 
 const SOURCE: InferenceSource = {
@@ -31,7 +31,7 @@ const SOURCE: InferenceSource = {
 };
 
 let tmpDir: string;
-let env: BaseEnv;
+let env: PosixToolEnv;
 
 beforeAll(async () => {
   tmpDir = await mkdtemp(join(tmpdir(), "tools-posix-sidecar-bundle-test-"));
@@ -41,6 +41,7 @@ beforeAll(async () => {
     defaultSource: SOURCE.id,
     storage,
     workdir: tmpDir,
+    toolCwd: tmpDir,
     audit: noopAuditStore(),
     authorize: permissiveAuthorize(),
     directors: createDefaultDirectorRegistry(),

--- a/packages/tools-posix/src/sidecar-bundle.ts
+++ b/packages/tools-posix/src/sidecar-bundle.ts
@@ -1,19 +1,35 @@
 // Sidecar-bundle entry for `@intx/tools-posix` — the convention-compliant
 // factory the tool-package loader invokes.
 //
-// The factory uses `BaseEnv` fields (`workdir`, `storage`) and the
+// The factory reads the working tree it operates on from `env.toolCwd`
+// and the blob store from the `BaseEnv` `storage` field, plus the
 // optional `plugins` slot. Plugins are filtered by shape: any element
 // of `env.plugins` that has a `tools` array, a `middleware` function,
 // or a `dispose` function is treated as a `ToolPlugin` and handed to
 // `createPosixTools`. This is how LSP (a plugin factory) plugs into
 // posix without posix needing to know about LSP by name.
 
-import { defineTool, isToolPluginInstance } from "@intx/agent";
+import { defineTool, isToolPluginInstance, type BaseEnv } from "@intx/agent";
 import { createBlobReader } from "@intx/types/runtime";
 
 import { createPosixTools } from "./index";
 import type { ToolPlugin } from "./plugin";
 import { GATED_TOOL_NAMES, TOOL_DEFINITIONS } from "./registry";
+
+/**
+ * Env contract for the posix sidecar bundle. `toolCwd` is the working
+ * tree the posix filesystem tools operate on: read, write, edit, shell,
+ * search, and grep resolve relative paths against it.
+ *
+ * It is independent of the `BaseEnv` `workdir` lock and storage
+ * boundary. Two agents may share one `toolCwd` while holding distinct
+ * `workdir` values; the posix tools apply no lock to `toolCwd`, so
+ * concurrent writes to a shared tree are the caller's corruption risk
+ * to own.
+ */
+export interface PosixToolEnv extends BaseEnv {
+  toolCwd: string;
+}
 
 function isToolPlugin(value: unknown): value is ToolPlugin {
   // Require the `kind: "tool-plugin"` marker minted by definePlugin
@@ -34,8 +50,9 @@ function isToolPlugin(value: unknown): value is ToolPlugin {
  * Named export the loader picks up. The id is package-namespaced per
  * the convention.
  */
-export const posix = defineTool({
+export const posix = defineTool<PosixToolEnv>({
   id: "@intx/tools-posix/sidecar-bundle",
+  requires: ["toolCwd"],
   definitions: TOOL_DEFINITIONS.map((def) => ({
     name: def.name,
     ...(GATED_TOOL_NAMES.has(def.name) ? { approval: "ask" as const } : {}),
@@ -44,7 +61,7 @@ export const posix = defineTool({
     const blobReader = createBlobReader(env.storage);
     const plugins = (env.plugins ?? []).filter(isToolPlugin);
     const tools = createPosixTools({
-      cwd: env.workdir,
+      cwd: env.toolCwd,
       blobReader,
       plugins,
     });

--- a/tests/agent/posix-toolcwd.test.ts
+++ b/tests/agent/posix-toolcwd.test.ts
@@ -1,0 +1,185 @@
+// Regression guard for INTR-170's design: the posix tool working
+// directory (`env.toolCwd`) is independent of the agent's singleton lock
+// boundary (`env.workdir`). Two agents may share one `toolCwd` while
+// holding distinct `workdir` values, because the lock guards `workdir`
+// and not the tool tree. These tests pin all three invariants the design
+// commits to: the shared-toolCwd coexistence, the lock key staying on
+// `workdir`, and the posix bundle requiring `toolCwd` through env-DI.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  AgentContextLockError,
+  AgentEnvError,
+  createAgent,
+  createDefaultDirectorRegistry,
+  defineAgent,
+  type Agent,
+  type AgentDefinition,
+  type BaseEnv,
+} from "@intx/agent";
+import { noopAuditStore, permissiveAuthorize } from "@intx/agent/testing";
+import { setupHarness, type Harness } from "@intx/inference-testing";
+import { createIsogitStore } from "@intx/storage-isogit/node";
+import { posix, type PosixToolEnv } from "@intx/tools-posix/sidecar-bundle";
+import type { InferenceSource } from "@intx/types/runtime";
+
+const SOURCE: InferenceSource = {
+  id: "anthropic:claude-3-5-sonnet",
+  provider: "anthropic",
+  baseURL: "https://api.anthropic.com",
+  apiKey: "sk-test-posix-toolcwd",
+  model: "claude-3-5-sonnet",
+};
+
+function definition(): AgentDefinition<PosixToolEnv> {
+  return defineAgent({
+    id: "posix-toolcwd-test",
+    systemPrompt: "posix toolCwd test",
+    tools: [posix],
+    capabilities: [],
+    inference: {
+      sources: [{ provider: SOURCE.provider, model: SOURCE.model }],
+    },
+  });
+}
+
+async function envFor(
+  workdir: string,
+  toolCwd: string,
+  harness: Harness,
+): Promise<PosixToolEnv> {
+  const storage = await createIsogitStore(workdir);
+  return {
+    sources: [SOURCE],
+    defaultSource: SOURCE.id,
+    storage,
+    workdir,
+    toolCwd,
+    audit: noopAuditStore(),
+    authorize: permissiveAuthorize(),
+    directors: createDefaultDirectorRegistry(),
+    deps: harness.deps,
+  };
+}
+
+// Drive one write_file tool call through the agent, letting the reactor
+// close the cycle with a follow-up text reply. permissiveAuthorize
+// returns { effect: "allow" }, so the gated write runs inline with no
+// approval suspension. The path MUST stay relative: an absolute path
+// bypasses toolCwd resolution entirely, so an absolute path here would
+// make the test pass without exercising the toolCwd wiring at all.
+async function driveWrite(
+  agent: Agent,
+  harness: Harness,
+  relPath: string,
+  content: string,
+): Promise<void> {
+  harness.scenario.replyOnce("anthropic", {
+    toolCalls: [
+      {
+        callId: `write-${relPath}`,
+        name: "write_file",
+        argsJSON: JSON.stringify({ path: relPath, content }),
+      },
+    ],
+  });
+  harness.scenario.replyOnce("anthropic", { text: "done" });
+  const sendPromise = agent.send(`write ${relPath}`);
+  await harness.run();
+  await sendPromise;
+}
+
+describe("@intx/agent posix toolCwd env-DI", () => {
+  let root: string;
+  let harness: Harness;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "agent-posix-toolcwd-"));
+    harness = setupHarness();
+  });
+
+  afterEach(() => {
+    harness.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("two agents share a toolCwd while holding distinct workdirs", async () => {
+    const toolCwd = mkdtempSync(join(root, "shared-tool-"));
+    const agentA = await createAgent(
+      definition(),
+      await envFor(join(root, "wd-a"), toolCwd, harness),
+    );
+    try {
+      const agentB = await createAgent(
+        definition(),
+        await envFor(join(root, "wd-b"), toolCwd, harness),
+      );
+      try {
+        await driveWrite(agentA, harness, "a.txt", "from agent a");
+        await driveWrite(agentB, harness, "b.txt", "from agent b");
+
+        expect(readFileSync(join(toolCwd, "a.txt"), "utf8")).toBe(
+          "from agent a",
+        );
+        expect(readFileSync(join(toolCwd, "b.txt"), "utf8")).toBe(
+          "from agent b",
+        );
+      } finally {
+        await agentB.close();
+      }
+    } finally {
+      await agentA.close();
+    }
+  });
+
+  test("the singleton lock still keys on workdir, not toolCwd", async () => {
+    const workdir = join(root, "shared-wd");
+    // Distinct toolCwd values so the shared workdir is the sole cause of
+    // the rejection -- otherwise this would merely restate the existing
+    // same-workdir lock test in lifecycle.test.ts.
+    const first = await createAgent(
+      definition(),
+      await envFor(workdir, mkdtempSync(join(root, "tool-a-")), harness),
+    );
+    try {
+      await expect(
+        createAgent(
+          definition(),
+          await envFor(workdir, mkdtempSync(join(root, "tool-b-")), harness),
+        ),
+      ).rejects.toBeInstanceOf(AgentContextLockError);
+    } finally {
+      await first.close();
+    }
+  });
+
+  test("the posix bundle requires toolCwd through env-DI", async () => {
+    const storage = await createIsogitStore(join(root, "wd-missing"));
+    const envWithoutToolCwd: BaseEnv = {
+      sources: [SOURCE],
+      defaultSource: SOURCE.id,
+      storage,
+      workdir: join(root, "wd-missing"),
+      audit: noopAuditStore(),
+      authorize: permissiveAuthorize(),
+      directors: createDefaultDirectorRegistry(),
+      deps: harness.deps,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- bypass the type-level toolCwd requirement to exercise runtime env-DI validation
+    const looseDef = definition() as unknown as AgentDefinition<BaseEnv>;
+    try {
+      await createAgent(looseDef, envWithoutToolCwd);
+      throw new Error("expected createAgent to reject the toolCwd-less env");
+    } catch (err) {
+      if (!(err instanceof AgentEnvError)) throw err;
+      expect(err.missing).toContain("toolCwd");
+      expect(err.contributors).toContain(
+        "tool:@intx/tools-posix/sidecar-bundle",
+      );
+    }
+  });
+});

--- a/tests/coding-agent/cli.test.ts
+++ b/tests/coding-agent/cli.test.ts
@@ -5,7 +5,13 @@
 // network call.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -75,6 +81,54 @@ describe("coding-agent CLI", () => {
     // The stream pump emits one line per reactor event; we should see
     // at least one event (`message.received`) before the cycle completes.
     expect(stderrBuf).toMatch(/\[message\.received\]/);
+  });
+
+  test("scopes posix tool writes to --cwd, not --context-dir", async () => {
+    // The model issues a write_file with a relative path. The coding agent
+    // flows the working directory through env-DI as toolCwd (the --cwd
+    // tree), distinct from workdir (the --context-dir isogit store), so a
+    // relative write resolves under --cwd and never touches --context-dir.
+    const editTree = join(workDir, "src");
+    const contextDir = join(workDir, "ctx");
+    mkdirSync(editTree, { recursive: true });
+
+    harness.scenario.replyOnce("anthropic", {
+      toolCalls: [
+        {
+          callId: "write-1",
+          name: "write_file",
+          argsJSON: JSON.stringify({
+            path: "sentinel.txt",
+            content: "scoped to toolCwd",
+          }),
+        },
+      ],
+    });
+    harness.scenario.replyOnce("anthropic", { text: "wrote the file" });
+
+    const runPromise = main(
+      ["--cwd", editTree, "--context-dir", contextDir, "write", "a", "file"],
+      { ANTHROPIC_API_KEY: "irrelevant" },
+      {
+        stdout: (s) => {
+          stdoutBuf += s;
+        },
+        stderr: (s) => {
+          stderrBuf += s;
+        },
+        sourceOverride: SOURCE,
+        deps: harness.deps,
+      },
+    );
+
+    await harness.run();
+    const code = await runPromise;
+
+    expect(code).toBe(0);
+    expect(readFileSync(join(editTree, "sentinel.txt"), "utf8")).toBe(
+      "scoped to toolCwd",
+    );
+    expect(existsSync(join(contextDir, "sentinel.txt"))).toBe(false);
   });
 
   test("missing ANTHROPIC_API_KEY (and no sourceOverride) returns exit code 1", async () => {


### PR DESCRIPTION
## Summary

- `env.toolCwd` names the working tree the posix and LSP filesystem tools
  operate on. It is declared per tool through `defineTool`/`definePlugin`
  `requires` and is distinct from `env.workdir`, the agent's singleton lock
  and isogit storage boundary.
- The `@intx/tools-posix` and `@intx/tools-lsp` sidecar bundles read
  `toolCwd`. The production sidecar step env supplies `toolCwd` equal to
  `workdir`, and the `coding-agent` and `posix-demo` examples flow the
  working directory through env-DI rather than constructor arguments.
- The singleton lock stays keyed on `workdir` alone, so two agents may share
  one `toolCwd` while holding distinct `workdir` values.

## Verification

- `make all` passes (lint, `tsc -b --force`, admin-ui bundle, tests).
- A regression test drives a real `write_file` from each of two agents that
  share a `toolCwd` with distinct `workdir`s into the shared tree, asserts
  the singleton lock still rejects a second agent on a shared `workdir`, and
  asserts the posix bundle fails env validation when `toolCwd` is absent.

Closes INTR-170