### PR TITLE
Sign hub-originated mail and resolve senders to durable keys

### DIFF
--- a/bin/audit-sender-keys.ts
+++ b/bin/audit-sender-keys.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env bun
+
+// Audit that every mail sender which could sign resolves to a durable public
+// key, so a durable-signature verifier sees no unresolvable signed senders.
+//
+// Read-only. Sweeps every workflow run past the deploy-ack window that carries a
+// sending address, and every active user principal, resolving each against the
+// hub's own key storage -- the same resolver the verifier uses. Run it before
+// turning on signature enforcement: it names any sender whose address does not
+// resolve so the hole is fixed before that sender's mail would be dropped. It
+// writes nothing.
+//
+//   set -a; . .env; . .env.hub; set +a
+//   bun run --conditions=intx-src bin/audit-sender-keys.ts
+//
+// It reads the same DB_* and PRINCIPAL_KEY_ENCRYPTION_KEY the hub uses. Exits
+// non-zero when any sender is unresolvable.
+
+import { setup, getLogger } from "@intx/log";
+import { auditSenderKeys, createDB, createPrincipalKeyStore } from "@intx/db";
+import { createEnvKeyCredentialCipher } from "@intx/crypto";
+import { hexDecode } from "@intx/types";
+
+import { resolveDbConfig } from "./lib/db-config";
+
+await setup({ dev: true });
+const log = getLogger(["audit-sender-keys"]);
+
+const keyHex = process.env["PRINCIPAL_KEY_ENCRYPTION_KEY"];
+if (keyHex === undefined || keyHex.trim() === "") {
+  throw new Error(
+    "PRINCIPAL_KEY_ENCRYPTION_KEY environment variable is required",
+  );
+}
+const cipher = createEnvKeyCredentialCipher(hexDecode(keyHex));
+
+const { db, close } = createDB(resolveDbConfig(process.env));
+try {
+  const store = createPrincipalKeyStore({ db, cipher });
+  const report = await auditSenderKeys(db, store);
+  log.info(
+    "Audit complete: checked {runsChecked} run sender(s) and " +
+      "{usersChecked} user sender(s); {unresolvedCount} unresolvable.",
+    { ...report, unresolvedCount: report.unresolved.length },
+  );
+  for (const sender of report.unresolved) {
+    log.error("Unresolvable {kind} sender: {address}", sender);
+  }
+  if (report.unresolved.length > 0) {
+    process.exitCode = 1;
+  }
+} finally {
+  await close();
+}

--- a/packages/db/migrations/0090_tenant_domain_lower_unique.sql
+++ b/packages/db/migrations/0090_tenant_domain_lower_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "tenant" DROP CONSTRAINT "tenant_domain_unique";--> statement-breakpoint
+CREATE UNIQUE INDEX "tenant_domain_lower_idx" ON "tenant" USING btree (lower("domain"));

