### PR TITLE
Warn on cleartext sidecar transport and correct the encryption docs

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -1197,7 +1197,7 @@ Both approaches support standard git workflows for managing agent versions.
 
 ## Agent Deployment: Git Pack Transport
 
-Deploy content travels from the hub to sidecars as git packfiles streamed over the existing WebSocket connection. State travels back from sidecars to the hub using the same mechanism. This avoids requiring sidecars to have network access to external git hosts and reuses the authenticated, encrypted channel already in place.
+Deploy content travels from the hub to sidecars as git packfiles streamed over the existing WebSocket connection. State travels back from sidecars to the hub using the same mechanism. This avoids requiring sidecars to have network access to external git hosts and reuses the authenticated WebSocket connection already in place. The protocol does not encrypt that connection; transport confidentiality depends on running it over TLS (`wss://`).
 
 ### Wire Frames
 

--- a/packages/hub-agent/src/ws/hub-link.test.ts
+++ b/packages/hub-agent/src/ws/hub-link.test.ts
@@ -17,6 +17,7 @@ import type { HarnessConfig } from "@intx/types/runtime";
 import {
   answerMalformedRequestFrame,
   classifyAssetPackRejectReason,
+  cleartextTransportWarning,
   createHubLink,
   type DeployRouter,
   type ReconnectScheduler,
@@ -2413,5 +2414,43 @@ describe("classifyAssetPackRejectReason", () => {
     expect(classifyAssetPackRejectReason("signature_unsigned: ...")).toBe(
       "signature_invalid",
     );
+  });
+});
+
+describe("cleartextTransportWarning", () => {
+  test("warns on cleartext ws:// to a non-loopback host", () => {
+    expect(
+      cleartextTransportWarning("ws://hub.example.com/api/sidecars/ws"),
+    ).toContain("cleartext ws://");
+    expect(
+      cleartextTransportWarning("ws://10.0.0.5:3000/api/sidecars/ws"),
+    ).toContain("cleartext ws://");
+  });
+
+  test("normalizes the host, so an uppercase remote still warns", () => {
+    expect(
+      cleartextTransportWarning("ws://HUB.EXAMPLE.COM/api/sidecars/ws"),
+    ).toContain("cleartext ws://");
+  });
+
+  test("stays silent for cleartext ws:// to a loopback host", () => {
+    for (const url of [
+      "ws://localhost/api/sidecars/ws",
+      "ws://localhost:3000/api/sidecars/ws",
+      "ws://127.0.0.1:3000/api/sidecars/ws",
+      "ws://[::1]:3000/api/sidecars/ws",
+    ]) {
+      expect(cleartextTransportWarning(url)).toBeNull();
+    }
+  });
+
+  test("stays silent for wss:// regardless of host", () => {
+    expect(
+      cleartextTransportWarning("wss://hub.example.com/api/sidecars/ws"),
+    ).toBeNull();
+  });
+
+  test("throws on a malformed hub URL rather than reporting no warning", () => {
+    expect(() => cleartextTransportWarning("not a url")).toThrow();
   });
 });

--- a/packages/hub-agent/src/ws/hub-link.ts
+++ b/packages/hub-agent/src/ws/hub-link.ts
@@ -673,6 +673,30 @@ export type HubLink = {
   }) => Promise<void>;
 };
 
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+/**
+ * The hub-sidecar WebSocket carries `agent.deploy` frames whose payload holds
+ * decrypted inference API keys and credential material. Over cleartext `ws://`
+ * to a non-loopback host those secrets cross the network unencrypted, so the
+ * operator must be told to deploy behind TLS (`wss://`).
+ *
+ * Returns the warning message when `hubURL` is cleartext `ws:` against a
+ * non-loopback host, or `null` when no warning is warranted. `null` means
+ * strictly "parsed successfully, transport is acceptable" -- a malformed
+ * `hubURL` throws from `new URL` rather than being reported as no-warning.
+ * `new URL` normalizes the host (lowercase, canonical IPv4, bracketed IPv6),
+ * so the set matches the common loopback spellings without variant handling.
+ * Other `127.0.0.0/8` addresses fall through to the warning; over-warning on a
+ * local address is safe, whereas missing a remote one is not.
+ */
+export function cleartextTransportWarning(hubURL: string): string | null {
+  const { protocol, hostname } = new URL(hubURL);
+  if (protocol !== "ws:") return null;
+  if (LOOPBACK_HOSTS.has(hostname)) return null;
+  return `Hub URL ${hubURL} uses cleartext ws://; deploy credentials cross the network unencrypted. Use wss:// with TLS for any non-loopback hub.`;
+}
+
 export function createHubLink(config: HubLinkConfig): HubLink {
   const {
     hubURL,
@@ -699,6 +723,11 @@ export function createHubLink(config: HubLinkConfig): HubLink {
     registerAckMaxAttempts = DEFAULT_REGISTER_ACK_MAX_ATTEMPTS,
     scheduleReconnect = defaultScheduleReconnect,
   } = config;
+
+  const cleartextWarning = cleartextTransportWarning(hubURL);
+  if (cleartextWarning !== null) {
+    logger.warn`${cleartextWarning}`;
+  }
 
   let ws: WebSocket | null = null;
   let closed = false;


### PR DESCRIPTION
## Summary

- The Git Pack Transport documentation states that hub-sidecar transport
  confidentiality depends on a TLS (wss://) deployment, rather than claiming
  the channel is already encrypted.
- The sidecar logs a warning at link creation when its hub URL is cleartext
  ws:// to a non-loopback host, because deploy frames carry decrypted
  inference keys and credential material.
- Cleartext ws:// to a loopback host stays silent for local development.

## Verification

- `make all` passes on the branch (exit 0).
- New unit tests cover the warn, no-warn (loopback and wss://), host
  normalization, and malformed-URL-throws cases.

Closes INTR-504