### PR TITLE
Repair the forked drizzle migration snapshot chain

### DIFF
--- a/packages/db/migrations/meta/0087_snapshot.json
+++ b/packages/db/migrations/meta/0087_snapshot.json
@@ -1,6 +1,6 @@
 {
   "id": "b673a276-410f-4e34-99f9-b563273d63e1",
-  "prevId": "0f093e94-6e56-4f60-8600-53e8592155b5",
+  "prevId": "c5723916-35b0-432b-a488-4f54f49ad26f",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -3544,6 +3544,12 @@
         },
         "model_preferences": {
           "name": "model_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_refs": {
+          "name": "credential_refs",
           "type": "jsonb",
           "primaryKey": false,
           "notNull": false

--- a/packages/db/migrations/meta/0088_snapshot.json
+++ b/packages/db/migrations/meta/0088_snapshot.json
@@ -3536,6 +3536,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "credential_refs": {
+          "name": "credential_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp",


### PR DESCRIPTION
## Summary

- Relinks a migration snapshot to its real predecessor and restores a column the fork silently dropped from the later snapshots, so the meta chain is linear and the latest snapshot matches the applied schema again.
- Unblocks `drizzle-kit generate`: it rejected the fork as a collision, and once past that it would re-emit the dropped column as a spurious `ADD COLUMN`.

## Verification

- `drizzle-kit generate` validates the full snapshot chain and emits no spurious statements. A prevId-only fix would still re-emit `ADD COLUMN credential_refs`, which breaks `bin/db-reset` (the column is already added by an earlier migration).
- The applied SQL files and the migration journal are unchanged, so `drizzle-kit migrate`, `bin/db-reset`, and runtime are unaffected — only new-migration generation was blocked.