### PR TITLE
Add durable per-principal signing keys

### DIFF
--- a/.env.hub.example
+++ b/.env.hub.example
@@ -9,6 +9,11 @@ BETTER_AUTH_BASE_URL=http://localhost:3000
 # without it. 32 bytes, hex -- generate with `openssl rand -hex 32`.
 CREDENTIAL_ENCRYPTION_KEY=
 
+# Seals per-principal signing keys at rest. Required: the hub refuses to
+# start without it. A SEPARATE key from CREDENTIAL_ENCRYPTION_KEY so the two
+# rotate independently. 32 bytes, hex -- generate with `openssl rand -hex 32`.
+PRINCIPAL_KEY_ENCRYPTION_KEY=
+
 HUB_DATA_DIR=./tmp/hub-data
 # PORT=3000               # override the default hub port
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -66,12 +66,15 @@ runs:
         sed -i "s/^BETTER_AUTH_SECRET=.*/BETTER_AUTH_SECRET=${secret}/" .env.hub
         cred_key=$(openssl rand -hex 32)
         sed -i "s/^CREDENTIAL_ENCRYPTION_KEY=.*/CREDENTIAL_ENCRYPTION_KEY=${cred_key}/" .env.hub
+        principal_key=$(openssl rand -hex 32)
+        sed -i "s/^PRINCIPAL_KEY_ENCRYPTION_KEY=.*/PRINCIPAL_KEY_ENCRYPTION_KEY=${principal_key}/" .env.hub
 
     # The DB/hub-api test harness skips only when the env files are absent, so a
     # missing file would silently drop the entire DB layer while CI stays green.
-    # Fail loudly instead: the files must exist, BETTER_AUTH_SECRET and
-    # CREDENTIAL_ENCRYPTION_KEY must be non-empty (else the spawned hub
-    # hard-fails at boot), and Postgres must be reachable.
+    # Fail loudly instead: the files must exist, BETTER_AUTH_SECRET,
+    # CREDENTIAL_ENCRYPTION_KEY, and PRINCIPAL_KEY_ENCRYPTION_KEY must be
+    # non-empty (else the spawned hub hard-fails at boot), and Postgres must be
+    # reachable.
     - name: Assert DB test env is wired
       if: ${{ inputs.database == 'true' }}
       shell: bash
@@ -81,6 +84,7 @@ runs:
         test -f .env.hub
         grep -q '^BETTER_AUTH_SECRET=.\+' .env.hub
         grep -q '^CREDENTIAL_ENCRYPTION_KEY=.\+' .env.hub
+        grep -q '^PRINCIPAL_KEY_ENCRYPTION_KEY=.\+' .env.hub
         pg_isready -h localhost -p 5432
 
     # Pre-create the two roles db-reset assumes exist (deriving each password

--- a/DEV.md
+++ b/DEV.md
@@ -40,7 +40,7 @@ cp .env.hub.example .env.hub
 cp .env.migrate.example .env.migrate
 ```
 
-The example files contain working dev defaults for most values. The only value you must generate is `BETTER_AUTH_SECRET` in `.env.hub` (any 32+ byte hex string works, e.g. `openssl rand -hex 32`).
+The example files contain working dev defaults for most values, but three secrets in `.env.hub` ship blank and you must generate each as a 32-byte hex value (`openssl rand -hex 32`): `BETTER_AUTH_SECRET`, `CREDENTIAL_ENCRYPTION_KEY`, and `PRINCIPAL_KEY_ENCRYPTION_KEY`. The hub refuses to start without the two encryption keys.
 
 | File           | Contains                                                         |
 | -------------- | ---------------------------------------------------------------- |
@@ -64,6 +64,8 @@ files next to the matching service config.
 | `HUB_URL`                            | `bin/seed`                                   | `http://localhost:3000`             | Base URL `bin/seed` targets when seeding via the hub API.                                                                                            |
 | `HUB_MAX_TARBALL_BYTES`              | hub (`apps/hub`)                             | 10 MiB                              | Per-tarball cap for tool packages uploaded to the package registry.                                                                                  |
 | `PG_SCHEMA`                          | hub (`apps/hub`)                             | unset                               | Pins the hub to a postgres schema. Integration-test-only; leave unset normally.                                                                      |
+| `CREDENTIAL_ENCRYPTION_KEY`          | hub (`apps/hub`)                             | none (required)                     | 32-byte hex key that seals credential secrets and OAuth client secrets at rest in the database. The hub refuses to start without it.                 |
+| `PRINCIPAL_KEY_ENCRYPTION_KEY`       | hub (`apps/hub`)                             | none (required)                     | 32-byte hex key that seals per-principal signing keys at rest, separate from `CREDENTIAL_ENCRYPTION_KEY`. The hub refuses to start without it.       |
 | `SIDECAR_CREDENTIAL_ENCRYPTION_KEY`  | sidecar (`apps/sidecar`)                     | none (required)                     | 32-byte hex key that seals credential material (inference apiKeys) at rest under `SIDECAR_DATA_DIR`. The sidecar refuses to start without it.        |
 | `SIDECAR_CACHE_DIR`                  | sidecar (`apps/sidecar`)                     | `<SIDECAR_DATA_DIR>/cache/tarballs` | Directory for the tool-package tarball cache.                                                                                                        |
 | `SIDECAR_CACHE_MAX_BYTES`            | sidecar (`apps/sidecar`)                     | 10 GiB                              | Maximum total size of the tarball cache.                                                                                                             |

--- a/apps/hub/src/server.ts
+++ b/apps/hub/src/server.ts
@@ -1,6 +1,7 @@
 import {
   createDB,
   createGrantStore,
+  createPrincipalKeyStore,
   createSidecarAllocationStore,
   createWorkflowRunDispatchStore,
 } from "@intx/db";
