### PR TITLE
Carry a hub-verified sender address on every inbound mail frame

### DIFF
--- a/packages/db/migrations/0091_workflow_run_dispatch_sender_address.sql
+++ b/packages/db/migrations/0091_workflow_run_dispatch_sender_address.sql
@@ -1,0 +1,21 @@
+ALTER TABLE "workflow_run_dispatch" ADD COLUMN "sender_address" text;--> statement-breakpoint
+-- Fail in-flight mail dispatches that predate the authenticated-sender
+-- requirement. They carry no persisted hub-verified sender, and neither
+-- fabricating one nor re-reading the signed From is permitted, so they are
+-- failed in place rather than delivered unauthenticated. Only unsettled
+-- (pending/acknowledged) mail rows are ever re-dispatched and reconstruct a
+-- mail.inbound frame; terminal (settled/failed) mail rows never do, so they
+-- keep their NULL sender under the status-scoped check below. On a fresh
+-- database this affects zero rows.
+UPDATE "workflow_run_dispatch"
+SET "status" = 'failed',
+	"failure_code" = 'sender_address_migration',
+	"failure_message" = 'in-flight mail dispatch predates the authenticated-sender requirement and carries no hub-verified sender',
+	"next_attempt_at" = NULL,
+	"delivery_lease_id" = NULL,
+	"delivery_lease_expires_at" = NULL,
+	"updated_at" = now()
+WHERE "kind" = 'mail'
+	AND "status" IN ('pending', 'acknowledged')
+	AND "sender_address" IS NULL;--> statement-breakpoint
+ALTER TABLE "workflow_run_dispatch" ADD CONSTRAINT "workflow_run_dispatch_mail_sender_check" CHECK ("workflow_run_dispatch"."kind" <> 'mail' or "workflow_run_dispatch"."status" in ('settled', 'failed') or "workflow_run_dispatch"."sender_address" is not null);