--- a/packages/db/migrations/meta/0090_snapshot.json
+++ b/packages/db/migrations/meta/0090_snapshot.json
@@ -1,0 +1,4387 @@
+{
+  "id": "653888de-540b-4acb-bb53-e1b58089bba9",
+  "prevId": "29cab816-ceea-4770-a010-9e3a1b28d2dc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.federation_trust": {
+      "name": "federation_trust",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_tenant_id": {
+          "name": "target_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "federation_trust_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "federation_trust_target_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_target_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "tableTo": "tenant",
+          "columnsFrom": ["target_tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federation_trust_tenant_id_target_tenant_id_unique": {
+          "name": "federation_trust_tenant_id_target_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "target_tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant": {
+      "name": "tenant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenant_domain_lower_idx": {
+          "name": "tenant_domain_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_parent_id_tenant_id_fk": {
+          "name": "tenant_parent_id_tenant_id_fk",
+          "tableFrom": "tenant",
+          "tableTo": "tenant",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_slug_unique": {
+          "name": "tenant_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal": {
+      "name": "principal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_tenant_id_tenant_id_fk": {
+          "name": "principal_tenant_id_tenant_id_fk",
+          "tableFrom": "principal",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "principal_tenant_id_kind_ref_id_unique": {
+          "name": "principal_tenant_id_kind_ref_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "kind", "ref_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal_key": {
+      "name": "principal_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principal_key_one_active": {
+          "name": "principal_key_one_active",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"principal_key\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principal_key_principal_id_principal_id_fk": {
+          "name": "principal_key_principal_id_principal_id_fk",
+          "tableFrom": "principal_key",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "principal_key_public_key_unique": {
+          "name": "principal_key_public_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["public_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_role": {
+      "name": "agent_role",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_role_agent_id_workflow_definition_id_fk": {
+          "name": "agent_role_agent_id_workflow_definition_id_fk",
+          "tableFrom": "agent_role",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_role_role_id_role_id_fk": {
+          "name": "agent_role_role_id_role_id_fk",
+          "tableFrom": "agent_role",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_role_agent_id_role_id_pk": {
+          "name": "agent_role_agent_id_role_id_pk",
+          "columns": ["agent_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal_role": {
+      "name": "principal_role",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_role_principal_id_principal_id_fk": {
+          "name": "principal_role_principal_id_principal_id_fk",
+          "tableFrom": "principal_role",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "principal_role_role_id_role_id_fk": {
+          "name": "principal_role_role_id_role_id_fk",
+          "tableFrom": "principal_role",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "principal_role_principal_id_role_id_pk": {
+          "name": "principal_role_principal_id_role_id_pk",
+          "columns": ["principal_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_tenant_id_tenant_id_fk": {
+          "name": "role_tenant_id_tenant_id_fk",
+          "tableFrom": "role",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grant": {
+      "name": "grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grant_tenant_id_tenant_id_fk": {
+          "name": "grant_tenant_id_tenant_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grant_role_id_role_id_fk": {
+          "name": "grant_role_id_role_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grant_principal_id_principal_id_fk": {
+          "name": "grant_principal_id_principal_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grant_target_exactly_one": {
+          "name": "grant_target_exactly_one",
+          "value": "num_nonnulls(\"grant\".\"principal_id\", \"grant\".\"role_id\") = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.approval": {
+      "name": "approval",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_address": {
+          "name": "agent_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_definition": {
+          "name": "tool_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_arguments": {
+          "name": "tool_arguments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "timeout_at": {
+          "name": "timeout_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approval_tenant_status_idx": {
+          "name": "approval_tenant_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_anchor_run_idx": {
+          "name": "approval_anchor_run_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_run_idx": {
+          "name": "approval_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_tenant_id_tenant_id_fk": {
+          "name": "approval_tenant_id_tenant_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_anchor_run_id_workflow_run_id_fk": {
+          "name": "approval_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_run_id_workflow_run_id_fk": {
+          "name": "approval_run_id_workflow_run_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approval_correlation_id_unique": {
+          "name": "approval_correlation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["correlation_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_correlation": {
+      "name": "signal_correlation",
+      "schema": "",
+      "columns": {
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_address": {
+          "name": "agent_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_name": {
+          "name": "signal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_id": {
+          "name": "signal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signal_correlation_tenant_id_tenant_id_fk": {
+          "name": "signal_correlation_tenant_id_tenant_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signal_correlation_anchor_run_id_workflow_run_id_fk": {
+          "name": "signal_correlation_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signal_correlation_run_id_workflow_run_id_fk": {
+          "name": "signal_correlation_run_id_workflow_run_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_info_url": {
+          "name": "user_info_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_tenant_id_tenant_id_fk": {
+          "name": "provider_tenant_id_tenant_id_fk",
+          "tableFrom": "provider",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_tenant_name": {
+          "name": "provider_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_scopes": {
+          "name": "default_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_tenant_id_tenant_id_fk": {
+          "name": "oauth_client_tenant_id_tenant_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_client_provider_id_provider_id_fk": {
+          "name": "oauth_client_provider_id_provider_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_tenant_provider": {
+          "name": "oauth_client_tenant_provider",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "provider_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credential": {
+      "name": "credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_secret": {
+          "name": "refresh_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credential_tenant_id_tenant_id_fk": {
+          "name": "credential_tenant_id_tenant_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_principal_id_principal_id_fk": {
+          "name": "credential_principal_id_principal_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credential_provider_id_provider_id_fk": {
+          "name": "credential_provider_id_provider_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_oauth_client_id_oauth_client_id_fk": {
+          "name": "credential_oauth_client_id_oauth_client_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "credential_tenant_name": {
+          "name": "credential_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset": {
+      "name": "asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_tenant_id_tenant_id_fk": {
+          "name": "asset_tenant_id_tenant_id_fk",
+          "tableFrom": "asset",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "asset_creator_principal_id_principal_id_fk": {
+          "name": "asset_creator_principal_id_principal_id_fk",
+          "tableFrom": "asset",
+          "tableTo": "principal",
+          "columnsFrom": ["creator_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_tenant_kind_name": {
+          "name": "asset_tenant_kind_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "kind", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_wallet_id_wallet_id_fk": {
+          "name": "transaction_wallet_id_wallet_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_run_id_workflow_run_id_fk": {
+          "name": "transaction_run_id_workflow_run_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet": {
+      "name": "wallet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend_type": {
+          "name": "backend_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallet_tenant_id_tenant_id_fk": {
+          "name": "wallet_tenant_id_tenant_id_fk",
+          "tableFrom": "wallet",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offering": {
+      "name": "offering",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "offering_agent_id_workflow_definition_id_fk": {
+          "name": "offering_agent_id_workflow_definition_id_fk",
+          "tableFrom": "offering",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "offering_tenant_id_tenant_id_fk": {
+          "name": "offering_tenant_id_tenant_id_fk",
+          "tableFrom": "offering",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model": {
+      "name": "model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_tenant_id_tenant_id_fk": {
+          "name": "model_tenant_id_tenant_id_fk",
+          "tableFrom": "model",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_tenant_canonical_name": {
+          "name": "model_tenant_canonical_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "canonical_name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_offering": {
+      "name": "model_offering",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_tags": {
+          "name": "deployment_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "quirks": {
+          "name": "quirks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_offering_tenant_id_tenant_id_fk": {
+          "name": "model_offering_tenant_id_tenant_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_offering_model_id_model_id_fk": {
+          "name": "model_offering_model_id_model_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_offering_provider_id_model_provider_id_fk": {
+          "name": "model_offering_provider_id_model_provider_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "model_provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_offering_tenant_model_provider": {
+          "name": "model_offering_tenant_model_provider",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "model_id", "provider_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_pricing": {
+      "name": "model_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offering_id": {
+          "name": "offering_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_token_price": {
+          "name": "input_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_token_price": {
+          "name": "output_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_token_price": {
+          "name": "cache_read_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_write_token_price": {
+          "name": "cache_write_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thinking_token_price": {
+          "name": "thinking_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_request_fee": {
+          "name": "per_request_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_image_fee": {
+          "name": "per_image_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_audio_fee": {
+          "name": "per_audio_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_pricing_tenant_id_tenant_id_fk": {
+          "name": "model_pricing_tenant_id_tenant_id_fk",
+          "tableFrom": "model_pricing",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_pricing_offering_id_model_offering_id_fk": {
+          "name": "model_pricing_offering_id_model_offering_id_fk",
+          "tableFrom": "model_pricing",
+          "tableTo": "model_offering",
+          "columnsFrom": ["offering_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_pricing_offering_currency_effective_from": {
+          "name": "model_pricing_offering_currency_effective_from",
+          "nullsNotDistinct": false,
+          "columns": ["offering_id", "currency", "effective_from"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider": {
+      "name": "model_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_provider_tenant_id_tenant_id_fk": {
+          "name": "model_provider_tenant_id_tenant_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_credential_id_credential_id_fk": {
+          "name": "model_provider_credential_id_credential_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "credential",
+          "columnsFrom": ["credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "model_provider_wallet_id_wallet_id_fk": {
+          "name": "model_provider_wallet_id_wallet_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_provider_tenant_name": {
+          "name": "model_provider_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "model_provider_auth_xor": {
+          "name": "model_provider_auth_xor",
+          "value": "(\"model_provider\".\"credential_id\" is not null) <> (\"model_provider\".\"wallet_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sidecar": {
+      "name": "sidecar",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash_sha256": {
+          "name": "token_hash_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sidecar_token_hash_sha256_unique": {
+          "name": "sidecar_token_hash_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash_sha256"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidecar_allocation": {
+      "name": "sidecar_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_api_version": {
+          "name": "provisioner_api_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_binding_fingerprint": {
+          "name": "provisioner_binding_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ensure_accepted_generation": {
+          "name": "ensure_accepted_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation_lease_id": {
+          "name": "reconciliation_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation_lease_expires_at": {
+          "name": "reconciliation_lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ensure_attempts": {
+          "name": "ensure_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "destroy_attempts": {
+          "name": "destroy_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connect_deadline": {
+          "name": "connect_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sidecar_allocation_anchor_run_idx": {
+          "name": "sidecar_allocation_anchor_run_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sidecar_allocation_active_sidecar_idx": {
+          "name": "sidecar_allocation_active_sidecar_idx",
+          "columns": [
+            {
+              "expression": "sidecar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sidecar_allocation\".\"status\" in ('provisioning', 'allocated', 'replacing', 'releasing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sidecar_allocation_sidecar_idx": {
+          "name": "sidecar_allocation_sidecar_idx",
+          "columns": [
+            {
+              "expression": "sidecar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sidecar_allocation_reconciliation_idx": {
+          "name": "sidecar_allocation_reconciliation_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sidecar_allocation\".\"status\" in ('pending', 'provisioning', 'allocated', 'replacing', 'releasing') and \"sidecar_allocation\".\"next_attempt_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sidecar_allocation_anchor_run_id_workflow_run_id_fk": {
+          "name": "sidecar_allocation_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "sidecar_allocation",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sidecar_allocation_tenant_id_tenant_id_fk": {
+          "name": "sidecar_allocation_tenant_id_tenant_id_fk",
+          "tableFrom": "sidecar_allocation",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sidecar_allocation_sidecar_id_sidecar_id_fk": {
+          "name": "sidecar_allocation_sidecar_id_sidecar_id_fk",
+          "tableFrom": "sidecar_allocation",
+          "tableTo": "sidecar",
+          "columnsFrom": ["sidecar_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sidecar_allocation_status_check": {
+          "name": "sidecar_allocation_status_check",
+          "value": "\"sidecar_allocation\".\"status\" in ('pending', 'provisioning', 'allocated', 'replacing', 'releasing', 'released', 'failed')"
+        },
+        "sidecar_allocation_generation_check": {
+          "name": "sidecar_allocation_generation_check",
+          "value": "\"sidecar_allocation\".\"generation\" >= 0"
+        },
+        "sidecar_allocation_accepted_generation_check": {
+          "name": "sidecar_allocation_accepted_generation_check",
+          "value": "\"sidecar_allocation\".\"ensure_accepted_generation\" is null or \"sidecar_allocation\".\"ensure_accepted_generation\" <= \"sidecar_allocation\".\"generation\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_session": {
+      "name": "agent_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_session_tenant_id_tenant_id_fk": {
+          "name": "agent_session_tenant_id_tenant_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_agent_id_workflow_definition_id_fk": {
+          "name": "agent_session_agent_id_workflow_definition_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_session_principal_id_principal_id_fk": {
+          "name": "agent_session_principal_id_principal_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_asset": {
+      "name": "session_asset",
+      "schema": "",
+      "columns": {
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mount_path": {
+          "name": "mount_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_pack_sha": {
+          "name": "asset_pack_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "materialized_at": {
+          "name": "materialized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_asset_pack_sha_idx": {
+          "name": "session_asset_pack_sha_idx",
+          "columns": [
+            {
+              "expression": "asset_pack_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_asset_instance_id_mount_path_pk": {
+          "name": "session_asset_instance_id_mount_path_pk",
+          "columns": ["instance_id", "mount_path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inference_turn": {
+      "name": "inference_turn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "inference_turn_instance_id_started_at_idx": {
+          "name": "inference_turn_instance_id_started_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inference_turn_session_id_agent_session_id_fk": {
+          "name": "inference_turn_session_id_agent_session_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inference_turn_tenant_id_tenant_id_fk": {
+          "name": "inference_turn_tenant_id_tenant_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_mail": {
+      "name": "session_mail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "raw": {
+          "name": "raw",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_mail_instance_id_created_at_idx": {
+          "name": "session_mail_instance_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_mail_session_id_created_at_idx": {
+          "name": "session_mail_session_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_mail_session_id_agent_session_id_fk": {
+          "name": "session_mail_session_id_agent_session_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_mail_tenant_id_tenant_id_fk": {
+          "name": "session_mail_tenant_id_tenant_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turn_part": {
+      "name": "turn_part",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "turn_part_turn_id_inference_turn_id_fk": {
+          "name": "turn_part_turn_id_inference_turn_id_fk",
+          "tableFrom": "turn_part",
+          "tableTo": "inference_turn",
+          "columnsFrom": ["turn_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_part_session_id_agent_session_id_fk": {
+          "name": "turn_part_session_id_agent_session_id_fk",
+          "tableFrom": "turn_part",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_token": {
+      "name": "git_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash_sha256": {
+          "name": "token_hash_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_pattern": {
+          "name": "ref_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "git_token_user_id_name_active_idx": {
+          "name": "git_token_user_id_name_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"git_token\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "git_token_tenant_id_tenant_id_fk": {
+          "name": "git_token_tenant_id_tenant_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "git_token_user_id_user_id_fk": {
+          "name": "git_token_user_id_user_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_token_principal_id_principal_id_fk": {
+          "name": "git_token_principal_id_principal_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "git_token_token_hash_sha256_unique": {
+          "name": "git_token_token_hash_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash_sha256"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition": {
+      "name": "workflow_definition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wire_hash": {
+          "name": "wire_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_requirements": {
+          "name": "grant_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_requirements": {
+          "name": "model_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_bindings": {
+          "name": "credential_bindings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_definition_tenant_idx": {
+          "name": "workflow_definition_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_definition_asset_wire_hash_idx": {
+          "name": "workflow_definition_asset_wire_hash_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wire_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definition_tenant_id_tenant_id_fk": {
+          "name": "workflow_definition_tenant_id_tenant_id_fk",
+          "tableFrom": "workflow_definition",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_definition_creator_principal_id_principal_id_fk": {
+          "name": "workflow_definition_creator_principal_id_principal_id_fk",
+          "tableFrom": "workflow_definition",
+          "tableTo": "principal",
+          "columnsFrom": ["creator_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_definition_asset_id_asset_id_fk": {
+          "name": "workflow_definition_asset_id_asset_id_fk",
+          "tableFrom": "workflow_definition",
+          "tableTo": "asset",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_version": {
+      "name": "workflow_definition_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "approved_wire_hash": {
+          "name": "approved_wire_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_snapshot": {
+          "name": "grant_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_definition_version_definition_idx": {
+          "name": "workflow_definition_version_definition_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definition_version_definition_id_workflow_definition_id_fk": {
+          "name": "workflow_definition_version_definition_id_workflow_definition_id_fk",
+          "tableFrom": "workflow_definition_version",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["definition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_definition_version_definition_version": {
+          "name": "workflow_definition_version_definition_version",
+          "nullsNotDistinct": false,
+          "columns": ["definition_id", "version"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run": {
+      "name": "workflow_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kernel_id": {
+          "name": "kernel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_preferences": {
+          "name": "model_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_refs": {
+          "name": "credential_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_definition_idx": {
+          "name": "workflow_run_definition_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_address_idx": {
+          "name": "workflow_run_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_run\".\"address\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_definition_id_workflow_definition_id_fk": {
+          "name": "workflow_run_definition_id_workflow_definition_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["definition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_anchor_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_tenant_id_tenant_id_fk": {
+          "name": "workflow_run_tenant_id_tenant_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_principal_id_principal_id_fk": {
+          "name": "workflow_run_principal_id_principal_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflow_run_sidecar_id_sidecar_id_fk": {
+          "name": "workflow_run_sidecar_id_sidecar_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "sidecar",
+          "columnsFrom": ["sidecar_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_dispatch": {
+      "name": "workflow_run_dispatch",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mail'"
+        },
+        "raw_message": {
+          "name": "raw_message",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_grants": {
+          "name": "step_grants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "acknowledged_generation": {
+          "name": "acknowledged_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "delivery_lease_id": {
+          "name": "delivery_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_lease_expires_at": {
+          "name": "delivery_lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_dispatch_anchor_message_idx": {
+          "name": "workflow_run_dispatch_anchor_message_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_dispatch_delivery_idx": {
+          "name": "workflow_run_dispatch_delivery_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_run_dispatch\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_dispatch_anchor_status_idx": {
+          "name": "workflow_run_dispatch_anchor_status_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_dispatch_anchor_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_dispatch_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run_dispatch",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_dispatch_status_check": {
+          "name": "workflow_run_dispatch_status_check",
+          "value": "\"workflow_run_dispatch\".\"status\" in ('pending', 'acknowledged', 'settled', 'failed')"
+        },
+        "workflow_run_dispatch_kind_check": {
+          "name": "workflow_run_dispatch_kind_check",
+          "value": "\"workflow_run_dispatch\".\"kind\" in ('mail', 'signal')"
+        },
+        "workflow_run_dispatch_attempt_count_check": {
+          "name": "workflow_run_dispatch_attempt_count_check",
+          "value": "\"workflow_run_dispatch\".\"attempt_count\" >= 0"
+        },
+        "workflow_run_dispatch_acknowledged_generation_check": {
+          "name": "workflow_run_dispatch_acknowledged_generation_check",
+          "value": "\"workflow_run_dispatch\".\"acknowledged_generation\" is null or \"workflow_run_dispatch\".\"acknowledged_generation\" >= 0"
+        },
+        "workflow_run_dispatch_acknowledged_state_check": {
+          "name": "workflow_run_dispatch_acknowledged_state_check",
+          "value": "\"workflow_run_dispatch\".\"status\" <> 'acknowledged' or \"workflow_run_dispatch\".\"acknowledged_generation\" is not null"
+        },
+        "workflow_run_dispatch_pending_schedule_check": {
+          "name": "workflow_run_dispatch_pending_schedule_check",
+          "value": "\"workflow_run_dispatch\".\"status\" <> 'pending' or \"workflow_run_dispatch\".\"next_attempt_at\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_launch_spec": {
+      "name": "workflow_run_launch_spec",
+      "schema": "",
+      "columns": {
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_domain": {
+          "name": "deployment_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_authority_principal_id": {
+          "name": "source_authority_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frozen_approval_bundle": {
+          "name": "frozen_approval_bundle",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_offering_ids": {
+          "name": "source_offering_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_source_offering_id": {
+          "name": "default_source_offering_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deploy_content": {
+          "name": "deploy_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_package_pins": {
+          "name": "tool_package_pins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_run_launch_spec_anchor_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_launch_spec_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run_launch_spec",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_launch_spec_source_authority_principal_id_principal_id_fk": {
+          "name": "workflow_run_launch_spec_source_authority_principal_id_principal_id_fk",
+          "tableFrom": "workflow_run_launch_spec",
+          "tableTo": "principal",
+          "columnsFrom": ["source_authority_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_execution": {
+      "name": "workflow_run_execution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_execution_run_id_id_idx": {
+          "name": "workflow_run_execution_run_id_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_execution_status_idx": {
+          "name": "workflow_run_execution_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_execution_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_execution_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run_execution",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_probe": {
+      "name": "workflow_probe",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_asset_id": {
+          "name": "definition_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pin": {
+          "name": "pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_api_version": {
+          "name": "provisioner_api_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_binding_fingerprint": {
+          "name": "provisioner_binding_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_probe_active_idx": {
+          "name": "workflow_probe_active_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_probe\".\"status\" in ('pending', 'provisioning', 'probing', 'releasing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_probe_sidecar_idx": {
+          "name": "workflow_probe_sidecar_idx",
+          "columns": [
+            {
+              "expression": "sidecar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_probe_tenant_id_tenant_id_fk": {
+          "name": "workflow_probe_tenant_id_tenant_id_fk",
+          "tableFrom": "workflow_probe",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workflow_probe_definition_asset_id_asset_id_fk": {
+          "name": "workflow_probe_definition_asset_id_asset_id_fk",
+          "tableFrom": "workflow_probe",
+          "tableTo": "asset",
+          "columnsFrom": ["definition_asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workflow_probe_sidecar_id_sidecar_id_fk": {
+          "name": "workflow_probe_sidecar_id_sidecar_id_fk",
+          "tableFrom": "workflow_probe",
+          "tableTo": "sidecar",
+          "columnsFrom": ["sidecar_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_probe_status_check": {
+          "name": "workflow_probe_status_check",
+          "value": "\"workflow_probe\".\"status\" in ('pending', 'provisioning', 'probing', 'releasing', 'succeeded', 'failed')"
+        },
+        "workflow_probe_succeeded_result_check": {
+          "name": "workflow_probe_succeeded_result_check",
+          "value": "\"workflow_probe\".\"status\" <> 'succeeded' or \"workflow_probe\".\"result\" is not null"
+        },
+        "workflow_probe_generation_check": {
+          "name": "workflow_probe_generation_check",
+          "value": "\"workflow_probe\".\"generation\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -624,6 +624,13 @@
       "when": 1788617577404,
       "tag": "0089_tense_selene",
       "breakpoints": true
+    },
+    {
+      "idx": 90,
+      "version": "7",
+      "when": 1788736070428,
+      "tag": "0090_tenant_domain_lower_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -23,6 +23,12 @@ export {
 } from "./principal-key-store";
 export { lookupLocalPrincipalSigner } from "./signer-identity";
 export {
+  resolveSenderKey,
+  auditSenderKeys,
+  type SenderKeyResolution,
+  type SenderKeyAuditReport,
+} from "./sender-key-resolver";
+export {
   createApprovalStore,
   type ApprovalStore,
   type ResolveApprovalArgs,

--- a/packages/db/src/schema/tenants.ts
+++ b/packages/db/src/schema/tenants.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
   foreignKey,
   jsonb,
@@ -5,6 +6,7 @@ import {
   text,
   timestamp,
   unique,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 
 export const tenant = pgTable(
@@ -13,13 +15,22 @@ export const tenant = pgTable(
     id: text("id").primaryKey(),
     name: text("name").notNull(),
     slug: text("slug").notNull().unique(),
-    domain: text("domain").notNull().unique(),
+    // Unique on `lower(domain)`, not the raw column: an inbound mail `From` is
+    // lowercased when parsed, so a sender address must map to exactly one
+    // tenant. A case-sensitive unique would let case-variant domains coexist and
+    // let a case-variant registration shadow another tenant's senders. The
+    // creation boundary lowercases the domain; this index enforces it for every
+    // write path.
+    domain: text("domain").notNull(),
     parentId: text("parent_id"),
     config: jsonb("config"),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },
-  (t) => [foreignKey({ columns: [t.parentId], foreignColumns: [t.id] })],
+  (t) => [
+    foreignKey({ columns: [t.parentId], foreignColumns: [t.id] }),
+    uniqueIndex("tenant_domain_lower_idx").on(sql`lower(${t.domain})`),
+  ],
 );
 
 export const federationTrust = pgTable(

--- a/packages/db/src/sender-key-resolver.ts
+++ b/packages/db/src/sender-key-resolver.ts
@@ -1,0 +1,207 @@
+import { and, eq, isNotNull, or, sql } from "drizzle-orm";
+
+import { parseAddress } from "@intx/types";
+
+import type { DBExecutor } from "./client";
+import type { PrincipalKeyStore } from "./principal-key-store";
+import { principal } from "./schema/principals";
+import { tenant } from "./schema/tenants";
+import { workflowRun } from "./schema/workflow-run";
+
+const RUN_PREFIX = "run_";
+
+/**
+ * The durable public key that authenticates a signed mail sender, resolved from
+ * the hub's own storage. `source` records which store the key came from -- a
+ * run sender's key is the sidecar-minted key recorded on the deployment anchor,
+ * a user sender's key is the hub-custodied principal key -- so a consumer can
+ * bucket a resolution without re-parsing the address.
+ */
+export type SenderKeyResolution =
+  | { source: "run"; publicKey: string }
+  | { source: "user"; publicKey: string };
+
+/**
+ * Resolve the durable public key a signed mail sender must verify against,
+ * unioning the two existing durable-key sources: a run address
+ * (`run_<id>@<domain>`) resolves to the run's `workflow_run.public_key`; any
+ * other address (`<refId>@<domain>`) is treated as a user sender and resolves
+ * to that principal's hub-custodied key.
+ *
+ * Read-only. Returns `null` when the sender has no durable key to resolve -- a
+ * malformed address, an unknown run, a run whose deploy has not been acked yet,
+ * or an address that matches no user principal. A `null` is a legitimate
+ * "unresolvable sender" answer the caller acts on; it is NOT an error.
+ *
+ * Addresses are matched case-insensitively. Inbound `From` addresses are
+ * lowercased when parsed (see `@intx/mime` `extractAddrSpec`), but a stored
+ * tenant domain derives from an unnormalized slug, so the address is normalized
+ * here and stored values are compared under `lower(...)`. Because the tenant
+ * domain and principal `refId` uniqueness constraints are case-sensitive,
+ * case-variant rows can coexist and a case-insensitive user-address match can
+ * hit more than one. The resolver prefers the exact (already-lowercase,
+ * canonical) row; only when no exact row exists AND the case-insensitive match
+ * is not unique is the sender genuinely ambiguous, and the resolver throws
+ * rather than silently return one row's key -- which could be another tenant's.
+ */
+export async function resolveSenderKey(
+  db: DBExecutor,
+  principalKeyStore: PrincipalKeyStore,
+  address: string,
+): Promise<SenderKeyResolution | null> {
+  const normalized = address.toLowerCase();
+  const parsed = parseAddress(normalized);
+  if (parsed === null) return null;
+  const { localPart, domain } = parsed;
+
+  if (localPart.startsWith(RUN_PREFIX)) {
+    // A run sender resolves to the sidecar-minted key the hub recorded on the
+    // deployment anchor at `agent.deploy.ack`. `workflow_run.address` is unique
+    // among the runs that set it, so there is at most one row. A row whose
+    // `public_key` is still null is a deployed-but-not-yet-acked run -- the
+    // expected pre-ack state -- so it resolves to nothing rather than erroring,
+    // unlike the keyless-principal invariant break below.
+    const [row] = await db
+      .select({ publicKey: workflowRun.publicKey })
+      .from(workflowRun)
+      .where(eq(sql`lower(${workflowRun.address})`, normalized))
+      .limit(1);
+    if (row === undefined || row.publicKey === null) return null;
+    return { source: "run", publicKey: row.publicKey };
+  }
+
+  // A user sender resolves to its hub-custodied principal key, keyed by the
+  // `(tenant domain, user refId)` its From address carries. Prefer the exact
+  // (already-lowercase, canonical) row: the normalized address equals it, and
+  // the tenant domain is case-sensitively unique, so at most one tenant holds
+  // exactly this domain.
+  const principalId = await resolveUserPrincipalId(db, domain, localPart);
+  if (principalId === null) return null;
+  // The principal exists; a principal with no active key violates INTR-164's
+  // invariant that every principal is minted with one, so `getPublicKey` throws
+  // rather than defaulting. Do not soften that to null -- unlike the pre-ack run
+  // key above, a keyless principal is a real breakage that must surface.
+  const publicKey = await principalKeyStore.getPublicKey(principalId, db);
+  return { source: "user", publicKey };
+}
+
+/**
+ * Resolve the user principal a normalized `<localPart>@<domain>` address names,
+ * or `null` when none matches. Prefers the exact (already-lowercase) row; only
+ * when no exact row exists does it fall back to a case-insensitive match, and a
+ * non-unique case-insensitive match with no exact row is genuinely ambiguous --
+ * two case-variant senders with no canonical row -- so it throws rather than
+ * return an arbitrary one, which could be another tenant's principal.
+ */
+async function resolveUserPrincipalId(
+  db: DBExecutor,
+  domain: string,
+  localPart: string,
+): Promise<string | null> {
+  const [exact] = await db
+    .select({ principalId: principal.id })
+    .from(principal)
+    .innerJoin(tenant, eq(principal.tenantId, tenant.id))
+    .where(
+      and(
+        eq(tenant.domain, domain),
+        eq(principal.kind, "user"),
+        eq(principal.refId, localPart),
+      ),
+    )
+    .limit(1);
+  if (exact !== undefined) return exact.principalId;
+
+  const caseInsensitive = await db
+    .select({ principalId: principal.id })
+    .from(principal)
+    .innerJoin(tenant, eq(principal.tenantId, tenant.id))
+    .where(
+      and(
+        eq(sql`lower(${tenant.domain})`, domain),
+        eq(principal.kind, "user"),
+        eq(sql`lower(${principal.refId})`, localPart),
+      ),
+    )
+    .limit(2);
+  if (caseInsensitive.length === 0) return null;
+  if (caseInsensitive.length > 1) {
+    throw new Error(
+      `resolveSenderKey: user sender ${localPart}@${domain} is ambiguous; it ` +
+        `matches multiple case-variant principals with no canonical row -- ` +
+        `case-variant tenant domains or refIds must be reconciled`,
+    );
+  }
+  const [only] = caseInsensitive;
+  return only === undefined ? null : only.principalId;
+}
+
+/**
+ * The outcome of sweeping every sender that could sign a piece of mail: how many
+ * of each kind were checked, and any whose address did not resolve to a durable
+ * key. An empty `unresolved` is the "no unresolvable signed senders" state a
+ * durable-signature verifier depends on.
+ */
+export type SenderKeyAuditReport = {
+  runsChecked: number;
+  usersChecked: number;
+  unresolved: { address: string; kind: "run" | "user" }[];
+};
+
+/**
+ * Sweep every mail sender that could sign and confirm each resolves to a durable
+ * public key via {@link resolveSenderKey}. Read-only.
+ *
+ * The senders that can sign are every workflow run that holds a signing key or
+ * is live ("running") and carries a sending address, plus every active user
+ * principal. A never-signed run -- deployed-but-not-yet-acked, or failed or
+ * cancelled before ack (address set, key null) -- is excluded. Any checked
+ * sender that does not resolve is collected in `unresolved`. A keyless user
+ * principal is an INTR-164 invariant break, so `resolveSenderKey` throws and the
+ * sweep fails loudly rather than folding it into `unresolved` -- it is a
+ * different, more serious fault than an unresolvable address.
+ */
+export async function auditSenderKeys(
+  db: DBExecutor,
+  principalKeyStore: PrincipalKeyStore,
+): Promise<SenderKeyAuditReport> {
+  const unresolved: { address: string; kind: "run" | "user" }[] = [];
+
+  const runs = await db
+    .select({ address: workflowRun.address })
+    .from(workflowRun)
+    .where(
+      and(
+        isNotNull(workflowRun.address),
+        // A run can only have signed if it holds a key, so every key-null row is
+        // a non-signer EXCEPT a live "running" run, which is the genuine
+        // can-sign-but-keyless hole to flag. This includes all key-bearing rows
+        // (any status -- a terminal run's in-flight mail is still verifiable)
+        // and excludes both the pre-ack "deployed" window and a run that failed
+        // or was cancelled before ack (address set, key null, never signed).
+        // Match "running" literally, NOT isLiveWorkflowRunStatus, which also
+        // admits "deployed" and would re-open the pre-ack false positive.
+        or(isNotNull(workflowRun.publicKey), eq(workflowRun.status, "running")),
+      ),
+    );
+  for (const run of runs) {
+    if (run.address === null) continue;
+    if ((await resolveSenderKey(db, principalKeyStore, run.address)) === null) {
+      unresolved.push({ address: run.address, kind: "run" });
+    }
+  }
+
+  const users = await db
+    .select({ refId: principal.refId, domain: tenant.domain })
+    .from(principal)
+    .innerJoin(tenant, eq(principal.tenantId, tenant.id))
+    .where(and(eq(principal.kind, "user"), eq(principal.status, "active")));
+  for (const user of users) {
+    const address = `${user.refId}@${user.domain}`;
+    if ((await resolveSenderKey(db, principalKeyStore, address)) === null) {
+      unresolved.push({ address, kind: "user" });
+    }
+  }
+
+  return { runsChecked: runs.length, usersChecked: users.length, unresolved };
+}

--- a/packages/db/src/sender-key-resolver.ts
+++ b/packages/db/src/sender-key-resolver.ts
@@ -34,15 +34,17 @@ export type SenderKeyResolution =
  * "unresolvable sender" answer the caller acts on; it is NOT an error.
  *
  * Addresses are matched case-insensitively. Inbound `From` addresses are
- * lowercased when parsed (see `@intx/mime` `extractAddrSpec`), but a stored
- * tenant domain derives from an unnormalized slug, so the address is normalized
- * here and stored values are compared under `lower(...)`. Because the tenant
- * domain and principal `refId` uniqueness constraints are case-sensitive,
- * case-variant rows can coexist and a case-insensitive user-address match can
- * hit more than one. The resolver prefers the exact (already-lowercase,
- * canonical) row; only when no exact row exists AND the case-insensitive match
- * is not unique is the sender genuinely ambiguous, and the resolver throws
- * rather than silently return one row's key -- which could be another tenant's.
+ * lowercased when parsed (see `@intx/mime` `extractAddrSpec`), so the address is
+ * normalized here and stored values are compared under `lower(...)`. Tenant
+ * domains are `lower(domain)`-unique (`tenant_domain_lower_idx`), so a
+ * normalized domain matches at most one tenant. A user `refId` is a
+ * case-sensitively-unique betterAuth id that can carry uppercase; lowercasing it
+ * to reconcile with the parser is lossy, so the resolver prefers the exact
+ * (already-lowercase) row and falls back to a case-insensitive match to find a
+ * mixed-case-stored refId. When two principals in one tenant hold case-variant
+ * refIds the case-insensitive match is not unique and no exact row disambiguates
+ * it: the resolver throws rather than silently return one, which would attribute
+ * the sender to the wrong principal.
  */
 export async function resolveSenderKey(
   db: DBExecutor,
@@ -71,10 +73,7 @@ export async function resolveSenderKey(
   }
 
   // A user sender resolves to its hub-custodied principal key, keyed by the
-  // `(tenant domain, user refId)` its From address carries. Prefer the exact
-  // (already-lowercase, canonical) row: the normalized address equals it, and
-  // the tenant domain is case-sensitively unique, so at most one tenant holds
-  // exactly this domain.
+  // `(tenant domain, user refId)` its From address carries.
   const principalId = await resolveUserPrincipalId(db, domain, localPart);
   if (principalId === null) return null;
   // The principal exists; a principal with no active key violates INTR-164's
@@ -87,11 +86,17 @@ export async function resolveSenderKey(
 
 /**
  * Resolve the user principal a normalized `<localPart>@<domain>` address names,
- * or `null` when none matches. Prefers the exact (already-lowercase) row; only
- * when no exact row exists does it fall back to a case-insensitive match, and a
- * non-unique case-insensitive match with no exact row is genuinely ambiguous --
- * two case-variant senders with no canonical row -- so it throws rather than
- * return an arbitrary one, which could be another tenant's principal.
+ * or `null` when none matches. `lower(domain)` is unique, so the domain selects
+ * at most one tenant; within it, prefer the principal whose `refId` is exactly
+ * the normalized localPart (the canonical lowercase refId). The domain is
+ * matched case-insensitively in both queries because an existing tenant's stored
+ * domain may be mixed-case (creation lowercases new ones, but legacy rows are
+ * left as stored). Only when no exact refId exists does it fall back to a
+ * case-insensitive refId match, which finds a mixed-case-stored refId. A
+ * non-unique case-insensitive match with no exact row means two principals in
+ * the tenant hold case-variant refIds; that is genuinely ambiguous, so it throws
+ * rather than return an arbitrary one and attribute the sender to the wrong
+ * principal.
  */
 async function resolveUserPrincipalId(
   db: DBExecutor,
@@ -104,7 +109,7 @@ async function resolveUserPrincipalId(
     .innerJoin(tenant, eq(principal.tenantId, tenant.id))
     .where(
       and(
-        eq(tenant.domain, domain),
+        eq(sql`lower(${tenant.domain})`, domain),
         eq(principal.kind, "user"),
         eq(principal.refId, localPart),
       ),
@@ -128,8 +133,8 @@ async function resolveUserPrincipalId(
   if (caseInsensitive.length > 1) {
     throw new Error(
       `resolveSenderKey: user sender ${localPart}@${domain} is ambiguous; it ` +
-        `matches multiple case-variant principals with no canonical row -- ` +
-        `case-variant tenant domains or refIds must be reconciled`,
+        `matches multiple principals with case-variant refIds and no canonical ` +
+        `row -- the colliding principal refIds must be reconciled`,
     );
   }
   const [only] = caseInsensitive;

--- a/packages/hub-api/src/routes/tenants.ts
+++ b/packages/hub-api/src/routes/tenants.ts
@@ -1,4 +1,4 @@
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
 
@@ -81,10 +81,16 @@ export function createTenantRoutes({
       const body = c.req.valid("json");
 
       const tenantId = generateId("tenant");
-      const domain = `${body.slug}.localhost`;
+      // Derive the domain from a lowercased slug and check the slug conflict
+      // case-insensitively. An inbound mail `From` is lowercased when parsed, so
+      // a sender address must map to exactly one tenant; `tenant_domain_lower_idx`
+      // enforces a unique `lower(domain)`. Normalizing here keeps a case-variant
+      // slug a clean 409 instead of a unique-violation 500, and stops a
+      // case-variant registration from shadowing another tenant's senders.
+      const domain = `${body.slug.toLowerCase()}.localhost`;
 
       const existing = await db.query.tenant.findFirst({
-        where: eq(tenant.slug, body.slug),
+        where: eq(sql`lower(${tenant.slug})`, body.slug.toLowerCase()),
       });
       if (existing) {
         return c.json(

--- a/packages/hub-api/src/routes/workflows.test.ts
+++ b/packages/hub-api/src/routes/workflows.test.ts
@@ -6,7 +6,10 @@ import git from "isomorphic-git";
 import { type, type Type } from "arktype";
 
 import { createInMemoryGrantStore, evaluateGrants } from "@intx/authz";
-import { WorkflowRunDispatchPayloadConflictError } from "@intx/db";
+import {
+  WorkflowRunDispatchPayloadConflictError,
+  type PrincipalKeyStore,
+} from "@intx/db";
 import { base64Decode, ErrorResponse, signalName } from "@intx/types";
 import type { GrantWalkSnapshot, SidecarAllocationStatus } from "@intx/types";
 import type { GrantRule } from "@intx/types/authz";
@@ -545,6 +548,25 @@ function createMockSessionService(): SessionService {
   };
 }
 
+function createMockPrincipalKeyStore(): PrincipalKeyStore {
+  function notImpl(name: string): never {
+    throw new Error(`mock: principalKeyStore.${name} not implemented`);
+  }
+  return {
+    // The trigger mints the run principal's key while materializing grants; the
+    // return value is not read, so a canned hex public key suffices.
+    generate: async () => "ab".repeat(32),
+    getPublicKey: () => notImpl("getPublicKey"),
+    // The trigger signs the outbound mail with the caller's principal key.
+    // This suite asserts route behavior (status, run.grants ordering, grant
+    // materialization), not signature validity, so return a fixed-length raw
+    // Ed25519 signature the PGP packet assembler accepts. A real caller key
+    // signing a verifiable message is covered by the run-mail-send integration
+    // test.
+    sign: async () => new Uint8Array(64),
+  };
+}
+
 type WorkflowDispatchEnqueue = Parameters<
   WorkflowDispatchService["enqueue"]
 >[0];
@@ -781,6 +803,7 @@ function createTestApp(opts: TestAppOpts = {}) {
     getSession: createMockGetSession(),
     authHandler: () => new Response("", { status: 404 }),
     db,
+    principalKeyStore: createMockPrincipalKeyStore(),
     grantStore: createInMemoryGrantStore(opts.grants ?? [makeGrant()]),
     sidecarRouter: createMockSidecarRouter(
       opts.signalCalls ?? [],

--- a/packages/hub-api/src/workflow-run-trigger.test.ts
+++ b/packages/hub-api/src/workflow-run-trigger.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect } from "bun:test";
+
+import { createWorkflowRunTrigger } from "./workflow-run-trigger";
+import type { PrincipalRow, TenantRow } from "./context";
+
+// The signing guard runs before any dependency is touched, so each dep is a
+// proxy that throws if execution ever reaches it. The deps object itself is a
+// real literal -- the factory destructures it, which reads the proxy VALUES
+// without accessing anything ON them; a trap only fires when the trigger later
+// uses a store or the db, which only a principal that PASSES the guard does.
+function unusedDep<T extends object>(label: string): T {
+  const trap = new Proxy(
+    {},
+    {
+      get() {
+        throw new Error(
+          `triggerWorkflowRun guard test: ${label} must not be used`,
+        );
+      },
+    },
+  );
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the guard throws before any dep is accessed; a structural mock of these rich store interfaces would be dead weight the test never exercises
+  return trap as T;
+}
+
+function makeTenant(): TenantRow {
+  const now = new Date("2025-01-01");
+  return {
+    id: "tnt_guard",
+    name: "guard",
+    slug: "guard",
+    domain: "guard.interchange",
+    parentId: null,
+    config: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function makePrincipal(kind: PrincipalRow["kind"]): PrincipalRow {
+  const now = new Date("2025-01-01");
+  return {
+    id: `prn_${kind}`,
+    tenantId: "tnt_guard",
+    kind,
+    refId: `ref_${kind}`,
+    status: "active",
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function makeTrigger() {
+  return createWorkflowRunTrigger({
+    db: unusedDep("db"),
+    principalKeyStore: unusedDep("principalKeyStore"),
+    grantStore: unusedDep("grantStore"),
+    sidecarRouter: unusedDep("sidecarRouter"),
+    repoStore: unusedDep("repoStore"),
+  });
+}
+
+describe("triggerWorkflowRun signing-principal guard", () => {
+  test("rejects a workflow-kind principal before any signing", async () => {
+    const trigger = makeTrigger();
+    await expect(
+      trigger({
+        tenant: makeTenant(),
+        principal: makePrincipal("workflow"),
+        userName: null,
+        anchorRunId: "run_guard",
+        message: { content: "hi" },
+      }),
+    ).rejects.toThrow(/only a user principal may originate hub-signed mail/);
+  });
+
+  test("rejects an agent-kind principal before any signing", async () => {
+    const trigger = makeTrigger();
+    await expect(
+      trigger({
+        tenant: makeTenant(),
+        principal: makePrincipal("agent"),
+        userName: null,
+        anchorRunId: "run_guard",
+        message: { content: "hi" },
+      }),
+    ).rejects.toThrow(/only a user principal may originate hub-signed mail/);
+  });
+
+  test("lets a user-kind principal past the guard into dependency use", async () => {
+    const trigger = makeTrigger();
+    // A user principal clears the guard and proceeds until it touches a dep;
+    // the first touch is the db read, which the proxy rejects. Asserting on the
+    // dep-use error (not the guard error) proves the guard gates ONLY non-user
+    // principals rather than rejecting every caller.
+    await expect(
+      trigger({
+        tenant: makeTenant(),
+        principal: makePrincipal("user"),
+        userName: null,
+        anchorRunId: "run_guard",
+        message: { content: "hi" },
+      }),
+    ).rejects.toThrow(/db must not be used/);
+  });
+});

--- a/packages/hub-api/src/workflow-run-trigger.ts
+++ b/packages/hub-api/src/workflow-run-trigger.ts
@@ -28,10 +28,9 @@ import type { GrantStore } from "@intx/types/authz";
 import {
   assembleSignedContent,
   assembleMessage,
-  createDetachedSignatureFromProvider,
   type MessageHeaders,
 } from "@intx/mime";
-import { generateKeyPair, createEd25519Crypto } from "@intx/crypto";
+import { createDetachedSignatureWithSigner } from "@intx/crypto";
 import {
   base64Encode,
   deriveWorkflowRunId,
@@ -143,6 +142,26 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
     args: TriggerWorkflowRunArgs,
   ): Promise<TriggerWorkflowRunResult> {
     const { tenant, principal, anchorRunId, message: body } = args;
+
+    // The outbound mail is signed with the caller's durable hub principal key,
+    // and its From address (`${principal.refId}@${tenant.domain}`) must resolve
+    // back to that same key when the signature is verified. Only a user
+    // principal's address resolves to its hub principal key; a run principal's
+    // address resolves to the sidecar-minted `workflow_run.public_key`, and an
+    // agent principal's address has no resolution surface, so signing here as a
+    // non-user principal would guarantee a verification mismatch. The route
+    // layer only ever admits user principals to this path, so this is an
+    // invariant assertion, not a client-facing rejection: fail loud if a wiring
+    // change ever lets another kind through, rather than silently emitting mail
+    // that verification cannot resolve. Revisit this fence if the resolver
+    // learns to resolve agent addresses.
+    if (principal.kind !== "user") {
+      throw new Error(
+        `triggerWorkflowRun: signing principal ${principal.id} has kind ` +
+          `${principal.kind}; only a user principal may originate hub-signed mail`,
+      );
+    }
+
     const address = deriveRunAddress({
       runId: anchorRunId,
       domain: tenant.domain,
@@ -369,8 +388,6 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
     // through sessionService.sendUserMessage because that path stamps
     // interchangeSessionId/agentId headers that scope the message to an
     // agent session; a workflow run trigger has no such session.
-    const keyPair = await generateKeyPair();
-    const crypto = createEd25519Crypto(keyPair);
     const headers: MessageHeaders = {
       from,
       to: [address],
@@ -398,9 +415,9 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
         ? { attachments: messageAttachments }
         : {}),
     });
-    const signature = await createDetachedSignatureFromProvider(
+    const signature = await createDetachedSignatureWithSigner(
       signedContent,
-      crypto,
+      (input) => principalKeyStore.sign(principal.id, input),
     );
     const rawMessage = assembleMessage(headers, signedContent, signature);
     const base64 = base64Encode(rawMessage);

--- a/packages/types/src/agent-address.test.ts
+++ b/packages/types/src/agent-address.test.ts
@@ -3,6 +3,7 @@ import { describe, test, expect } from "bun:test";
 import {
   formatRunAddress,
   isRunAddress,
+  parseAddress,
   parseRunAddress,
 } from "./agent-address";
 
@@ -11,6 +12,38 @@ describe("formatRunAddress", () => {
     expect(formatRunAddress("run_abc123", "tenant.example")).toBe(
       "run_abc123@tenant.example",
     );
+  });
+});
+
+describe("parseAddress", () => {
+  test("splits any local part from its domain without a prefix check", () => {
+    expect(parseAddress("usr_alice@tenant.example")).toEqual({
+      localPart: "usr_alice",
+      domain: "tenant.example",
+    });
+    expect(parseAddress("run_abc123@tenant.example")).toEqual({
+      localPart: "run_abc123",
+      domain: "tenant.example",
+    });
+  });
+
+  test("returns null when the @ is missing", () => {
+    expect(parseAddress("no-at-sign")).toBeNull();
+  });
+
+  test("returns null when the local part is empty", () => {
+    expect(parseAddress("@tenant.example")).toBeNull();
+  });
+
+  test("returns null when the domain part is empty", () => {
+    expect(parseAddress("usr_alice@")).toBeNull();
+  });
+
+  test("splits on the first @ and treats the rest as the domain", () => {
+    expect(parseAddress("usr_alice@foo@bar")).toEqual({
+      localPart: "usr_alice",
+      domain: "foo@bar",
+    });
   });
 });
 

--- a/packages/types/src/agent-address.ts
+++ b/packages/types/src/agent-address.ts
@@ -17,16 +17,30 @@ export function formatRunAddress(runId: string, domain: string): string {
   return `${runId}@${domain}`;
 }
 
+/**
+ * Split an `<local>@<domain>` address into its two halves, or `null` when it is
+ * not a well-formed address (no `@`, an empty local part, or an empty domain).
+ * The single owner of the `@`-split so a run address and any other address
+ * validate the same way; callers branch on the local part after this returns.
+ */
+export function parseAddress(
+  address: string,
+): { localPart: string; domain: string } | null {
+  const atIdx = address.indexOf("@");
+  if (atIdx <= 0) return null;
+  const localPart = address.slice(0, atIdx);
+  const domain = address.slice(atIdx + 1);
+  if (domain.length === 0) return null;
+  return { localPart, domain };
+}
+
 export function parseRunAddress(
   address: string,
 ): { runId: string; domain: string } | null {
-  const atIdx = address.indexOf("@");
-  if (atIdx <= 0) return null;
-  const runId = address.slice(0, atIdx);
-  const domain = address.slice(atIdx + 1);
-  if (!runId.startsWith(RUN_PREFIX)) return null;
-  if (domain.length === 0) return null;
-  return { runId, domain };
+  const parsed = parseAddress(address);
+  if (parsed === null) return null;
+  if (!parsed.localPart.startsWith(RUN_PREFIX)) return null;
+  return { runId: parsed.localPart, domain: parsed.domain };
 }
 
 export function isRunAddress(address: string): boolean {

--- a/tests/db/audit-sender-keys-driver.test.ts
+++ b/tests/db/audit-sender-keys-driver.test.ts
@@ -1,0 +1,132 @@
+// Drive `bin/audit-sender-keys.ts` as the operator runs it -- a real subprocess
+// against a seeded schema -- and assert its process contract: it exits non-zero
+// when a sender is unresolvable (so a pre-enforce gate actually fails), exits
+// zero when every sender resolves, and refuses to run without its encryption
+// key. A green-only test here would be worthless -- an unresolved sender that
+// still exits zero reads as "safe to enforce" -- so the exit-code assertion is
+// the point.
+
+import path from "node:path";
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { tenant as tenantTable } from "@intx/db/schema";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  loadHarnessDbConfig,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import { seedWorkflowRun } from "@intx/test-harness/seed";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "..", "..");
+// The audit never decrypts (it reads plaintext public keys), so any valid
+// 32-byte hex satisfies the env-key cipher the driver constructs.
+const ENCRYPTION_KEY = "ab".repeat(32);
+
+describe.skipIf(!harnessDbEnvAvailable())("audit-sender-keys driver", () => {
+  let h: TestDb;
+
+  beforeAll(async () => {
+    h = await createTestDb();
+  });
+
+  afterAll(async () => {
+    await h.close();
+  });
+
+  beforeEach(async () => {
+    await h.reset();
+  });
+
+  function driverEnv(
+    overrides: Record<string, string | undefined>,
+  ): Record<string, string> {
+    const cfg = loadHarnessDbConfig();
+    const base: Record<string, string | undefined> = {
+      ...process.env,
+      DB_HOST: cfg.host,
+      DB_PORT: String(cfg.port),
+      DB_NAME: cfg.database,
+      DB_USER: cfg.user,
+      DB_PASSWORD: cfg.password,
+      // Pin the subprocess to this test's isolated schema.
+      PG_SCHEMA: h.schema,
+      PRINCIPAL_KEY_ENCRYPTION_KEY: ENCRYPTION_KEY,
+      ...overrides,
+    };
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(base)) {
+      if (v !== undefined) env[k] = v;
+    }
+    return env;
+  }
+
+  async function runDriver(
+    overrides: Record<string, string | undefined> = {},
+  ): Promise<{ exitCode: number; output: string }> {
+    const proc = Bun.spawn(
+      [process.execPath, "--conditions=intx-src", "bin/audit-sender-keys.ts"],
+      {
+        cwd: REPO_ROOT,
+        env: driverEnv(overrides),
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    // The driver's structured log lines land on either stream depending on
+    // level, so read both and match the combined output.
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    const exitCode = await proc.exited;
+    return { exitCode, output: stdout + stderr };
+  }
+
+  test("exits zero when every sender resolves", async () => {
+    const { exitCode, output } = await runDriver();
+    expect(exitCode).toBe(0);
+    // Guard against a false pass: confirm the audit actually ran rather than
+    // dying early (which would also exit zero for a different reason).
+    expect(output).toContain("Audit complete");
+  });
+
+  test("exits non-zero when a sender is unresolvable", async () => {
+    await h.db.insert(tenantTable).values({
+      id: "tnt_driver",
+      name: "driver",
+      slug: "driver",
+      domain: "driver.localhost",
+      parentId: null,
+    });
+    // A live run carrying a sending address but no key: the genuine
+    // unresolvable-signed-sender hole the audit gates on.
+    await seedWorkflowRun(h.db, {
+      id: "run_driver_hole",
+      tenantId: "tnt_driver",
+      address: "run_driver_hole@driver.localhost",
+      publicKey: null,
+      status: "running",
+    });
+
+    const { exitCode, output } = await runDriver();
+    expect(exitCode).toBe(1);
+    expect(output).toContain("Unresolvable");
+  });
+
+  test("refuses to run without PRINCIPAL_KEY_ENCRYPTION_KEY", async () => {
+    const { exitCode, output } = await runDriver({
+      PRINCIPAL_KEY_ENCRYPTION_KEY: undefined,
+    });
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain("PRINCIPAL_KEY_ENCRYPTION_KEY");
+  });
+});

--- a/tests/db/sender-key-resolver.test.ts
+++ b/tests/db/sender-key-resolver.test.ts
@@ -148,61 +148,86 @@ describe.skipIf(!harnessDbEnvAvailable())("resolveSenderKey (real DB)", () => {
     ).toEqual({ source: "run", publicKey: RUN_PUBLIC_KEY });
   });
 
-  test("prefers the exact canonical row when a case-variant domain collides", async () => {
-    // Tenant domains are only case-sensitively unique, so a mixed-case variant
-    // can coexist with the canonical lowercase domain. Seed the WRONG (mixed)
-    // one first; the lowercased inbound address must still resolve to the
-    // canonical lowercase tenant's key, not an arbitrary colliding row.
-    await seedTenant("tnt_upper", "Acme.localhost");
+  test("prefers the exact canonical refId when a case-variant refId collides", async () => {
+    // A refId is a case-sensitively-unique betterAuth id that can carry
+    // uppercase, so two principals in one tenant can hold case-variant refIds.
+    // Seed the mixed-case variant first; the lowercased inbound address must
+    // still resolve to the exact (canonical lowercase) principal's key.
+    await seedTenant("tnt_case", "case.localhost");
     await seedPrincipal(h.db, {
-      id: "prn_upper",
-      tenantId: "tnt_upper",
+      id: "prn_variant",
+      tenantId: "tnt_case",
+      kind: "user",
+      refId: "USR_Alice",
+      status: "active",
+    });
+    await store.generate("prn_variant");
+    await seedPrincipal(h.db, {
+      id: "prn_exact",
+      tenantId: "tnt_case",
       kind: "user",
       refId: "usr_alice",
       status: "active",
     });
-    await store.generate("prn_upper");
+    const keyExact = await store.generate("prn_exact");
 
-    await seedTenant("tnt_lower", "acme.localhost");
+    expect(
+      await resolveSenderKey(h.db, store, "usr_alice@case.localhost"),
+    ).toEqual({ source: "user", publicKey: keyExact });
+  });
+
+  test("prefers the exact refId even when the tenant's stored domain is mixed-case", async () => {
+    // A legacy tenant whose stored domain was never lowercased (creation
+    // lowercases new ones; existing rows are left as stored). The exact-refId
+    // preference must still fire -- the domain is matched case-insensitively --
+    // so a mixed-case stored domain does not force the ambiguous ci fallback.
+    await seedTenant("tnt_legacy", "Acme.Localhost");
     await seedPrincipal(h.db, {
-      id: "prn_lower",
-      tenantId: "tnt_lower",
+      id: "prn_legacy_variant",
+      tenantId: "tnt_legacy",
+      kind: "user",
+      refId: "USR_Alice",
+      status: "active",
+    });
+    await store.generate("prn_legacy_variant");
+    await seedPrincipal(h.db, {
+      id: "prn_legacy_exact",
+      tenantId: "tnt_legacy",
       kind: "user",
       refId: "usr_alice",
       status: "active",
     });
-    const keyLower = await store.generate("prn_lower");
+    const keyExact = await store.generate("prn_legacy_exact");
 
     expect(
       await resolveSenderKey(h.db, store, "usr_alice@acme.localhost"),
-    ).toEqual({ source: "user", publicKey: keyLower });
+    ).toEqual({ source: "user", publicKey: keyExact });
   });
 
-  test("throws when a user address is ambiguous with no canonical row", async () => {
-    // Two case-variant domains, neither equal to the lowercased inbound address,
-    // so no canonical row disambiguates them. Rather than return an arbitrary
-    // tenant's key, resolution fails loud.
-    await seedTenant("tnt_v1", "Acme.localhost");
+  test("throws when a user address is ambiguous with no canonical refId", async () => {
+    // Two principals in one tenant with case-variant refIds, neither equal to
+    // the lowercased inbound localPart, so no canonical row disambiguates them.
+    // Rather than attribute the sender to an arbitrary principal, it fails loud.
+    await seedTenant("tnt_amb", "amb.localhost");
     await seedPrincipal(h.db, {
       id: "prn_v1",
-      tenantId: "tnt_v1",
+      tenantId: "tnt_amb",
       kind: "user",
-      refId: "usr_alice",
+      refId: "Usr_Alice",
       status: "active",
     });
     await store.generate("prn_v1");
-    await seedTenant("tnt_v2", "ACME.localhost");
     await seedPrincipal(h.db, {
       id: "prn_v2",
-      tenantId: "tnt_v2",
+      tenantId: "tnt_amb",
       kind: "user",
-      refId: "usr_alice",
+      refId: "USR_ALICE",
       status: "active",
     });
     await store.generate("prn_v2");
 
     await expect(
-      resolveSenderKey(h.db, store, "usr_alice@acme.localhost"),
+      resolveSenderKey(h.db, store, "usr_alice@amb.localhost"),
     ).rejects.toThrow(/ambiguous/);
   });
 

--- a/tests/db/sender-key-resolver.test.ts
+++ b/tests/db/sender-key-resolver.test.ts
@@ -1,0 +1,321 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import {
+  auditSenderKeys,
+  createPrincipalKeyStore,
+  resolveSenderKey,
+  type PrincipalKeyStore,
+} from "@intx/db";
+import { tenant as tenantTable } from "@intx/db/schema";
+import { createTestCredentialCipher } from "@intx/test-harness/crypto";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+import { seedPrincipal, seedWorkflowRun } from "@intx/test-harness/seed";
+
+const cipher = createTestCredentialCipher();
+const RUN_PUBLIC_KEY = "ab".repeat(32);
+
+describe.skipIf(!harnessDbEnvAvailable())("resolveSenderKey (real DB)", () => {
+  let h: TestDb;
+  let store: PrincipalKeyStore;
+
+  beforeAll(async () => {
+    h = await createTestDb();
+  });
+
+  afterAll(async () => {
+    await h.close();
+  });
+
+  beforeEach(async () => {
+    await h.reset();
+    store = createPrincipalKeyStore({ db: h.db, cipher });
+  });
+
+  async function seedTenant(id: string, domain: string): Promise<void> {
+    await h.db.insert(tenantTable).values({
+      id,
+      name: id,
+      slug: id,
+      domain,
+      parentId: null,
+    });
+  }
+
+  test("resolves a run address to the key recorded on its deployment anchor", async () => {
+    await seedTenant("tnt_run", "run.localhost");
+    const address = "run_deadbeef@run.localhost";
+    await seedWorkflowRun(h.db, {
+      id: "run_deadbeef",
+      tenantId: "tnt_run",
+      address,
+      publicKey: RUN_PUBLIC_KEY,
+      status: "running",
+    });
+
+    expect(await resolveSenderKey(h.db, store, address)).toEqual({
+      source: "run",
+      publicKey: RUN_PUBLIC_KEY,
+    });
+  });
+
+  test("returns null for a run whose deploy has not been acked yet", async () => {
+    await seedTenant("tnt_preack", "preack.localhost");
+    const address = "run_preack01@preack.localhost";
+    // A deployed-but-not-yet-acked anchor carries an address with a null
+    // public_key; that is the expected pre-ack state, not an error.
+    await seedWorkflowRun(h.db, {
+      id: "run_preack01",
+      tenantId: "tnt_preack",
+      address,
+      publicKey: null,
+      status: "deployed",
+    });
+
+    expect(await resolveSenderKey(h.db, store, address)).toBeNull();
+  });
+
+  test("returns null for an unknown run address", async () => {
+    expect(
+      await resolveSenderKey(h.db, store, "run_missing@nowhere.localhost"),
+    ).toBeNull();
+  });
+
+  test("resolves a user address to the principal's hub key", async () => {
+    await seedTenant("tnt_user", "user.localhost");
+    await seedPrincipal(h.db, {
+      id: "prn_user",
+      tenantId: "tnt_user",
+      kind: "user",
+      refId: "usr_alice",
+      status: "active",
+    });
+    const publicKey = await store.generate("prn_user");
+
+    expect(
+      await resolveSenderKey(h.db, store, "usr_alice@user.localhost"),
+    ).toEqual({ source: "user", publicKey });
+  });
+
+  test("returns null for an address that matches no user principal", async () => {
+    await seedTenant("tnt_nouser", "nouser.localhost");
+    expect(
+      await resolveSenderKey(h.db, store, "usr_ghost@nouser.localhost"),
+    ).toBeNull();
+  });
+
+  test("returns null for a malformed address", async () => {
+    expect(await resolveSenderKey(h.db, store, "no-at-sign")).toBeNull();
+    expect(await resolveSenderKey(h.db, store, "@empty-local")).toBeNull();
+    expect(await resolveSenderKey(h.db, store, "empty-domain@")).toBeNull();
+  });
+
+  test("matches the stored domain and refId case-insensitively", async () => {
+    // The stored domain derives from an unnormalized slug (mixed case), while an
+    // inbound From is lowercased when parsed. Resolution must still succeed.
+    await seedTenant("tnt_case", "Acme.Localhost");
+    await seedPrincipal(h.db, {
+      id: "prn_case",
+      tenantId: "tnt_case",
+      kind: "user",
+      refId: "USR_Case",
+      status: "active",
+    });
+    const publicKey = await store.generate("prn_case");
+    await seedWorkflowRun(h.db, {
+      id: "run_caseabc0",
+      tenantId: "tnt_case",
+      address: "run_caseabc0@Acme.Localhost",
+      publicKey: RUN_PUBLIC_KEY,
+      status: "running",
+    });
+
+    expect(
+      await resolveSenderKey(h.db, store, "usr_case@acme.localhost"),
+    ).toEqual({ source: "user", publicKey });
+    expect(
+      await resolveSenderKey(h.db, store, "run_caseabc0@acme.localhost"),
+    ).toEqual({ source: "run", publicKey: RUN_PUBLIC_KEY });
+  });
+
+  test("prefers the exact canonical row when a case-variant domain collides", async () => {
+    // Tenant domains are only case-sensitively unique, so a mixed-case variant
+    // can coexist with the canonical lowercase domain. Seed the WRONG (mixed)
+    // one first; the lowercased inbound address must still resolve to the
+    // canonical lowercase tenant's key, not an arbitrary colliding row.
+    await seedTenant("tnt_upper", "Acme.localhost");
+    await seedPrincipal(h.db, {
+      id: "prn_upper",
+      tenantId: "tnt_upper",
+      kind: "user",
+      refId: "usr_alice",
+      status: "active",
+    });
+    await store.generate("prn_upper");
+
+    await seedTenant("tnt_lower", "acme.localhost");
+    await seedPrincipal(h.db, {
+      id: "prn_lower",
+      tenantId: "tnt_lower",
+      kind: "user",
+      refId: "usr_alice",
+      status: "active",
+    });
+    const keyLower = await store.generate("prn_lower");
+
+    expect(
+      await resolveSenderKey(h.db, store, "usr_alice@acme.localhost"),
+    ).toEqual({ source: "user", publicKey: keyLower });
+  });
+
+  test("throws when a user address is ambiguous with no canonical row", async () => {
+    // Two case-variant domains, neither equal to the lowercased inbound address,
+    // so no canonical row disambiguates them. Rather than return an arbitrary
+    // tenant's key, resolution fails loud.
+    await seedTenant("tnt_v1", "Acme.localhost");
+    await seedPrincipal(h.db, {
+      id: "prn_v1",
+      tenantId: "tnt_v1",
+      kind: "user",
+      refId: "usr_alice",
+      status: "active",
+    });
+    await store.generate("prn_v1");
+    await seedTenant("tnt_v2", "ACME.localhost");
+    await seedPrincipal(h.db, {
+      id: "prn_v2",
+      tenantId: "tnt_v2",
+      kind: "user",
+      refId: "usr_alice",
+      status: "active",
+    });
+    await store.generate("prn_v2");
+
+    await expect(
+      resolveSenderKey(h.db, store, "usr_alice@acme.localhost"),
+    ).rejects.toThrow(/ambiguous/);
+  });
+
+  test("throws for a user principal with no active key", async () => {
+    await seedTenant("tnt_keyless", "keyless.localhost");
+    await seedPrincipal(h.db, {
+      id: "prn_keyless",
+      tenantId: "tnt_keyless",
+      kind: "user",
+      refId: "usr_keyless",
+      status: "active",
+    });
+    // The principal exists but was never minted a key -- an INTR-164 invariant
+    // break -- so resolution fails loudly rather than returning null.
+    await expect(
+      resolveSenderKey(h.db, store, "usr_keyless@keyless.localhost"),
+    ).rejects.toThrow(/no active key/);
+  });
+
+  test("audit: reports no unresolved senders when every sender has a key", async () => {
+    // Stand up a mixed population of senders that COULD sign -- two acked runs,
+    // one deployed-but-not-yet-acked run (the legitimate address-set, key-null
+    // row), and two active user principals across a lower- and a mixed-case
+    // domain -- then sweep. The bin/ audit runs this same sweep against live
+    // data; here it runs against seeds.
+    await seedTenant("tnt_a", "a.localhost");
+    await seedTenant("tnt_b", "B.Localhost");
+
+    await seedPrincipal(h.db, {
+      id: "prn_a1",
+      tenantId: "tnt_a",
+      kind: "user",
+      refId: "usr_a1",
+      status: "active",
+    });
+    await store.generate("prn_a1");
+    await seedPrincipal(h.db, {
+      id: "prn_b1",
+      tenantId: "tnt_b",
+      kind: "user",
+      refId: "usr_b1",
+      status: "active",
+    });
+    await store.generate("prn_b1");
+
+    await seedWorkflowRun(h.db, {
+      id: "run_a1",
+      tenantId: "tnt_a",
+      address: "run_a1@a.localhost",
+      publicKey: RUN_PUBLIC_KEY,
+      status: "running",
+    });
+    await seedWorkflowRun(h.db, {
+      id: "run_a2",
+      tenantId: "tnt_a",
+      address: "run_a2@a.localhost",
+      publicKey: RUN_PUBLIC_KEY,
+      status: "completed",
+    });
+    await seedWorkflowRun(h.db, {
+      id: "run_a3",
+      tenantId: "tnt_a",
+      address: "run_a3@a.localhost",
+      publicKey: null,
+      status: "deployed",
+    });
+
+    const report = await auditSenderKeys(h.db, store);
+    // The pre-ack run (run_a3) is excluded from the sweep, so two runs and two
+    // users are checked and none is unresolvable.
+    expect(report).toEqual({
+      runsChecked: 2,
+      usersChecked: 2,
+      unresolved: [],
+    });
+  });
+
+  test("audit: reports a signing sender that has no durable key", async () => {
+    await seedTenant("tnt_hole", "hole.localhost");
+    // A run past the pre-ack window whose key was never recorded: the exact
+    // unresolvable-signed-sender hole the audit exists to find.
+    await seedWorkflowRun(h.db, {
+      id: "run_hole",
+      tenantId: "tnt_hole",
+      address: "run_hole@hole.localhost",
+      publicKey: null,
+      status: "running",
+    });
+
+    const report = await auditSenderKeys(h.db, store);
+    expect(report.unresolved).toEqual([
+      { address: "run_hole@hole.localhost", kind: "run" },
+    ]);
+  });
+
+  test("audit: ignores a run that failed before its deploy was acked", async () => {
+    await seedTenant("tnt_failed", "failed.localhost");
+    // A deploy that fails before ack flips the anchor deployed -> failed while
+    // the public key is still null and the address is kept. It never signed, so
+    // the audit must NOT flag it -- the boundary is not merely "past deployed".
+    await seedWorkflowRun(h.db, {
+      id: "run_failedanchor",
+      tenantId: "tnt_failed",
+      address: "run_failedanchor@failed.localhost",
+      publicKey: null,
+      status: "failed",
+    });
+
+    const report = await auditSenderKeys(h.db, store);
+    expect(report).toEqual({
+      runsChecked: 0,
+      usersChecked: 0,
+      unresolved: [],
+    });
+  });
+});

--- a/tests/db/tenant-domain-unique.test.ts
+++ b/tests/db/tenant-domain-unique.test.ts
@@ -1,0 +1,62 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { tenant as tenantTable } from "@intx/db/schema";
+import {
+  createTestDb,
+  harnessDbEnvAvailable,
+  type TestDb,
+} from "@intx/test-harness/db-harness";
+
+describe.skipIf(!harnessDbEnvAvailable())("tenant domain uniqueness", () => {
+  let h: TestDb;
+
+  beforeAll(async () => {
+    h = await createTestDb();
+  });
+
+  afterAll(async () => {
+    await h.close();
+  });
+
+  beforeEach(async () => {
+    await h.reset();
+  });
+
+  async function insertTenant(id: string, domain: string): Promise<void> {
+    await h.db.insert(tenantTable).values({
+      id,
+      name: id,
+      slug: id,
+      domain,
+      parentId: null,
+    });
+  }
+
+  test("rejects a second tenant whose domain differs only in case", async () => {
+    // An inbound mail `From` is lowercased when parsed, so two case-variant
+    // domains would collapse to one sender address. `tenant_domain_lower_idx`
+    // makes `lower(domain)` unique so they cannot both exist -- otherwise a
+    // case-variant registration could shadow another tenant's senders.
+    await insertTenant("tnt_a", "acme.localhost");
+    await expect(insertTenant("tnt_b", "ACME.localhost")).rejects.toThrow();
+  });
+
+  test("still rejects an exact duplicate domain", async () => {
+    await insertTenant("tnt_a", "acme.localhost");
+    await expect(insertTenant("tnt_b", "acme.localhost")).rejects.toThrow();
+  });
+
+  test("allows distinct domains", async () => {
+    await insertTenant("tnt_a", "acme.localhost");
+    await insertTenant("tnt_b", "beta.localhost");
+    const rows = await h.db.select().from(tenantTable);
+    expect(rows).toHaveLength(2);
+  });
+});

--- a/tests/hub-api/tenant-create-slug.test.ts
+++ b/tests/hub-api/tenant-create-slug.test.ts
@@ -1,0 +1,68 @@
+// The tenant-create route normalizes case so a mail sender (whose From is
+// lowercased when parsed) maps to exactly one tenant: it derives the domain from
+// a lowercased slug and rejects a case-variant slug as a clean 409 rather than
+// letting the `lower(domain)` unique index surface a 500. Driven against a real
+// spawned hub through the production HTTP route.
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  harnessHubEnvAvailable,
+  startHub,
+  type HubHandle,
+} from "./lib/git-harness";
+import { apiCall, signUpUser } from "./lib/git-asset-fixtures";
+
+const stops: (() => Promise<void>)[] = [];
+
+afterEach(async () => {
+  for (const stop of stops.splice(0)) {
+    await stop();
+  }
+});
+
+async function startHubTracked(): Promise<HubHandle> {
+  const hub = await startHub();
+  stops.push(hub.stop);
+  return hub;
+}
+
+describe.skipIf(!harnessHubEnvAvailable())(
+  "tenant create slug case-insensitivity",
+  () => {
+    test("lowercases the domain and rejects a case-variant slug with 409", async () => {
+      const hub = await startHubTracked();
+      const user = await signUpUser(hub.url);
+
+      const created = await apiCall(
+        hub.url,
+        "POST",
+        "/api/tenants",
+        { name: "Acme", slug: "AcmeCiTest" },
+        user.cookies,
+      );
+      expect(created.status).toBe(201);
+      const body = created.data;
+      if (typeof body !== "object" || body === null) {
+        throw new Error(`unexpected create body: ${JSON.stringify(body)}`);
+      }
+      // The slug is stored as provided; the domain is derived from a lowercased
+      // slug so a lowercased sender address resolves to it.
+      expect(body).toMatchObject({
+        slug: "AcmeCiTest",
+        domain: "acmecitest.localhost",
+      });
+
+      // A slug differing only in case collides on lower(slug): a clean 409, not
+      // a 500 from the lower(domain) unique-index violation.
+      const conflict = await apiCall(
+        hub.url,
+        "POST",
+        "/api/tenants",
+        { name: "Acme Two", slug: "acmecitest" },
+        user.cookies,
+      );
+      expect(conflict.status).toBe(409);
+    });
+  },
+);

--- a/tests/lib/seed.ts
+++ b/tests/lib/seed.ts
@@ -8,8 +8,10 @@
 // assertions actually depend on.
 
 import type { DB } from "@intx/db";
+import { createPrincipalKeyStore } from "@intx/db";
 import type { WorkflowRunCredentialRefs } from "@intx/db/schema";
 import type { GrantWalkSnapshot } from "@intx/types";
+import { createNoopCredentialCipher } from "@intx/crypto";
 import {
   asset,
   credential,
@@ -111,6 +113,28 @@ export async function seedPrincipal(db: Db, p: SeedPrincipal): Promise<void> {
     refId: p.refId ?? p.id,
     status: p.status ?? "active",
   });
+}
+
+/**
+ * Mint the active `principal_key` a principal carries in production. INTR-164
+ * mints a key in the same transaction a principal is created, so every real
+ * principal has one; `seedPrincipal` inserts the row directly and bypasses that
+ * path, so a fixture whose principal must SIGN (for example, the caller of a
+ * hub-originated mail trigger) mints the key explicitly here. Seals the seed
+ * with the noop cipher -- the same fallback `createApp` uses when no
+ * `PRINCIPAL_KEY_ENCRYPTION_KEY` is configured -- so the app's key store reads
+ * it back. Returns the hex-encoded public key so a test can verify signatures
+ * against it. The principal row must already exist.
+ */
+export async function seedPrincipalKey(
+  db: Db,
+  principalId: string,
+): Promise<string> {
+  const keyStore = createPrincipalKeyStore({
+    db,
+    cipher: createNoopCredentialCipher(),
+  });
+  return keyStore.generate(principalId);
 }
 
 export type SeedProvider = {

--- a/tests/workflow-deploy/mail-federation-derived-grants-roundtrip.test.ts
+++ b/tests/workflow-deploy/mail-federation-derived-grants-roundtrip.test.ts
@@ -91,6 +91,7 @@ import {
   seedAsset,
   seedGrant,
   seedPrincipal,
+  seedPrincipalKey,
   seedWorkflowDefinitionVersion,
 } from "@intx/test-harness/seed";
 import { defineWorkflow, step, type WorkflowDefinition } from "@intx/workflow";
@@ -308,6 +309,10 @@ describe.skipIf(!harnessDbEnvAvailable())(
         refId: CALLER_USER_ID,
         status: "active",
       });
+      // The caller signs the trigger mail with its durable hub principal key,
+      // which production mints at principal creation; the direct row insert
+      // above bypasses that, so mint it here or the trigger's sign() throws.
+      await seedPrincipalKey(h.db, CALLER_PRINCIPAL_ID);
       await seedPrincipal(h.db, {
         id: CREATOR_PRINCIPAL_ID,
         tenantId: TENANT_ID,

--- a/tests/workflow-deploy/mail-trigger-derived-grants-roundtrip.test.ts
+++ b/tests/workflow-deploy/mail-trigger-derived-grants-roundtrip.test.ts
@@ -85,7 +85,12 @@ import {
   harnessDbEnvAvailable,
   type TestDb,
 } from "@intx/test-harness/db-harness";
-import { seedAsset, seedGrant, seedPrincipal } from "@intx/test-harness/seed";
+import {
+  seedAsset,
+  seedGrant,
+  seedPrincipal,
+  seedPrincipalKey,
+} from "@intx/test-harness/seed";
 import { deriveRunAddress, type ApprovalSet } from "@intx/workflow-deploy";
 
 import {
@@ -261,6 +266,10 @@ describe.skipIf(!harnessDbEnvAvailable())(
         refId: CALLER_USER_ID,
         status: "active",
       });
+      // The caller signs the trigger mail with its durable hub principal key,
+      // which production mints at principal creation; the direct row insert
+      // above bypasses that, so mint it here or the trigger's sign() throws.
+      await seedPrincipalKey(h.db, CALLER_PRINCIPAL_ID);
       // The `workflow`-kind asset the frozen definition projects over. The
       // deploy freeze writes a `workflow_definition` over this asset, and the
       // trigger route reads this asset row to hydrate.

--- a/tests/workflow-deploy/mail-trigger-run-completes-real-route.test.ts
+++ b/tests/workflow-deploy/mail-trigger-run-completes-real-route.test.ts
@@ -54,7 +54,12 @@ import {
   harnessDbEnvAvailable,
   type TestDb,
 } from "@intx/test-harness/db-harness";
-import { seedAsset, seedGrant, seedPrincipal } from "@intx/test-harness/seed";
+import {
+  seedAsset,
+  seedGrant,
+  seedPrincipal,
+  seedPrincipalKey,
+} from "@intx/test-harness/seed";
 import { deriveRunAddress } from "@intx/workflow-deploy";
 
 import {
@@ -189,6 +194,10 @@ describe.skipIf(!harnessDbEnvAvailable())(
         refId: CALLER_USER_ID,
         status: "active",
       });
+      // The caller signs the trigger mail with its durable hub principal key,
+      // which production mints at principal creation; the direct row insert
+      // above bypasses that, so mint it here or the trigger's sign() throws.
+      await seedPrincipalKey(h.db, CALLER_PRINCIPAL_ID);
       await seedAsset(h.db, {
         id: DEFINITION_ASSET_ID,
         tenantId: TENANT_ID,

--- a/tests/workflow-deploy/run-mail-send-real-route.test.ts
+++ b/tests/workflow-deploy/run-mail-send-real-route.test.ts
@@ -32,14 +32,28 @@ import {
   createAssetService,
   type EventCollectorRegistry,
   type SessionService,
+  type SidecarRouter,
 } from "@intx/hub-sessions";
+import {
+  parseHeaderSection,
+  parseMimePart,
+  parseMultipart,
+  extractBoundary,
+} from "@intx/mime";
+import { verifyDetachedSignature } from "@intx/crypto";
+import { base64Decode, hexDecode } from "@intx/types";
 import type { HarnessConfig, InferenceSource } from "@intx/types/runtime";
 import {
   createTestDb,
   harnessDbEnvAvailable,
   type TestDb,
 } from "@intx/test-harness/db-harness";
-import { seedAsset, seedGrant, seedPrincipal } from "@intx/test-harness/seed";
+import {
+  seedAsset,
+  seedGrant,
+  seedPrincipal,
+  seedPrincipalKey,
+} from "@intx/test-harness/seed";
 import { deriveRunAddress } from "@intx/workflow-deploy";
 
 import {
@@ -79,6 +93,7 @@ const TriggerResponse = type({
 
 let env: DeployFlowEnv;
 let h: TestDb;
+let callerPublicKey = "";
 
 function createMockGetSession(userId: string): GetSession {
   const now = new Date("2025-01-01");
@@ -156,6 +171,11 @@ describe.skipIf(!harnessDbEnvAvailable())(
         refId: CALLER_USER_ID,
         status: "active",
       });
+      // The caller signs the trigger mail with its durable hub principal key,
+      // which production mints at principal creation; the direct row insert
+      // above bypasses that, so mint it here or the trigger's sign() throws.
+      // The returned public key anchors the outbound-signature assertion below.
+      callerPublicKey = await seedPrincipalKey(h.db, CALLER_PRINCIPAL_ID);
       await seedAsset(h.db, {
         id: DEFINITION_ASSET_ID,
         tenantId: TENANT_ID,
@@ -249,12 +269,23 @@ describe.skipIf(!harnessDbEnvAvailable())(
         db: h.db,
         repoStore: env.hub.agentRepoStore.repoStore,
       });
+      // Capture the base64 the trigger hands to routeMail so the outbound
+      // signature can be verified, while still delegating to the real router so
+      // the send reaches the sidecar and the reconciliation assertions hold.
+      let capturedMail: string | undefined;
+      const capturingRouter: SidecarRouter = {
+        ...env.hub.router,
+        routeMail(agentAddress, rawMessage, messageId) {
+          capturedMail = rawMessage;
+          return env.hub.router.routeMail(agentAddress, rawMessage, messageId);
+        },
+      };
       const runApp = createApp({
         getSession: createMockGetSession(CALLER_USER_ID),
         authHandler: () => new Response("", { status: 404 }),
         db: h.db,
         grantStore,
-        sidecarRouter: env.hub.router,
+        sidecarRouter: capturingRouter,
         sessionService: createMockSessionService(),
         eventCollectors: createMockEventCollectors(),
         assetService,
@@ -288,6 +319,40 @@ describe.skipIf(!harnessDbEnvAvailable())(
       expect(runRows).toHaveLength(1);
       expect(runRows[0]?.id).toBe(DEPLOYMENT_ID);
       expect(runRows[0]?.anchorRunId).toBe(DEPLOYMENT_ID);
+
+      // The trigger signs hub-originated mail with the caller's durable hub
+      // principal key: the outbound message's detached signature verifies
+      // against the caller principal's public key, not a per-call throwaway
+      // key, so a user sender resolves to the key that signed its mail.
+      if (capturedMail === undefined) {
+        throw new Error("routeMail was not called; no outbound mail captured");
+      }
+      const rawMail = base64Decode(capturedMail);
+      const { headers, bodyOffset } = parseHeaderSection(rawMail);
+      const contentType = headers.get("content-type");
+      if (contentType === undefined) {
+        throw new Error("captured mail has no content-type header");
+      }
+      const boundary = extractBoundary(contentType);
+      if (!boundary) {
+        throw new Error("captured mail has no multipart boundary");
+      }
+      const parts = parseMultipart(rawMail.slice(bodyOffset), boundary);
+      expect(parts).toHaveLength(2);
+      const signedPart = parts[0];
+      const signaturePart = parts[1];
+      if (signedPart === undefined || signaturePart === undefined) {
+        throw new Error(
+          "captured mail is not a two-part multipart/signed body",
+        );
+      }
+      const parsedSignature = parseMimePart(signaturePart);
+      const verified = await verifyDetachedSignature(
+        signedPart,
+        parsedSignature.body,
+        hexDecode(callerPublicKey),
+      );
+      expect(verified).toBe(true);
     });
   },
 );

--- a/tests/workflow-deploy/scope-always-roundtrip.test.ts
+++ b/tests/workflow-deploy/scope-always-roundtrip.test.ts
@@ -107,7 +107,12 @@ import {
   harnessDbEnvAvailable,
   type TestDb,
 } from "@intx/test-harness/db-harness";
-import { seedAsset, seedGrant, seedPrincipal } from "@intx/test-harness/seed";
+import {
+  seedAsset,
+  seedGrant,
+  seedPrincipal,
+  seedPrincipalKey,
+} from "@intx/test-harness/seed";
 import { deriveRunAddress, type ApprovalSet } from "@intx/workflow-deploy";
 import { deriveDeploymentId } from "@intx/sidecar-app/src/workflow-host-wiring";
 
@@ -565,6 +570,10 @@ describe.skipIf(!harnessDbEnvAvailable())(
         refId: OPERATOR_USER_ID,
         status: "active",
       });
+      // The operator signs the trigger mail with its durable hub principal key,
+      // which production mints at principal creation; the direct row insert
+      // above bypasses that, so mint it here or the trigger's sign() throws.
+      await seedPrincipalKey(h.db, OPERATOR_PRINCIPAL_ID);
       await seedAsset(h.db, {
         id: DEFINITION_ASSET_ID,
         tenantId: TENANT_ID,


### PR DESCRIPTION
## Summary

- The workflow-run trigger — which carries both deployment triggers and user mail — signs its outbound message with the caller's hub-custodied principal key instead of a per-call throwaway key, binding each sender to a durable identity a verifier can resolve.
- A read-only resolver maps a sender's From address to the durable public key its signature must verify against (a run address to its deployment anchor's key, a user address to the sender's principal key); a `bin/` sweep audits that no signable sender is unresolvable. Nothing consumes the resolver yet.
- Tenant domains become case-insensitively unique (a `lower(domain)` unique index plus lowercase-at-creation), so a lowercased sender maps to exactly one tenant and cannot be shadowed by a case-variant registration.

## Verification

- `make all` passes: build, lint, and all three test passes green (unit 7290, workflow 178, core 736; 0 failures), including dedicated resolver, tenant-uniqueness, and trigger-guard suites.
- A whole-branch security review found no defects: no sender resolves to a wrong or cross-tenant key, ambiguous matches fail closed (never an arbitrary key), and the migration aborts rather than half-applying if legacy data collides.

Closes INTR-511