@@ -97,6 +98,27 @@ export async function createHubServer({
   const credentialCipher = createEnvKeyCredentialCipher(
     hexDecode(credentialEncryptionKeyHex),
   );
+
+  // Per-principal signing keys are sealed at rest under their own operator key,
+  // separate from CREDENTIAL_ENCRYPTION_KEY so the two rotate independently.
+  // Required at boot for the same reason: a missing key would silently persist
+  // minted private keys in the clear. 32 bytes, hex.
+  const principalKeyEncryptionKeyHex =
+    process.env["PRINCIPAL_KEY_ENCRYPTION_KEY"];
+  if (
+    principalKeyEncryptionKeyHex === undefined ||
+    principalKeyEncryptionKeyHex.trim() === ""
+  ) {
+    throw new Error(
+      "PRINCIPAL_KEY_ENCRYPTION_KEY environment variable is required",
+    );
+  }
+  const principalKeyStore = createPrincipalKeyStore({
+    db,
+    cipher: createEnvKeyCredentialCipher(
+      hexDecode(principalKeyEncryptionKeyHex),
+    ),
+  });
 
   // 10 MiB is the production cap for tool-package tarballs uploaded via
   // the package-registry PUT endpoint. The npm registry's own per-tarball
@@ -215,6 +237,7 @@ export async function createHubServer({
     materializeMailTriggeredRunGrants: createMailTriggeredRunGrantsMaterializer(
       {
         db,
+        principalKeyStore,
         grantStore: createGrantStore(db),
       },
     ),
@@ -414,6 +437,7 @@ export async function createHubServer({
     workflowDispatchService,
     eventCollectors,
     credentialCipher,
+    principalKeyStore,
     assetService,
     repoStore: agentRepoStore.repoStore,
     maxTarballBytes: hubMaxTarballBytes,

--- a/bin/backfill-principal-keys.test.ts
+++ b/bin/backfill-principal-keys.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "..");
+
+// The backfill seals private key seeds under the cipher the hub decrypts with,
+// so a missing PRINCIPAL_KEY_ENCRYPTION_KEY must hard-fail rather than fall back
+// to a noop cipher (which would seal seeds unrecoverably). The key check runs
+// before any DB connection, so spawning with the key absent surfaces exactly
+// that guard.
+describe("bin/backfill-principal-keys env guard", () => {
+  test("fails hard when PRINCIPAL_KEY_ENCRYPTION_KEY is absent", async () => {
+    const env: Record<string, string> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+      if (key !== "PRINCIPAL_KEY_ENCRYPTION_KEY" && value !== undefined) {
+        env[key] = value;
+      }
+    }
+
+    const proc = Bun.spawn(
+      ["bun", "run", "--conditions=intx-src", "bin/backfill-principal-keys.ts"],
+      { cwd: REPO_ROOT, env, stdout: "pipe", stderr: "pipe" },
+    );
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(
+      /PRINCIPAL_KEY_ENCRYPTION_KEY environment variable is required/,
+    );
+  });
+});

--- a/bin/backfill-principal-keys.ts
+++ b/bin/backfill-principal-keys.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env bun
+
+// Backfill per-principal signing keys onto principals that predate the
+// per-principal-key feature.
+//
+// Run ONCE as the last step of the deploy that introduces per-principal keys,
+// AFTER the key-minting hub is live. It is safe against a live hub: nothing
+// reads principal keys yet, the hub only mints for newly-created principals,
+// and the active-key unique index blocks a double key. Idempotent -- a
+// principal that already holds an active key is skipped -- so it is safe to
+// re-run or resume after a partial failure. On a database where every principal
+// was created after the feature landed (e.g. local dev), it does nothing.
+//
+//   set -a; . .env; . .env.hub; set +a
+//   bun run --conditions=intx-src bin/backfill-principal-keys.ts
+//
+// It reads the same DB_* and PRINCIPAL_KEY_ENCRYPTION_KEY the hub uses. The key
+// is required: the seeds must be sealed under the same cipher the hub decrypts
+// with, so there is no noop fallback.
+
+import { setup, getLogger } from "@intx/log";
+import {
+  backfillPrincipalKeys,
+  createDB,
+  createPrincipalKeyStore,
+} from "@intx/db";
+import { createEnvKeyCredentialCipher } from "@intx/crypto";
+import { hexDecode } from "@intx/types";
+
+import { resolveDbConfig } from "./lib/db-config";
+
+await setup({ dev: true });
+const log = getLogger(["backfill-principal-keys"]);
+
+const keyHex = process.env["PRINCIPAL_KEY_ENCRYPTION_KEY"];
+if (keyHex === undefined || keyHex.trim() === "") {
+  throw new Error(
+    "PRINCIPAL_KEY_ENCRYPTION_KEY environment variable is required",
+  );
+}
+const cipher = createEnvKeyCredentialCipher(hexDecode(keyHex));
+
+const { db, close } = createDB(resolveDbConfig(process.env));
+try {
+  const store = createPrincipalKeyStore({ db, cipher });
+  const report = await backfillPrincipalKeys(db, store);
+  log.info(
+    "Backfill complete: minted {keysGenerated} new signing key(s); " +
+      "{alreadyKeyed} principal(s) already keyed.",
+    report,
+  );
+} finally {
+  await close();
+}

--- a/bin/e2e-provision.ts
+++ b/bin/e2e-provision.ts
@@ -57,6 +57,11 @@ async function up(): Promise<void> {
           "CREDENTIAL_ENCRYPTION_KEY",
           ".env.hub",
         ),
+        PRINCIPAL_KEY_ENCRYPTION_KEY: requireKey(
+          hubEnv,
+          "PRINCIPAL_KEY_ENCRYPTION_KEY",
+          ".env.hub",
+        ),
       },
       // The migration role's connection to the provisioned database. It owns
       // the freshly-migrated tables, so it is the identity harness pre-flight

--- a/bun.lock
+++ b/bun.lock
@@ -285,6 +285,7 @@
       "dependencies": {
         "@intx/authz": "workspace:*",
         "@intx/crypto": "workspace:*",
+        "@intx/hub-common": "workspace:*",
         "@intx/log": "workspace:*",
         "@intx/types": "workspace:*",
         "arktype": "catalog:",

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -61,6 +61,8 @@ The private key seed is sealed at rest with the same AEAD cipher that protects c
 
 Custody is an **attribution** model, not non-repudiation. A signature proves the action came from a holder of the principal's private key, which is enough to attribute the action to the principal within the system. It is **not** proof against the hub operator, who also holds the key and could sign as the principal. Non-repudiation would require the private key to live somewhere the hub cannot reach, which the hub-custodied model does not provide.
 
+Every principal is minted a signing key when it is created, in the same transaction as the principal row, so a principal never exists without a key. The hub seals the seed under `PRINCIPAL_KEY_ENCRYPTION_KEY` (32 bytes, hex) -- a separate key from `CREDENTIAL_ENCRYPTION_KEY`, so the two rotate independently -- and refuses to start without it.
+
 ### Request resolution flow
 
 ```

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -41,6 +41,26 @@ principal
   UNIQUE(tenant_id, kind, ref_id)
 ```
 
+### Signing keys
+
+The `principal_key` table holds a principal's Ed25519 signing key, giving it a stable cryptographic identity. The public key is a stable handle a verifier can check a signature against; the hub custodies the private key.
+
+```
+principal_key
+  id            text PK        -- pky_...
+  principal_id  text FK -> principal (ON DELETE CASCADE)
+  public_key    text NOT NULL UNIQUE  -- hex-encoded 32-byte Ed25519 public key
+  private_key   text NOT NULL         -- hex-encoded 32-byte seed, sealed by the cipher
+  status        text NOT NULL         -- 'active' | 'retired'
+  created_at    timestamptz
+  updated_at    timestamptz
+  UNIQUE(principal_id) WHERE status = 'active'   -- one active key per principal
+```
+
+The private key seed is sealed at rest with the same AEAD cipher that protects credential secrets, bound to its row and column so a sealed key cannot be transplanted to another row. See [CREDENTIALS.md](./CREDENTIALS.md) for the encryption-at-rest mechanics.
+
+Custody is an **attribution** model, not non-repudiation. A signature proves the action came from a holder of the principal's private key, which is enough to attribute the action to the principal within the system. It is **not** proof against the hub operator, who also holds the key and could sign as the principal. Non-repudiation would require the private key to live somewhere the hub cannot reach, which the hub-custodied model does not provide.
+
 ### Request resolution flow
 
 ```

--- a/docs/CREDENTIALS.md
+++ b/docs/CREDENTIALS.md
@@ -213,6 +213,8 @@ Credential secrets are encrypted at rest: the credential `secret` and `refresh_s
 
 Encryption is a pluggable seam, the `CredentialCipher`. The built-in implementation encrypts under a single operator-provided key, `CREDENTIAL_ENCRYPTION_KEY` (32 bytes, hex); the hub refuses to start without it. A future KMS or envelope-encryption plugin implements the same seam and can keep key material inside the KMS without touching any call site.
 
+The same cipher seam seals per-principal signing keys at rest, under a separate key `PRINCIPAL_KEY_ENCRYPTION_KEY` so the two rotate independently. See [AUTH.md](./AUTH.md) for the principal signing-key custody and attribution model.
+
 The threat model this addresses is **database-only compromise** — a stolen backup, a replica leak, a SQL-injection read, a snoop over the table. It does **not** defend against full host compromise, where the attacker holds both the key and the data; that requires a KMS/envelope plugin.
 
 Deploying encryption over a database whose rows predate it requires a one-time re-key of the legacy plaintext. With the hub **stopped** (so no write races an un-re-keyed row against the strict read path), run `bin/rekey-credential-secrets.ts` with the hub's environment sourced, then start the hub. The pass is idempotent — already-encrypted rows are skipped — so it is safe to re-run or resume.

--- a/packages/db/migrations/0089_tense_selene.sql
+++ b/packages/db/migrations/0089_tense_selene.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "principal_key" (
+	"id" text PRIMARY KEY NOT NULL,
+	"principal_id" text NOT NULL,
+	"public_key" text NOT NULL,
+	"private_key" text NOT NULL,
+	"status" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "principal_key_public_key_unique" UNIQUE("public_key")
+);
+--> statement-breakpoint
+ALTER TABLE "principal_key" ADD CONSTRAINT "principal_key_principal_id_principal_id_fk" FOREIGN KEY ("principal_id") REFERENCES "public"."principal"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "principal_key_one_active" ON "principal_key" USING btree ("principal_id") WHERE "principal_key"."status" = 'active';

--- a/packages/db/migrations/meta/0087_snapshot.json
+++ b/packages/db/migrations/meta/0087_snapshot.json
@@ -1,6 +1,6 @@
 {
   "id": "b673a276-410f-4e34-99f9-b563273d63e1",
-  "prevId": "0f093e94-6e56-4f60-8600-53e8592155b5",
+  "prevId": "c5723916-35b0-432b-a488-4f54f49ad26f",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -3544,6 +3544,12 @@
         },
         "model_preferences": {
           "name": "model_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_refs": {
+          "name": "credential_refs",
           "type": "jsonb",
           "primaryKey": false,
           "notNull": false

--- a/packages/db/migrations/meta/0088_snapshot.json
+++ b/packages/db/migrations/meta/0088_snapshot.json
@@ -3536,6 +3536,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "credential_refs": {
+          "name": "credential_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp",

--- a/packages/db/migrations/meta/0089_snapshot.json
+++ b/packages/db/migrations/meta/0089_snapshot.json
@@ -1,0 +1,4376 @@
+{
+  "id": "29cab816-ceea-4770-a010-9e3a1b28d2dc",
+  "prevId": "bdac2dcb-57fe-4ec7-a524-42a2bbe2bc0d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.federation_trust": {
+      "name": "federation_trust",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_tenant_id": {
+          "name": "target_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "federation_trust_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "federation_trust_target_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_target_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "tableTo": "tenant",
+          "columnsFrom": ["target_tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federation_trust_tenant_id_target_tenant_id_unique": {
+          "name": "federation_trust_tenant_id_target_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "target_tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant": {
+      "name": "tenant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_parent_id_tenant_id_fk": {
+          "name": "tenant_parent_id_tenant_id_fk",
+          "tableFrom": "tenant",
+          "tableTo": "tenant",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_slug_unique": {
+          "name": "tenant_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "tenant_domain_unique": {
+          "name": "tenant_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": ["domain"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal": {
+      "name": "principal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_tenant_id_tenant_id_fk": {
+          "name": "principal_tenant_id_tenant_id_fk",
+          "tableFrom": "principal",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "principal_tenant_id_kind_ref_id_unique": {
+          "name": "principal_tenant_id_kind_ref_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "kind", "ref_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal_key": {
+      "name": "principal_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principal_key_one_active": {
+          "name": "principal_key_one_active",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"principal_key\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principal_key_principal_id_principal_id_fk": {
+          "name": "principal_key_principal_id_principal_id_fk",
+          "tableFrom": "principal_key",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "principal_key_public_key_unique": {
+          "name": "principal_key_public_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["public_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_role": {
+      "name": "agent_role",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_role_agent_id_workflow_definition_id_fk": {
+          "name": "agent_role_agent_id_workflow_definition_id_fk",
+          "tableFrom": "agent_role",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_role_role_id_role_id_fk": {
+          "name": "agent_role_role_id_role_id_fk",
+          "tableFrom": "agent_role",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_role_agent_id_role_id_pk": {
+          "name": "agent_role_agent_id_role_id_pk",
+          "columns": ["agent_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal_role": {
+      "name": "principal_role",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_role_principal_id_principal_id_fk": {
+          "name": "principal_role_principal_id_principal_id_fk",
+          "tableFrom": "principal_role",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "principal_role_role_id_role_id_fk": {
+          "name": "principal_role_role_id_role_id_fk",
+          "tableFrom": "principal_role",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "principal_role_principal_id_role_id_pk": {
+          "name": "principal_role_principal_id_role_id_pk",
+          "columns": ["principal_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_tenant_id_tenant_id_fk": {
+          "name": "role_tenant_id_tenant_id_fk",
+          "tableFrom": "role",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grant": {
+      "name": "grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grant_tenant_id_tenant_id_fk": {
+          "name": "grant_tenant_id_tenant_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grant_role_id_role_id_fk": {
+          "name": "grant_role_id_role_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grant_principal_id_principal_id_fk": {
+          "name": "grant_principal_id_principal_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grant_target_exactly_one": {
+          "name": "grant_target_exactly_one",
+          "value": "num_nonnulls(\"grant\".\"principal_id\", \"grant\".\"role_id\") = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.approval": {
+      "name": "approval",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_address": {
+          "name": "agent_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_definition": {
+          "name": "tool_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_arguments": {
+          "name": "tool_arguments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "timeout_at": {
+          "name": "timeout_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approval_tenant_status_idx": {
+          "name": "approval_tenant_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_anchor_run_idx": {
+          "name": "approval_anchor_run_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_run_idx": {
+          "name": "approval_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_tenant_id_tenant_id_fk": {
+          "name": "approval_tenant_id_tenant_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_anchor_run_id_workflow_run_id_fk": {
+          "name": "approval_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_run_id_workflow_run_id_fk": {
+          "name": "approval_run_id_workflow_run_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approval_correlation_id_unique": {
+          "name": "approval_correlation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["correlation_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_correlation": {
+      "name": "signal_correlation",
+      "schema": "",
+      "columns": {
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_address": {
+          "name": "agent_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_name": {
+          "name": "signal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_id": {
+          "name": "signal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signal_correlation_tenant_id_tenant_id_fk": {
+          "name": "signal_correlation_tenant_id_tenant_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signal_correlation_anchor_run_id_workflow_run_id_fk": {
+          "name": "signal_correlation_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signal_correlation_run_id_workflow_run_id_fk": {
+          "name": "signal_correlation_run_id_workflow_run_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_info_url": {
+          "name": "user_info_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_tenant_id_tenant_id_fk": {
+          "name": "provider_tenant_id_tenant_id_fk",
+          "tableFrom": "provider",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_tenant_name": {
+          "name": "provider_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_scopes": {
+          "name": "default_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_tenant_id_tenant_id_fk": {
+          "name": "oauth_client_tenant_id_tenant_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_client_provider_id_provider_id_fk": {
+          "name": "oauth_client_provider_id_provider_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_tenant_provider": {
+          "name": "oauth_client_tenant_provider",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "provider_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credential": {
+      "name": "credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_secret": {
+          "name": "refresh_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credential_tenant_id_tenant_id_fk": {
+          "name": "credential_tenant_id_tenant_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_principal_id_principal_id_fk": {
+          "name": "credential_principal_id_principal_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credential_provider_id_provider_id_fk": {
+          "name": "credential_provider_id_provider_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_oauth_client_id_oauth_client_id_fk": {
+          "name": "credential_oauth_client_id_oauth_client_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "credential_tenant_name": {
+          "name": "credential_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset": {
+      "name": "asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_tenant_id_tenant_id_fk": {
+          "name": "asset_tenant_id_tenant_id_fk",
+          "tableFrom": "asset",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "asset_creator_principal_id_principal_id_fk": {
+          "name": "asset_creator_principal_id_principal_id_fk",
+          "tableFrom": "asset",
+          "tableTo": "principal",
+          "columnsFrom": ["creator_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_tenant_kind_name": {
+          "name": "asset_tenant_kind_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "kind", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_wallet_id_wallet_id_fk": {
+          "name": "transaction_wallet_id_wallet_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_run_id_workflow_run_id_fk": {
+          "name": "transaction_run_id_workflow_run_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet": {
+      "name": "wallet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend_type": {
+          "name": "backend_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallet_tenant_id_tenant_id_fk": {
+          "name": "wallet_tenant_id_tenant_id_fk",
+          "tableFrom": "wallet",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offering": {
+      "name": "offering",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "offering_agent_id_workflow_definition_id_fk": {
+          "name": "offering_agent_id_workflow_definition_id_fk",
+          "tableFrom": "offering",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "offering_tenant_id_tenant_id_fk": {
+          "name": "offering_tenant_id_tenant_id_fk",
+          "tableFrom": "offering",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model": {
+      "name": "model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_tenant_id_tenant_id_fk": {
+          "name": "model_tenant_id_tenant_id_fk",
+          "tableFrom": "model",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_tenant_canonical_name": {
+          "name": "model_tenant_canonical_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "canonical_name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_offering": {
+      "name": "model_offering",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_tags": {
+          "name": "deployment_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "quirks": {
+          "name": "quirks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_offering_tenant_id_tenant_id_fk": {
+          "name": "model_offering_tenant_id_tenant_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_offering_model_id_model_id_fk": {
+          "name": "model_offering_model_id_model_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_offering_provider_id_model_provider_id_fk": {
+          "name": "model_offering_provider_id_model_provider_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "model_provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_offering_tenant_model_provider": {
+          "name": "model_offering_tenant_model_provider",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "model_id", "provider_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_pricing": {
+      "name": "model_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offering_id": {
+          "name": "offering_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_token_price": {
+          "name": "input_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_token_price": {
+          "name": "output_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_token_price": {
+          "name": "cache_read_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_write_token_price": {
+          "name": "cache_write_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thinking_token_price": {
+          "name": "thinking_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_request_fee": {
+          "name": "per_request_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_image_fee": {
+          "name": "per_image_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_audio_fee": {
+          "name": "per_audio_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_pricing_tenant_id_tenant_id_fk": {
+          "name": "model_pricing_tenant_id_tenant_id_fk",
+          "tableFrom": "model_pricing",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_pricing_offering_id_model_offering_id_fk": {
+          "name": "model_pricing_offering_id_model_offering_id_fk",
+          "tableFrom": "model_pricing",
+          "tableTo": "model_offering",
+          "columnsFrom": ["offering_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_pricing_offering_currency_effective_from": {
+          "name": "model_pricing_offering_currency_effective_from",
+          "nullsNotDistinct": false,
+          "columns": ["offering_id", "currency", "effective_from"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider": {
+      "name": "model_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_provider_tenant_id_tenant_id_fk": {
+          "name": "model_provider_tenant_id_tenant_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_credential_id_credential_id_fk": {
+          "name": "model_provider_credential_id_credential_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "credential",
+          "columnsFrom": ["credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "model_provider_wallet_id_wallet_id_fk": {
+          "name": "model_provider_wallet_id_wallet_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_provider_tenant_name": {
+          "name": "model_provider_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "model_provider_auth_xor": {
+          "name": "model_provider_auth_xor",
+          "value": "(\"model_provider\".\"credential_id\" is not null) <> (\"model_provider\".\"wallet_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sidecar": {
+      "name": "sidecar",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash_sha256": {
+          "name": "token_hash_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sidecar_token_hash_sha256_unique": {
+          "name": "sidecar_token_hash_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash_sha256"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidecar_allocation": {
+      "name": "sidecar_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_api_version": {
+          "name": "provisioner_api_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_binding_fingerprint": {
+          "name": "provisioner_binding_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ensure_accepted_generation": {
+          "name": "ensure_accepted_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation_lease_id": {
+          "name": "reconciliation_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation_lease_expires_at": {
+          "name": "reconciliation_lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ensure_attempts": {
+          "name": "ensure_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "destroy_attempts": {
+          "name": "destroy_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connect_deadline": {
+          "name": "connect_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sidecar_allocation_anchor_run_idx": {
+          "name": "sidecar_allocation_anchor_run_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sidecar_allocation_active_sidecar_idx": {
+          "name": "sidecar_allocation_active_sidecar_idx",
+          "columns": [
+            {
+              "expression": "sidecar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sidecar_allocation\".\"status\" in ('provisioning', 'allocated', 'replacing', 'releasing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sidecar_allocation_sidecar_idx": {
+          "name": "sidecar_allocation_sidecar_idx",
+          "columns": [
+            {
+              "expression": "sidecar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sidecar_allocation_reconciliation_idx": {
+          "name": "sidecar_allocation_reconciliation_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sidecar_allocation\".\"status\" in ('pending', 'provisioning', 'allocated', 'replacing', 'releasing') and \"sidecar_allocation\".\"next_attempt_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sidecar_allocation_anchor_run_id_workflow_run_id_fk": {
+          "name": "sidecar_allocation_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "sidecar_allocation",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sidecar_allocation_tenant_id_tenant_id_fk": {
+          "name": "sidecar_allocation_tenant_id_tenant_id_fk",
+          "tableFrom": "sidecar_allocation",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sidecar_allocation_sidecar_id_sidecar_id_fk": {
+          "name": "sidecar_allocation_sidecar_id_sidecar_id_fk",
+          "tableFrom": "sidecar_allocation",
+          "tableTo": "sidecar",
+          "columnsFrom": ["sidecar_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sidecar_allocation_status_check": {
+          "name": "sidecar_allocation_status_check",
+          "value": "\"sidecar_allocation\".\"status\" in ('pending', 'provisioning', 'allocated', 'replacing', 'releasing', 'released', 'failed')"
+        },
+        "sidecar_allocation_generation_check": {
+          "name": "sidecar_allocation_generation_check",
+          "value": "\"sidecar_allocation\".\"generation\" >= 0"
+        },
+        "sidecar_allocation_accepted_generation_check": {
+          "name": "sidecar_allocation_accepted_generation_check",
+          "value": "\"sidecar_allocation\".\"ensure_accepted_generation\" is null or \"sidecar_allocation\".\"ensure_accepted_generation\" <= \"sidecar_allocation\".\"generation\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_session": {
+      "name": "agent_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_session_tenant_id_tenant_id_fk": {
+          "name": "agent_session_tenant_id_tenant_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_agent_id_workflow_definition_id_fk": {
+          "name": "agent_session_agent_id_workflow_definition_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_session_principal_id_principal_id_fk": {
+          "name": "agent_session_principal_id_principal_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_asset": {
+      "name": "session_asset",
+      "schema": "",
+      "columns": {
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mount_path": {
+          "name": "mount_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_pack_sha": {
+          "name": "asset_pack_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "materialized_at": {
+          "name": "materialized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_asset_pack_sha_idx": {
+          "name": "session_asset_pack_sha_idx",
+          "columns": [
+            {
+              "expression": "asset_pack_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_asset_instance_id_mount_path_pk": {
+          "name": "session_asset_instance_id_mount_path_pk",
+          "columns": ["instance_id", "mount_path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inference_turn": {
+      "name": "inference_turn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "inference_turn_instance_id_started_at_idx": {
+          "name": "inference_turn_instance_id_started_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inference_turn_session_id_agent_session_id_fk": {
+          "name": "inference_turn_session_id_agent_session_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inference_turn_tenant_id_tenant_id_fk": {
+          "name": "inference_turn_tenant_id_tenant_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_mail": {
+      "name": "session_mail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "raw": {
+          "name": "raw",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_mail_instance_id_created_at_idx": {
+          "name": "session_mail_instance_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_mail_session_id_created_at_idx": {
+          "name": "session_mail_session_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_mail_session_id_agent_session_id_fk": {
+          "name": "session_mail_session_id_agent_session_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_mail_tenant_id_tenant_id_fk": {
+          "name": "session_mail_tenant_id_tenant_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turn_part": {
+      "name": "turn_part",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "turn_part_turn_id_inference_turn_id_fk": {
+          "name": "turn_part_turn_id_inference_turn_id_fk",
+          "tableFrom": "turn_part",
+          "tableTo": "inference_turn",
+          "columnsFrom": ["turn_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_part_session_id_agent_session_id_fk": {
+          "name": "turn_part_session_id_agent_session_id_fk",
+          "tableFrom": "turn_part",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_token": {
+      "name": "git_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash_sha256": {
+          "name": "token_hash_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_pattern": {
+          "name": "ref_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "git_token_user_id_name_active_idx": {
+          "name": "git_token_user_id_name_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"git_token\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "git_token_tenant_id_tenant_id_fk": {
+          "name": "git_token_tenant_id_tenant_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "git_token_user_id_user_id_fk": {
+          "name": "git_token_user_id_user_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_token_principal_id_principal_id_fk": {
+          "name": "git_token_principal_id_principal_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "git_token_token_hash_sha256_unique": {
+          "name": "git_token_token_hash_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash_sha256"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition": {
+      "name": "workflow_definition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wire_hash": {
+          "name": "wire_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_requirements": {
+          "name": "grant_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_requirements": {
+          "name": "model_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_bindings": {
+          "name": "credential_bindings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_definition_tenant_idx": {
+          "name": "workflow_definition_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_definition_asset_wire_hash_idx": {
+          "name": "workflow_definition_asset_wire_hash_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wire_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definition_tenant_id_tenant_id_fk": {
+          "name": "workflow_definition_tenant_id_tenant_id_fk",
+          "tableFrom": "workflow_definition",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_definition_creator_principal_id_principal_id_fk": {
+          "name": "workflow_definition_creator_principal_id_principal_id_fk",
+          "tableFrom": "workflow_definition",
+          "tableTo": "principal",
+          "columnsFrom": ["creator_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_definition_asset_id_asset_id_fk": {
+          "name": "workflow_definition_asset_id_asset_id_fk",
+          "tableFrom": "workflow_definition",
+          "tableTo": "asset",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_version": {
+      "name": "workflow_definition_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "approved_wire_hash": {
+          "name": "approved_wire_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_snapshot": {
+          "name": "grant_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_definition_version_definition_idx": {
+          "name": "workflow_definition_version_definition_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definition_version_definition_id_workflow_definition_id_fk": {
+          "name": "workflow_definition_version_definition_id_workflow_definition_id_fk",
+          "tableFrom": "workflow_definition_version",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["definition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_definition_version_definition_version": {
+          "name": "workflow_definition_version_definition_version",
+          "nullsNotDistinct": false,
+          "columns": ["definition_id", "version"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run": {
+      "name": "workflow_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kernel_id": {
+          "name": "kernel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_preferences": {
+          "name": "model_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_refs": {
+          "name": "credential_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_definition_idx": {
+          "name": "workflow_run_definition_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_address_idx": {
+          "name": "workflow_run_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_run\".\"address\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_definition_id_workflow_definition_id_fk": {
+          "name": "workflow_run_definition_id_workflow_definition_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["definition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_anchor_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_tenant_id_tenant_id_fk": {
+          "name": "workflow_run_tenant_id_tenant_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_principal_id_principal_id_fk": {
+          "name": "workflow_run_principal_id_principal_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflow_run_sidecar_id_sidecar_id_fk": {
+          "name": "workflow_run_sidecar_id_sidecar_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "sidecar",
+          "columnsFrom": ["sidecar_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_dispatch": {
+      "name": "workflow_run_dispatch",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mail'"
+        },
+        "raw_message": {
+          "name": "raw_message",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_grants": {
+          "name": "step_grants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "acknowledged_generation": {
+          "name": "acknowledged_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "delivery_lease_id": {
+          "name": "delivery_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_lease_expires_at": {
+          "name": "delivery_lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_dispatch_anchor_message_idx": {
+          "name": "workflow_run_dispatch_anchor_message_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_dispatch_delivery_idx": {
+          "name": "workflow_run_dispatch_delivery_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_run_dispatch\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_dispatch_anchor_status_idx": {
+          "name": "workflow_run_dispatch_anchor_status_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_dispatch_anchor_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_dispatch_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run_dispatch",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_dispatch_status_check": {
+          "name": "workflow_run_dispatch_status_check",
+          "value": "\"workflow_run_dispatch\".\"status\" in ('pending', 'acknowledged', 'settled', 'failed')"
+        },
+        "workflow_run_dispatch_kind_check": {
+          "name": "workflow_run_dispatch_kind_check",
+          "value": "\"workflow_run_dispatch\".\"kind\" in ('mail', 'signal')"
+        },
+        "workflow_run_dispatch_attempt_count_check": {
+          "name": "workflow_run_dispatch_attempt_count_check",
+          "value": "\"workflow_run_dispatch\".\"attempt_count\" >= 0"
+        },
+        "workflow_run_dispatch_acknowledged_generation_check": {
+          "name": "workflow_run_dispatch_acknowledged_generation_check",
+          "value": "\"workflow_run_dispatch\".\"acknowledged_generation\" is null or \"workflow_run_dispatch\".\"acknowledged_generation\" >= 0"
+        },
+        "workflow_run_dispatch_acknowledged_state_check": {
+          "name": "workflow_run_dispatch_acknowledged_state_check",
+          "value": "\"workflow_run_dispatch\".\"status\" <> 'acknowledged' or \"workflow_run_dispatch\".\"acknowledged_generation\" is not null"
+        },
+        "workflow_run_dispatch_pending_schedule_check": {
+          "name": "workflow_run_dispatch_pending_schedule_check",
+          "value": "\"workflow_run_dispatch\".\"status\" <> 'pending' or \"workflow_run_dispatch\".\"next_attempt_at\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_launch_spec": {
+      "name": "workflow_run_launch_spec",
+      "schema": "",
+      "columns": {
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_domain": {
+          "name": "deployment_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_authority_principal_id": {
+          "name": "source_authority_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frozen_approval_bundle": {
+          "name": "frozen_approval_bundle",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_offering_ids": {
+          "name": "source_offering_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_source_offering_id": {
+          "name": "default_source_offering_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deploy_content": {
+          "name": "deploy_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_package_pins": {
+          "name": "tool_package_pins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_run_launch_spec_anchor_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_launch_spec_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run_launch_spec",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_launch_spec_source_authority_principal_id_principal_id_fk": {
+          "name": "workflow_run_launch_spec_source_authority_principal_id_principal_id_fk",
+          "tableFrom": "workflow_run_launch_spec",
+          "tableTo": "principal",
+          "columnsFrom": ["source_authority_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_execution": {
+      "name": "workflow_run_execution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_execution_run_id_id_idx": {
+          "name": "workflow_run_execution_run_id_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_execution_status_idx": {
+          "name": "workflow_run_execution_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_execution_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_execution_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run_execution",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_probe": {
+      "name": "workflow_probe",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_asset_id": {
+          "name": "definition_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pin": {
+          "name": "pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_api_version": {
+          "name": "provisioner_api_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_binding_fingerprint": {
+          "name": "provisioner_binding_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_probe_active_idx": {
+          "name": "workflow_probe_active_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_probe\".\"status\" in ('pending', 'provisioning', 'probing', 'releasing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_probe_sidecar_idx": {
+          "name": "workflow_probe_sidecar_idx",
+          "columns": [
+            {
+              "expression": "sidecar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_probe_tenant_id_tenant_id_fk": {
+          "name": "workflow_probe_tenant_id_tenant_id_fk",
+          "tableFrom": "workflow_probe",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workflow_probe_definition_asset_id_asset_id_fk": {
+          "name": "workflow_probe_definition_asset_id_asset_id_fk",
+          "tableFrom": "workflow_probe",
+          "tableTo": "asset",
+          "columnsFrom": ["definition_asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workflow_probe_sidecar_id_sidecar_id_fk": {
+          "name": "workflow_probe_sidecar_id_sidecar_id_fk",
+          "tableFrom": "workflow_probe",
+          "tableTo": "sidecar",
+          "columnsFrom": ["sidecar_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_probe_status_check": {
+          "name": "workflow_probe_status_check",
+          "value": "\"workflow_probe\".\"status\" in ('pending', 'provisioning', 'probing', 'releasing', 'succeeded', 'failed')"
+        },
+        "workflow_probe_succeeded_result_check": {
+          "name": "workflow_probe_succeeded_result_check",
+          "value": "\"workflow_probe\".\"status\" <> 'succeeded' or \"workflow_probe\".\"result\" is not null"
+        },
+        "workflow_probe_generation_check": {
+          "name": "workflow_probe_generation_check",
+          "value": "\"workflow_probe\".\"generation\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -617,6 +617,13 @@
       "when": 1788200236163,
       "tag": "0088_thick_sprite",
       "breakpoints": true
+    },
+    {
+      "idx": 89,
+      "version": "7",
+      "when": 1788617577404,
+      "tag": "0089_tense_selene",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@intx/authz": "workspace:*",
     "@intx/crypto": "workspace:*",
+    "@intx/hub-common": "workspace:*",
     "@intx/log": "workspace:*",
     "@intx/types": "workspace:*",
     "arktype": "catalog:",

--- a/packages/db/src/backfill-principal-keys.ts
+++ b/packages/db/src/backfill-principal-keys.ts
@@ -1,0 +1,74 @@
+// Backfill per-principal signing keys onto the principals that predate the
+// feature.
+//
+// Minting a key lives only in the principal-creation owner, so every principal
+// CREATED after that landed already has an active key. This one-shot pass keys
+// the pre-existing population so the whole non-agent principal set matches the
+// invariant "every non-agent principal has an active key".
+//
+// Scope is every `user` and `workflow` principal REGARDLESS of status, not just
+// active ones. A status flip (e.g. an invite moving from `invited` to `active`)
+// reuses the same principal row and does not re-mint, so an active-only pass
+// would leave a pre-existing `invited`/`suspended` principal keyless and turn it
+// into a keyless ACTIVE principal the moment it is activated. `agent` is a
+// legacy/inert kind that is never keyed at creation either, so it is skipped to
+// keep the populations consistent.
+//
+// Idempotent: a principal that already holds an active key is skipped, so the
+// pass is safe to re-run or resume after a partial failure. Each principal is
+// keyed in its own autocommit, so a partial failure leaves the earlier
+// principals keyed. Safe to run against a LIVE hub -- nothing reads principal
+// keys yet, the hub only mints for newly-created principals (disjoint from this
+// pass's pre-existing set), and the `principal_key` active-key unique index
+// blocks a double active key.
+
+import { and, eq, inArray } from "drizzle-orm";
+
+import type { DB } from "./client";
+import { principal } from "./schema/principals";
+import { principalKey } from "./schema/principal-keys";
+import type { PrincipalKeyStore } from "./principal-key-store";
+
+const BACKFILLED_KINDS = ["user", "workflow"] as const;
+
+export type BackfillPrincipalKeysReport = {
+  /** Principals that were keyless and received a fresh active key. */
+  keysGenerated: number;
+  /** Principals that already held an active key and were left untouched. */
+  alreadyKeyed: number;
+};
+
+export async function backfillPrincipalKeys(
+  db: DB["db"],
+  principalKeyStore: PrincipalKeyStore,
+): Promise<BackfillPrincipalKeysReport> {
+  // The left join is scoped to the active key, so `activeKeyId` is null exactly
+  // when the principal has no active key -- a principal holding only a retired
+  // key counts as keyless and is re-keyed. The active-key unique index makes at
+  // most one active row per principal, so each principal appears once.
+  const rows = await db
+    .select({ principalId: principal.id, activeKeyId: principalKey.id })
+    .from(principal)
+    .leftJoin(
+      principalKey,
+      and(
+        eq(principalKey.principalId, principal.id),
+        eq(principalKey.status, "active"),
+      ),
+    )
+    .where(inArray(principal.kind, [...BACKFILLED_KINDS]));
+
+  const report: BackfillPrincipalKeysReport = {
+    keysGenerated: 0,
+    alreadyKeyed: 0,
+  };
+  for (const row of rows) {
+    if (row.activeKeyId !== null) {
+      report.alreadyKeyed += 1;
+      continue;
+    }
+    await principalKeyStore.generate(row.principalId);
+    report.keysGenerated += 1;
+  }
+  return report;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -13,6 +13,11 @@ export {
 export { createGrantStore } from "./grant-store";
 export { createPrincipalStore, type PrincipalStore } from "./principal-store";
 export {
+  createPrincipalKeyStore,
+  type CreatePrincipalKeyStoreDeps,
+  type PrincipalKeyStore,
+} from "./principal-key-store";
+export {
   createApprovalStore,
   type ApprovalStore,
   type ResolveApprovalArgs,
@@ -128,6 +133,7 @@ export {
   parseGrantRow,
   parseApprovalRow,
   parsePrincipalRow,
+  parsePrincipalKeyRow,
   parseSignalCorrelationRow,
   parseWorkflowRunRow,
   parseWorkflowRunDispatchRow,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -10,6 +10,10 @@ export {
   rekeyCredentialSecrets,
   type RekeyReport,
 } from "./rekey-credential-secrets";
+export {
+  backfillPrincipalKeys,
+  type BackfillPrincipalKeysReport,
+} from "./backfill-principal-keys";
 export { createGrantStore } from "./grant-store";
 export { createPrincipalStore, type PrincipalStore } from "./principal-store";
 export {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21,6 +21,7 @@ export {
   type CreatePrincipalKeyStoreDeps,
   type PrincipalKeyStore,
 } from "./principal-key-store";
+export { lookupLocalPrincipalSigner } from "./signer-identity";
 export {
   createApprovalStore,
   type ApprovalStore,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -11,6 +11,7 @@ export {
   type RekeyReport,
 } from "./rekey-credential-secrets";
 export { createGrantStore } from "./grant-store";
+export { createPrincipalStore, type PrincipalStore } from "./principal-store";
 export {
   createApprovalStore,
   type ApprovalStore,

--- a/packages/db/src/parse-row.ts
+++ b/packages/db/src/parse-row.ts
@@ -30,6 +30,7 @@ import type {
   oauthClient,
   offering,
   principal,
+  principalKey,
   provider,
   signalCorrelation,
   tenant,
@@ -89,6 +90,9 @@ const WorkflowDefinitionVersionStatusValidator = type.enumerated(
 
 const PrincipalKindValidator = type.enumerated(...principalKinds);
 const PrincipalStatusValidator = type.enumerated(...principalStatuses);
+
+const principalKeyStatuses = ["active", "retired"] as const;
+const PrincipalKeyStatusValidator = type.enumerated(...principalKeyStatuses);
 
 const credentialTypes = [
   "api_key",
@@ -187,6 +191,13 @@ export function parsePrincipalRow(row: typeof principal.$inferSelect) {
     ...row,
     kind: PrincipalKindValidator.assert(row.kind),
     status: PrincipalStatusValidator.assert(row.status),
+  };
+}
+
+export function parsePrincipalKeyRow(row: typeof principalKey.$inferSelect) {
+  return {
+    ...row,
+    status: PrincipalKeyStatusValidator.assert(row.status),
   };
 }
 

--- a/packages/db/src/principal-key-store.ts
+++ b/packages/db/src/principal-key-store.ts
@@ -1,0 +1,126 @@
+import { and, eq } from "drizzle-orm";
+
+import { generateKeyPair, signEd25519 } from "@intx/crypto";
+import { hexDecode, hexEncode, principalKeyAad } from "@intx/types";
+import type { CredentialCipher } from "@intx/types";
+import { generateId } from "@intx/hub-common";
+
+import type { DB, DBExecutor } from "./client";
+import { principalKey } from "./schema/principal-keys";
+
+type DBHandle = DB["db"];
+
+export type CreatePrincipalKeyStoreDeps = {
+  db: DBHandle;
+  /**
+   * Seals the private key seed at rest. Production supplies a real env-key
+   * cipher under `PRINCIPAL_KEY_ENCRYPTION_KEY`; tests and local dev may supply
+   * the noop cipher, which stores the seed as plaintext.
+   */
+  cipher: CredentialCipher;
+};
+
+/**
+ * Store for the `principal_key` table -- a principal's Ed25519 signing key.
+ *
+ * The hub custodies the private key: it mints, seals, and signs with it on the
+ * principal's behalf. A signature therefore ATTRIBUTES an action to a principal
+ * but is NOT non-repudiable against the hub operator, who holds the key. See
+ * docs/AUTH.md.
+ *
+ * The store owns the one-active-key-per-principal invariant end to end: `sign`
+ * and `getPublicKey` resolve the single active row, and `generate` inserts a new
+ * active key that the table's partial unique index rejects if the principal
+ * already has one. The private seed never leaves this module -- `sign` decrypts,
+ * signs, and discards it; no method returns private material.
+ */
+export function createPrincipalKeyStore({
+  db,
+  cipher,
+}: CreatePrincipalKeyStoreDeps) {
+  async function loadActive(principalId: string, tx?: DBExecutor) {
+    const [row] = await (tx ?? db)
+      .select()
+      .from(principalKey)
+      .where(
+        and(
+          eq(principalKey.principalId, principalId),
+          eq(principalKey.status, "active"),
+        ),
+      )
+      .limit(1);
+    return row;
+  }
+
+  return {
+    /**
+     * Mint a fresh active signing key for a principal. Generates an Ed25519 key
+     * pair, seals the hex-encoded 32-byte seed with the cipher bound to the
+     * key's row and column, and inserts it. A principal that already holds an
+     * active key trips the partial unique index and this throws. Returns the
+     * hex-encoded public key; never returns private material.
+     */
+    async generate(principalId: string, tx?: DBExecutor): Promise<string> {
+      const id = generateId("principalKey");
+      const keyPair = await generateKeyPair();
+      const sealedPrivateKey = await cipher.encrypt(
+        hexEncode(keyPair.privateKey),
+        principalKeyAad(id, "private_key"),
+      );
+      const publicKey = hexEncode(keyPair.publicKey);
+      const now = new Date();
+      await (tx ?? db).insert(principalKey).values({
+        id,
+        principalId,
+        publicKey,
+        privateKey: sealedPrivateKey,
+        status: "active",
+        createdAt: now,
+        updatedAt: now,
+      });
+      return publicKey;
+    },
+
+    /**
+     * Sign a message with the principal's active key. Decrypts the sealed seed,
+     * produces the raw 64-byte Ed25519 signature, and discards the seed. Throws
+     * when the principal has no active key. The seed stays a local that goes out
+     * of scope; it is never returned or logged.
+     */
+    async sign(
+      principalId: string,
+      message: Uint8Array,
+      tx?: DBExecutor,
+    ): Promise<Uint8Array> {
+      const row = await loadActive(principalId, tx);
+      if (row === undefined) {
+        throw new Error(
+          `principalKeyStore.sign: principal ${principalId} has no active key`,
+        );
+      }
+      const seedHex = await cipher.decrypt(
+        row.privateKey,
+        principalKeyAad(row.id, "private_key"),
+      );
+      const seed = hexDecode(seedHex);
+      return signEd25519(seed, message);
+    },
+
+    /**
+     * The hex-encoded public key of a principal's active signing key. Throws
+     * when the principal has no active key rather than defaulting, so a missing
+     * key surfaces at the call site instead of downstream.
+     */
+    async getPublicKey(principalId: string, tx?: DBExecutor): Promise<string> {
+      const row = await loadActive(principalId, tx);
+      if (row === undefined) {
+        throw new Error(
+          `principalKeyStore.getPublicKey: principal ${principalId} has no active key`,
+        );
+      }
+      return row.publicKey;
+    },
+  };
+}
+
+export type PrincipalKeyStore = ReturnType<typeof createPrincipalKeyStore>;

--- a/packages/db/src/principal-store.ts
+++ b/packages/db/src/principal-store.ts
@@ -1,6 +1,7 @@
 import type { DB, DBExecutor } from "./client";
 import { principal } from "./schema/principals";
 import { parsePrincipalRow } from "./parse-row";
+import type { PrincipalKeyStore } from "./principal-key-store";
 
 type DBHandle = DB["db"];
 
@@ -9,40 +10,53 @@ type ParsedPrincipal = ReturnType<typeof parsePrincipalRow>;
 
 /**
  * Store for the `principal` table -- the single owner of principal creation.
- * Every principal insert in the system routes through this one factory so the
- * create path lives in exactly one place. Each method accepts an optional
- * transaction handle so the principal row can be written in the same
- * transaction that co-writes its roles and grants.
+ * Every principal insert in the system routes through this one factory, and
+ * every principal it creates is minted an active signing key in the same
+ * transaction, so a principal never exists without a key.
+ *
+ * Each method accepts an optional transaction handle so the principal row and
+ * its key join the transaction that co-writes the principal's roles and grants.
+ * When no handle is passed the store opens its own transaction, because the
+ * principal insert and the key mint are two writes that must commit together.
  */
-export function createPrincipalStore(db: DBHandle) {
+export function createPrincipalStore(
+  db: DBHandle,
+  principalKeyStore: PrincipalKeyStore,
+) {
   return {
     /**
-     * Insert a new principal, failing loudly on a natural-key conflict. Callers
-     * that have already established the principal is new (a fresh tenant owner,
-     * an invite past its existence pre-check) use this so a concurrent duplicate
-     * surfaces as a unique violation rather than a silent success.
+     * Insert a new principal and mint its signing key, failing loudly on a
+     * natural-key conflict. Callers that have already established the principal
+     * is new (a fresh tenant owner, an invite past its existence pre-check) use
+     * this so a concurrent duplicate surfaces as a unique violation rather than
+     * a silent success.
      */
     async create(
       row: PrincipalInsert,
       tx?: DBExecutor,
     ): Promise<ParsedPrincipal> {
-      const [inserted] = await (tx ?? db)
-        .insert(principal)
-        .values(row)
-        .returning();
-      if (inserted === undefined) {
-        throw new Error(
-          `principalStore.create: insert returned no row for ${row.id}`,
-        );
-      }
-      return parsePrincipalRow(inserted);
+      const run = async (executor: DBExecutor): Promise<ParsedPrincipal> => {
+        const [inserted] = await executor
+          .insert(principal)
+          .values(row)
+          .returning();
+        if (inserted === undefined) {
+          throw new Error(
+            `principalStore.create: insert returned no row for ${row.id}`,
+          );
+        }
+        await principalKeyStore.generate(inserted.id, executor);
+        return parsePrincipalRow(inserted);
+      };
+      return tx === undefined ? db.transaction(run) : run(tx);
     },
 
     /**
      * Idempotent variant of `create` for the run path, where concurrent first
-     * deliveries race to reserve the same principal. Returns the parsed row only
-     * when this call performed the insert, and `null` when a concurrent winner
-     * already holds it, so the caller can fall back to the winner's state.
+     * deliveries race to reserve the same principal. On a win it inserts the
+     * principal, mints its key, and returns the parsed row; on a loss it returns
+     * `null` WITHOUT minting -- the winning transaction already minted the one
+     * active key -- so the caller can fall back to the winner's state.
      *
      * The conflict target is the natural key `(tenantId, kind, refId)`, NOT the
      * surrogate `id`: user principals carry a random `generateId("principal")`,
@@ -54,14 +68,21 @@ export function createPrincipalStore(db: DBHandle) {
       row: PrincipalInsert,
       tx?: DBExecutor,
     ): Promise<ParsedPrincipal | null> {
-      const [inserted] = await (tx ?? db)
-        .insert(principal)
-        .values(row)
-        .onConflictDoNothing({
-          target: [principal.tenantId, principal.kind, principal.refId],
-        })
-        .returning();
-      return inserted === undefined ? null : parsePrincipalRow(inserted);
+      const run = async (
+        executor: DBExecutor,
+      ): Promise<ParsedPrincipal | null> => {
+        const [inserted] = await executor
+          .insert(principal)
+          .values(row)
+          .onConflictDoNothing({
+            target: [principal.tenantId, principal.kind, principal.refId],
+          })
+          .returning();
+        if (inserted === undefined) return null;
+        await principalKeyStore.generate(inserted.id, executor);
+        return parsePrincipalRow(inserted);
+      };
+      return tx === undefined ? db.transaction(run) : run(tx);
     },
   };
 }

--- a/packages/db/src/principal-store.ts
+++ b/packages/db/src/principal-store.ts
@@ -1,0 +1,69 @@
+import type { DB, DBExecutor } from "./client";
+import { principal } from "./schema/principals";
+import { parsePrincipalRow } from "./parse-row";
+
+type DBHandle = DB["db"];
+
+type PrincipalInsert = typeof principal.$inferInsert;
+type ParsedPrincipal = ReturnType<typeof parsePrincipalRow>;
+
+/**
+ * Store for the `principal` table -- the single owner of principal creation.
+ * Every principal insert in the system routes through this one factory so the
+ * create path lives in exactly one place. Each method accepts an optional
+ * transaction handle so the principal row can be written in the same
+ * transaction that co-writes its roles and grants.
+ */
+export function createPrincipalStore(db: DBHandle) {
+  return {
+    /**
+     * Insert a new principal, failing loudly on a natural-key conflict. Callers
+     * that have already established the principal is new (a fresh tenant owner,
+     * an invite past its existence pre-check) use this so a concurrent duplicate
+     * surfaces as a unique violation rather than a silent success.
+     */
+    async create(
+      row: PrincipalInsert,
+      tx?: DBExecutor,
+    ): Promise<ParsedPrincipal> {
+      const [inserted] = await (tx ?? db)
+        .insert(principal)
+        .values(row)
+        .returning();
+      if (inserted === undefined) {
+        throw new Error(
+          `principalStore.create: insert returned no row for ${row.id}`,
+        );
+      }
+      return parsePrincipalRow(inserted);
+    },
+
+    /**
+     * Idempotent variant of `create` for the run path, where concurrent first
+     * deliveries race to reserve the same principal. Returns the parsed row only
+     * when this call performed the insert, and `null` when a concurrent winner
+     * already holds it, so the caller can fall back to the winner's state.
+     *
+     * The conflict target is the natural key `(tenantId, kind, refId)`, NOT the
+     * surrogate `id`: user principals carry a random `generateId("principal")`,
+     * so their only real conflict key is the natural triple. The run path
+     * derives a deterministic id that agrees with the triple, so one target
+     * unifies both callers. Do not switch this to `principal.id`.
+     */
+    async createIfAbsent(
+      row: PrincipalInsert,
+      tx?: DBExecutor,
+    ): Promise<ParsedPrincipal | null> {
+      const [inserted] = await (tx ?? db)
+        .insert(principal)
+        .values(row)
+        .onConflictDoNothing({
+          target: [principal.tenantId, principal.kind, principal.refId],
+        })
+        .returning();
+      return inserted === undefined ? null : parsePrincipalRow(inserted);
+    },
+  };
+}
+
+export type PrincipalStore = ReturnType<typeof createPrincipalStore>;

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,6 +1,7 @@
 export * from "./auth";
 export * from "./tenants";
 export * from "./principals";
+export * from "./principal-keys";
 export * from "./roles";
 export * from "./grants";
 export * from "./approvals";

--- a/packages/db/src/schema/principal-keys.ts
+++ b/packages/db/src/schema/principal-keys.ts
@@ -1,0 +1,34 @@
+import { sql } from "drizzle-orm";
+import { pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+
+import { principal } from "./principals";
+
+// A principal's Ed25519 signing key. `public_key` is the hex-encoded 32-byte
+// public point; `private_key` holds the hex-encoded 32-byte seed sealed by the
+// credential cipher (`enc:aead:...` ciphertext), so the seed is never at rest in
+// plaintext under a configured key. The hub custodies the private key: a
+// signature attributes an action to the principal, but is not non-repudiable
+// against the hub operator. See docs/AUTH.md.
+//
+// The `status` axis expresses the one-active-key-per-principal invariant, which
+// the partial unique index below enforces at the database. No path retires a
+// key; every key a principal holds today is "active".
+export const principalKey = pgTable(
+  "principal_key",
+  {
+    id: text("id").primaryKey(),
+    principalId: text("principal_id")
+      .notNull()
+      .references(() => principal.id, { onDelete: "cascade" }),
+    publicKey: text("public_key").notNull().unique(),
+    privateKey: text("private_key").notNull(),
+    status: text("status", { enum: ["active", "retired"] }).notNull(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex("principal_key_one_active")
+      .on(t.principalId)
+      .where(sql`${t.status} = 'active'`),
+  ],
+);

--- a/packages/db/src/signer-identity.ts
+++ b/packages/db/src/signer-identity.ts
@@ -1,0 +1,24 @@
+import type { LocalPrincipalSigner } from "@intx/types";
+
+import type { DBExecutor } from "./client";
+import type { PrincipalKeyStore } from "./principal-key-store";
+
+/**
+ * Resolve a principal's trusted signer identity from the hub's own key store.
+ *
+ * The returned `publicKey` is the principal's active key as the hub holds it, so
+ * a verifier can check a signature against it without trusting any key on the
+ * wire. Throws when the principal has no active key -- an unresolvable signer
+ * must fail loudly rather than default.
+ */
+export async function lookupLocalPrincipalSigner(
+  principalKeyStore: PrincipalKeyStore,
+  principalId: string,
+  tx?: DBExecutor,
+): Promise<LocalPrincipalSigner> {
+  return {
+    kind: "local-principal",
+    principalId,
+    publicKey: await principalKeyStore.getPublicKey(principalId, tx),
+  };
+}

--- a/packages/hub-api/src/app.ts
+++ b/packages/hub-api/src/app.ts
@@ -10,9 +10,11 @@ import type { CredentialCipher } from "@intx/types";
 import {
   type DB,
   type ApprovalStore,
+  type PrincipalKeyStore,
   type SignalCorrelationStore,
   createGrantStore,
   createApprovalStore,
+  createPrincipalKeyStore,
   createSignalCorrelationStore,
 } from "@intx/db";
 import type { ConditionRegistry, GrantStore } from "@intx/types/authz";
@@ -93,6 +95,26 @@ function resolveCredentialCipher(
   return createNoopCredentialCipher();
 }
 
+/**
+ * Resolve the principal key store, falling back to a noop-cipher store when
+ * none is provided. The fallback seals nothing, so a minted signing key's
+ * private seed is stored in the CLEAR; it is expected only in tests and local
+ * development and warns loudly so a production deployment that forgot to
+ * configure `PRINCIPAL_KEY_ENCRYPTION_KEY` is not silently persisting private
+ * keys unencrypted. The composition root (`apps/hub`) always supplies a real
+ * store, gated by a required key at boot.
+ */
+function resolvePrincipalKeyStore(
+  provided: PrincipalKeyStore | undefined,
+  db: DB["db"],
+): PrincipalKeyStore {
+  if (provided) return provided;
+  log.warn(
+    "No principalKeyStore configured; principal signing keys will be stored UNENCRYPTED. Expected in tests/local dev but MUST NOT happen in production.",
+  );
+  return createPrincipalKeyStore({ db, cipher: createNoopCredentialCipher() });
+}
+
 export type CreateHubContextMiddlewareDeps = {
   getSession: GetSession;
 };
@@ -122,6 +144,13 @@ export type MountHubRoutesDeps = {
    * secrets can omit it.
    */
   credentialCipher?: CredentialCipher;
+  /**
+   * Mints and custodies the per-principal signing key on principal creation.
+   * Optional: when omitted, a noop-cipher store is used and a warning is
+   * logged. Production supplies a real store gated by
+   * `PRINCIPAL_KEY_ENCRYPTION_KEY`; tests may omit it.
+   */
+  principalKeyStore?: PrincipalKeyStore;
   grantStore?: GrantStore;
   conditionRegistry?: ConditionRegistry;
   approvalStore?: ApprovalStore;
@@ -160,6 +189,10 @@ export function mountHubRoutes(
   opts: MountHubRoutesDeps,
 ): void {
   const credentialCipher = resolveCredentialCipher(opts.credentialCipher);
+  const principalKeyStore = resolvePrincipalKeyStore(
+    opts.principalKeyStore,
+    opts.db,
+  );
   const {
     db,
     sidecarRouter,
@@ -247,7 +280,7 @@ export function mountHubRoutes(
   app.use("/api/tenants/:tenantId/*", resolveTenant);
 
   // Global tenant routes (create needs auth, detail/update handle auth inline)
-  app.route("/api/tenants", createTenantRoutes({ db }));
+  app.route("/api/tenants", createTenantRoutes({ db, principalKeyStore }));
 
   // Tenant-scoped routes
   app.route(
@@ -256,7 +289,7 @@ export function mountHubRoutes(
   );
   app.route(
     "/api/tenants/:tenantId/members/invite",
-    createInviteRoutes({ db, requireGrant }),
+    createInviteRoutes({ db, principalKeyStore, requireGrant }),
   );
   app.route(
     "/api/tenants/:tenantId/roles",
@@ -283,6 +316,7 @@ export function mountHubRoutes(
     "/api/tenants/:tenantId/workflows/runs",
     createRunRoutes({
       db,
+      principalKeyStore,
       sessionService,
       sidecarRouter,
       eventCollectors,
@@ -316,6 +350,7 @@ export function mountHubRoutes(
       "/api/tenants/:tenantId/workflows",
       createWorkflowRoutes({
         db,
+        principalKeyStore,
         ...(workflowAllocationService !== undefined
           ? { workflowAllocationService }
           : {}),
@@ -504,6 +539,13 @@ export type CreateAppOpts = {
    * secrets can omit it.
    */
   credentialCipher?: CredentialCipher;
+  /**
+   * Mints and custodies the per-principal signing key on principal creation.
+   * Optional: when omitted, a noop-cipher store is used and a warning is
+   * logged. Production supplies a real store gated by
+   * `PRINCIPAL_KEY_ENCRYPTION_KEY`.
+   */
+  principalKeyStore?: PrincipalKeyStore;
   grantStore?: GrantStore;
   approvalStore?: ApprovalStore;
   signalCorrelationStore?: SignalCorrelationStore;
@@ -529,6 +571,7 @@ export function createApp({
   workflowDispatchService,
   eventCollectors,
   credentialCipher,
+  principalKeyStore,
   grantStore,
   approvalStore,
   signalCorrelationStore,
@@ -563,6 +606,7 @@ export function createApp({
       : {}),
     eventCollectors,
     ...(credentialCipher ? { credentialCipher } : {}),
+    ...(principalKeyStore ? { principalKeyStore } : {}),
     assetService,
     repoStore,
     maxTarballBytes,

--- a/packages/hub-api/src/routes/principals.ts
+++ b/packages/hub-api/src/routes/principals.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
 
 import { principal, principalRole, role, user } from "@intx/db/schema";
-import { parsePrincipalRow } from "@intx/db";
+import { createPrincipalStore, parsePrincipalRow } from "@intx/db";
 import type { DB } from "@intx/db";
 import {
   PrincipalResponse,
@@ -14,7 +14,7 @@ import {
 } from "@intx/types";
 
 import type { TenantEnv } from "../context";
-import { first, ts } from "../format";
+import { ts } from "../format";
 import { generateId } from "@intx/hub-common";
 import { idResource } from "../middleware/grant";
 import type { RequireGrant } from "../middleware/grant";
@@ -381,6 +381,7 @@ export function createInviteRoutes({
   requireGrant,
 }: CreateInviteRoutesDeps): Hono<TenantEnv> {
   const inviteApp = new Hono<TenantEnv>();
+  const principalStore = createPrincipalStore(db);
 
   inviteApp.post(
     "/",
@@ -447,38 +448,42 @@ export function createInviteRoutes({
       }
 
       const now = new Date();
-      const principalId = generateId("principal");
 
-      const row = first(
-        await db
-          .insert(principal)
-          .values({
-            id: principalId,
+      const roleRow = body.roleId
+        ? await db.query.role.findFirst({
+            where: and(
+              eq(role.id, body.roleId),
+              eq(role.tenantId, tenantCtx.id),
+            ),
+          })
+        : undefined;
+
+      const row = await db.transaction(async (tx) => {
+        const invited = await principalStore.create(
+          {
+            id: generateId("principal"),
             tenantId: tenantCtx.id,
             kind: "user",
             refId: invitedUser.id,
             status: "invited",
             createdAt: now,
             updatedAt: now,
-          })
-          .returning(),
-      );
-
-      let roles: { id: string; name: string }[] = [];
-
-      if (body.roleId) {
-        const roleRow = await db.query.role.findFirst({
-          where: and(eq(role.id, body.roleId), eq(role.tenantId, tenantCtx.id)),
-        });
+          },
+          tx,
+        );
         if (roleRow) {
-          await db.insert(principalRole).values({
-            principalId,
+          await tx.insert(principalRole).values({
+            principalId: invited.id,
             roleId: roleRow.id,
             createdAt: now,
           });
-          roles = [{ id: roleRow.id, name: roleRow.name }];
         }
-      }
+        return invited;
+      });
+
+      const roles: { id: string; name: string }[] = roleRow
+        ? [{ id: roleRow.id, name: roleRow.name }]
+        : [];
 
       const identity: ResolvedIdentity = {
         displayName: invitedUser.name,

--- a/packages/hub-api/src/routes/principals.ts
+++ b/packages/hub-api/src/routes/principals.ts
@@ -4,7 +4,7 @@ import { describeRoute, resolver, validator } from "hono-openapi";
 
 import { principal, principalRole, role, user } from "@intx/db/schema";
 import { createPrincipalStore, parsePrincipalRow } from "@intx/db";
-import type { DB } from "@intx/db";
+import type { DB, PrincipalKeyStore } from "@intx/db";
 import {
   PrincipalResponse,
   UpdatePrincipal,
@@ -373,15 +373,17 @@ export function createPrincipalRoutes({
 // Invite is mounted separately at ../members/invite in app.ts
 export type CreateInviteRoutesDeps = {
   db: DB["db"];
+  principalKeyStore: PrincipalKeyStore;
   requireGrant: RequireGrant;
 };
 
 export function createInviteRoutes({
   db,
+  principalKeyStore,
   requireGrant,
 }: CreateInviteRoutesDeps): Hono<TenantEnv> {
   const inviteApp = new Hono<TenantEnv>();
-  const principalStore = createPrincipalStore(db);
+  const principalStore = createPrincipalStore(db, principalKeyStore);
 
   inviteApp.post(
     "/",

--- a/packages/hub-api/src/routes/runs.ts
+++ b/packages/hub-api/src/routes/runs.ts
@@ -9,7 +9,7 @@ import {
   workflowDefinition,
   workflowRun,
 } from "@intx/db/schema";
-import type { DB, ApprovalStore } from "@intx/db";
+import type { DB, ApprovalStore, PrincipalKeyStore } from "@intx/db";
 import { authorize } from "@intx/authz";
 import type { ConditionRegistry, GrantStore } from "@intx/types/authz";
 import { extractPartByPath } from "@intx/mime";
@@ -150,6 +150,7 @@ function runToRecord(row: RunListRow): RoutableRecord {
 
 export type CreateRunRoutesDeps = {
   db: DB["db"];
+  principalKeyStore: PrincipalKeyStore;
   sessionService: SessionService;
   sidecarRouter: SidecarRouter;
   eventCollectors: EventCollectorRegistry;
@@ -172,6 +173,7 @@ export type CreateRunRoutesDeps = {
 
 export function createRunRoutes({
   db,
+  principalKeyStore,
   sidecarRouter,
   eventCollectors,
   repoStore,
@@ -196,6 +198,7 @@ export function createRunRoutes({
     repoStore !== null
       ? createWorkflowRunTrigger({
           db,
+          principalKeyStore,
           grantStore,
           sidecarRouter,
           ...(workflowDispatchService !== undefined

--- a/packages/hub-api/src/routes/tenants.ts
+++ b/packages/hub-api/src/routes/tenants.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
 
 import { tenant, principal, role, principalRole, grant } from "@intx/db/schema";
-import { parseTenantRow } from "@intx/db";
+import { createPrincipalStore, parseTenantRow } from "@intx/db";
 import type { DB } from "@intx/db";
 import {
   CreateTenant,
@@ -40,6 +40,7 @@ export function createTenantRoutes({
   db,
 }: CreateTenantRoutesDeps): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
+  const principalStore = createPrincipalStore(db);
 
   app.post(
     "/",
@@ -94,124 +95,130 @@ export function createTenantRoutes({
 
       const now = new Date();
 
-      const tenantRow = first(
-        await db
-          .insert(tenant)
-          .values({
-            id: tenantId,
-            name: body.name,
-            slug: body.slug,
-            domain,
-            parentId: body.parentId ?? null,
+      const tenantRow = await db.transaction(async (tx) => {
+        const inserted = first(
+          await tx
+            .insert(tenant)
+            .values({
+              id: tenantId,
+              name: body.name,
+              slug: body.slug,
+              domain,
+              parentId: body.parentId ?? null,
+              createdAt: now,
+              updatedAt: now,
+            })
+            .returning(),
+        );
+
+        const roleIds: Record<string, string> = {};
+        for (const roleName of SYSTEM_ROLES) {
+          const roleId = generateId("role");
+          roleIds[roleName] = roleId;
+          await tx.insert(role).values({
+            id: roleId,
+            tenantId,
+            name: roleName,
+            description: `System ${roleName} role`,
+            isSystem: true,
             createdAt: now,
             updatedAt: now,
-          })
-          .returning(),
-      );
+          });
+        }
 
-      const roleIds: Record<string, string> = {};
-      for (const roleName of SYSTEM_ROLES) {
-        const roleId = generateId("role");
-        roleIds[roleName] = roleId;
-        await db.insert(role).values({
-          id: roleId,
+        const ownerRoleId = roleIds["owner"];
+        if (!ownerRoleId) throw new Error("Owner role was not created");
+
+        const ownerPrincipal = await principalStore.create(
+          {
+            id: generateId("principal"),
+            tenantId,
+            kind: "user",
+            refId: user.id,
+            status: "active",
+            createdAt: now,
+            updatedAt: now,
+          },
+          tx,
+        );
+
+        await tx.insert(principalRole).values({
+          principalId: ownerPrincipal.id,
+          roleId: ownerRoleId,
+          createdAt: now,
+        });
+
+        // Grant owner role full access
+        await tx.insert(grant).values({
+          id: generateId("grant"),
           tenantId,
-          name: roleName,
-          description: `System ${roleName} role`,
-          isSystem: true,
+          roleId: ownerRoleId,
+          resource: "*",
+          action: "*",
+          effect: "allow",
+          origin: "system",
           createdAt: now,
           updatedAt: now,
         });
-      }
 
-      const ownerRoleId = roleIds["owner"];
-      if (!ownerRoleId) throw new Error("Owner role was not created");
+        // Grant admin role broad management access
+        const adminRoleId = roleIds["admin"];
+        if (adminRoleId) {
+          await tx.insert(grant).values([
+            {
+              id: generateId("grant"),
+              tenantId,
+              roleId: adminRoleId,
+              resource: "*",
+              action: "read",
+              effect: "allow",
+              origin: "system",
+              createdAt: now,
+              updatedAt: now,
+            },
+            {
+              id: generateId("grant"),
+              tenantId,
+              roleId: adminRoleId,
+              resource: "*",
+              action: "create",
+              effect: "allow",
+              origin: "system",
+              createdAt: now,
+              updatedAt: now,
+            },
+            {
+              id: generateId("grant"),
+              tenantId,
+              roleId: adminRoleId,
+              resource: "*",
+              action: "manage",
+              effect: "allow",
+              origin: "system",
+              createdAt: now,
+              updatedAt: now,
+            },
+          ]);
+        }
 
-      const principalId = generateId("principal");
-      await db.insert(principal).values({
-        id: principalId,
-        tenantId,
-        kind: "user",
-        refId: user.id,
-        status: "active",
-        createdAt: now,
-        updatedAt: now,
-      });
-
-      await db.insert(principalRole).values({
-        principalId,
-        roleId: ownerRoleId,
-        createdAt: now,
-      });
-
-      // Grant owner role full access
-      await db.insert(grant).values({
-        id: generateId("grant"),
-        tenantId,
-        roleId: ownerRoleId,
-        resource: "*",
-        action: "*",
-        effect: "allow",
-        origin: "system",
-        createdAt: now,
-        updatedAt: now,
-      });
-
-      // Grant admin role broad management access
-      const adminRoleId = roleIds["admin"];
-      if (adminRoleId) {
-        await db.insert(grant).values([
-          {
+        // Grant member role read-only access
+        const memberRoleId = roleIds["member"];
+        if (memberRoleId) {
+          await tx.insert(grant).values({
             id: generateId("grant"),
             tenantId,
-            roleId: adminRoleId,
+            roleId: memberRoleId,
             resource: "*",
             action: "read",
             effect: "allow",
             origin: "system",
             createdAt: now,
             updatedAt: now,
-          },
-          {
-            id: generateId("grant"),
-            tenantId,
-            roleId: adminRoleId,
-            resource: "*",
-            action: "create",
-            effect: "allow",
-            origin: "system",
-            createdAt: now,
-            updatedAt: now,
-          },
-          {
-            id: generateId("grant"),
-            tenantId,
-            roleId: adminRoleId,
-            resource: "*",
-            action: "manage",
-            effect: "allow",
-            origin: "system",
-            createdAt: now,
-            updatedAt: now,
-          },
-        ]);
-      }
+          });
+        }
 
-      // Grant member role read-only access
-      const memberRoleId = roleIds["member"];
-      if (memberRoleId) {
-        await db.insert(grant).values({
-          id: generateId("grant"),
-          tenantId,
-          roleId: memberRoleId,
-          resource: "*",
-          action: "read",
-          effect: "allow",
-          origin: "system",
-          createdAt: now,
-          updatedAt: now,
-        });
-      }
+        return inserted;
+      });
 
       return c.json(formatTenant(tenantRow), 201);
     },

--- a/packages/hub-api/src/routes/tenants.ts
+++ b/packages/hub-api/src/routes/tenants.ts
@@ -4,7 +4,7 @@ import { describeRoute, resolver, validator } from "hono-openapi";
 
 import { tenant, principal, role, principalRole, grant } from "@intx/db/schema";
 import { createPrincipalStore, parseTenantRow } from "@intx/db";
-import type { DB } from "@intx/db";
+import type { DB, PrincipalKeyStore } from "@intx/db";
 import {
   CreateTenant,
   UpdateTenant,
@@ -34,13 +34,15 @@ function formatTenant(row: typeof tenant.$inferSelect) {
 
 export type CreateTenantRoutesDeps = {
   db: DB["db"];
+  principalKeyStore: PrincipalKeyStore;
 };
 
 export function createTenantRoutes({
   db,
+  principalKeyStore,
 }: CreateTenantRoutesDeps): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
-  const principalStore = createPrincipalStore(db);
+  const principalStore = createPrincipalStore(db, principalKeyStore);
 
   app.post(
     "/",

--- a/packages/hub-api/src/routes/workflows.ts
+++ b/packages/hub-api/src/routes/workflows.ts
@@ -12,7 +12,11 @@ import {
   workflowDefinition,
   workflowRun,
 } from "@intx/db/schema";
-import { WorkflowRunDispatchPayloadConflictError, type DB } from "@intx/db";
+import {
+  WorkflowRunDispatchPayloadConflictError,
+  type DB,
+  type PrincipalKeyStore,
+} from "@intx/db";
 import type { GrantStore } from "@intx/types/authz";
 import {
   correlationIdFromSignalName,
@@ -188,6 +192,7 @@ async function deploymentAnchorRunExists(
 
 export type CreateWorkflowRoutesDeps = {
   db: DB["db"];
+  principalKeyStore: PrincipalKeyStore;
   workflowAllocationService?: WorkflowAllocationService;
   workflowDispatchService?: WorkflowDispatchService;
   sidecarRouter: SidecarRouter;
@@ -198,6 +203,7 @@ export type CreateWorkflowRoutesDeps = {
 
 export function createWorkflowRoutes({
   db,
+  principalKeyStore,
   workflowAllocationService,
   workflowDispatchService,
   sidecarRouter,
@@ -209,6 +215,7 @@ export function createWorkflowRoutes({
   const runReader = createWorkflowRunReader(repoStore);
   const triggerWorkflowRun = createWorkflowRunTrigger({
     db,
+    principalKeyStore,
     grantStore,
     sidecarRouter,
     ...(workflowDispatchService !== undefined

--- a/packages/hub-api/src/run-grant-materialization.test.ts
+++ b/packages/hub-api/src/run-grant-materialization.test.ts
@@ -7,8 +7,18 @@ import {
   workflowDefinitionVersion as workflowDefinitionVersionTable,
   workflowRun as workflowRunTable,
 } from "@intx/db/schema";
+import type { PrincipalKeyStore } from "@intx/db";
 
 import { createMailTriggeredRunGrantsMaterializer } from "./run-grant-materialization";
+
+// This suite exercises grant materialization, not key minting. The key store is
+// a no-op stub so the winning-reservation path does not try to insert into
+// principal_key against the hand-rolled mock DB.
+const stubPrincipalKeyStore: PrincipalKeyStore = {
+  generate: async () => "pky_stub",
+  sign: async () => new Uint8Array(64),
+  getPublicKey: async () => "pky_stub_public",
+};
 
 const TENANT_ID = "tenant-1";
 const ASSET_ID = "asset-wf";
@@ -181,6 +191,7 @@ describe("createMailTriggeredRunGrantsMaterializer staging", () => {
         assetRow,
         grantSnapshot: snapshot(),
       }),
+      principalKeyStore: stubPrincipalKeyStore,
       grantStore: createInMemoryGrantStore([creatorGrant()]),
     });
     const result = await materialize({
@@ -200,6 +211,7 @@ describe("createMailTriggeredRunGrantsMaterializer staging", () => {
         snapshotReads: reads,
         topLevelRunStatus: "completed",
       }),
+      principalKeyStore: stubPrincipalKeyStore,
       grantStore: createInMemoryGrantStore([creatorGrant()]),
     });
 
@@ -226,6 +238,7 @@ describe("createMailTriggeredRunGrantsMaterializer staging", () => {
         topLevelRunStatus: null,
         lockedRunStatus: "failed",
       }),
+      principalKeyStore: stubPrincipalKeyStore,
       grantStore: createInMemoryGrantStore([creatorGrant()]),
     });
 
@@ -244,6 +257,7 @@ describe("createMailTriggeredRunGrantsMaterializer staging", () => {
   test("stages the tool grant and the creator requirement, omitting the invoker one", async () => {
     const materialize = createMailTriggeredRunGrantsMaterializer({
       db: mockDb({ deploymentRow, assetRow, grantSnapshot: snapshot() }),
+      principalKeyStore: stubPrincipalKeyStore,
       grantStore: createInMemoryGrantStore([creatorGrant()]),
     });
 
@@ -282,6 +296,7 @@ describe("createMailTriggeredRunGrantsMaterializer staging", () => {
         assetRow,
         grantSnapshot: invokerOnlySnapshot(),
       }),
+      principalKeyStore: stubPrincipalKeyStore,
       grantStore: createInMemoryGrantStore([]),
     });
     const result = await materialize({
@@ -303,6 +318,7 @@ describe("createMailTriggeredRunGrantsMaterializer staging", () => {
     // materializer must raise rather than launch a run with an empty grant set.
     const materialize = createMailTriggeredRunGrantsMaterializer({
       db: mockDb({ deploymentRow, assetRow, grantSnapshot: null }),
+      principalKeyStore: stubPrincipalKeyStore,
       grantStore: createInMemoryGrantStore([creatorGrant()]),
     });
 
@@ -325,6 +341,7 @@ describe("createMailTriggeredRunGrantsMaterializer frozen basis", () => {
         grantSnapshot: snapshot(),
         snapshotReads: reads,
       }),
+      principalKeyStore: stubPrincipalKeyStore,
       grantStore: createInMemoryGrantStore([creatorGrant()]),
     });
 

--- a/packages/hub-api/src/run-grant-materialization.ts
+++ b/packages/hub-api/src/run-grant-materialization.ts
@@ -27,7 +27,11 @@ import {
   workflowRun,
 } from "@intx/db/schema";
 import type { DB, DBExecutor } from "@intx/db";
-import { createWorkflowRunStore, loadFrozenGrantSnapshot } from "@intx/db";
+import {
+  createPrincipalStore,
+  createWorkflowRunStore,
+  loadFrozenGrantSnapshot,
+} from "@intx/db";
 import type { GrantStore, GrantRule } from "@intx/types/authz";
 import {
   isSidecarAllocationDispatchable,
@@ -480,6 +484,7 @@ export async function commitRunGrants(
   tx?: DBExecutor,
 ): Promise<RunGrantsFrame["stepGrants"]> {
   const workflowRunStore = createWorkflowRunStore(args.db);
+  const principalStore = createPrincipalStore(args.db);
   const commit = async (
     executor: DBExecutor,
   ): Promise<RunGrantsFrame["stepGrants"]> => {
@@ -490,9 +495,8 @@ export async function commitRunGrants(
     );
     if (existing !== null) return existing.stepGrants;
 
-    const [insertedPrincipal] = await executor
-      .insert(principalTable)
-      .values({
+    const insertedPrincipal = await principalStore.createIfAbsent(
+      {
         id: args.runPrincipalId,
         tenantId: args.tenantId,
         kind: "workflow",
@@ -500,16 +504,10 @@ export async function commitRunGrants(
         status: "active",
         createdAt: args.now,
         updatedAt: args.now,
-      })
-      .onConflictDoNothing({
-        target: [
-          principalTable.tenantId,
-          principalTable.kind,
-          principalTable.refId,
-        ],
-      })
-      .returning({ id: principalTable.id });
-    if (insertedPrincipal === undefined) {
+      },
+      executor,
+    );
+    if (insertedPrincipal === null) {
       const winner = await loadCommittedRunGrantsFromExecutor(
         executor,
         args.tenantId,

--- a/packages/hub-api/src/run-grant-materialization.ts
+++ b/packages/hub-api/src/run-grant-materialization.ts
@@ -26,7 +26,7 @@ import {
   workflowDefinition,
   workflowRun,
 } from "@intx/db/schema";
-import type { DB, DBExecutor } from "@intx/db";
+import type { DB, DBExecutor, PrincipalKeyStore } from "@intx/db";
 import {
   createPrincipalStore,
   createWorkflowRunStore,
@@ -282,6 +282,7 @@ export async function collectCreatorGrants(
 
 export type CommitRunGrantsArgs = {
   db: DB["db"];
+  principalKeyStore: PrincipalKeyStore;
   tenantId: string;
   anchorRunId: string;
   /**
@@ -484,7 +485,7 @@ export async function commitRunGrants(
   tx?: DBExecutor,
 ): Promise<RunGrantsFrame["stepGrants"]> {
   const workflowRunStore = createWorkflowRunStore(args.db);
-  const principalStore = createPrincipalStore(args.db);
+  const principalStore = createPrincipalStore(args.db, args.principalKeyStore);
   const commit = async (
     executor: DBExecutor,
   ): Promise<RunGrantsFrame["stepGrants"]> => {
@@ -547,6 +548,7 @@ export async function commitRunGrants(
 
 export type MailTriggeredRunGrantsDeps = {
   db: DB["db"];
+  principalKeyStore: PrincipalKeyStore;
   grantStore: GrantStore;
 };
 
@@ -743,6 +745,7 @@ export function createMailTriggeredRunGrantsMaterializer(
       return commitRunGrants(
         {
           db: deps.db,
+          principalKeyStore: deps.principalKeyStore,
           tenantId,
           anchorRunId,
           definitionId: anchor.definitionId,

--- a/packages/hub-api/src/workflow-run-trigger.ts
+++ b/packages/hub-api/src/workflow-run-trigger.ts
@@ -22,7 +22,7 @@ import {
   workflowDefinition,
   workflowRun,
 } from "@intx/db/schema";
-import type { DB } from "@intx/db";
+import type { DB, PrincipalKeyStore } from "@intx/db";
 import { loadFrozenGrantSnapshot } from "@intx/db";
 import type { GrantStore } from "@intx/types/authz";
 import {
@@ -82,6 +82,7 @@ export const WorkflowRunTriggerResponse = type({
 
 export type TriggerWorkflowRunDeps = {
   db: DB["db"];
+  principalKeyStore: PrincipalKeyStore;
   grantStore: GrantStore;
   sidecarRouter: SidecarRouter;
   workflowDispatchService?: WorkflowDispatchService;
@@ -117,8 +118,14 @@ export type TriggerWorkflowRunResult =
  * result the caller maps onto its route surface.
  */
 export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
-  const { db, grantStore, sidecarRouter, workflowDispatchService, repoStore } =
-    deps;
+  const {
+    db,
+    principalKeyStore,
+    grantStore,
+    sidecarRouter,
+    workflowDispatchService,
+    repoStore,
+  } = deps;
 
   async function readRunLifecycle(
     anchorRunId: string,
@@ -436,6 +443,7 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
         const canonicalStepGrants = await commitRunGrants(
           {
             db,
+            principalKeyStore,
             tenantId: tenant.id,
             anchorRunId,
             definitionId: anchor.definitionId,
@@ -495,6 +503,7 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
       return commitRunGrants(
         {
           db,
+          principalKeyStore,
           tenantId: tenant.id,
           anchorRunId,
           definitionId: anchor.definitionId,

--- a/packages/hub-common/src/ids.ts
+++ b/packages/hub-common/src/ids.ts
@@ -3,6 +3,7 @@ import { hexEncode } from "@intx/types";
 const PREFIXES = {
   tenant: "tnt_",
   principal: "prn_",
+  principalKey: "pky_",
   role: "rol_",
   grant: "grt_",
   federationTrust: "ftr_",

--- a/packages/types/src/credential-cipher.ts
+++ b/packages/types/src/credential-cipher.ts
@@ -40,3 +40,16 @@ export interface CredentialCipher {
 export function credentialAad(id: string, column: string): string {
   return JSON.stringify(["credential-secret", id, column]);
 }
+
+/**
+ * Build the additional-authenticated-data string binding a principal signing
+ * key's sealed private material to the `principal_key` row and column it belongs
+ * to. Shares the AEAD primitive and encoding rules with `credentialAad` but uses
+ * a distinct `"principal-key"` tag domain, so a credential-secret ciphertext and
+ * a principal-key ciphertext are never interchangeable even under the same key.
+ * The mint (write) and sign (read) sites MUST build the `aad` through this one
+ * function so the value matches.
+ */
+export function principalKeyAad(id: string, column: string): string {
+  return JSON.stringify(["principal-key", id, column]);
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -16,6 +16,7 @@ export * from "./providers";
 export * from "./oauth-clients";
 export * from "./credentials";
 export * from "./credential-cipher";
+export * from "./signer-identity";
 export * from "./mediated-credential";
 export * from "./assets";
 export * from "./offerings";

--- a/packages/types/src/signer-identity.ts
+++ b/packages/types/src/signer-identity.ts
@@ -1,0 +1,33 @@
+// How the signer behind a signature is identified.
+//
+// The only signer today is a principal whose Ed25519 private key the hub
+// custodies (`local-principal`). The union is keyed on `kind` so a future
+// signer flavour (say a hub-held key, or an externally-held key) is added with
+// `.or()` and every by-value consumer that switches on `kind` gains a compile
+// error for the unhandled variant.
+
+import { type } from "arktype";
+
+/**
+ * A signer whose private key the hub custodies on a principal's behalf.
+ *
+ * `publicKey` is the RESOLVED, hex-encoded Ed25519 public key read from the
+ * hub's own principal-key store -- it is the trusted key for `principalId`. It
+ * MUST NOT be populated from untrusted input (e.g. a public key claimed on an
+ * inbound message): a verifier resolves the key from the store by `principalId`
+ * and checks the signature against that, never against a key from the wire.
+ */
+export const LocalPrincipalSigner = type({
+  kind: "'local-principal'",
+  principalId: "string",
+  publicKey: "string",
+});
+export type LocalPrincipalSigner = typeof LocalPrincipalSigner.infer;
+
+/**
+ * Discriminated union over how a signature's signer is identified, keyed on
+ * `kind`. Only the hub-custodied `local-principal` signer exists today; widen
+ * it here with `.or()` and every by-value consumer follows.
+ */
+export const SignerIdentity = LocalPrincipalSigner;
+export type SignerIdentity = typeof SignerIdentity.infer;

--- a/tests/admin-ui-e2e/harness/global-setup.ts
+++ b/tests/admin-ui-e2e/harness/global-setup.ts
@@ -155,6 +155,7 @@ const ProvisionResult = type({
     DB_PASSWORD: "string",
     BETTER_AUTH_SECRET: "string",
     CREDENTIAL_ENCRYPTION_KEY: "string",
+    PRINCIPAL_KEY_ENCRYPTION_KEY: "string",
   },
   // The migration role's connection to the provisioned database. The seed
   // writes through this table-owning identity; unlike the hub role it always

--- a/tests/db/backfill-principal-keys.test.ts
+++ b/tests/db/backfill-principal-keys.test.ts
@@ -1,0 +1,142 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { and, eq } from "drizzle-orm";
+
+import { backfillPrincipalKeys, createPrincipalKeyStore } from "@intx/db";
+import { principalKey } from "@intx/db/schema";
+import { createTestCredentialCipher } from "@intx/test-harness/crypto";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import { seedPrincipal, seedTenants } from "@intx/test-harness/seed";
+
+const TENANT = "tnt_bf";
+const cipher = createTestCredentialCipher();
+
+// Every non-agent principal is keyless at seed time except `prn_keyed`, which
+// is pre-keyed below. Covers both kinds and every status, since the backfill
+// keys them all.
+const KEYLESS_NON_AGENT = [
+  { id: "prn_user_active", kind: "user" as const, status: "active" as const },
+  { id: "prn_user_invited", kind: "user" as const, status: "invited" as const },
+  { id: "prn_wf_active", kind: "workflow" as const, status: "active" as const },
+  {
+    id: "prn_wf_suspended",
+    kind: "workflow" as const,
+    status: "suspended" as const,
+  },
+  {
+    id: "prn_wf_deactivated",
+    kind: "workflow" as const,
+    status: "deactivated" as const,
+  },
+];
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "backfillPrincipalKeys (real DB)",
+  () => {
+    let h: TestDb;
+
+    beforeAll(async () => {
+      h = await createTestDb();
+    });
+
+    afterAll(async () => {
+      await h.close();
+    });
+
+    beforeEach(async () => {
+      await h.reset();
+      await seedTenants(h.db, [{ id: TENANT }]);
+      for (const p of KEYLESS_NON_AGENT) {
+        await seedPrincipal(h.db, {
+          id: p.id,
+          tenantId: TENANT,
+          kind: p.kind,
+          status: p.status,
+        });
+      }
+      // An `agent`-kind principal must be skipped entirely.
+      await seedPrincipal(h.db, {
+        id: "prn_agent",
+        tenantId: TENANT,
+        kind: "agent",
+        status: "active",
+      });
+      // A principal that already holds an active key must be left untouched.
+      await seedPrincipal(h.db, {
+        id: "prn_keyed",
+        tenantId: TENANT,
+        kind: "user",
+        status: "active",
+      });
+    });
+
+    function newStore() {
+      return createPrincipalKeyStore({ db: h.db, cipher });
+    }
+
+    async function activeKeyRow(principalId: string) {
+      const [row] = await h.db
+        .select()
+        .from(principalKey)
+        .where(
+          and(
+            eq(principalKey.principalId, principalId),
+            eq(principalKey.status, "active"),
+          ),
+        );
+      return row;
+    }
+
+    async function keyCount(principalId: string): Promise<number> {
+      const rows = await h.db
+        .select()
+        .from(principalKey)
+        .where(eq(principalKey.principalId, principalId));
+      return rows.length;
+    }
+
+    test("keys every keyless non-agent principal, skips agent and already-keyed", async () => {
+      const store = newStore();
+      await store.generate("prn_keyed");
+      const before = await activeKeyRow("prn_keyed");
+      if (before === undefined) throw new Error("expected a pre-keyed row");
+
+      const report = await backfillPrincipalKeys(h.db, store);
+      expect(report).toEqual({ keysGenerated: 5, alreadyKeyed: 1 });
+
+      // Every keyless non-agent principal now holds exactly one active key.
+      for (const p of KEYLESS_NON_AGENT) {
+        expect(await keyCount(p.id)).toBe(1);
+        expect((await activeKeyRow(p.id))?.status).toBe("active");
+      }
+
+      // The agent-kind principal was skipped -- no key minted.
+      expect(await keyCount("prn_agent")).toBe(0);
+
+      // The already-keyed principal is byte-for-byte unchanged.
+      const after = await activeKeyRow("prn_keyed");
+      expect(after?.id).toBe(before.id);
+      expect(after?.publicKey).toBe(before.publicKey);
+      expect(after?.privateKey).toBe(before.privateKey);
+      expect(await keyCount("prn_keyed")).toBe(1);
+    });
+
+    test("a re-run is a no-op with positive confirmation", async () => {
+      const store = newStore();
+      await backfillPrincipalKeys(h.db, store);
+
+      const rerun = await backfillPrincipalKeys(h.db, store);
+      expect(rerun).toEqual({ keysGenerated: 0, alreadyKeyed: 6 });
+    });
+  },
+);

--- a/tests/db/mail-triggered-run-grants.test.ts
+++ b/tests/db/mail-triggered-run-grants.test.ts
@@ -9,7 +9,7 @@ import {
 
 import { eq } from "drizzle-orm";
 
-import { createGrantStore } from "@intx/db";
+import { createGrantStore, createPrincipalKeyStore } from "@intx/db";
 import {
   grant,
   principal,
@@ -24,6 +24,7 @@ import {
   harnessDbEnvAvailable,
   type TestDb,
 } from "@intx/test-harness/db-harness";
+import { createTestCredentialCipher } from "@intx/test-harness/crypto";
 import {
   seedAsset,
   seedGrant,
@@ -141,6 +142,10 @@ describe.skipIf(!harnessDbEnvAvailable())(
     ): ReturnType<ReturnType<typeof createMailTriggeredRunGrantsMaterializer>> {
       const materialize = createMailTriggeredRunGrantsMaterializer({
         db: h.db,
+        principalKeyStore: createPrincipalKeyStore({
+          db: h.db,
+          cipher: createTestCredentialCipher(),
+        }),
         grantStore: createGrantStore(h.db),
       });
       return materialize({ agentAddress: WORKFLOW_ADDRESS, runId });

--- a/tests/db/principal-key-store.test.ts
+++ b/tests/db/principal-key-store.test.ts
@@ -1,0 +1,118 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { eq } from "drizzle-orm";
+
+import {
+  createPrincipalKeyStore,
+  parsePrincipalKeyRow,
+  pgErrorCode,
+  PG_UNIQUE_VIOLATION,
+} from "@intx/db";
+import { principalKey } from "@intx/db/schema";
+import { isCiphertext, verifyEd25519 } from "@intx/crypto";
+import { hexDecode } from "@intx/types";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import { createTestCredentialCipher } from "@intx/test-harness/crypto";
+import { seedPrincipal, seedTenants } from "@intx/test-harness/seed";
+
+const TENANT = "tnt_pk";
+const PRINCIPAL = "prn_pk";
+// A real env-key cipher, not the noop cipher: the AEAD and its AAD binding must
+// actually run so a bug in principalKeyAad or the seal/unseal path fails a test
+// rather than passing silently through an identity cipher.
+const cipher = createTestCredentialCipher();
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "createPrincipalKeyStore (real DB)",
+  () => {
+    let h: TestDb;
+
+    beforeAll(async () => {
+      h = await createTestDb();
+    });
+
+    afterAll(async () => {
+      await h.close();
+    });
+
+    beforeEach(async () => {
+      await h.reset();
+      await seedTenants(h.db, [{ id: TENANT }]);
+      await seedPrincipal(h.db, { id: PRINCIPAL, tenantId: TENANT });
+    });
+
+    test("generate then getPublicKey then sign round-trips through verify", async () => {
+      const store = createPrincipalKeyStore({ db: h.db, cipher });
+
+      const publicKey = await store.generate(PRINCIPAL);
+      expect(await store.getPublicKey(PRINCIPAL)).toBe(publicKey);
+
+      const message = new TextEncoder().encode("attribute this action");
+      const signature = await store.sign(PRINCIPAL, message);
+      expect(signature).toHaveLength(64);
+      expect(
+        await verifyEd25519(message, signature, hexDecode(publicKey)),
+      ).toBe(true);
+    });
+
+    test("the private seed is sealed at rest and never exposed on the interface", async () => {
+      const store = createPrincipalKeyStore({ db: h.db, cipher });
+      const publicKey = await store.generate(PRINCIPAL);
+
+      const [row] = await h.db
+        .select()
+        .from(principalKey)
+        .where(eq(principalKey.principalId, PRINCIPAL));
+      // The stored private key is AEAD ciphertext, not the raw hex seed.
+      expect(isCiphertext(row?.privateKey ?? "")).toBe(true);
+      // The only key material the store hands back is the public key.
+      expect(publicKey).not.toBe(row?.privateKey);
+      expect(isCiphertext(publicKey)).toBe(false);
+    });
+
+    test("a principal may hold only one active key", async () => {
+      const store = createPrincipalKeyStore({ db: h.db, cipher });
+      await store.generate(PRINCIPAL);
+
+      let code: string | undefined;
+      try {
+        await store.generate(PRINCIPAL);
+      } catch (err) {
+        code = pgErrorCode(err);
+      }
+      expect(code).toBe(PG_UNIQUE_VIOLATION);
+    });
+
+    test("sign and getPublicKey throw for a principal with no active key", async () => {
+      const store = createPrincipalKeyStore({ db: h.db, cipher });
+      await expect(store.getPublicKey(PRINCIPAL)).rejects.toThrow(
+        /no active key/,
+      );
+      await expect(
+        store.sign(PRINCIPAL, new Uint8Array([1, 2, 3])),
+      ).rejects.toThrow(/no active key/);
+    });
+
+    test("parsePrincipalKeyRow validates the status enum", async () => {
+      const store = createPrincipalKeyStore({ db: h.db, cipher });
+      await store.generate(PRINCIPAL);
+
+      const [row] = await h.db
+        .select()
+        .from(principalKey)
+        .where(eq(principalKey.principalId, PRINCIPAL));
+      if (row === undefined) throw new Error("expected a minted key row");
+      expect(parsePrincipalKeyRow(row).status).toBe("active");
+    });
+  },
+);

--- a/tests/db/principal-store.test.ts
+++ b/tests/db/principal-store.test.ts
@@ -1,0 +1,114 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { and, eq } from "drizzle-orm";
+
+import { createPrincipalStore } from "@intx/db";
+import { principal } from "@intx/db/schema";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import { seedTenants } from "@intx/test-harness/seed";
+
+const TENANT = "tnt_ps";
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "createPrincipalStore (real DB)",
+  () => {
+    let h: TestDb;
+
+    beforeAll(async () => {
+      h = await createTestDb();
+    });
+
+    afterAll(async () => {
+      await h.close();
+    });
+
+    beforeEach(async () => {
+      await h.reset();
+      await seedTenants(h.db, [{ id: TENANT }]);
+    });
+
+    test("createIfAbsent is idempotent on the natural key", async () => {
+      const store = createPrincipalStore(h.db);
+      const now = new Date();
+      const row = {
+        id: "prn_first",
+        tenantId: TENANT,
+        kind: "user" as const,
+        refId: "usr_shared",
+        status: "active" as const,
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      const first = await store.createIfAbsent(row);
+      expect(first?.id).toBe("prn_first");
+
+      // A second reservation of the same (tenantId, kind, refId) -- even with a
+      // different surrogate id -- must not insert a new row.
+      const second = await store.createIfAbsent({ ...row, id: "prn_second" });
+      expect(second).toBeNull();
+
+      const rows = await h.db
+        .select()
+        .from(principal)
+        .where(
+          and(
+            eq(principal.tenantId, TENANT),
+            eq(principal.kind, "user"),
+            eq(principal.refId, "usr_shared"),
+          ),
+        );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.id).toBe("prn_first");
+    });
+
+    test("create fails loudly on a natural-key conflict", async () => {
+      const store = createPrincipalStore(h.db);
+      const now = new Date();
+      const row = {
+        id: "prn_a",
+        tenantId: TENANT,
+        kind: "user" as const,
+        refId: "usr_dup",
+        status: "active" as const,
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      await store.create(row);
+      await expect(store.create({ ...row, id: "prn_b" })).rejects.toThrow();
+    });
+
+    test("create preserves the caller-supplied status", async () => {
+      const store = createPrincipalStore(h.db);
+      const now = new Date();
+
+      const created = await store.create({
+        id: "prn_invited",
+        tenantId: TENANT,
+        kind: "user",
+        refId: "usr_invited",
+        status: "invited",
+        createdAt: now,
+        updatedAt: now,
+      });
+      expect(created.status).toBe("invited");
+
+      const [persisted] = await h.db
+        .select()
+        .from(principal)
+        .where(eq(principal.id, "prn_invited"));
+      expect(persisted?.status).toBe("invited");
+    });
+  },
+);

--- a/tests/db/principal-store.test.ts
+++ b/tests/db/principal-store.test.ts
@@ -8,16 +8,18 @@ import {
 } from "bun:test";
 import { and, eq } from "drizzle-orm";
 
-import { createPrincipalStore } from "@intx/db";
-import { principal } from "@intx/db/schema";
+import { createPrincipalStore, createPrincipalKeyStore } from "@intx/db";
+import { principal, principalKey } from "@intx/db/schema";
 import {
   createTestDb,
   harnessDbEnvAvailable,
   type TestDb,
 } from "@intx/test-harness/db-harness";
+import { createTestCredentialCipher } from "@intx/test-harness/crypto";
 import { seedTenants } from "@intx/test-harness/seed";
 
 const TENANT = "tnt_ps";
+const cipher = createTestCredentialCipher();
 
 describe.skipIf(!harnessDbEnvAvailable())(
   "createPrincipalStore (real DB)",
@@ -37,8 +39,28 @@ describe.skipIf(!harnessDbEnvAvailable())(
       await seedTenants(h.db, [{ id: TENANT }]);
     });
 
-    test("createIfAbsent is idempotent on the natural key", async () => {
-      const store = createPrincipalStore(h.db);
+    function newStore() {
+      return createPrincipalStore(
+        h.db,
+        createPrincipalKeyStore({ db: h.db, cipher }),
+      );
+    }
+
+    async function activeKeyCount(principalId: string): Promise<number> {
+      const rows = await h.db
+        .select()
+        .from(principalKey)
+        .where(
+          and(
+            eq(principalKey.principalId, principalId),
+            eq(principalKey.status, "active"),
+          ),
+        );
+      return rows.length;
+    }
+
+    test("createIfAbsent inserts, mints a key, and is idempotent", async () => {
+      const store = newStore();
       const now = new Date();
       const row = {
         id: "prn_first",
@@ -52,9 +74,11 @@ describe.skipIf(!harnessDbEnvAvailable())(
 
       const first = await store.createIfAbsent(row);
       expect(first?.id).toBe("prn_first");
+      expect(await activeKeyCount("prn_first")).toBe(1);
 
       // A second reservation of the same (tenantId, kind, refId) -- even with a
-      // different surrogate id -- must not insert a new row.
+      // different surrogate id -- inserts no row and mints no second key: the
+      // winning transaction already minted the one active key.
       const second = await store.createIfAbsent({ ...row, id: "prn_second" });
       expect(second).toBeNull();
 
@@ -70,10 +94,29 @@ describe.skipIf(!harnessDbEnvAvailable())(
         );
       expect(rows).toHaveLength(1);
       expect(rows[0]?.id).toBe("prn_first");
+      expect(await activeKeyCount("prn_first")).toBe(1);
+      expect(await activeKeyCount("prn_second")).toBe(0);
+    });
+
+    test("create mints an active signing key for the new principal", async () => {
+      const store = newStore();
+      const now = new Date();
+
+      const created = await store.create({
+        id: "prn_keyed",
+        tenantId: TENANT,
+        kind: "user",
+        refId: "usr_keyed",
+        status: "active",
+        createdAt: now,
+        updatedAt: now,
+      });
+      expect(created.id).toBe("prn_keyed");
+      expect(await activeKeyCount("prn_keyed")).toBe(1);
     });
 
     test("create fails loudly on a natural-key conflict", async () => {
-      const store = createPrincipalStore(h.db);
+      const store = newStore();
       const now = new Date();
       const row = {
         id: "prn_a",
@@ -90,7 +133,7 @@ describe.skipIf(!harnessDbEnvAvailable())(
     });
 
     test("create preserves the caller-supplied status", async () => {
-      const store = createPrincipalStore(h.db);
+      const store = newStore();
       const now = new Date();
 
       const created = await store.create({

--- a/tests/db/principal-store.test.ts
+++ b/tests/db/principal-store.test.ts
@@ -8,7 +8,11 @@ import {
 } from "bun:test";
 import { and, eq } from "drizzle-orm";
 
-import { createPrincipalStore, createPrincipalKeyStore } from "@intx/db";
+import {
+  createPrincipalStore,
+  createPrincipalKeyStore,
+  type PrincipalKeyStore,
+} from "@intx/db";
 import { principal, principalKey } from "@intx/db/schema";
 import {
   createTestDb,
@@ -152,6 +156,55 @@ describe.skipIf(!harnessDbEnvAvailable())(
         .from(principal)
         .where(eq(principal.id, "prn_invited"));
       expect(persisted?.status).toBe("invited");
+    });
+
+    async function principalExists(id: string): Promise<boolean> {
+      const rows = await h.db
+        .select()
+        .from(principal)
+        .where(eq(principal.id, id));
+      return rows.length > 0;
+    }
+
+    test("a failed key mint rolls back the principal insert", async () => {
+      // The key store throws on mint, so the whole transaction -- the principal
+      // insert included -- must roll back and leave no principal row. This pins
+      // the feature's headline invariant: a principal never exists without a key.
+      const throwingKeyStore: PrincipalKeyStore = {
+        generate: async () => {
+          throw new Error("mint boom");
+        },
+        sign: async () => new Uint8Array(64),
+        getPublicKey: async () => "pky_unused",
+      };
+      const store = createPrincipalStore(h.db, throwingKeyStore);
+      const now = new Date();
+
+      await expect(
+        store.create({
+          id: "prn_create_rollback",
+          tenantId: TENANT,
+          kind: "user",
+          refId: "usr_create_rollback",
+          status: "active",
+          createdAt: now,
+          updatedAt: now,
+        }),
+      ).rejects.toThrow(/mint boom/);
+      expect(await principalExists("prn_create_rollback")).toBe(false);
+
+      await expect(
+        store.createIfAbsent({
+          id: "prn_ifabsent_rollback",
+          tenantId: TENANT,
+          kind: "user",
+          refId: "usr_ifabsent_rollback",
+          status: "active",
+          createdAt: now,
+          updatedAt: now,
+        }),
+      ).rejects.toThrow(/mint boom/);
+      expect(await principalExists("prn_ifabsent_rollback")).toBe(false);
     });
   },
 );

--- a/tests/db/signer-identity.test.ts
+++ b/tests/db/signer-identity.test.ts
@@ -1,0 +1,65 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { type } from "arktype";
+
+import { createPrincipalKeyStore, lookupLocalPrincipalSigner } from "@intx/db";
+import { SignerIdentity } from "@intx/types";
+import { createTestCredentialCipher } from "@intx/test-harness/crypto";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import { seedPrincipal, seedTenants } from "@intx/test-harness/seed";
+
+const TENANT = "tnt_si";
+const PRINCIPAL = "prn_si";
+const cipher = createTestCredentialCipher();
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "lookupLocalPrincipalSigner (real DB)",
+  () => {
+    let h: TestDb;
+
+    beforeAll(async () => {
+      h = await createTestDb();
+    });
+
+    afterAll(async () => {
+      await h.close();
+    });
+
+    beforeEach(async () => {
+      await h.reset();
+      await seedTenants(h.db, [{ id: TENANT }]);
+      await seedPrincipal(h.db, { id: PRINCIPAL, tenantId: TENANT });
+    });
+
+    test("returns the local-principal variant carrying the resolved public key", async () => {
+      const store = createPrincipalKeyStore({ db: h.db, cipher });
+      const mintedPublicKey = await store.generate(PRINCIPAL);
+
+      const signer = await lookupLocalPrincipalSigner(store, PRINCIPAL);
+      expect(signer).toEqual({
+        kind: "local-principal",
+        principalId: PRINCIPAL,
+        publicKey: mintedPublicKey,
+      });
+      // Secondary: the resolved shape validates against the SignerIdentity type.
+      expect(SignerIdentity(signer) instanceof type.errors).toBe(false);
+    });
+
+    test("throws for a principal with no active key", async () => {
+      const store = createPrincipalKeyStore({ db: h.db, cipher });
+      await expect(
+        lookupLocalPrincipalSigner(store, PRINCIPAL),
+      ).rejects.toThrow(/no active key/);
+    });
+  },
+);

--- a/tests/hub-agent/lib/deploy-flow-env.ts
+++ b/tests/hub-agent/lib/deploy-flow-env.ts
@@ -99,6 +99,11 @@ export const AGENT_ID = "run_test-agent";
 export const SESSION_ID = "ses_integration-1";
 export const SIDECAR_ID = "sc-integration-1";
 export const TOKEN = "test-token";
+
+// Grace period for each stage of the teardown's sidecar reap (SIGTERM, then
+// SIGKILL). Bounds the wait so a sidecar that is slow to reap under contention
+// cannot wedge the afterAll hook.
+const SIDECAR_REAP_GRACE_MS = 10_000;
 // A second sidecar identity, for tests that need two sidecars on one hub
 // (e.g. proving a cross-sidecar/federated mail deliver reaches the
 // receiver). The default fixture only spawns the first; a caller spawns the
@@ -1214,23 +1219,39 @@ export async function startDeployFlowEnv(
 
   const teardown = async (): Promise<void> => {
     // Close every tracked hub-side WebSocket handle before killing the
-    // sidecar so no live link lingers. Then wait for the sidecar
-    // subprocess to fully exit before removing its data directory. The
-    // earlier shape (kill, then immediately rm) raced the sidecar's
-    // still-open file handles inside `sidecar-data-*`; on a slow CI host
-    // the rm would observe EBUSY, EACCES, or partial removal, which the
-    // `.catch(() => {})` shrouded. Errors must surface from the rm, so
-    // the catch is dropped here. The server stops are bounded
-    // (`stopServerBounded`) because a test that dropped the hub link
-    // leaves Bun with a phantom connection its `server.stop` would wait
-    // on forever.
+    // sidecar so no live link lingers. Then reap the sidecar subprocess with a
+    // bounded SIGTERM -> timeout -> SIGKILL escalation -- the same shape the
+    // production sidecar provisioner uses -- before removing its data
+    // directory. The sidecar installs no graceful-shutdown SIGTERM handler, so
+    // under teardown contention (e.g. a sidecar still reaping its own
+    // crash-looping workflow-process children) a plain SIGTERM can leave
+    // `proc.exited` unresolved; an unbounded wait there wedged the afterAll
+    // hook until the whole suite was torn down. Waiting for the exit before the
+    // rm keeps the earlier fix intact: removing `sidecar-data-*` while the
+    // subprocess still holds file handles raced EBUSY/EACCES on slow hosts, so
+    // errors must surface from the rm rather than be shrouded. The server stops
+    // are bounded (`stopServerBounded`) because a test that dropped the hub
+    // link leaves Bun with a phantom connection its `server.stop` would wait on
+    // forever.
     deployments.clear();
     for (const handle of hub.liveHandles) {
       handle.close();
     }
     hub.liveHandles.clear();
+    const sidecarExitedWithin = (ms: number) =>
+      Promise.race([
+        sidecar.proc.exited.then(() => true),
+        new Promise<boolean>((resolve) => setTimeout(() => resolve(false), ms)),
+      ]);
     sidecar.proc.kill();
-    await sidecar.proc.exited;
+    if (!(await sidecarExitedWithin(SIDECAR_REAP_GRACE_MS))) {
+      sidecar.proc.kill(9);
+      if (!(await sidecarExitedWithin(SIDECAR_REAP_GRACE_MS))) {
+        throw new Error(
+          `deploy-flow-env teardown: sidecar pid ${String(sidecar.proc.pid)} did not exit after SIGKILL`,
+        );
+      }
+    }
     await stopServerBounded(hub.server);
     await stopServerBounded(inference.server);
     for (const d of tempDirs.splice(0)) {

--- a/tests/hub-api/invite-route.test.ts
+++ b/tests/hub-api/invite-route.test.ts
@@ -1,0 +1,220 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { and, eq } from "drizzle-orm";
+
+import { createInMemoryGrantStore } from "@intx/authz";
+import { createApp, type GetSession } from "@intx/hub-api";
+import { createPrincipalKeyStore } from "@intx/db";
+import { principal, principalKey, user } from "@intx/db/schema";
+import {
+  createSidecarEmitter,
+  type EventCollectorRegistry,
+  type SessionService,
+  type SidecarRouter,
+} from "@intx/hub-sessions";
+import type { GrantRule } from "@intx/types/authz";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import { createTestCredentialCipher } from "@intx/test-harness/crypto";
+import { seedPrincipal, seedTenants } from "@intx/test-harness/seed";
+
+// Exercises the invite route end to end through the in-process hub app with a
+// real key store, proving the invited principal is both created and minted an
+// active signing key on the write path.
+
+const TENANT_ID = "tnt_invite";
+const ACTOR_PRINCIPAL_ID = "prn_invite_actor";
+const ACTOR_USER_ID = "usr_invite_actor";
+const INVITEE_USER_ID = "usr_invitee";
+const INVITEE_EMAIL = "invitee@invite.test";
+const cipher = createTestCredentialCipher();
+
+function createMockGetSession(userId: string): GetSession {
+  const now = new Date("2025-01-01");
+  return async () => ({
+    user: {
+      id: userId,
+      email: "actor@invite.test",
+      emailVerified: true,
+      name: "Actor",
+      createdAt: now,
+      updatedAt: now,
+    },
+    session: {
+      id: "session_test",
+      userId,
+      token: "tok_test",
+      expiresAt: new Date("2999-01-01"),
+      createdAt: now,
+      updatedAt: now,
+    },
+  });
+}
+
+function notImpl(name: string): never {
+  throw new Error(`mock: ${name} not implemented`);
+}
+
+function createMockSidecarRouter(): SidecarRouter {
+  return {
+    handleOpen: () => notImpl("handleOpen"),
+    handleMessage: () => notImpl("handleMessage"),
+    handleClose: () => notImpl("handleClose"),
+    routeMail: () => notImpl("routeMail"),
+    sendRunGrants: () => notImpl("sendRunGrants"),
+    sendAgentUndeploy: () => notImpl("sendAgentUndeploy"),
+    sendSourcesUpdate: () => notImpl("sendSourcesUpdate"),
+    sendCredentialsUpdate: () => notImpl("sendCredentialsUpdate"),
+    sendSyncRequest: () => notImpl("sendSyncRequest"),
+    sendSignalDeliver: () => notImpl("sendSignalDeliver"),
+    sendDrain: () => notImpl("sendDrain"),
+    subscribeAgent: () => notImpl("subscribeAgent"),
+    dispatchAgentEvent: () => undefined,
+    getConnectedSidecars: () => [],
+    getRoutableAddresses: () => [],
+    getConnectorState: () => null,
+    events: createSidecarEmitter(),
+  };
+}
+
+function createMockSessionService(): SessionService {
+  return {
+    stageWorkflowStep: () => notImpl("stageWorkflowStep"),
+    sendUserMessage: () => notImpl("sendUserMessage"),
+    endSession: () => notImpl("endSession"),
+  };
+}
+
+function createMockEventCollectors(): EventCollectorRegistry {
+  return {
+    create: () => notImpl("create"),
+    dispatch: () => notImpl("dispatch"),
+    abandon: () => notImpl("abandon"),
+    has: () => false,
+    getStatus: () => undefined,
+    getAccumulatedText: () => undefined,
+    getCurrentTurnId: () => undefined,
+    getLastTurnId: () => undefined,
+  };
+}
+
+function inviteCreateGrant(): GrantRule {
+  return {
+    id: "grant-invite-create",
+    resource: "principal:*",
+    action: "create",
+    effect: "allow",
+    origin: "system",
+    conditions: null,
+    expiresAt: null,
+    roleId: null,
+    principalId: ACTOR_PRINCIPAL_ID,
+  };
+}
+
+let h: TestDb;
+
+beforeAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
+  h = await createTestDb();
+});
+
+afterAll(async () => {
+  if (!harnessDbEnvAvailable()) return;
+  await h.close();
+});
+
+beforeEach(async () => {
+  if (!harnessDbEnvAvailable()) return;
+  await h.reset();
+});
+
+async function setup() {
+  await seedTenants(h.db, [{ id: TENANT_ID }]);
+  // The acting user's active principal makes it a tenant member; the grant
+  // authorizes the invite.
+  await seedPrincipal(h.db, {
+    id: ACTOR_PRINCIPAL_ID,
+    tenantId: TENANT_ID,
+    kind: "user",
+    refId: ACTOR_USER_ID,
+  });
+  // The invite resolves the target by email, so the user row must exist.
+  const now = new Date();
+  await h.db.insert(user).values({
+    id: INVITEE_USER_ID,
+    name: "Invitee",
+    email: INVITEE_EMAIL,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return createApp({
+    getSession: createMockGetSession(ACTOR_USER_ID),
+    authHandler: () => new Response("", { status: 404 }),
+    db: h.db,
+    grantStore: createInMemoryGrantStore([inviteCreateGrant()]),
+    principalKeyStore: createPrincipalKeyStore({ db: h.db, cipher }),
+    sidecarRouter: createMockSidecarRouter(),
+    sessionService: createMockSessionService(),
+    eventCollectors: createMockEventCollectors(),
+    assetService: null,
+    repoStore: null,
+    maxTarballBytes: 10_000_000,
+  });
+}
+
+describe.skipIf(!harnessDbEnvAvailable())(
+  "POST /api/tenants/:tenantId/members/invite",
+  () => {
+    test("creates the invited principal and mints its active signing key", async () => {
+      const app = await setup();
+
+      const res = await app.request(
+        `/api/tenants/${TENANT_ID}/members/invite`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ email: INVITEE_EMAIL }),
+        },
+      );
+      expect(res.status).toBe(201);
+
+      const [invited] = await h.db
+        .select()
+        .from(principal)
+        .where(
+          and(
+            eq(principal.tenantId, TENANT_ID),
+            eq(principal.kind, "user"),
+            eq(principal.refId, INVITEE_USER_ID),
+          ),
+        );
+      if (invited === undefined) {
+        throw new Error("invited principal was not created");
+      }
+      expect(invited.status).toBe("invited");
+
+      const [key] = await h.db
+        .select()
+        .from(principalKey)
+        .where(
+          and(
+            eq(principalKey.principalId, invited.id),
+            eq(principalKey.status, "active"),
+          ),
+        );
+      expect(key).toBeDefined();
+    });
+  },
+);

--- a/tests/hub-api/lib/git-harness.ts
+++ b/tests/hub-api/lib/git-harness.ts
@@ -121,6 +121,7 @@ type HarnessEnv = {
   db: DBConfig;
   betterAuthSecret: string;
   credentialEncryptionKey: string;
+  principalKeyEncryptionKey: string;
 };
 
 /**
@@ -162,6 +163,11 @@ async function loadHubEnv(): Promise<HarnessEnv> {
     credentialEncryptionKey: requireKey(
       sharedAndHub,
       "CREDENTIAL_ENCRYPTION_KEY",
+      ".env.hub",
+    ),
+    principalKeyEncryptionKey: requireKey(
+      sharedAndHub,
+      "PRINCIPAL_KEY_ENCRYPTION_KEY",
       ".env.hub",
     ),
   };
@@ -491,6 +497,7 @@ export async function startHub(
     HUB_DATA_DIR: hubDataDir,
     BETTER_AUTH_SECRET: hubEnv.betterAuthSecret,
     CREDENTIAL_ENCRYPTION_KEY: hubEnv.credentialEncryptionKey,
+    PRINCIPAL_KEY_ENCRYPTION_KEY: hubEnv.principalKeyEncryptionKey,
     BETTER_AUTH_BASE_URL: `http://127.0.0.1:${port}`,
   };
   // --conditions=intx-src resolves @intx/* to source; the spawned hub

--- a/tests/workflow-deploy/mail-federation-run-completes.test.ts
+++ b/tests/workflow-deploy/mail-federation-run-completes.test.ts
@@ -51,7 +51,8 @@ import {
   test,
 } from "bun:test";
 
-import { createGrantStore } from "@intx/db";
+import { createGrantStore, createPrincipalKeyStore } from "@intx/db";
+import { createTestCredentialCipher } from "@intx/test-harness/crypto";
 import { tenant as tenantTable } from "@intx/db/schema";
 import { createMailTriggeredRunGrantsMaterializer } from "@intx/hub-api";
 import type { HarnessConfig, InferenceSource } from "@intx/types/runtime";
@@ -146,6 +147,10 @@ describe.skipIf(!harnessDbEnvAvailable())(
       // deliverMailToRecipient through its true grants-write seam.
       const materializer = createMailTriggeredRunGrantsMaterializer({
         db: h.db,
+        principalKeyStore: createPrincipalKeyStore({
+          db: h.db,
+          cipher: createTestCredentialCipher(),
+        }),
         grantStore: createGrantStore(h.db),
       });
       env = await startDeployFlowEnv({


### PR DESCRIPTION
## Summary

- Every principal (user and workflow-run) gets a durable signing key in a new `principal_key` table; the private key is sealed at rest with AES-256-GCM under a hub-held DEK (`PRINCIPAL_KEY_ENCRYPTION_KEY`), and `PrincipalKeyStore` signs internally without ever exposing private bytes.
- All principal creation routes through one owner that mints and seals the key inside the creating transaction, so no path can produce a keyless principal; a code-driven one-shot job backfills the pre-existing population (every user and workflow principal, any status).
- A discriminated `SignerIdentity` type with a store-backed lookup resolves a principal's trusted, hub-held public key for a future verifier. Hub-custodied user keys are attribution, not non-repudiation.
- Also carries two unrelated fixes the feature work surfaced: a repair of a forked drizzle migration snapshot chain that otherwise blocks generating any new migration, and a bounded sidecar-reap escalation in the deploy-flow test teardown that keeps it from wedging under contention.

## Verification

- `make all` passes on the branch: build, lint (including API-docs freshness), and all three test passes green (unit 7281, workflow 178, core 717; 0 failures).
- The backfill is idempotent and safe to run against a live hub as the last deploy step.

Closes INTR-164