--- a/packages/db/migrations/meta/0091_snapshot.json
+++ b/packages/db/migrations/meta/0091_snapshot.json
@@ -1,0 +1,4397 @@
+{
+  "id": "56e38751-4533-4edb-b2c2-486e735d9332",
+  "prevId": "653888de-540b-4acb-bb53-e1b58089bba9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.federation_trust": {
+      "name": "federation_trust",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_tenant_id": {
+          "name": "target_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "federation_trust_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "federation_trust_target_tenant_id_tenant_id_fk": {
+          "name": "federation_trust_target_tenant_id_tenant_id_fk",
+          "tableFrom": "federation_trust",
+          "tableTo": "tenant",
+          "columnsFrom": ["target_tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federation_trust_tenant_id_target_tenant_id_unique": {
+          "name": "federation_trust_tenant_id_target_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "target_tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant": {
+      "name": "tenant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenant_domain_lower_idx": {
+          "name": "tenant_domain_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_parent_id_tenant_id_fk": {
+          "name": "tenant_parent_id_tenant_id_fk",
+          "tableFrom": "tenant",
+          "tableTo": "tenant",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_slug_unique": {
+          "name": "tenant_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal": {
+      "name": "principal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_tenant_id_tenant_id_fk": {
+          "name": "principal_tenant_id_tenant_id_fk",
+          "tableFrom": "principal",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "principal_tenant_id_kind_ref_id_unique": {
+          "name": "principal_tenant_id_kind_ref_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "kind", "ref_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal_key": {
+      "name": "principal_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principal_key_one_active": {
+          "name": "principal_key_one_active",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"principal_key\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principal_key_principal_id_principal_id_fk": {
+          "name": "principal_key_principal_id_principal_id_fk",
+          "tableFrom": "principal_key",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "principal_key_public_key_unique": {
+          "name": "principal_key_public_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["public_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_role": {
+      "name": "agent_role",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_role_agent_id_workflow_definition_id_fk": {
+          "name": "agent_role_agent_id_workflow_definition_id_fk",
+          "tableFrom": "agent_role",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_role_role_id_role_id_fk": {
+          "name": "agent_role_role_id_role_id_fk",
+          "tableFrom": "agent_role",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_role_agent_id_role_id_pk": {
+          "name": "agent_role_agent_id_role_id_pk",
+          "columns": ["agent_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal_role": {
+      "name": "principal_role",
+      "schema": "",
+      "columns": {
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "principal_role_principal_id_principal_id_fk": {
+          "name": "principal_role_principal_id_principal_id_fk",
+          "tableFrom": "principal_role",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "principal_role_role_id_role_id_fk": {
+          "name": "principal_role_role_id_role_id_fk",
+          "tableFrom": "principal_role",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "principal_role_principal_id_role_id_pk": {
+          "name": "principal_role_principal_id_role_id_pk",
+          "columns": ["principal_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_tenant_id_tenant_id_fk": {
+          "name": "role_tenant_id_tenant_id_fk",
+          "tableFrom": "role",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grant": {
+      "name": "grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grant_tenant_id_tenant_id_fk": {
+          "name": "grant_tenant_id_tenant_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grant_role_id_role_id_fk": {
+          "name": "grant_role_id_role_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "role",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "grant_principal_id_principal_id_fk": {
+          "name": "grant_principal_id_principal_id_fk",
+          "tableFrom": "grant",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "grant_target_exactly_one": {
+          "name": "grant_target_exactly_one",
+          "value": "num_nonnulls(\"grant\".\"principal_id\", \"grant\".\"role_id\") = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.approval": {
+      "name": "approval",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_address": {
+          "name": "agent_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_definition": {
+          "name": "tool_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_arguments": {
+          "name": "tool_arguments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "timeout_at": {
+          "name": "timeout_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approval_tenant_status_idx": {
+          "name": "approval_tenant_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_anchor_run_idx": {
+          "name": "approval_anchor_run_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_run_idx": {
+          "name": "approval_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_tenant_id_tenant_id_fk": {
+          "name": "approval_tenant_id_tenant_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_anchor_run_id_workflow_run_id_fk": {
+          "name": "approval_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_run_id_workflow_run_id_fk": {
+          "name": "approval_run_id_workflow_run_id_fk",
+          "tableFrom": "approval",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approval_correlation_id_unique": {
+          "name": "approval_correlation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["correlation_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_correlation": {
+      "name": "signal_correlation",
+      "schema": "",
+      "columns": {
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_address": {
+          "name": "agent_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_name": {
+          "name": "signal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_id": {
+          "name": "signal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signal_correlation_tenant_id_tenant_id_fk": {
+          "name": "signal_correlation_tenant_id_tenant_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signal_correlation_anchor_run_id_workflow_run_id_fk": {
+          "name": "signal_correlation_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signal_correlation_run_id_workflow_run_id_fk": {
+          "name": "signal_correlation_run_id_workflow_run_id_fk",
+          "tableFrom": "signal_correlation",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_info_url": {
+          "name": "user_info_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_tenant_id_tenant_id_fk": {
+          "name": "provider_tenant_id_tenant_id_fk",
+          "tableFrom": "provider",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_tenant_name": {
+          "name": "provider_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_scopes": {
+          "name": "default_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_tenant_id_tenant_id_fk": {
+          "name": "oauth_client_tenant_id_tenant_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_client_provider_id_provider_id_fk": {
+          "name": "oauth_client_provider_id_provider_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_tenant_provider": {
+          "name": "oauth_client_tenant_provider",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "provider_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credential": {
+      "name": "credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_secret": {
+          "name": "refresh_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credential_tenant_id_tenant_id_fk": {
+          "name": "credential_tenant_id_tenant_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_principal_id_principal_id_fk": {
+          "name": "credential_principal_id_principal_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credential_provider_id_provider_id_fk": {
+          "name": "credential_provider_id_provider_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_oauth_client_id_oauth_client_id_fk": {
+          "name": "credential_oauth_client_id_oauth_client_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["oauth_client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "credential_tenant_name": {
+          "name": "credential_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset": {
+      "name": "asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_tenant_id_tenant_id_fk": {
+          "name": "asset_tenant_id_tenant_id_fk",
+          "tableFrom": "asset",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "asset_creator_principal_id_principal_id_fk": {
+          "name": "asset_creator_principal_id_principal_id_fk",
+          "tableFrom": "asset",
+          "tableTo": "principal",
+          "columnsFrom": ["creator_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_tenant_kind_name": {
+          "name": "asset_tenant_kind_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "kind", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_wallet_id_wallet_id_fk": {
+          "name": "transaction_wallet_id_wallet_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_run_id_workflow_run_id_fk": {
+          "name": "transaction_run_id_workflow_run_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet": {
+      "name": "wallet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend_type": {
+          "name": "backend_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallet_tenant_id_tenant_id_fk": {
+          "name": "wallet_tenant_id_tenant_id_fk",
+          "tableFrom": "wallet",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offering": {
+      "name": "offering",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "offering_agent_id_workflow_definition_id_fk": {
+          "name": "offering_agent_id_workflow_definition_id_fk",
+          "tableFrom": "offering",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "offering_tenant_id_tenant_id_fk": {
+          "name": "offering_tenant_id_tenant_id_fk",
+          "tableFrom": "offering",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model": {
+      "name": "model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_tenant_id_tenant_id_fk": {
+          "name": "model_tenant_id_tenant_id_fk",
+          "tableFrom": "model",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_tenant_canonical_name": {
+          "name": "model_tenant_canonical_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "canonical_name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_offering": {
+      "name": "model_offering",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_tags": {
+          "name": "deployment_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "quirks": {
+          "name": "quirks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_offering_tenant_id_tenant_id_fk": {
+          "name": "model_offering_tenant_id_tenant_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_offering_model_id_model_id_fk": {
+          "name": "model_offering_model_id_model_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_offering_provider_id_model_provider_id_fk": {
+          "name": "model_offering_provider_id_model_provider_id_fk",
+          "tableFrom": "model_offering",
+          "tableTo": "model_provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_offering_tenant_model_provider": {
+          "name": "model_offering_tenant_model_provider",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "model_id", "provider_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_pricing": {
+      "name": "model_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offering_id": {
+          "name": "offering_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_token_price": {
+          "name": "input_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_token_price": {
+          "name": "output_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_token_price": {
+          "name": "cache_read_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_write_token_price": {
+          "name": "cache_write_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thinking_token_price": {
+          "name": "thinking_token_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_request_fee": {
+          "name": "per_request_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_image_fee": {
+          "name": "per_image_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_audio_fee": {
+          "name": "per_audio_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_pricing_tenant_id_tenant_id_fk": {
+          "name": "model_pricing_tenant_id_tenant_id_fk",
+          "tableFrom": "model_pricing",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_pricing_offering_id_model_offering_id_fk": {
+          "name": "model_pricing_offering_id_model_offering_id_fk",
+          "tableFrom": "model_pricing",
+          "tableTo": "model_offering",
+          "columnsFrom": ["offering_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_pricing_offering_currency_effective_from": {
+          "name": "model_pricing_offering_currency_effective_from",
+          "nullsNotDistinct": false,
+          "columns": ["offering_id", "currency", "effective_from"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider": {
+      "name": "model_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_provider_tenant_id_tenant_id_fk": {
+          "name": "model_provider_tenant_id_tenant_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_credential_id_credential_id_fk": {
+          "name": "model_provider_credential_id_credential_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "credential",
+          "columnsFrom": ["credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "model_provider_wallet_id_wallet_id_fk": {
+          "name": "model_provider_wallet_id_wallet_id_fk",
+          "tableFrom": "model_provider",
+          "tableTo": "wallet",
+          "columnsFrom": ["wallet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_provider_tenant_name": {
+          "name": "model_provider_tenant_name",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "model_provider_auth_xor": {
+          "name": "model_provider_auth_xor",
+          "value": "(\"model_provider\".\"credential_id\" is not null) <> (\"model_provider\".\"wallet_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sidecar": {
+      "name": "sidecar",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash_sha256": {
+          "name": "token_hash_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sidecar_token_hash_sha256_unique": {
+          "name": "sidecar_token_hash_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash_sha256"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidecar_allocation": {
+      "name": "sidecar_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_api_version": {
+          "name": "provisioner_api_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_binding_fingerprint": {
+          "name": "provisioner_binding_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ensure_accepted_generation": {
+          "name": "ensure_accepted_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation_lease_id": {
+          "name": "reconciliation_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation_lease_expires_at": {
+          "name": "reconciliation_lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ensure_attempts": {
+          "name": "ensure_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "destroy_attempts": {
+          "name": "destroy_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connect_deadline": {
+          "name": "connect_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sidecar_allocation_anchor_run_idx": {
+          "name": "sidecar_allocation_anchor_run_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sidecar_allocation_active_sidecar_idx": {
+          "name": "sidecar_allocation_active_sidecar_idx",
+          "columns": [
+            {
+              "expression": "sidecar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sidecar_allocation\".\"status\" in ('provisioning', 'allocated', 'replacing', 'releasing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sidecar_allocation_sidecar_idx": {
+          "name": "sidecar_allocation_sidecar_idx",
+          "columns": [
+            {
+              "expression": "sidecar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sidecar_allocation_reconciliation_idx": {
+          "name": "sidecar_allocation_reconciliation_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sidecar_allocation\".\"status\" in ('pending', 'provisioning', 'allocated', 'replacing', 'releasing') and \"sidecar_allocation\".\"next_attempt_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sidecar_allocation_anchor_run_id_workflow_run_id_fk": {
+          "name": "sidecar_allocation_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "sidecar_allocation",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sidecar_allocation_tenant_id_tenant_id_fk": {
+          "name": "sidecar_allocation_tenant_id_tenant_id_fk",
+          "tableFrom": "sidecar_allocation",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sidecar_allocation_sidecar_id_sidecar_id_fk": {
+          "name": "sidecar_allocation_sidecar_id_sidecar_id_fk",
+          "tableFrom": "sidecar_allocation",
+          "tableTo": "sidecar",
+          "columnsFrom": ["sidecar_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sidecar_allocation_status_check": {
+          "name": "sidecar_allocation_status_check",
+          "value": "\"sidecar_allocation\".\"status\" in ('pending', 'provisioning', 'allocated', 'replacing', 'releasing', 'released', 'failed')"
+        },
+        "sidecar_allocation_generation_check": {
+          "name": "sidecar_allocation_generation_check",
+          "value": "\"sidecar_allocation\".\"generation\" >= 0"
+        },
+        "sidecar_allocation_accepted_generation_check": {
+          "name": "sidecar_allocation_accepted_generation_check",
+          "value": "\"sidecar_allocation\".\"ensure_accepted_generation\" is null or \"sidecar_allocation\".\"ensure_accepted_generation\" <= \"sidecar_allocation\".\"generation\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_session": {
+      "name": "agent_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_session_tenant_id_tenant_id_fk": {
+          "name": "agent_session_tenant_id_tenant_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_agent_id_workflow_definition_id_fk": {
+          "name": "agent_session_agent_id_workflow_definition_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agent_session_principal_id_principal_id_fk": {
+          "name": "agent_session_principal_id_principal_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_asset": {
+      "name": "session_asset",
+      "schema": "",
+      "columns": {
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mount_path": {
+          "name": "mount_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_pack_sha": {
+          "name": "asset_pack_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "materialized_at": {
+          "name": "materialized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_asset_pack_sha_idx": {
+          "name": "session_asset_pack_sha_idx",
+          "columns": [
+            {
+              "expression": "asset_pack_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_asset_instance_id_mount_path_pk": {
+          "name": "session_asset_instance_id_mount_path_pk",
+          "columns": ["instance_id", "mount_path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inference_turn": {
+      "name": "inference_turn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "inference_turn_instance_id_started_at_idx": {
+          "name": "inference_turn_instance_id_started_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inference_turn_session_id_agent_session_id_fk": {
+          "name": "inference_turn_session_id_agent_session_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inference_turn_tenant_id_tenant_id_fk": {
+          "name": "inference_turn_tenant_id_tenant_id_fk",
+          "tableFrom": "inference_turn",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_mail": {
+      "name": "session_mail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "raw": {
+          "name": "raw",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_mail_instance_id_created_at_idx": {
+          "name": "session_mail_instance_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_mail_session_id_created_at_idx": {
+          "name": "session_mail_session_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_mail_session_id_agent_session_id_fk": {
+          "name": "session_mail_session_id_agent_session_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_mail_tenant_id_tenant_id_fk": {
+          "name": "session_mail_tenant_id_tenant_id_fk",
+          "tableFrom": "session_mail",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turn_part": {
+      "name": "turn_part",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "turn_part_turn_id_inference_turn_id_fk": {
+          "name": "turn_part_turn_id_inference_turn_id_fk",
+          "tableFrom": "turn_part",
+          "tableTo": "inference_turn",
+          "columnsFrom": ["turn_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_part_session_id_agent_session_id_fk": {
+          "name": "turn_part_session_id_agent_session_id_fk",
+          "tableFrom": "turn_part",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_token": {
+      "name": "git_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash_sha256": {
+          "name": "token_hash_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_pattern": {
+          "name": "ref_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "git_token_user_id_name_active_idx": {
+          "name": "git_token_user_id_name_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"git_token\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "git_token_tenant_id_tenant_id_fk": {
+          "name": "git_token_tenant_id_tenant_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "git_token_user_id_user_id_fk": {
+          "name": "git_token_user_id_user_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_token_principal_id_principal_id_fk": {
+          "name": "git_token_principal_id_principal_id_fk",
+          "tableFrom": "git_token",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "git_token_token_hash_sha256_unique": {
+          "name": "git_token_token_hash_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash_sha256"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition": {
+      "name": "workflow_definition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_principal_id": {
+          "name": "creator_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wire_hash": {
+          "name": "wire_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_requirements": {
+          "name": "grant_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_requirements": {
+          "name": "model_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_bindings": {
+          "name": "credential_bindings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_definition_tenant_idx": {
+          "name": "workflow_definition_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_definition_asset_wire_hash_idx": {
+          "name": "workflow_definition_asset_wire_hash_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "wire_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definition_tenant_id_tenant_id_fk": {
+          "name": "workflow_definition_tenant_id_tenant_id_fk",
+          "tableFrom": "workflow_definition",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_definition_creator_principal_id_principal_id_fk": {
+          "name": "workflow_definition_creator_principal_id_principal_id_fk",
+          "tableFrom": "workflow_definition",
+          "tableTo": "principal",
+          "columnsFrom": ["creator_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_definition_asset_id_asset_id_fk": {
+          "name": "workflow_definition_asset_id_asset_id_fk",
+          "tableFrom": "workflow_definition",
+          "tableTo": "asset",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_version": {
+      "name": "workflow_definition_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "approved_wire_hash": {
+          "name": "approved_wire_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_snapshot": {
+          "name": "grant_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_definition_version_definition_idx": {
+          "name": "workflow_definition_version_definition_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definition_version_definition_id_workflow_definition_id_fk": {
+          "name": "workflow_definition_version_definition_id_workflow_definition_id_fk",
+          "tableFrom": "workflow_definition_version",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["definition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_definition_version_definition_version": {
+          "name": "workflow_definition_version_definition_version",
+          "nullsNotDistinct": false,
+          "columns": ["definition_id", "version"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run": {
+      "name": "workflow_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kernel_id": {
+          "name": "kernel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_preferences": {
+          "name": "model_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_refs": {
+          "name": "credential_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_definition_idx": {
+          "name": "workflow_run_definition_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_address_idx": {
+          "name": "workflow_run_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_run\".\"address\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_definition_id_workflow_definition_id_fk": {
+          "name": "workflow_run_definition_id_workflow_definition_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "workflow_definition",
+          "columnsFrom": ["definition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_anchor_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_tenant_id_tenant_id_fk": {
+          "name": "workflow_run_tenant_id_tenant_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_principal_id_principal_id_fk": {
+          "name": "workflow_run_principal_id_principal_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "principal",
+          "columnsFrom": ["principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflow_run_sidecar_id_sidecar_id_fk": {
+          "name": "workflow_run_sidecar_id_sidecar_id_fk",
+          "tableFrom": "workflow_run",
+          "tableTo": "sidecar",
+          "columnsFrom": ["sidecar_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_dispatch": {
+      "name": "workflow_run_dispatch",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mail'"
+        },
+        "sender_address": {
+          "name": "sender_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_message": {
+          "name": "raw_message",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_grants": {
+          "name": "step_grants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "acknowledged_generation": {
+          "name": "acknowledged_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "delivery_lease_id": {
+          "name": "delivery_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_lease_expires_at": {
+          "name": "delivery_lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_dispatch_anchor_message_idx": {
+          "name": "workflow_run_dispatch_anchor_message_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_dispatch_delivery_idx": {
+          "name": "workflow_run_dispatch_delivery_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_run_dispatch\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_dispatch_anchor_status_idx": {
+          "name": "workflow_run_dispatch_anchor_status_idx",
+          "columns": [
+            {
+              "expression": "anchor_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_dispatch_anchor_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_dispatch_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run_dispatch",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_dispatch_status_check": {
+          "name": "workflow_run_dispatch_status_check",
+          "value": "\"workflow_run_dispatch\".\"status\" in ('pending', 'acknowledged', 'settled', 'failed')"
+        },
+        "workflow_run_dispatch_kind_check": {
+          "name": "workflow_run_dispatch_kind_check",
+          "value": "\"workflow_run_dispatch\".\"kind\" in ('mail', 'signal')"
+        },
+        "workflow_run_dispatch_attempt_count_check": {
+          "name": "workflow_run_dispatch_attempt_count_check",
+          "value": "\"workflow_run_dispatch\".\"attempt_count\" >= 0"
+        },
+        "workflow_run_dispatch_acknowledged_generation_check": {
+          "name": "workflow_run_dispatch_acknowledged_generation_check",
+          "value": "\"workflow_run_dispatch\".\"acknowledged_generation\" is null or \"workflow_run_dispatch\".\"acknowledged_generation\" >= 0"
+        },
+        "workflow_run_dispatch_acknowledged_state_check": {
+          "name": "workflow_run_dispatch_acknowledged_state_check",
+          "value": "\"workflow_run_dispatch\".\"status\" <> 'acknowledged' or \"workflow_run_dispatch\".\"acknowledged_generation\" is not null"
+        },
+        "workflow_run_dispatch_pending_schedule_check": {
+          "name": "workflow_run_dispatch_pending_schedule_check",
+          "value": "\"workflow_run_dispatch\".\"status\" <> 'pending' or \"workflow_run_dispatch\".\"next_attempt_at\" is not null"
+        },
+        "workflow_run_dispatch_mail_sender_check": {
+          "name": "workflow_run_dispatch_mail_sender_check",
+          "value": "\"workflow_run_dispatch\".\"kind\" <> 'mail' or \"workflow_run_dispatch\".\"status\" in ('settled', 'failed') or \"workflow_run_dispatch\".\"sender_address\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_launch_spec": {
+      "name": "workflow_run_launch_spec",
+      "schema": "",
+      "columns": {
+        "anchor_run_id": {
+          "name": "anchor_run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_domain": {
+          "name": "deployment_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_authority_principal_id": {
+          "name": "source_authority_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frozen_approval_bundle": {
+          "name": "frozen_approval_bundle",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_offering_ids": {
+          "name": "source_offering_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_source_offering_id": {
+          "name": "default_source_offering_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deploy_content": {
+          "name": "deploy_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_package_pins": {
+          "name": "tool_package_pins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_run_launch_spec_anchor_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_launch_spec_anchor_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run_launch_spec",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["anchor_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_launch_spec_source_authority_principal_id_principal_id_fk": {
+          "name": "workflow_run_launch_spec_source_authority_principal_id_principal_id_fk",
+          "tableFrom": "workflow_run_launch_spec",
+          "tableTo": "principal",
+          "columnsFrom": ["source_authority_principal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_execution": {
+      "name": "workflow_run_execution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_execution_run_id_id_idx": {
+          "name": "workflow_run_execution_run_id_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_execution_status_idx": {
+          "name": "workflow_run_execution_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_execution_run_id_workflow_run_id_fk": {
+          "name": "workflow_run_execution_run_id_workflow_run_id_fk",
+          "tableFrom": "workflow_run_execution",
+          "tableTo": "workflow_run",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_probe": {
+      "name": "workflow_probe",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_asset_id": {
+          "name": "definition_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pin": {
+          "name": "pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_api_version": {
+          "name": "provisioner_api_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_binding_fingerprint": {
+          "name": "provisioner_binding_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sidecar_id": {
+          "name": "sidecar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_probe_active_idx": {
+          "name": "workflow_probe_active_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_probe\".\"status\" in ('pending', 'provisioning', 'probing', 'releasing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_probe_sidecar_idx": {
+          "name": "workflow_probe_sidecar_idx",
+          "columns": [
+            {
+              "expression": "sidecar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_probe_tenant_id_tenant_id_fk": {
+          "name": "workflow_probe_tenant_id_tenant_id_fk",
+          "tableFrom": "workflow_probe",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workflow_probe_definition_asset_id_asset_id_fk": {
+          "name": "workflow_probe_definition_asset_id_asset_id_fk",
+          "tableFrom": "workflow_probe",
+          "tableTo": "asset",
+          "columnsFrom": ["definition_asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workflow_probe_sidecar_id_sidecar_id_fk": {
+          "name": "workflow_probe_sidecar_id_sidecar_id_fk",
+          "tableFrom": "workflow_probe",
+          "tableTo": "sidecar",
+          "columnsFrom": ["sidecar_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_probe_status_check": {
+          "name": "workflow_probe_status_check",
+          "value": "\"workflow_probe\".\"status\" in ('pending', 'provisioning', 'probing', 'releasing', 'succeeded', 'failed')"
+        },
+        "workflow_probe_succeeded_result_check": {
+          "name": "workflow_probe_succeeded_result_check",
+          "value": "\"workflow_probe\".\"status\" <> 'succeeded' or \"workflow_probe\".\"result\" is not null"
+        },
+        "workflow_probe_generation_check": {
+          "name": "workflow_probe_generation_check",
+          "value": "\"workflow_probe\".\"generation\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -631,6 +631,13 @@
       "when": 1788736070428,
       "tag": "0090_tenant_domain_lower_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 91,
+      "version": "7",
+      "when": 1788849155396,
+      "tag": "0091_workflow_run_dispatch_sender_address",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/workflow-run-dispatch.ts
+++ b/packages/db/src/schema/workflow-run-dispatch.ts
@@ -43,6 +43,7 @@ export const workflowRunDispatch = pgTable(
       .$type<WorkflowRunDispatchKind>()
       .notNull()
       .default("mail"),
+    senderAddress: text("sender_address"),
     rawMessage: bytea("raw_message").notNull(),
     stepGrants: jsonb("step_grants").notNull(),
     status: text("status")
@@ -96,6 +97,15 @@ export const workflowRunDispatch = pgTable(
     check(
       "workflow_run_dispatch_pending_schedule_check",
       sql`${t.status} <> 'pending' or ${t.nextAttemptAt} is not null`,
+    ),
+    // A deliverable mail dispatch must carry the hub-verified sender that
+    // its inbound frame is stamped with; signals have no sender. Terminal
+    // (settled/failed) mail rows are exempt because they are never
+    // re-dispatched and so never reconstruct a frame -- this is what lets a
+    // migration fail legacy in-flight mail in place rather than delete it.
+    check(
+      "workflow_run_dispatch_mail_sender_check",
+      sql`${t.kind} <> 'mail' or ${t.status} in ('settled', 'failed') or ${t.senderAddress} is not null`,
     ),
   ],
 );

--- a/packages/db/src/workflow-run-dispatch-store.ts
+++ b/packages/db/src/workflow-run-dispatch-store.ts
@@ -30,6 +30,7 @@ export type EnqueueWorkflowRunDispatchArgs = {
   readonly id: string;
   readonly anchorRunId: string;
   readonly messageId: string;
+  readonly senderAddress: string;
   readonly rawMessage: Uint8Array;
   readonly stepGrants: RunGrantsFrameType["stepGrants"];
   readonly now?: Date;
@@ -53,6 +54,7 @@ type InsertOrReconcileDispatchArgs = {
   readonly anchorRunId: string;
   readonly messageId: string;
   readonly kind: ParsedDispatch["kind"];
+  readonly senderAddress: string | null;
   readonly rawMessage: Uint8Array;
   readonly stepGrants: RunGrantsFrameType["stepGrants"];
   readonly now?: Date;
@@ -158,6 +160,7 @@ async function insertOrReconcileDispatch(
       anchorRunId: args.anchorRunId,
       messageId: args.messageId,
       kind: args.kind,
+      senderAddress: args.senderAddress,
       rawMessage: args.rawMessage,
       stepGrants: args.stepGrants,
       status: "pending",
@@ -242,6 +245,7 @@ export function createWorkflowRunDispatchStore(db: DBHandle) {
         anchorRunId: args.anchorRunId,
         messageId: args.messageId,
         kind: "mail",
+        senderAddress: args.senderAddress,
         rawMessage: args.rawMessage,
         stepGrants,
         ...(args.now !== undefined ? { now: args.now } : {}),
@@ -263,6 +267,7 @@ export function createWorkflowRunDispatchStore(db: DBHandle) {
         anchorRunId: args.anchorRunId,
         messageId: signal.signalId,
         kind: "signal",
+        senderAddress: null,
         rawMessage: encoded,
         stepGrants: [],
         ...(args.now !== undefined ? { now: args.now } : {}),

--- a/packages/hub-agent/src/ws/hub-link-mail-router.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-mail-router.test.ts
@@ -308,13 +308,25 @@ describe("hub-link mail.inbound throwing router", () => {
       // First mail.inbound: the router throws. With the C4 fix in
       // place, the link's switch arm catches the throw and logs it
       // without rejecting the messageQueue chain.
-      expect(env.router.routeMail(deploymentAddress, encoded)).toBe(true);
+      expect(
+        env.router.routeMail(
+          deploymentAddress,
+          encoded,
+          "user@integration.interchange",
+        ),
+      ).toBe(true);
 
       // Second mail.inbound: the router accepts. With the fix in
       // place this frame still flows through; without the fix the
       // chain has been wedged by the prior rejection and the router
       // is never consulted.
-      expect(env.router.routeMail(deploymentAddress, encoded)).toBe(true);
+      expect(
+        env.router.routeMail(
+          deploymentAddress,
+          encoded,
+          "user@integration.interchange",
+        ),
+      ).toBe(true);
 
       await waitFor(() => routedAfterThrow.length > 0);
       expect(routedAfterThrow).toHaveLength(1);

--- a/packages/hub-agent/src/ws/hub-link.test.ts
+++ b/packages/hub-agent/src/ws/hub-link.test.ts
@@ -1160,7 +1160,11 @@ describe("sidecar↔hub integration", () => {
       );
 
       const encoded = base64Encode(VALID_MESSAGE);
-      const accepted = env.router.routeMail(deploymentAddress, encoded);
+      const accepted = env.router.routeMail(
+        deploymentAddress,
+        encoded,
+        "user@integration.interchange",
+      );
       expect(accepted).toBe(true);
 
       await waitFor(() => routed.length > 0);

--- a/packages/hub-api/src/app.test.ts
+++ b/packages/hub-api/src/app.test.ts
@@ -38,9 +38,6 @@ const sessionService: SessionService = {
   stageWorkflowStep(_params) {
     throw new Error("mock: sessionService.stageWorkflowStep not implemented");
   },
-  sendUserMessage(_params) {
-    throw new Error("mock: sessionService.sendUserMessage not implemented");
-  },
   endSession(_addr, _reason) {
     throw new Error("mock: sessionService.endSession not implemented");
   },

--- a/packages/hub-api/src/routes/approvals.test.ts
+++ b/packages/hub-api/src/routes/approvals.test.ts
@@ -370,6 +370,7 @@ function createMockWorkflowDispatchService(
           anchorRunId: args.anchorRunId,
           messageId: args.signal.signalId,
           kind: "signal",
+          senderAddress: null,
           rawMessage: new TextEncoder().encode(JSON.stringify(args.signal)),
           stepGrants: [],
           status: "pending",

--- a/packages/hub-api/src/routes/approvals.test.ts
+++ b/packages/hub-api/src/routes/approvals.test.ts
@@ -323,7 +323,6 @@ function createMockSessionService(): SessionService {
   }
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/packages/hub-api/src/routes/assets.test.ts
+++ b/packages/hub-api/src/routes/assets.test.ts
@@ -298,9 +298,6 @@ function createMockSessionService(): SessionService {
     stageWorkflowStep: () => {
       throw new Error("mock: sessionService.stageWorkflowStep not implemented");
     },
-    sendUserMessage: () => {
-      throw new Error("mock: sessionService.sendUserMessage not implemented");
-    },
     endSession: () => {
       throw new Error("mock: sessionService.endSession not implemented");
     },

--- a/packages/hub-api/src/routes/catalog-routes.test.ts
+++ b/packages/hub-api/src/routes/catalog-routes.test.ts
@@ -229,9 +229,6 @@ function createMockSessionService(): SessionService {
     stageWorkflowStep: () => {
       throw new Error("mock: sessionService.stageWorkflowStep not implemented");
     },
-    sendUserMessage: () => {
-      throw new Error("mock: sessionService.sendUserMessage not implemented");
-    },
     endSession: () => {
       throw new Error("mock: sessionService.endSession not implemented");
     },

--- a/packages/hub-api/src/routes/git-tokens.test.ts
+++ b/packages/hub-api/src/routes/git-tokens.test.ts
@@ -232,9 +232,6 @@ function createMockSessionService(): SessionService {
     stageWorkflowStep: () => {
       throw new Error("mock: sessionService.stageWorkflowStep not implemented");
     },
-    sendUserMessage: () => {
-      throw new Error("mock: sessionService.sendUserMessage not implemented");
-    },
     endSession: () => {
       throw new Error("mock: sessionService.endSession not implemented");
     },

--- a/packages/hub-api/src/routes/runs.test.ts
+++ b/packages/hub-api/src/routes/runs.test.ts
@@ -319,9 +319,6 @@ function createMockSessionService(): SessionService {
     stageWorkflowStep(_params) {
       return notImpl("stageWorkflowStep");
     },
-    sendUserMessage(_params) {
-      return notImpl("sendUserMessage");
-    },
     endSession(_addr, _reason) {
       return notImpl("endSession");
     },

--- a/packages/hub-api/src/routes/workflow-definitions.test.ts
+++ b/packages/hub-api/src/routes/workflow-definitions.test.ts
@@ -194,7 +194,6 @@ function createMockSidecarRouter(): SidecarRouter {
 function createMockSessionService(): SessionService {
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/packages/hub-api/src/routes/workflows.test.ts
+++ b/packages/hub-api/src/routes/workflows.test.ts
@@ -485,7 +485,11 @@ function createMockGetSession(): GetSession {
 }
 
 type SignalCall = Parameters<SidecarRouter["sendSignalDeliver"]>[0];
-type RouteMailCall = { address: string; rawMessage: string };
+type RouteMailCall = {
+  address: string;
+  rawMessage: string;
+  authenticatedSender: string;
+};
 type RunGrantsCall = {
   address: string;
   runId: string;
@@ -510,8 +514,8 @@ function createMockSidecarRouter(
     handleOpen: () => notImpl("handleOpen"),
     handleMessage: () => notImpl("handleMessage"),
     handleClose: () => notImpl("handleClose"),
-    routeMail: (address, rawMessage) => {
-      routeMailCalls.push({ address, rawMessage });
+    routeMail: (address, rawMessage, authenticatedSender) => {
+      routeMailCalls.push({ address, rawMessage, authenticatedSender });
       sendOrder.push({ kind: "mail", address });
       return routeMailResult;
     },
@@ -1595,6 +1599,10 @@ describe("POST /workflows/:anchorRunId/mail", () => {
     const call = routeMailCalls[0];
     if (call === undefined) throw new Error("missing routeMail call");
     expect(call.address).toBe(`${DEPLOYMENT_ID}@${DOMAIN}`);
+    // The trigger stamps the hub-verified principal address as the
+    // authenticated sender (fromAddr = principal.refId@tenant.domain), not
+    // anything parsed from the message body.
+    expect(call.authenticatedSender).toBe(`${USER_ID}@${DOMAIN}`);
     // The wire payload is base64-encoded MIME carrying the body text.
     const decoded = new TextDecoder().decode(base64Decode(call.rawMessage));
     expect(decoded).toContain("kick off");

--- a/packages/hub-api/src/routes/workflows.test.ts
+++ b/packages/hub-api/src/routes/workflows.test.ts
@@ -543,7 +543,6 @@ function createMockSessionService(): SessionService {
   }
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/packages/hub-api/src/routes/workflows.test.ts
+++ b/packages/hub-api/src/routes/workflows.test.ts
@@ -614,6 +614,7 @@ function createMockWorkflowDispatchService(
           anchorRunId: args.anchorRunId,
           messageId: args.signal.signalId,
           kind: "signal",
+          senderAddress: null,
           rawMessage: new TextEncoder().encode(JSON.stringify(args.signal)),
           stepGrants: [],
           status: "pending",

--- a/packages/hub-api/src/workflow-run-trigger.ts
+++ b/packages/hub-api/src/workflow-run-trigger.ts
@@ -569,7 +569,15 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
       };
     }
 
-    const delivered = sidecarRouter.routeMail(address, base64, messageId);
+    // Stamp the hub-verified principal address (fromAddr, the address the
+    // message is signed and addressed under) as the authenticated sender --
+    // never the message's own MIME From.
+    const delivered = sidecarRouter.routeMail(
+      address,
+      base64,
+      fromAddr,
+      messageId,
+    );
     if (!delivered) {
       return {
         ok: false,

--- a/packages/hub-api/src/workflow-run-trigger.ts
+++ b/packages/hub-api/src/workflow-run-trigger.ts
@@ -380,14 +380,11 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
     }
 
     // A trigger occurrence is threading-less at the mail boundary, so no
-    // inReplyTo or references are stamped. The supervisor decides whether
-    // this first-fires the absent top-level log or resumes a live onTrigger
-    // input. This is the same fresh-signed-message
-    // shape the deploy-flow fixture's mail trigger and the production
-    // session-service mail path assemble. The route does not route
-    // through sessionService.sendUserMessage because that path stamps
-    // interchangeSessionId/agentId headers that scope the message to an
-    // agent session; a workflow run trigger has no such session.
+    // inReplyTo or references are stamped, and it carries no agent session, so
+    // the interchangeSessionId/agentId headers are left unset. The supervisor
+    // decides whether this first-fires the absent top-level log or resumes a
+    // live onTrigger input. This is the same fresh-signed-message shape the
+    // deploy-flow fixture's mail trigger assembles.
     const headers: MessageHeaders = {
       from,
       to: [address],

--- a/packages/hub-api/src/workflow-run-trigger.ts
+++ b/packages/hub-api/src/workflow-run-trigger.ts
@@ -473,6 +473,7 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
             id: `dispatch:${anchorRunId}:${messageId}`,
             anchorRunId: anchorRunId,
             messageId,
+            senderAddress: fromAddr,
             rawMessage,
             stepGrants: canonicalStepGrants,
             now,

--- a/packages/hub-sessions/src/session-service.test.ts
+++ b/packages/hub-sessions/src/session-service.test.ts
@@ -4,12 +4,8 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import * as tar from "tar";
-import type {
-  CryptoProvider,
-  HarnessConfig,
-  MessageAttachment,
-} from "@intx/types/runtime";
-import { base64Decode, hexEncode } from "@intx/types";
+import type { HarnessConfig } from "@intx/types/runtime";
+import { hexEncode } from "@intx/types";
 import { computeWireDefinitionHash } from "@intx/types/wire-definition-hash";
 import { projectLiveToInert } from "@intx/workflow";
 import {
@@ -17,7 +13,6 @@ import {
   WorkflowProjectionDefinition,
 } from "@intx/types/sidecar";
 import type { ToolPackageManifest } from "@intx/types/tool-packages";
-import { extractAttachments } from "@intx/mime";
 import { sessionAsset as sessionAssetTable } from "@intx/db/schema";
 import type { DB } from "@intx/db";
 import { generateId } from "@intx/hub-common";
@@ -26,11 +21,7 @@ import { createNoopCredentialCipher } from "@intx/crypto";
 import type { AgentRepoStore, DeployContent } from "./agent-repo";
 import type { AssetService } from "./asset-service";
 import type { Principal, RepoId, RepoStore } from "./repo-store";
-import {
-  createSessionService,
-  SessionLaunchError,
-  type UserMessageParams,
-} from "./session-service";
+import { createSessionService, SessionLaunchError } from "./session-service";
 import type {
   SendPackOptions,
   SidecarAllocationRouter,
@@ -507,163 +498,6 @@ describe("SessionService", () => {
     if (call === undefined) throw new Error("unreachable");
     expect(call.method).toBe("sendAgentUndeploy");
     expect(call.args).toEqual([AGENT_ADDRESS, "test_end"]);
-  });
-
-  // --- sendUserMessage tests ---
-
-  function mockCryptoProvider(): CryptoProvider {
-    const fakeSig = new Uint8Array(64);
-    fakeSig.fill(0xab);
-    return {
-      sign: async (_data: Uint8Array) => fakeSig,
-      signSSH: async () => "unused-in-this-test",
-      verify: async () => true,
-      getPublicKey: () => new Uint8Array(32),
-    };
-  }
-
-  function userMessageParams(
-    overrides?: Partial<UserMessageParams>,
-  ): UserMessageParams {
-    return {
-      agentAddress: AGENT_ADDRESS,
-      from: "user@test.local",
-      messageId: "<msg-1@test.local>",
-      date: new Date("2026-01-15T12:00:00Z"),
-      content: "Hello agent",
-      sessionId: "ses-1",
-      tenantId: "tenant-1",
-      cryptoProvider: mockCryptoProvider(),
-      ...overrides,
-    };
-  }
-
-  test("sendUserMessage calls routeMail with base64 MIME", async () => {
-    const service = createSessionService({
-      sidecarRouter: router,
-      agentRepoStore: repoStore,
-    });
-
-    await service.sendUserMessage(userMessageParams());
-
-    const mailCalls = router.calls.filter((c) => c.method === "routeMail");
-    expect(mailCalls.length).toBe(1);
-    const call = mailCalls[0];
-    if (call === undefined) throw new Error("unreachable");
-    expect(call.args[0]).toBe(AGENT_ADDRESS);
-
-    const rawArg = call.args[1];
-    if (typeof rawArg !== "string") throw new Error("expected string arg");
-    const decoded = new TextDecoder().decode(base64Decode(rawArg));
-    expect(decoded).toContain("From: user@test.local");
-    expect(decoded).toContain(`To: ${AGENT_ADDRESS}`);
-    expect(decoded).toContain("Message-ID: <msg-1@test.local>");
-    expect(decoded).toContain("Interchange-Session-ID: ses-1");
-    expect(decoded).toContain("Interchange-Tenant-ID: tenant-1");
-    expect(decoded).toContain("Hello agent");
-  });
-
-  test("sendUserMessage includes threading headers", async () => {
-    const service = createSessionService({
-      sidecarRouter: router,
-      agentRepoStore: repoStore,
-    });
-
-    await service.sendUserMessage(
-      userMessageParams({
-        inReplyTo: "<prev@test.local>",
-        references: ["<root@test.local>", "<prev@test.local>"],
-      }),
-    );
-
-    const call = router.calls.find((c) => c.method === "routeMail");
-    if (call === undefined) throw new Error("unreachable");
-
-    const rawArg1 = call.args[1];
-    if (typeof rawArg1 !== "string") throw new Error("expected string arg");
-    const decoded = new TextDecoder().decode(base64Decode(rawArg1));
-    expect(decoded).toContain("In-Reply-To: <prev@test.local>");
-    expect(decoded).toContain(
-      "References: <root@test.local> <prev@test.local>",
-    );
-  });
-
-  test("sendUserMessage threads attachments into the signed envelope", async () => {
-    const service = createSessionService({
-      sidecarRouter: router,
-      agentRepoStore: repoStore,
-    });
-
-    const attachments: MessageAttachment[] = [
-      {
-        name: "shot.png",
-        contentType: "image/png",
-        data: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
-      },
-    ];
-
-    await service.sendUserMessage(userMessageParams({ attachments }));
-
-    const call = router.calls.find((c) => c.method === "routeMail");
-    if (call === undefined) throw new Error("unreachable");
-    const rawArg = call.args[1];
-    if (typeof rawArg !== "string") throw new Error("expected string arg");
-    const raw = base64Decode(rawArg);
-
-    const extracted = extractAttachments(raw);
-    expect(extracted).toHaveLength(1);
-    const got = extracted[0];
-    const orig = attachments[0];
-    if (got === undefined || orig === undefined) {
-      throw new Error("unreachable");
-    }
-    expect(got.name).toBe("shot.png");
-    expect(got.contentType).toBe("image/png");
-    expect(Array.from(got.data)).toEqual(Array.from(orig.data));
-  });
-
-  test("sendUserMessage throws when agent is unreachable", async () => {
-    router.routeMailResult = false;
-
-    const service = createSessionService({
-      sidecarRouter: router,
-      agentRepoStore: repoStore,
-    });
-
-    const err = await service
-      .sendUserMessage(userMessageParams())
-      .catch((e: unknown) => e);
-
-    expect(err).toBeInstanceOf(Error);
-    if (!(err instanceof Error)) throw new Error("unreachable");
-    expect(err.message).toContain("unreachable");
-  });
-
-  test("sendUserMessage propagates signing failure", async () => {
-    const badProvider: CryptoProvider = {
-      sign: async () => {
-        throw new Error("signing failed");
-      },
-      signSSH: async () => {
-        throw new Error("unreachable in this test");
-      },
-      verify: async () => true,
-      getPublicKey: () => new Uint8Array(32),
-    };
-
-    const service = createSessionService({
-      sidecarRouter: router,
-      agentRepoStore: repoStore,
-    });
-
-    const err = await service
-      .sendUserMessage(userMessageParams({ cryptoProvider: badProvider }))
-      .catch((e: unknown) => e);
-
-    expect(err).toBeInstanceOf(Error);
-    if (!(err instanceof Error)) throw new Error("unreachable");
-    expect(err.message).toBe("signing failed");
-    expect(router.calls.filter((c) => c.method === "routeMail").length).toBe(0);
   });
 
   // ---------------------------------------------------------------------

--- a/packages/hub-sessions/src/session-service.ts
+++ b/packages/hub-sessions/src/session-service.ts
@@ -3,12 +3,6 @@ import { and, eq, isNull } from "drizzle-orm";
 
 import { getLogger } from "@intx/log";
 import {
-  assembleMessage,
-  assembleSignedContent,
-  createDetachedSignatureFromProvider,
-  type MessageHeaders,
-} from "@intx/mime";
-import {
   buildCredentialDelivery,
   listAssetsForTenant,
   resolveInferenceMaterials,
@@ -20,19 +14,14 @@ import {
   workflowRun as workflowRunTable,
   type WorkflowRunCredentialRefs,
 } from "@intx/db/schema";
-import { base64Encode, hexEncode } from "@intx/types";
+import { hexEncode } from "@intx/types";
 import type {
   CredentialDelivery,
   CredentialMaterialEntry,
 } from "@intx/types/sidecar";
 import type { CredentialCipher } from "@intx/types";
 import { sessionAsset as sessionAssetTable } from "@intx/db/schema";
-import type {
-  CryptoProvider,
-  HarnessConfig,
-  InferenceSource,
-  MessageAttachment,
-} from "@intx/types/runtime";
+import type { HarnessConfig, InferenceSource } from "@intx/types/runtime";
 import {
   type RegistryConfig,
   type RegistrySource,
@@ -130,13 +119,6 @@ export type SessionService = {
   }): Promise<void>;
 
   /**
-   * Compose a signed RFC 2822 message from the user and deliver it to the
-   * agent via the mail transport. Throws if the agent is unreachable.
-   * Returns the raw MIME bytes of the assembled message.
-   */
-  sendUserMessage(params: UserMessageParams): Promise<Uint8Array>;
-
-  /**
    * Undeploy an agent and wait for the sidecar to acknowledge.
    */
   endSession(agentAddress: string, reason: string): Promise<void>;
@@ -222,20 +204,6 @@ export type PreparedWorkflowDeployer = {
   deployPreparedCodeSourcedWorkflow(
     params: DeployPreparedCodeSourcedWorkflowParams,
   ): Promise<DeployWorkflowDefinitionResult>;
-};
-
-export type UserMessageParams = {
-  agentAddress: string;
-  from: string;
-  messageId: string;
-  date: Date;
-  content: string;
-  attachments?: MessageAttachment[];
-  inReplyTo?: string;
-  references?: string[];
-  sessionId: string;
-  tenantId: string;
-  cryptoProvider: CryptoProvider;
 };
 
 export type SessionServiceDeps = {
@@ -1846,66 +1814,6 @@ export function createSessionService(
     };
   }
 
-  async function sendUserMessage(
-    params: UserMessageParams,
-  ): Promise<Uint8Array> {
-    const {
-      agentAddress,
-      from,
-      messageId,
-      date,
-      content,
-      attachments,
-      inReplyTo,
-      references,
-      sessionId,
-      tenantId,
-      cryptoProvider,
-    } = params;
-
-    const headers: MessageHeaders = {
-      from,
-      to: [agentAddress],
-      cc: undefined,
-      date,
-      messageId,
-      subject: undefined,
-      inReplyTo,
-      references,
-      mimeVersion: "1.0",
-      interchangeType: "conversation.message",
-      interchangeCorrelationId: undefined,
-      interchangeTenantId: tenantId,
-      interchangeAgentId: undefined,
-      interchangeSessionId: sessionId,
-      interchangeOfferingId: undefined,
-      interchangeSchemaVersion: undefined,
-      traceparent: undefined,
-      tracestate: undefined,
-    };
-
-    const signedContent = assembleSignedContent({
-      kind: "conversation",
-      text: content,
-      ...(attachments !== undefined ? { attachments } : {}),
-    });
-    const signature = await createDetachedSignatureFromProvider(
-      signedContent,
-      cryptoProvider,
-    );
-    const rawMessage = assembleMessage(headers, signedContent, signature);
-    const base64 = base64Encode(rawMessage);
-
-    const delivered = sidecarRouter.routeMail(agentAddress, base64, messageId);
-    if (!delivered) {
-      throw new Error(
-        `Failed to deliver message to ${agentAddress}: agent is unreachable`,
-      );
-    }
-
-    return rawMessage;
-  }
-
   async function endSession(
     agentAddress: string,
     reason: string,
@@ -1917,7 +1825,6 @@ export function createSessionService(
     stageWorkflowStep,
     installAndApproveWorkflowSource,
     deployPreparedCodeSourcedWorkflow,
-    sendUserMessage,
     endSession,
   };
 }

--- a/packages/hub-sessions/src/workflow-dispatch-service.test.ts
+++ b/packages/hub-sessions/src/workflow-dispatch-service.test.ts
@@ -126,6 +126,7 @@ describe("createWorkflowDispatchService", () => {
         "run_abc",
         [],
         "cmF3IG1haWw=",
+        "principal-1@tenant-1.example",
         "message-1",
       ],
     ]);

--- a/packages/hub-sessions/src/workflow-dispatch-service.test.ts
+++ b/packages/hub-sessions/src/workflow-dispatch-service.test.ts
@@ -21,6 +21,7 @@ function dispatch(overrides: Partial<ClaimedDispatch> = {}): ClaimedDispatch {
     anchorRunId: "deployment-1",
     messageId: "message-1",
     kind: "mail",
+    senderAddress: "principal-1@tenant-1.example",
     rawMessage: new TextEncoder().encode("raw mail"),
     stepGrants: [],
     status: "pending",

--- a/packages/hub-sessions/src/workflow-dispatch-service.ts
+++ b/packages/hub-sessions/src/workflow-dispatch-service.ts
@@ -200,12 +200,23 @@ export function createWorkflowDispatchService({
           payload: signal.payload,
         });
       } else {
+        // A deliverable mail dispatch always carries the sender persisted at
+        // enqueue (the workflow_run_dispatch mail-sender check enforces it).
+        // A null here means the row bypassed that invariant, so fail loudly
+        // rather than deliver with no authenticated sender or fall back to the
+        // MIME From.
+        if (dispatch.senderAddress === null) {
+          throw new Error(
+            `mail dispatch ${dispatch.id} has no persisted authenticated sender`,
+          );
+        }
         await router.sendWorkflowRunDispatchToAllocation(
           target,
           agentAddress,
           deriveWorkflowRunId(agentAddress),
           dispatch.stepGrants,
           base64Encode(dispatch.rawMessage),
+          dispatch.senderAddress,
           dispatch.messageId,
         );
       }

--- a/packages/hub-sessions/src/ws/sidecar-handler.mail.test.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.mail.test.ts
@@ -14,6 +14,8 @@ import {
   type SidecarAuthIdentity,
 } from "./sidecar-handler";
 
+const TEST_SENDER = "sender@example.test";
+
 function framesOfType(ws: { sent: string[] }, type: string) {
   return parsedFrames(ws).filter(
     (frame): frame is Record<string, unknown> =>
@@ -35,10 +37,16 @@ describe("SidecarRouter allocation mail durability", () => {
     const router = createAllocatedRouter();
     await connectAllocated(router, [TEST_IDENTITY.workflowRunAddress]);
 
-    expect(router.routeMail(TEST_IDENTITY.workflowRunAddress, "aGVsbG8=")).toBe(
-      true,
-    );
-    expect(router.routeMail("unknown@example.test", "aGVsbG8=")).toBe(false);
+    expect(
+      router.routeMail(
+        TEST_IDENTITY.workflowRunAddress,
+        "aGVsbG8=",
+        TEST_SENDER,
+      ),
+    ).toBe(true);
+    expect(
+      router.routeMail("unknown@example.test", "aGVsbG8=", TEST_SENDER),
+    ).toBe(false);
   });
 
   test("redelivers identical bytes until the allocated sidecar acks", async () => {
@@ -54,6 +62,7 @@ describe("SidecarRouter allocation mail durability", () => {
       router.routeMail(
         TEST_IDENTITY.workflowRunAddress,
         "aGVsbG8=",
+        TEST_SENDER,
         "mid-retry",
       ),
     ).toBe(true);
@@ -76,7 +85,12 @@ describe("SidecarRouter allocation mail durability", () => {
     const ws = await connectAllocated(router, [
       TEST_IDENTITY.workflowRunAddress,
     ]);
-    router.routeMail(TEST_IDENTITY.workflowRunAddress, "aGk=", "mid-acked");
+    router.routeMail(
+      TEST_IDENTITY.workflowRunAddress,
+      "aGk=",
+      TEST_SENDER,
+      "mid-acked",
+    );
 
     router.handleMessage(
       ws,
@@ -134,7 +148,12 @@ describe("SidecarRouter allocation mail durability", () => {
     );
     await tick();
 
-    router.routeMail(TEST_IDENTITY.workflowRunAddress, "b3duZWQ=", "mid-owned");
+    router.routeMail(
+      TEST_IDENTITY.workflowRunAddress,
+      "b3duZWQ=",
+      TEST_SENDER,
+      "mid-owned",
+    );
     router.handleMessage(
       rogue,
       JSON.stringify({
@@ -169,7 +188,12 @@ describe("SidecarRouter allocation mail durability", () => {
       TEST_IDENTITY.workflowRunAddress,
     ]);
 
-    router.routeMail(TEST_IDENTITY.workflowRunAddress, "ZHJvcA==", "mid-drop");
+    router.routeMail(
+      TEST_IDENTITY.workflowRunAddress,
+      "ZHJvcA==",
+      TEST_SENDER,
+      "mid-drop",
+    );
     await new Promise((resolve) => setTimeout(resolve, 80));
 
     expect(inboundCount(ws, "mid-drop")).toBe(3);
@@ -190,7 +214,7 @@ describe("SidecarRouter allocation mail durability", () => {
       TEST_IDENTITY.workflowRunAddress,
     ]);
 
-    router.routeMail(TEST_IDENTITY.workflowRunAddress, "eXk=");
+    router.routeMail(TEST_IDENTITY.workflowRunAddress, "eXk=", TEST_SENDER);
     await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(framesOfType(ws, "mail.inbound")).toHaveLength(1);
@@ -207,6 +231,7 @@ describe("SidecarRouter allocation mail durability", () => {
     router.routeMail(
       TEST_IDENTITY.workflowRunAddress,
       "cmV0YWluZWQ=",
+      TEST_SENDER,
       "mid-retained",
     );
     router.handleClose(first);
@@ -234,6 +259,7 @@ describe("SidecarRouter allocation mail durability", () => {
     router.routeMail(
       TEST_IDENTITY.workflowRunAddress,
       "ZXhwaXJlZA==",
+      TEST_SENDER,
       "mid-expired",
     );
     router.handleClose(first);
@@ -261,6 +287,7 @@ describe("SidecarRouter allocation mail durability", () => {
       TEST_IDENTITY.anchorRunId,
       [],
       "dHJpZ2dlcg==",
+      TEST_SENDER,
       "mid-grants",
     );
     router.handleClose(first);
@@ -400,5 +427,80 @@ describe("SidecarRouter workflow-trigger mail gating", () => {
         )
         .map((frame) => frame["type"]),
     ).toEqual(["mail.inbound"]);
+  });
+
+  test("relayed inbound mail carries the gate-verified sender", async () => {
+    const router = createAllocatedRouter();
+    const ws = await connectAllocated(router, [
+      TEST_IDENTITY.workflowRunAddress,
+    ]);
+
+    // The connection is gated on `senderAddress` by connOwnsAddress before the
+    // relay runs; the delivered frame must carry that hub-verified address as
+    // authenticatedSender, independent of whatever MIME From the opaque
+    // rawMessage bytes contain.
+    router.handleMessage(
+      ws,
+      JSON.stringify({
+        type: "mail.outbound",
+        senderAddress: TEST_IDENTITY.workflowRunAddress,
+        rawMessage,
+        recipients: [TEST_IDENTITY.workflowRunAddress],
+      }),
+    );
+    await tick();
+
+    const inbound = framesOfType(ws, "mail.inbound");
+    expect(inbound).toHaveLength(1);
+    expect(inbound[0]?.["authenticatedSender"]).toBe(
+      TEST_IDENTITY.workflowRunAddress,
+    );
+    // And explicitly NOT the spoofable MIME From carried in rawMessage
+    // (`From: sender@example.test`) -- value-level independence, not just
+    // equality to the gate value.
+    expect(inbound[0]?.["authenticatedSender"]).not.toBe("sender@example.test");
+  });
+
+  test("drops mail.outbound whose sender the connection does not own", async () => {
+    const router = createAllocatedRouter();
+    const ws = await connectAllocated(router, [
+      TEST_IDENTITY.workflowRunAddress,
+    ]);
+
+    // The ownership gate landed by outcome #1 must still hold: a sidecar
+    // cannot relay mail as an address it does not own, so nothing is routed.
+    router.handleMessage(
+      ws,
+      JSON.stringify({
+        type: "mail.outbound",
+        senderAddress: "not-owned@tenant.example",
+        rawMessage,
+        recipients: [TEST_IDENTITY.workflowRunAddress],
+      }),
+    );
+    await tick();
+
+    expect(framesOfType(ws, "mail.inbound")).toHaveLength(0);
+  });
+
+  test("durable-dispatch inbound mail carries the enqueue-time sender", async () => {
+    const router = createAllocatedRouter();
+    const ws = await connectAllocated(router, [
+      TEST_IDENTITY.workflowRunAddress,
+    ]);
+
+    await router.sendWorkflowRunDispatchToAllocation(
+      TEST_TARGET,
+      TEST_IDENTITY.workflowRunAddress,
+      TEST_IDENTITY.anchorRunId,
+      [],
+      "dHJpZ2dlcg==",
+      TEST_SENDER,
+      "durable-mid",
+    );
+
+    const inbound = framesOfType(ws, "mail.inbound");
+    expect(inbound).toHaveLength(1);
+    expect(inbound[0]?.["authenticatedSender"]).toBe(TEST_SENDER);
   });
 });

--- a/packages/hub-sessions/src/ws/sidecar-handler.test.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.test.ts
@@ -218,7 +218,12 @@ describe("SidecarRouter allocation routing", () => {
     const router = createAllocatedRouter();
     const first = await connect(router, [identity.workflowRunAddress]);
     expect(
-      router.routeMail(identity.workflowRunAddress, "aGVsbG8=", "message-1"),
+      router.routeMail(
+        identity.workflowRunAddress,
+        "aGVsbG8=",
+        "sender@example.test",
+        "message-1",
+      ),
     ).toBe(true);
     router.handleClose(first);
 
@@ -271,6 +276,7 @@ describe("SidecarRouter allocation routing", () => {
       identity.workflowRunAddress,
       [],
       "cmF3LW1haWw=",
+      "sender@example.test",
       "message-1",
     );
     expect(ws.sent.slice(-2).map((raw) => JSON.parse(raw).type)).toEqual([

--- a/packages/hub-sessions/src/ws/sidecar-handler.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.ts
@@ -191,7 +191,9 @@ export type SidecarRouter = {
   routeMail(
     agentAddress: string,
     rawMessage: string,
+    authenticatedSender: string,
     messageId?: string,
+    runGrants?: { runId: string; stepGrants: RunGrantsFrame["stepGrants"] },
   ): boolean;
   /**
    * Deliver a run's authorization grants to the sidecar hosting the named
@@ -377,6 +379,7 @@ export type SidecarAllocationRouter = {
     runId: string,
     stepGrants: RunGrantsFrame["stepGrants"],
     rawMessage: string,
+    authenticatedSender: string,
     messageId: string,
   ): Promise<void>;
   /** Deliver an idempotent signal to the exact provisioned generation. */
@@ -1023,7 +1026,14 @@ export function createSidecarRouter(
           return;
         }
         if (frame.delivered !== true) {
-          return handleMailOutbound(frame.rawMessage, frame.recipients);
+          // frame.senderAddress is the sender this connection was just gated
+          // on by connOwnsAddress above -- a hub-verified value. Thread it so
+          // the relayed inbound frame is stamped with it, not the MIME From.
+          return handleMailOutbound(
+            frame.rawMessage,
+            frame.senderAddress,
+            frame.recipients,
+          );
         }
         if (lookups.persistMail) {
           return handleMailPersist(
@@ -1308,6 +1318,7 @@ export function createSidecarRouter(
 
   async function handleMailOutbound(
     rawMessage: string,
+    authenticatedSender: string,
     recipients: string[],
   ): Promise<void> {
     // A mail addressed to more than one workflow deployment would birth a
@@ -1343,7 +1354,11 @@ export function createSidecarRouter(
       // co-recipients. The catch fails THIS recipient closed (its run never
       // starts under-authorized) and continues to the rest.
       try {
-        const outcome = await deliverMailToRecipient(recipient, rawMessage);
+        const outcome = await deliverMailToRecipient(
+          recipient,
+          rawMessage,
+          authenticatedSender,
+        );
         if (outcome === "unrouted") unrouted.push(recipient);
       } catch (err) {
         logger.error`Failed to deliver mail to ${recipient}: ${err instanceof Error ? err.message : String(err)}`;
@@ -1381,6 +1396,7 @@ export function createSidecarRouter(
   async function deliverMailToRecipient(
     recipient: string,
     rawMessage: string,
+    authenticatedSender: string,
   ): Promise<"routed" | "unrouted" | "failed-closed"> {
     if (
       lookups.materializeMailTriggeredRunGrants !== undefined &&
@@ -1430,6 +1446,7 @@ export function createSidecarRouter(
         const outcome: "routed" | "unrouted" = routeMail(
           recipient,
           rawMessage,
+          authenticatedSender,
           messageId,
           { runId, stepGrants: result.stepGrants },
         )
@@ -1442,7 +1459,9 @@ export function createSidecarRouter(
       // authorize. No run is committed here, so no ack handshake is needed.
     }
 
-    return routeMail(recipient, rawMessage) ? "routed" : "unrouted";
+    return routeMail(recipient, rawMessage, authenticatedSender)
+      ? "routed"
+      : "unrouted";
   }
 
   async function handleMailPersist(
@@ -2357,9 +2376,17 @@ export function createSidecarRouter(
   function routeMail(
     agentAddress: string,
     rawMessage: string,
+    authenticatedSender: string,
     messageId?: string,
     runGrants?: { runId: string; stepGrants: RunGrantsFrame["stepGrants"] },
   ): boolean {
+    // `authenticatedSender` is hub-assigned by the caller from a hub-verified
+    // value (the ownership-gated sender of a relayed mail, or the triggering
+    // principal's address) -- never the message's own MIME `From`. It rides
+    // the frame as the hub-verified sender of record, so a recipient can take
+    // the sender from it rather than the forgeable `From`; no consumer reads
+    // it yet.
+    //
     // Carry the hub-minted messageId on the frame so the sidecar's durable-
     // receipt ack (`mail.inbound.ack`) keys on the same id the hub tracks, and
     // a redelivery replays identical bytes for the downstream RunStarted dedup.
@@ -2370,6 +2397,7 @@ export function createSidecarRouter(
       type: "mail.inbound",
       agentAddress,
       rawMessage,
+      authenticatedSender,
       ...(messageId !== undefined ? { messageId } : {}),
     };
     const ws = addressIndex.get(agentAddress);
@@ -2433,6 +2461,7 @@ export function createSidecarRouter(
     runId: string,
     stepGrants: RunGrantsFrame["stepGrants"],
     rawMessage: string,
+    authenticatedSender: string,
     messageId: string,
   ): Promise<void> {
     const { ws, conn } = await getAllocatedConnection(target, "routing");
@@ -2448,10 +2477,14 @@ export function createSidecarRouter(
       runId,
       stepGrants,
     });
+    // authenticatedSender is the sender persisted at enqueue on the dispatch
+    // row (the triggering principal's hub-verified address); the caller reads
+    // it from that row. It is never the message's MIME From.
     const frame: HubFrame = {
       type: "mail.inbound",
       agentAddress,
       rawMessage,
+      authenticatedSender,
       messageId,
     };
     conn.send(frame);

--- a/packages/types/src/sidecar.ts
+++ b/packages/types/src/sidecar.ts
@@ -228,11 +228,21 @@ export type SignalCorrelationRegisterAckFrame =
  * makes at-least-once effectively-once. Present only on hub-originated mail
  * that participates in the ack/retry handshake (workflow trigger mail, session
  * conversation mail); agent-to-agent relayed mail omits it.
+ *
+ * `authenticatedSender` is the hub-verified sender ADDRESS of this message.
+ * The hub assigns it at the frame's construction site from a value it has
+ * itself verified -- the ownership-gated sender of a relayed mail, the
+ * address persisted at enqueue for a durable dispatch, or the triggering
+ * principal's address for hub-originated mail -- NEVER from the message's
+ * own (spoofable) MIME `From`. No consumer reads it yet; it is carried so a
+ * recipient can take the sender of record from this hub-verified value
+ * rather than the forgeable `From`.
  */
 export const MailInboundFrame = type({
   type: "'mail.inbound'",
   agentAddress: "string",
   rawMessage: "string",
+  authenticatedSender: "string",
   "messageId?": "string",
 });
 export type MailInboundFrame = typeof MailInboundFrame.infer;

--- a/tests/db/sidecar-allocation-store.test.ts
+++ b/tests/db/sidecar-allocation-store.test.ts
@@ -585,6 +585,7 @@ describe.skipIf(!harnessDbEnvAvailable())(
         id: "dispatch-terminal",
         anchorRunId: ANCHOR_RUN_ID,
         messageId: "message-terminal",
+        senderAddress: "principal-alloc@tenant.example",
         rawMessage: new Uint8Array([1, 2, 3]),
         stepGrants: [],
       });
@@ -775,6 +776,7 @@ describe.skipIf(!harnessDbEnvAvailable())(
         id: "dispatch-unrecoverable-pending",
         anchorRunId: ANCHOR_RUN_ID,
         messageId: "message-unrecoverable-pending",
+        senderAddress: "principal-alloc@tenant.example",
         rawMessage: new Uint8Array([1, 2, 3]),
         stepGrants: [],
       });
@@ -782,6 +784,7 @@ describe.skipIf(!harnessDbEnvAvailable())(
         id: "dispatch-unrecoverable-acknowledged",
         anchorRunId: ANCHOR_RUN_ID,
         messageId: "message-unrecoverable-acknowledged",
+        senderAddress: "principal-alloc@tenant.example",
         rawMessage: new Uint8Array([4, 5, 6]),
         stepGrants: [],
       });

--- a/tests/db/workflow-run-dispatch-store.test.ts
+++ b/tests/db/workflow-run-dispatch-store.test.ts
@@ -16,6 +16,7 @@ import {
   sidecar,
   sidecarAllocation,
   workflowDefinition,
+  workflowRunDispatch,
 } from "@intx/db/schema";
 import { RunGrantsFrame, SignalDeliverFrame } from "@intx/types/sidecar";
 import {
@@ -28,6 +29,7 @@ import { seedTenants, seedWorkflowRun } from "@intx/test-harness/seed";
 const TENANT_ID = "tnt-dispatch";
 const DEFINITION_ID = "wfd-dispatch";
 const ANCHOR_RUN_ID = "dep-dispatch";
+const SENDER_ADDRESS = "principal-dispatch@tnt-dispatch.example";
 
 describe.skipIf(!harnessDbEnvAvailable())(
   "workflowRunDispatchStore (real DB)",
@@ -88,12 +90,14 @@ describe.skipIf(!harnessDbEnvAvailable())(
         id: "dispatch-1",
         anchorRunId: ANCHOR_RUN_ID,
         messageId: "dispatch-message-1",
+        senderAddress: SENDER_ADDRESS,
         rawMessage,
         stepGrants: [],
       });
       expect(enqueued.created).toBe(true);
       expect(enqueued.dispatch.kind).toBe("mail");
       expect(enqueued.dispatch.status).toBe("pending");
+      expect(enqueued.dispatch.senderAddress).toBe(SENDER_ADDRESS);
 
       const claimed = await store.claimNextPending({
         leaseId: "delivery-lease-1",
@@ -142,6 +146,7 @@ describe.skipIf(!harnessDbEnvAvailable())(
         id: "dispatch-dedup",
         anchorRunId: ANCHOR_RUN_ID,
         messageId: "dispatch-message-dedup",
+        senderAddress: SENDER_ADDRESS,
         rawMessage: new Uint8Array([1, 2, 3]),
         stepGrants,
       };
@@ -177,6 +182,7 @@ describe.skipIf(!harnessDbEnvAvailable())(
         id: "dispatch-requeue",
         anchorRunId: ANCHOR_RUN_ID,
         messageId: "dispatch-message-requeue",
+        senderAddress: SENDER_ADDRESS,
         rawMessage: new Uint8Array([1]),
         stepGrants: [],
       });
@@ -203,6 +209,7 @@ describe.skipIf(!harnessDbEnvAvailable())(
         id: "dispatch-fenced-ack",
         anchorRunId: ANCHOR_RUN_ID,
         messageId: "message-fenced-ack",
+        senderAddress: SENDER_ADDRESS,
         rawMessage: new Uint8Array([1]),
         stepGrants: [],
       });
@@ -263,6 +270,7 @@ describe.skipIf(!harnessDbEnvAvailable())(
       const enqueued = await store.enqueueSignal(args);
       expect(enqueued.created).toBe(true);
       expect(enqueued.dispatch.kind).toBe("signal");
+      expect(enqueued.dispatch.senderAddress).toBeNull();
       expect(
         SignalDeliverFrame.assert(
           JSON.parse(new TextDecoder().decode(enqueued.dispatch.rawMessage)),
@@ -304,6 +312,7 @@ describe.skipIf(!harnessDbEnvAvailable())(
           id: "dispatch-mail-second",
           anchorRunId: ANCHOR_RUN_ID,
           messageId: signalFirst.signal.signalId,
+          senderAddress: SENDER_ADDRESS,
           rawMessage: signalDispatch.dispatch.rawMessage,
           stepGrants: [],
         }),
@@ -328,6 +337,7 @@ describe.skipIf(!harnessDbEnvAvailable())(
         id: "dispatch-mail-first",
         anchorRunId: ANCHOR_RUN_ID,
         messageId: mailFirstSignal.signalId,
+        senderAddress: SENDER_ADDRESS,
         rawMessage: encodedSignal,
         stepGrants: [],
       });
@@ -349,6 +359,7 @@ describe.skipIf(!harnessDbEnvAvailable())(
               id: "dispatch-mail-rollback",
               anchorRunId: ANCHOR_RUN_ID,
               messageId: "message-rollback",
+              senderAddress: SENDER_ADDRESS,
               rawMessage: new Uint8Array([1, 2, 3]),
               stepGrants: [],
             },
@@ -381,6 +392,7 @@ describe.skipIf(!harnessDbEnvAvailable())(
         id: "dispatch-already-consumed",
         anchorRunId: ANCHOR_RUN_ID,
         messageId: "message-consumed",
+        senderAddress: SENDER_ADDRESS,
         rawMessage: new Uint8Array([1]),
         stepGrants: [],
       });
@@ -413,6 +425,53 @@ describe.skipIf(!harnessDbEnvAvailable())(
         failureMessage: "run is terminal",
         nextAttemptAt: null,
       });
+    });
+
+    test("rejects a live mail dispatch with no sender", async () => {
+      // A mail dispatch that can still be re-dispatched must carry a
+      // hub-verified sender. The typed enqueue() API cannot express a null
+      // mail sender, so this writes the row directly to exercise the DB
+      // constraint that backstops the signal path and any direct writer.
+      const error = await h.db
+        .insert(workflowRunDispatch)
+        .values({
+          id: "dispatch-no-sender",
+          anchorRunId: ANCHOR_RUN_ID,
+          messageId: "message-no-sender",
+          kind: "mail",
+          rawMessage: new Uint8Array([1]),
+          stepGrants: [],
+        })
+        .then(
+          () => null,
+          (e: unknown) => e,
+        );
+      expect(error).not.toBeNull();
+      // drizzle wraps the driver error as "Failed query: ..."; the violated
+      // constraint name is carried on the cause, not the wrapper message.
+      const cause = error instanceof Error ? error.cause : error;
+      const causeMessage =
+        cause instanceof Error ? cause.message : String(cause);
+      expect(causeMessage).toContain("workflow_run_dispatch_mail_sender_check");
+    });
+
+    test("exempts a terminal mail dispatch with no sender", async () => {
+      // A settled or failed mail dispatch never reconstructs a frame, so it
+      // needs no sender. This is what lets the migration fail in-flight
+      // legacy mail rows in place rather than delete them.
+      await h.db.insert(workflowRunDispatch).values({
+        id: "dispatch-terminal-no-sender",
+        anchorRunId: ANCHOR_RUN_ID,
+        messageId: "message-terminal-no-sender",
+        kind: "mail",
+        status: "failed",
+        rawMessage: new Uint8Array([1]),
+        stepGrants: [],
+      });
+      const store = createWorkflowRunDispatchStore(h.db);
+      const row = await store.findById("dispatch-terminal-no-sender");
+      expect(row?.status).toBe("failed");
+      expect(row?.senderAddress).toBeNull();
     });
   },
 );

--- a/tests/hub-agent/lib/deploy-flow-env.ts
+++ b/tests/hub-agent/lib/deploy-flow-env.ts
@@ -1859,7 +1859,11 @@ export async function fireMailTrigger(
     );
   }
 
-  const delivered = env.hub.router.routeMail(address, base64);
+  // Route the trigger the way the production route does, stamping the
+  // signed-under address as the authenticated sender. This fixture reuses
+  // that same address as the MIME From, so it is not a From-independence
+  // check.
+  const delivered = env.hub.router.routeMail(address, base64, from);
   if (!delivered) {
     throw new Error(
       `fireMailTrigger: routeMail returned false for ${address}; address is not routable on the hub`,

--- a/tests/hub-api/asset-routes.test.ts
+++ b/tests/hub-api/asset-routes.test.ts
@@ -159,7 +159,6 @@ function createMockSidecarRouter(): SidecarRouter {
 function createMockSessionService(): SessionService {
   return {
     stageWorkflowStep: notImplemented("sessionService.stageWorkflowStep"),
-    sendUserMessage: notImplemented("sessionService.sendUserMessage"),
     endSession: notImplemented("sessionService.endSession"),
   };
 }

--- a/tests/hub-api/blob-route-folded-run.test.ts
+++ b/tests/hub-api/blob-route-folded-run.test.ts
@@ -124,7 +124,6 @@ function createMockSidecarRouter(): SidecarRouter {
 function createMockSessionService(): SessionService {
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/tests/hub-api/credential-routes.test.ts
+++ b/tests/hub-api/credential-routes.test.ts
@@ -139,7 +139,6 @@ async function waitUntil(pred: () => boolean, timeoutMs = 2000): Promise<void> {
 function createMockSessionService(): SessionService {
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/tests/hub-api/grant-routes.test.ts
+++ b/tests/hub-api/grant-routes.test.ts
@@ -67,7 +67,6 @@ function mockSessionService(): SessionService {
   };
   return {
     stageWorkflowStep: notImpl("stageWorkflowStep"),
-    sendUserMessage: notImpl("sendUserMessage"),
     endSession: notImpl("endSession"),
   };
 }

--- a/tests/hub-api/invite-route.test.ts
+++ b/tests/hub-api/invite-route.test.ts
@@ -89,7 +89,6 @@ function createMockSidecarRouter(): SidecarRouter {
 function createMockSessionService(): SessionService {
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/tests/hub-api/offering-definition-repoint.test.ts
+++ b/tests/hub-api/offering-definition-repoint.test.ts
@@ -87,7 +87,6 @@ function createMockSidecarRouter(): SidecarRouter {
 function createMockSessionService(): SessionService {
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/tests/hub-api/principal-routes.test.ts
+++ b/tests/hub-api/principal-routes.test.ts
@@ -94,7 +94,6 @@ function createMockSidecarRouter(): SidecarRouter {
 function createMockSessionService(): SessionService {
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/tests/hub-api/run-list.test.ts
+++ b/tests/hub-api/run-list.test.ts
@@ -87,7 +87,6 @@ function createMockSidecarRouter(): SidecarRouter {
 function createMockSessionService(): SessionService {
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/tests/hub-api/wallet-routes.test.ts
+++ b/tests/hub-api/wallet-routes.test.ts
@@ -89,7 +89,6 @@ function createMockSidecarRouter(): SidecarRouter {
 function createMockSessionService(): SessionService {
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/tests/hub-api/workflow-deployment-list.test.ts
+++ b/tests/hub-api/workflow-deployment-list.test.ts
@@ -93,7 +93,6 @@ function createMockSidecarRouter(): SidecarRouter {
 function createMockSessionService(): SessionService {
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/tests/workflow-deploy/approval-tracer-roundtrip.test.ts
+++ b/tests/workflow-deploy/approval-tracer-roundtrip.test.ts
@@ -243,7 +243,6 @@ function notImpl(name: string): never {
 function createMockSessionService(): SessionService {
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/tests/workflow-deploy/mail-edge-cases.test.ts
+++ b/tests/workflow-deploy/mail-edge-cases.test.ts
@@ -466,6 +466,7 @@ describe.skipIf(!harnessDbEnvAvailable())("mail-handling edge cases", () => {
     const delivered = env.hub.router.routeMail(
       ctx.deploymentMailAddress,
       base64,
+      "edge@integration.interchange",
       messageId,
     );
     expect(delivered).toBe(true);
@@ -650,7 +651,14 @@ async function routeRaw(
     );
   }
   const base64 = base64Encode(raw);
-  const delivered = env.hub.router.routeMail(address, base64);
+  // The hub-verified sender is independent of the raw message's own (possibly
+  // malformed) MIME From -- that independence is the point of these edge-case
+  // routes -- so stamp a fixed hub-side sender the way the trigger route does.
+  const delivered = env.hub.router.routeMail(
+    address,
+    base64,
+    "user@integration.interchange",
+  );
   if (!delivered) {
     throw new Error(
       `routeRaw: routeMail returned false for ${address}; address is not routable on the hub`,

--- a/tests/workflow-deploy/mail-federation-derived-grants-roundtrip.test.ts
+++ b/tests/workflow-deploy/mail-federation-derived-grants-roundtrip.test.ts
@@ -178,7 +178,6 @@ function notImpl(name: string): never {
 function createMockSessionService(): SessionService {
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/tests/workflow-deploy/mail-trigger-derived-grants-roundtrip.test.ts
+++ b/tests/workflow-deploy/mail-trigger-derived-grants-roundtrip.test.ts
@@ -161,7 +161,6 @@ function notImpl(name: string): never {
 function createMockSessionService(): SessionService {
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/tests/workflow-deploy/reconnect-reemits-parked-correlation.test.ts
+++ b/tests/workflow-deploy/reconnect-reemits-parked-correlation.test.ts
@@ -218,7 +218,6 @@ function notImpl(name: string): never {
 function createMockSessionService(): SessionService {
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/tests/workflow-deploy/run-mail-send-real-route.test.ts
+++ b/tests/workflow-deploy/run-mail-send-real-route.test.ts
@@ -124,7 +124,6 @@ function notImpl(name: string): never {
 function createMockSessionService(): SessionService {
   return {
     stageWorkflowStep: () => notImpl("stageWorkflowStep"),
-    sendUserMessage: () => notImpl("sendUserMessage"),
     endSession: () => notImpl("endSession"),
   };
 }

--- a/tests/workflow-deploy/run-mail-send-real-route.test.ts
+++ b/tests/workflow-deploy/run-mail-send-real-route.test.ts
@@ -274,9 +274,9 @@ describe.skipIf(!harnessDbEnvAvailable())(
       let capturedMail: string | undefined;
       const capturingRouter: SidecarRouter = {
         ...env.hub.router,
-        routeMail(agentAddress, rawMessage, messageId) {
-          capturedMail = rawMessage;
-          return env.hub.router.routeMail(agentAddress, rawMessage, messageId);
+        routeMail(...args: Parameters<SidecarRouter["routeMail"]>) {
+          capturedMail = args[1];
+          return env.hub.router.routeMail(...args);
         },
       };
       const runApp = createApp({


### PR DESCRIPTION
## Summary

- Every inbound mail frame carries a required `authenticatedSender` — the
  hub-verified sender address — populated at each producer from a value the
  hub controls: the ownership-gated sender of a relayed mail, the address
  persisted at enqueue for a durable dispatch, or the triggering principal's
  address for a hub trigger. It is never taken from the spoofable MIME `From`.
- `workflow_run_dispatch` gains a `sender_address` column persisted at enqueue,
  with a status-scoped CHECK that requires a sender for deliverable mail while
  exempting hub-internal signals and terminal rows.
- The dead, spoofable `sendUserMessage` send path is removed.

## Verification

- `make all` passes (unit 7288, workflow 178, core 744; 0 failures).
- New tests cover the DB constraint (a deliverable mail row with no sender is
  rejected; a terminal one is exempt) and every producer (relay, trigger, and
  durable-dispatch frames carry the hub-verified sender, asserted distinct from
  the message's MIME `From`; the ownership gate still drops non-owned senders).
- This branch establishes the verified-sender carrier only. No recipient reads
  `authenticatedSender` yet; resolving and trusting it (retiring the MIME `From`
  read) is INTR-431, and signature verification is INTR-512.

Closes INTR-492
