### PR TITLE
Shadow-verify inbound mail signatures at the sidecar ingress

### DIFF
--- a/apps/hub/src/server.ts
+++ b/apps/hub/src/server.ts
@@ -4,6 +4,7 @@ import {
   createPrincipalKeyStore,
   createSidecarAllocationStore,
   createWorkflowRunDispatchStore,
+  resolveFrameSenderKey,
 } from "@intx/db";
 import { createEnvKeyCredentialCipher } from "@intx/crypto";
 import { hexDecode, type SidecarCapabilityRule } from "@intx/types";
@@ -241,6 +242,8 @@ export async function createHubServer({
         grantStore: createGrantStore(db),
       },
     ),
+    resolveSenderKey: (address) =>
+      resolveFrameSenderKey(db, principalKeyStore, address),
   };
 
   const sidecarCredentials = createSidecarCredentialResolver({ db });

--- a/bun.lock
+++ b/bun.lock
@@ -319,6 +319,8 @@
         "@intx/harness": "workspace:*",
         "@intx/log": "workspace:*",
         "@intx/mail-memory": "workspace:*",
+        "@intx/mailbox": "workspace:*",
+        "@intx/mime": "workspace:*",
         "@intx/pack-transport": "workspace:*",
         "@intx/storage-isogit": "workspace:*",
         "@intx/types": "workspace:*",

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -24,6 +24,7 @@ export {
 export { lookupLocalPrincipalSigner } from "./signer-identity";
 export {
   resolveSenderKey,
+  resolveFrameSenderKey,
   auditSenderKeys,
   type SenderKeyResolution,
   type SenderKeyAuditReport,

--- a/packages/db/src/sender-key-resolver.ts
+++ b/packages/db/src/sender-key-resolver.ts
@@ -1,6 +1,7 @@
 import { and, eq, isNotNull, or, sql } from "drizzle-orm";
 
 import { parseAddress } from "@intx/types";
+import { getLogger } from "@intx/log";
 
 import type { DBExecutor } from "./client";
 import type { PrincipalKeyStore } from "./principal-key-store";
@@ -9,6 +10,8 @@ import { tenant } from "./schema/tenants";
 import { workflowRun } from "./schema/workflow-run";
 
 const RUN_PREFIX = "run_";
+
+const logger = getLogger(["db", "sender-key-resolver"]);
 
 /**
  * The durable public key that authenticates a signed mail sender, resolved from
@@ -82,6 +85,41 @@ export async function resolveSenderKey(
   // key above, a keyless principal is a real breakage that must surface.
   const publicKey = await principalKeyStore.getPublicKey(principalId, db);
   return { source: "user", publicKey };
+}
+
+/**
+ * Resolve the hex-encoded public key to stamp on an outbound mail frame, as a
+ * BEST-EFFORT value that never blocks delivery. Returns the key, or `null` when
+ * the sender has no resolvable key -- OR when resolution FAILS.
+ *
+ * {@link resolveSenderKey} throws on a genuine fault (an ambiguous user address,
+ * or a principal with no active key -- an INTR-164 invariant break). Those
+ * throws must fail loud for {@link auditSenderKeys}, but they must not break
+ * mail delivery: the frame key is nullable and shadow-only, so a recipient
+ * treats a null key as an unverifiable sender and admits the mail anyway.
+ * Coupling delivery to key resolution would let a data-integrity fault strand a
+ * run or drop mail. So a throw here degrades to `null` and is logged at ERROR
+ * with its cause -- a degraded fault, kept distinct from the ordinary
+ * unresolvable-sender `null`, which stays silent.
+ *
+ * The principal key store is real in production (INTR-164 mints every principal
+ * a key), so the throw path is a defensive safety net, not the common case: the
+ * normal outcome is a resolved, populated key.
+ */
+export async function resolveFrameSenderKey(
+  db: DBExecutor,
+  principalKeyStore: PrincipalKeyStore,
+  address: string,
+): Promise<string | null> {
+  try {
+    return (
+      (await resolveSenderKey(db, principalKeyStore, address))?.publicKey ??
+      null
+    );
+  } catch (cause) {
+    logger.error`Degraded to a null frame sender key for ${address}: resolving its public key failed (a fault, not an unresolvable sender): ${cause instanceof Error ? cause.message : String(cause)}`;
+    return null;
+  }
 }
 
 /**

--- a/packages/hub-agent/package.json
+++ b/packages/hub-agent/package.json
@@ -20,6 +20,8 @@
     "@intx/harness": "workspace:*",
     "@intx/log": "workspace:*",
     "@intx/mail-memory": "workspace:*",
+    "@intx/mailbox": "workspace:*",
+    "@intx/mime": "workspace:*",
     "@intx/pack-transport": "workspace:*",
     "@intx/storage-isogit": "workspace:*",
     "@intx/types": "workspace:*",

--- a/packages/hub-agent/src/ws/hub-link-mail-router.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-mail-router.test.ts
@@ -313,6 +313,7 @@ describe("hub-link mail.inbound throwing router", () => {
           deploymentAddress,
           encoded,
           "user@integration.interchange",
+          null,
         ),
       ).toBe(true);
 
@@ -325,6 +326,7 @@ describe("hub-link mail.inbound throwing router", () => {
           deploymentAddress,
           encoded,
           "user@integration.interchange",
+          null,
         ),
       ).toBe(true);
 

--- a/packages/hub-agent/src/ws/hub-link-mail-router.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-mail-router.test.ts
@@ -12,7 +12,14 @@
 // frame. This test exercises the patched arm end-to-end through the
 // real hub-link WS surface to make the regression observable.
 
-import { describe, test, expect, afterAll } from "bun:test";
+import {
+  describe,
+  test,
+  expect,
+  afterAll,
+  beforeAll,
+  beforeEach,
+} from "bun:test";
 import { Hono } from "hono";
 import { upgradeWebSocket, websocket } from "hono/bun";
 import {
@@ -27,8 +34,20 @@ import type {
   InboundMessage,
   KeyPair,
 } from "@intx/types/runtime";
-import { generateKeyPair, verifySSHSignature } from "@intx/crypto";
-import { hexDecode } from "@intx/types";
+import {
+  generateKeyPair,
+  verifySSHSignature,
+  createEd25519Crypto,
+} from "@intx/crypto";
+import { hexDecode, hexEncode } from "@intx/types";
+import {
+  assembleSignedContent,
+  assembleMessage,
+  createDetachedSignatureFromProvider,
+  generateMessageId,
+  type MessageHeaders,
+} from "@intx/mime";
+import { configureSync, getConfig, resetSync } from "@intx/log";
 
 import { createHubLink, type DeployRouter } from "./hub-link";
 import type { AgentKeyStore } from "../agent-key-store";
@@ -339,5 +358,254 @@ describe("hub-link mail.inbound throwing router", () => {
         () => !env.router.getConnectedSidecars().includes("sc-mail-wedge"),
       );
     }
+  });
+});
+
+type CapturedLog = {
+  category: readonly string[];
+  level: string;
+  properties: Record<string, unknown>;
+};
+
+const capturedLogs: CapturedLog[] = [];
+const savedLogConfig = getConfig();
+
+beforeAll(() => {
+  configureSync({
+    reset: true,
+    sinks: {
+      capture: (record) => {
+        capturedLogs.push({
+          category: record.category,
+          level: record.level,
+          properties: record.properties,
+        });
+      },
+    },
+    loggers: [
+      { category: [], lowestLevel: "debug", sinks: ["capture"] },
+      {
+        category: ["logtape", "meta"],
+        lowestLevel: "warning",
+        sinks: ["capture"],
+      },
+    ],
+  });
+});
+
+afterAll(() => {
+  if (savedLogConfig) {
+    configureSync({ reset: true, ...savedLogConfig });
+  } else {
+    resetSync();
+  }
+});
+
+function shadowVerdicts(): CapturedLog[] {
+  return capturedLogs.filter(
+    (r) =>
+      r.category.length >= 4 &&
+      r.category[2] === "ws" &&
+      r.category[3] === "inbound-signature-shadow",
+  );
+}
+
+function signedHeaders(from: string): MessageHeaders {
+  return {
+    from,
+    to: ["agent-1@test.interchange"],
+    cc: undefined,
+    date: new Date("2026-04-17T12:00:00Z"),
+    messageId: generateMessageId(from),
+    subject: undefined,
+    inReplyTo: undefined,
+    references: undefined,
+    mimeVersion: "1.0",
+    interchangeType: "conversation.message",
+    interchangeCorrelationId: undefined,
+    interchangeTenantId: undefined,
+    interchangeAgentId: undefined,
+    interchangeSessionId: undefined,
+    interchangeOfferingId: undefined,
+    interchangeSchemaVersion: undefined,
+    traceparent: undefined,
+    tracestate: undefined,
+  };
+}
+
+async function makeSignedMail(
+  crypto: Awaited<ReturnType<typeof createEd25519Crypto>>,
+  from: string,
+): Promise<Uint8Array> {
+  const content = assembleSignedContent({
+    kind: "conversation",
+    text: "signed body",
+  });
+  const sig = await createDetachedSignatureFromProvider(content, crypto);
+  return assembleMessage(signedHeaders(from), content, sig);
+}
+
+// Drives a `mail.inbound` frame across the real hub-link WS surface and proves
+// the INTR-512 shadow verify at the ingress seam LOGS a verdict and ADMITS the
+// mail in every case (the router still receives it), never dropping.
+describe("hub-link mail.inbound signature shadow", () => {
+  beforeEach(() => {
+    capturedLogs.length = 0;
+  });
+
+  async function withConnectedLink(
+    label: string,
+    body: (ctx: {
+      deploymentAddress: string;
+      routed: Uint8Array[];
+    }) => Promise<void>,
+  ): Promise<void> {
+    const transport = createInMemoryTransport();
+    const sessions = createMockSessionManager();
+    const deploymentAddress = `run_${label}@integration.interchange`;
+    sessions.addresses.push(deploymentAddress);
+
+    const routed: Uint8Array[] = [];
+    const mailInboundRouter = {
+      tryRoute(_address: string, message: Uint8Array): Promise<void> | null {
+        routed.push(message);
+        return Promise.resolve();
+      },
+    };
+
+    const bindings = withTestDeployBindings();
+    await provisionDeploymentKey(bindings.keyStore, deploymentAddress);
+    const client = createHubLink({
+      hubURL: `ws://localhost:${env.server.port}/ws`,
+      sidecarId: `sc-shadow-${label}`,
+      token: "test-token",
+      transport,
+      sessions,
+      ...bindings,
+      mailInboundRouter,
+      getWorkflowAddresses: () => [deploymentAddress],
+    });
+
+    client.connect();
+    try {
+      await waitFor(() =>
+        env.router.getRoutableAddresses().includes(deploymentAddress),
+      );
+      await body({ deploymentAddress, routed });
+    } finally {
+      client.close();
+      await waitFor(
+        () => !env.router.getConnectedSidecars().includes(`sc-shadow-${label}`),
+      );
+    }
+  }
+
+  test("a validly-signed frame logs a valid/match verdict and is admitted", async () => {
+    const sender = "external@remote.interchange";
+    const crypto = createEd25519Crypto(await generateKeyPair());
+    const raw = await makeSignedMail(crypto, sender);
+
+    await withConnectedLink(
+      "shadowvalid",
+      async ({ deploymentAddress, routed }) => {
+        expect(
+          env.router.routeMail(
+            deploymentAddress,
+            base64Encode(raw),
+            sender,
+            hexEncode(crypto.getPublicKey()),
+          ),
+        ).toBe(true);
+
+        await waitFor(() => shadowVerdicts().length > 0);
+        const verdict = shadowVerdicts()[0];
+        expect(verdict?.properties["signature"]).toBe("valid");
+        expect(verdict?.properties["fromMatch"]).toBe("match");
+        // Admitted: the frame still reached the mail router.
+        await waitFor(() => routed.length > 0);
+        expect(routed).toHaveLength(1);
+      },
+    );
+  });
+
+  test("a tampered signature logs invalid and is still admitted", async () => {
+    const sender = "external@remote.interchange";
+    const signer = createEd25519Crypto(await generateKeyPair());
+    const other = createEd25519Crypto(await generateKeyPair());
+    const raw = await makeSignedMail(signer, sender);
+
+    await withConnectedLink(
+      "shadowbad",
+      async ({ deploymentAddress, routed }) => {
+        // The hub stamps a key that does not match the signer, so the recipient
+        // verdict is invalid -- but shadow admits it anyway.
+        expect(
+          env.router.routeMail(
+            deploymentAddress,
+            base64Encode(raw),
+            sender,
+            hexEncode(other.getPublicKey()),
+          ),
+        ).toBe(true);
+
+        await waitFor(() => shadowVerdicts().length > 0);
+        expect(shadowVerdicts()[0]?.properties["signature"]).toBe("invalid");
+        await waitFor(() => routed.length > 0);
+        expect(routed).toHaveLength(1);
+      },
+    );
+  });
+
+  test("a null sender key logs unknown and is still admitted", async () => {
+    const sender = "external@remote.interchange";
+    const crypto = createEd25519Crypto(await generateKeyPair());
+    const raw = await makeSignedMail(crypto, sender);
+
+    await withConnectedLink(
+      "shadownull",
+      async ({ deploymentAddress, routed }) => {
+        expect(
+          env.router.routeMail(
+            deploymentAddress,
+            base64Encode(raw),
+            sender,
+            null,
+          ),
+        ).toBe(true);
+
+        await waitFor(() => shadowVerdicts().length > 0);
+        expect(shadowVerdicts()[0]?.properties["signature"]).toBe("unknown");
+        await waitFor(() => routed.length > 0);
+        expect(routed).toHaveLength(1);
+      },
+    );
+  });
+
+  test("a valid signature under a forged From is flagged and still admitted", async () => {
+    const stamp = "external@remote.interchange";
+    const forgedFrom = "victim@remote.interchange";
+    const crypto = createEd25519Crypto(await generateKeyPair());
+    const raw = await makeSignedMail(crypto, forgedFrom);
+
+    await withConnectedLink(
+      "shadowforge",
+      async ({ deploymentAddress, routed }) => {
+        expect(
+          env.router.routeMail(
+            deploymentAddress,
+            base64Encode(raw),
+            stamp,
+            hexEncode(crypto.getPublicKey()),
+          ),
+        ).toBe(true);
+
+        await waitFor(() => shadowVerdicts().length > 0);
+        const verdict = shadowVerdicts()[0];
+        expect(verdict?.properties["signature"]).toBe("valid");
+        expect(verdict?.properties["fromMatch"]).toBe("mismatch");
+        await waitFor(() => routed.length > 0);
+        expect(routed).toHaveLength(1);
+      },
+    );
   });
 });

--- a/packages/hub-agent/src/ws/hub-link.test.ts
+++ b/packages/hub-agent/src/ws/hub-link.test.ts
@@ -1164,6 +1164,7 @@ describe("sidecar↔hub integration", () => {
         deploymentAddress,
         encoded,
         "user@integration.interchange",
+        null,
       );
       expect(accepted).toBe(true);
 

--- a/packages/hub-agent/src/ws/hub-link.ts
+++ b/packages/hub-agent/src/ws/hub-link.ts
@@ -42,6 +42,7 @@ import {
   DEFAULT_REGISTER_ACK_MAX_ATTEMPTS,
   DEFAULT_REGISTER_ACK_TIMEOUT_MS,
 } from "./register-acker";
+import { shadowVerifyInboundSignature } from "./inbound-signature-shadow";
 import { base64Decode, base64Encode } from "@intx/types";
 import type { ApprovalSnapshot, InferenceEvent } from "@intx/types/runtime";
 
@@ -1423,6 +1424,30 @@ export function createHubLink(config: HubLinkConfig): HubLink {
     switch (frame.type) {
       case "mail.inbound": {
         const rawBytes = base64Decode(frame.rawMessage);
+        // This ingress is the one place raw inbound bytes meet the hub-verified
+        // sender identity (`authenticatedSender` + its resolved key), and every
+        // producer -- relay, trigger, durable dispatch -- converges here, so the
+        // signature shadow lives here. Verify off to the side and LOG the
+        // verdict; never gate delivery on it. Deferred to a microtask so even
+        // the verify's synchronous MIME re-parse runs after the admit below and
+        // off the messageQueue chain -- the shadow must never delay or wedge
+        // delivery. The in-process mail-memory transport (the standalone harness
+        // path) does not deliver through this seam and carries no hub-verified
+        // sender, so it is outside this path.
+        void Promise.resolve()
+          .then(() =>
+            shadowVerifyInboundSignature({
+              raw: rawBytes,
+              authenticatedSender: frame.authenticatedSender,
+              authenticatedSenderPublicKey: frame.authenticatedSenderPublicKey,
+              messageId: frame.messageId,
+              agentAddress: frame.agentAddress,
+            }),
+          )
+          .catch((cause: unknown) => {
+            const msg = cause instanceof Error ? cause.message : String(cause);
+            logger.error`inbound mail signature shadow-verify crashed for ${frame.agentAddress}: ${msg}`;
+          });
         // Supervised deployments register the deployment-level mail
         // address on `mailInboundRouter` once their supervisor spawns;
         // that handler delivers the bytes to the supervisor's mail-bus

--- a/packages/hub-agent/src/ws/inbound-signature-shadow.test.ts
+++ b/packages/hub-agent/src/ws/inbound-signature-shadow.test.ts
@@ -1,0 +1,255 @@
+import { describe, test, expect } from "bun:test";
+import { generateKeyPair, createEd25519Crypto } from "@intx/crypto";
+import {
+  assembleSignedContent,
+  assembleMessage,
+  createDetachedSignatureFromProvider,
+  generateMessageId,
+  type MessageHeaders,
+} from "@intx/mime";
+import { hexEncode } from "@intx/types";
+
+import { shadowVerifyInboundSignature } from "./inbound-signature-shadow";
+
+const AGENT_ADDRESS = "run_anchor@tenant.example";
+
+function headersFrom(from: string): MessageHeaders {
+  return {
+    from,
+    to: ["beta@test.interchange"],
+    cc: undefined,
+    date: new Date("2026-01-15T12:00:00Z"),
+    messageId: generateMessageId(from),
+    subject: undefined,
+    inReplyTo: undefined,
+    references: undefined,
+    mimeVersion: "1.0",
+    interchangeType: "conversation.message",
+    interchangeCorrelationId: undefined,
+    interchangeTenantId: undefined,
+    interchangeAgentId: undefined,
+    interchangeSessionId: undefined,
+    interchangeOfferingId: undefined,
+    interchangeSchemaVersion: undefined,
+    traceparent: undefined,
+    tracestate: undefined,
+  };
+}
+
+async function makeCrypto() {
+  return createEd25519Crypto(await generateKeyPair());
+}
+
+/** Build a validly-signed `multipart/signed` conversation message. */
+async function signedMessage(
+  crypto: Awaited<ReturnType<typeof makeCrypto>>,
+  from: string,
+  text = "hello world",
+): Promise<Uint8Array> {
+  const content = assembleSignedContent({ kind: "conversation", text });
+  const sig = await createDetachedSignatureFromProvider(content, crypto);
+  return assembleMessage(headersFrom(from), content, sig);
+}
+
+function hexKey(crypto: Awaited<ReturnType<typeof makeCrypto>>): string {
+  return hexEncode(crypto.getPublicKey());
+}
+
+describe("shadowVerifyInboundSignature", () => {
+  test("valid signature whose From matches the stamp: valid/match", async () => {
+    const sender = "alpha@test.interchange";
+    const crypto = await makeCrypto();
+    const raw = await signedMessage(crypto, sender);
+
+    const verdict = await shadowVerifyInboundSignature({
+      raw,
+      authenticatedSender: sender,
+      authenticatedSenderPublicKey: hexKey(crypto),
+      messageId: "mid-valid",
+      agentAddress: AGENT_ADDRESS,
+    });
+
+    expect(verdict.signature).toBe("valid");
+    expect(verdict.fromMatch).toBe("match");
+    expect(verdict.messageFrom).toBe(sender);
+  });
+
+  test("signature against a different key: invalid, From unchecked", async () => {
+    const sender = "alpha@test.interchange";
+    const signer = await makeCrypto();
+    const other = await makeCrypto();
+    const raw = await signedMessage(signer, sender);
+
+    const verdict = await shadowVerifyInboundSignature({
+      raw,
+      authenticatedSender: sender,
+      authenticatedSenderPublicKey: hexKey(other),
+      messageId: "mid-invalid",
+      agentAddress: AGENT_ADDRESS,
+    });
+
+    expect(verdict.signature).toBe("invalid");
+    // A From-binding is only meaningful atop a valid signature.
+    expect(verdict.fromMatch).toBe("unchecked");
+  });
+
+  test("message that is not multipart/signed: missing", async () => {
+    const sender = "alpha@test.interchange";
+    const crypto = await makeCrypto();
+    const raw = new TextEncoder().encode(
+      [
+        `From: ${sender}`,
+        "To: beta@test.interchange",
+        "Subject: plain",
+        "Content-Type: text/plain",
+        "",
+        "not signed",
+      ].join("\r\n"),
+    );
+
+    const verdict = await shadowVerifyInboundSignature({
+      raw,
+      authenticatedSender: sender,
+      authenticatedSenderPublicKey: hexKey(crypto),
+      messageId: "mid-missing",
+      agentAddress: AGENT_ADDRESS,
+    });
+
+    expect(verdict.signature).toBe("missing");
+    expect(verdict.fromMatch).toBe("unchecked");
+  });
+
+  test("valid signature under a forged From: valid/mismatch", async () => {
+    // The message is genuinely signed by `signer`'s key (so the hub stamps
+    // `signer`'s address + key), but its visible From claims a different
+    // sender. A valid signature over a borrowed display identity is the
+    // forgery this binding catches.
+    const signer = "alpha@test.interchange";
+    const forgedFrom = "victim@test.interchange";
+    const crypto = await makeCrypto();
+    const raw = await signedMessage(crypto, forgedFrom);
+
+    const verdict = await shadowVerifyInboundSignature({
+      raw,
+      authenticatedSender: signer,
+      authenticatedSenderPublicKey: hexKey(crypto),
+      messageId: "mid-forged",
+      agentAddress: AGENT_ADDRESS,
+    });
+
+    expect(verdict.signature).toBe("valid");
+    expect(verdict.fromMatch).toBe("mismatch");
+    expect(verdict.messageFrom).toBe(forgedFrom);
+  });
+
+  test("null sender key: unknown, admitted", async () => {
+    const sender = "alpha@test.interchange";
+    const crypto = await makeCrypto();
+    const raw = await signedMessage(crypto, sender);
+
+    const verdict = await shadowVerifyInboundSignature({
+      raw,
+      authenticatedSender: sender,
+      authenticatedSenderPublicKey: null,
+      messageId: "mid-null",
+      agentAddress: AGENT_ADDRESS,
+    });
+
+    expect(verdict.signature).toBe("unknown");
+    expect(verdict.fromMatch).toBe("unchecked");
+  });
+
+  test("malformed hex key degrades to a distinct error verdict", async () => {
+    const sender = "alpha@test.interchange";
+    const crypto = await makeCrypto();
+    const raw = await signedMessage(crypto, sender);
+
+    const verdict = await shadowVerifyInboundSignature({
+      raw,
+      authenticatedSender: sender,
+      authenticatedSenderPublicKey: "not-hex",
+      messageId: "mid-badhex",
+      agentAddress: AGENT_ADDRESS,
+    });
+
+    expect(verdict.signature).toBe("error");
+    expect(verdict.fromMatch).toBe("unchecked");
+  });
+
+  test("well-formed hex of the wrong length is an error, not a crash", async () => {
+    const sender = "alpha@test.interchange";
+    const crypto = await makeCrypto();
+    const raw = await signedMessage(crypto, sender);
+
+    const verdict = await shadowVerifyInboundSignature({
+      raw,
+      authenticatedSender: sender,
+      // 16 bytes of valid hex -- half an Ed25519 key.
+      authenticatedSenderPublicKey: "ab".repeat(16),
+      messageId: "mid-shortkey",
+      agentAddress: AGENT_ADDRESS,
+    });
+
+    expect(verdict.signature).toBe("error");
+  });
+
+  test("a display-name From still binds to the stamp addr-spec", async () => {
+    // extractAddrSpec strips the display name, so `Alpha <a@b>` binds to the
+    // bare stamp `a@b` without a false mismatch.
+    const crypto = await makeCrypto();
+    const raw = await signedMessage(crypto, "Alpha <alpha@test.interchange>");
+
+    const verdict = await shadowVerifyInboundSignature({
+      raw,
+      authenticatedSender: "alpha@test.interchange",
+      authenticatedSenderPublicKey: hexKey(crypto),
+      messageId: "mid-display",
+      agentAddress: AGENT_ADDRESS,
+    });
+
+    expect(verdict.signature).toBe("valid");
+    expect(verdict.fromMatch).toBe("match");
+    expect(verdict.messageFrom).toBe("alpha@test.interchange");
+  });
+
+  test("an unparseable multi-address From stays unchecked, not a false mismatch", async () => {
+    // A shadow must not turn a From it cannot reduce to one addr-spec into a
+    // forgery verdict -- that would poison the corpus (and later drop
+    // legitimate mail under enforcement). extractAddrSpec rejects the two-@
+    // input; the binding degrades to unchecked while the signature stands.
+    const crypto = await makeCrypto();
+    const raw = await signedMessage(
+      crypto,
+      "alpha@test.interchange, beta@test.interchange",
+    );
+
+    const verdict = await shadowVerifyInboundSignature({
+      raw,
+      authenticatedSender: "alpha@test.interchange",
+      authenticatedSenderPublicKey: hexKey(crypto),
+      messageId: "mid-multi",
+      agentAddress: AGENT_ADDRESS,
+    });
+
+    expect(verdict.signature).toBe("valid");
+    expect(verdict.fromMatch).toBe("unchecked");
+  });
+
+  test("case-variant From still matches the stamp", async () => {
+    // extractAddrSpec normalizes to lowercase, so an upper-case From binds to a
+    // lower-case stamp without a false mismatch.
+    const crypto = await makeCrypto();
+    const raw = await signedMessage(crypto, "Alpha@Test.Interchange");
+
+    const verdict = await shadowVerifyInboundSignature({
+      raw,
+      authenticatedSender: "alpha@test.interchange",
+      authenticatedSenderPublicKey: hexKey(crypto),
+      messageId: "mid-case",
+      agentAddress: AGENT_ADDRESS,
+    });
+
+    expect(verdict.signature).toBe("valid");
+    expect(verdict.fromMatch).toBe("match");
+  });
+});

--- a/packages/hub-agent/src/ws/inbound-signature-shadow.ts
+++ b/packages/hub-agent/src/ws/inbound-signature-shadow.ts
@@ -1,0 +1,185 @@
+import { getLogger } from "@intx/log";
+import { hexDecode } from "@intx/types";
+import { verifyMimeSignature } from "@intx/mailbox";
+import { parseHeaderSection, extractAddrSpec } from "@intx/mime";
+
+const logger = getLogger([
+  "interchange",
+  "hub-agent",
+  "ws",
+  "inbound-signature-shadow",
+]);
+
+// A raw Ed25519 public key is 32 bytes; the hub stamps it hex-encoded on the
+// frame.
+const ED25519_PUBLIC_KEY_BYTES = 32;
+
+/**
+ * The two-axis verdict of shadow-verifying one inbound mail frame.
+ *
+ * `signature` reuses the `SignatureStatus` vocabulary --
+ * `valid | invalid | missing | unknown` -- with an added `error` for a fault in
+ * the verifier itself (a malformed key, an unparseable sender). It answers: does
+ * the message's detached signature verify against the key the hub resolved for
+ * `authenticatedSender`?
+ *
+ * `fromMatch` is an orthogonal axis: given a VALID signature, does the message's
+ * visible `From` bind to `authenticatedSender`? A valid signature over a `From`
+ * that names a different sender is an identity forgery -- a legitimate key
+ * signing under a borrowed display identity -- and it can only arise atop a
+ * valid signature, so `fromMatch` is `unchecked` whenever the signature is not
+ * `valid` or the message carries no parseable `From`.
+ *
+ * The signature covers only the message's signed content part, NOT its
+ * top-level `From` header (see `@intx/mime` `assembleMessage`). The binding
+ * checked here is therefore the hub-stamped sender against the visible envelope
+ * `From`, not a `From` inside the signed bytes.
+ */
+export type InboundSignatureVerdict = {
+  signature: "valid" | "invalid" | "missing" | "unknown" | "error";
+  fromMatch: "match" | "mismatch" | "unchecked";
+  authenticatedSender: string;
+  messageFrom: string | null;
+};
+
+export type InboundSignatureShadowInput = {
+  raw: Uint8Array;
+  authenticatedSender: string;
+  authenticatedSenderPublicKey: string | null;
+  messageId: string | undefined;
+  agentAddress: string;
+};
+
+/**
+ * Verify an inbound mail frame's signature against the hub-resolved sender key
+ * and LOG the verdict. Shadow only: this NEVER rejects delivery and NEVER
+ * throws -- the caller runs it beside an unconditional admit. Returns the
+ * verdict so a caller (or a test) can read it without scraping the log.
+ *
+ * A fault in the verifier (malformed key, unparseable sender) degrades to an
+ * `error` verdict logged at ERROR -- surfaced loudly and kept distinct from the
+ * ordinary `unknown` of an unresolvable sender, which stays a quiet `info`.
+ */
+export async function shadowVerifyInboundSignature(
+  input: InboundSignatureShadowInput,
+): Promise<InboundSignatureVerdict> {
+  const { raw, authenticatedSender, authenticatedSenderPublicKey } = input;
+
+  if (authenticatedSenderPublicKey === null) {
+    // No hub-resolved key: an unresolvable sender (a run whose deploy is not yet
+    // acked, an address matching no principal). Nothing to verify against; the
+    // mail is admitted as an unverifiable sender. Not a fault -- a quiet
+    // `unknown`.
+    return logVerdict(
+      {
+        signature: "unknown",
+        fromMatch: "unchecked",
+        authenticatedSender,
+        messageFrom: null,
+      },
+      input,
+    );
+  }
+
+  let verdict: InboundSignatureVerdict;
+  try {
+    const key = hexDecode(authenticatedSenderPublicKey);
+    if (key.length !== ED25519_PUBLIC_KEY_BYTES) {
+      throw new Error(
+        `expected a ${ED25519_PUBLIC_KEY_BYTES}-byte Ed25519 key, got ${key.length}`,
+      );
+    }
+    const signature = await verifyMimeSignature(raw, key);
+    verdict = {
+      signature,
+      fromMatch: "unchecked",
+      authenticatedSender,
+      messageFrom: null,
+    };
+    if (signature === "valid") {
+      bindVisibleFrom(verdict, raw);
+    }
+  } catch (cause) {
+    logger.error(
+      "inbound mail signature shadow-verify FAULTED for {authenticatedSender} (messageId {messageId}, agentAddress {agentAddress}): {cause}",
+      {
+        // Carry the same `signature`/`fromMatch` keys the clean verdict logs, so
+        // a consumer counting the shadow corpus by `signature` sees faults too.
+        signature: "error",
+        fromMatch: "unchecked",
+        authenticatedSender,
+        messageId: input.messageId ?? null,
+        agentAddress: input.agentAddress,
+        cause: describeCause(cause),
+      },
+    );
+    return {
+      signature: "error",
+      fromMatch: "unchecked",
+      authenticatedSender,
+      messageFrom: null,
+    };
+  }
+
+  return logVerdict(verdict, input);
+}
+
+/**
+ * Bind the message's visible `From` to `authenticatedSender` on a VALID
+ * signature. A parse failure (a malformed `From`, or an `authenticatedSender`
+ * that is not a bare addr-spec) leaves the binding `unchecked` rather than
+ * clobbering the standing signature verdict -- the signature is the primary
+ * signal, and a shadow must not turn an unparseable header into a false verdict.
+ */
+function bindVisibleFrom(
+  verdict: InboundSignatureVerdict,
+  raw: Uint8Array,
+): void {
+  try {
+    const messageFrom = readMessageFrom(raw);
+    verdict.messageFrom = messageFrom;
+    if (messageFrom !== null) {
+      verdict.fromMatch =
+        messageFrom === extractAddrSpec(verdict.authenticatedSender)
+          ? "match"
+          : "mismatch";
+    }
+  } catch (cause) {
+    logger.debug(
+      "inbound mail From-binding unparseable for {authenticatedSender}: {cause}",
+      {
+        authenticatedSender: verdict.authenticatedSender,
+        cause: describeCause(cause),
+      },
+    );
+  }
+}
+
+function readMessageFrom(raw: Uint8Array): string | null {
+  const { headers } = parseHeaderSection(raw);
+  const from = headers.get("from");
+  if (from === undefined || from.trim() === "") return null;
+  return extractAddrSpec(from);
+}
+
+function logVerdict(
+  verdict: InboundSignatureVerdict,
+  input: InboundSignatureShadowInput,
+): InboundSignatureVerdict {
+  logger.info(
+    "inbound mail signature shadow verdict {signature}/{fromMatch} for {authenticatedSender} (from {messageFrom}, messageId {messageId}, agentAddress {agentAddress})",
+    {
+      signature: verdict.signature,
+      fromMatch: verdict.fromMatch,
+      authenticatedSender: verdict.authenticatedSender,
+      messageFrom: verdict.messageFrom,
+      messageId: input.messageId ?? null,
+      agentAddress: input.agentAddress,
+    },
+  );
+  return verdict;
+}
+
+function describeCause(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}

--- a/packages/hub-api/src/routes/workflows.test.ts
+++ b/packages/hub-api/src/routes/workflows.test.ts
@@ -489,6 +489,7 @@ type RouteMailCall = {
   address: string;
   rawMessage: string;
   authenticatedSender: string;
+  authenticatedSenderPublicKey: string | null;
 };
 type RunGrantsCall = {
   address: string;
@@ -514,8 +515,18 @@ function createMockSidecarRouter(
     handleOpen: () => notImpl("handleOpen"),
     handleMessage: () => notImpl("handleMessage"),
     handleClose: () => notImpl("handleClose"),
-    routeMail: (address, rawMessage, authenticatedSender) => {
-      routeMailCalls.push({ address, rawMessage, authenticatedSender });
+    routeMail: (
+      address,
+      rawMessage,
+      authenticatedSender,
+      authenticatedSenderPublicKey,
+    ) => {
+      routeMailCalls.push({
+        address,
+        rawMessage,
+        authenticatedSender,
+        authenticatedSenderPublicKey,
+      });
       sendOrder.push({ kind: "mail", address });
       return routeMailResult;
     },
@@ -552,14 +563,15 @@ function createMockSessionService(): SessionService {
 }
 
 function createMockPrincipalKeyStore(): PrincipalKeyStore {
-  function notImpl(name: string): never {
-    throw new Error(`mock: principalKeyStore.${name} not implemented`);
-  }
   return {
     // The trigger mints the run principal's key while materializing grants; the
     // return value is not read, so a canned hex public key suffices.
     generate: async () => "ab".repeat(32),
-    getPublicKey: () => notImpl("getPublicKey"),
+    // The trigger resolves the triggering principal's public key to stamp on
+    // the inbound frame (so the recipient can verify the mail). Return the same
+    // canned hex key the store mints; this suite asserts route behavior, not the
+    // key's cryptographic validity.
+    getPublicKey: async () => "ab".repeat(32),
     // The trigger signs the outbound mail with the caller's principal key.
     // This suite asserts route behavior (status, run.grants ordering, grant
     // materialization), not signature validity, so return a fixed-length raw
@@ -750,6 +762,7 @@ function createMockEventCollectors(): EventCollectorRegistry {
 type TestAppOpts = {
   db?: MockDBOpts;
   grants?: GrantRule[];
+  principalKeyStore?: PrincipalKeyStore;
   signalCalls?: SignalCall[];
   routeMailCalls?: RouteMailCall[];
   routeMailResult?: boolean;
@@ -807,7 +820,7 @@ function createTestApp(opts: TestAppOpts = {}) {
     getSession: createMockGetSession(),
     authHandler: () => new Response("", { status: 404 }),
     db,
-    principalKeyStore: createMockPrincipalKeyStore(),
+    principalKeyStore: opts.principalKeyStore ?? createMockPrincipalKeyStore(),
     grantStore: createInMemoryGrantStore(opts.grants ?? [makeGrant()]),
     sidecarRouter: createMockSidecarRouter(
       opts.signalCalls ?? [],
@@ -1603,12 +1616,46 @@ describe("POST /workflows/:anchorRunId/mail", () => {
     // authenticated sender (fromAddr = principal.refId@tenant.domain), not
     // anything parsed from the message body.
     expect(call.authenticatedSender).toBe(`${USER_ID}@${DOMAIN}`);
+    // The trigger resolves the authenticated sender's hub-held key and stamps
+    // it on the frame so the recipient can verify the signature. The mock key
+    // store mints this canned hex key for the triggering principal.
+    expect(call.authenticatedSenderPublicKey).toBe("ab".repeat(32));
     // The wire payload is base64-encoded MIME carrying the body text.
     const decoded = new TextDecoder().decode(base64Decode(call.rawMessage));
     expect(decoded).toContain("kick off");
     // A run trigger is threading-less: no In-Reply-To / References.
     expect(decoded).not.toContain("In-Reply-To");
     expect(decoded).not.toContain("References:");
+  });
+
+  test("routes the trigger mail even when the sender key cannot be resolved", async () => {
+    // The frame sender key is shadow-only and nullable, so a resolution fault
+    // (here a misconfigured key store whose getPublicKey throws) must degrade to
+    // null rather than fail the trigger. Otherwise the fault would strand a run
+    // whose grants (sent before the mail) have already gone out.
+    const routeMailCalls: RouteMailCall[] = [];
+    const throwingKeyStore: PrincipalKeyStore = {
+      ...createMockPrincipalKeyStore(),
+      getPublicKey: async () => {
+        throw new Error("mock: key store misconfigured");
+      },
+    };
+    const app = createTestApp({
+      grants: [manageGrant()],
+      routeMailCalls,
+      principalKeyStore: throwingKeyStore,
+      db: { deploymentRow, assetRow: workflowAssetRow },
+    });
+
+    const res = await app.fetch(
+      authedPost(`${base()}/${DEPLOYMENT_ID}/mail`, { content: "kick off" }),
+    );
+
+    expect(res.status).toBe(202);
+    expect(routeMailCalls).toHaveLength(1);
+    // The resolution fault degrades to a null stamped key rather than
+    // propagating; the mail still routes so the run is not stranded.
+    expect(routeMailCalls[0]?.authenticatedSenderPublicKey).toBeNull();
   });
 
   test("a later trigger occurrence reuses the live run's committed grants", async () => {

--- a/packages/hub-api/src/workflow-run-trigger.ts
+++ b/packages/hub-api/src/workflow-run-trigger.ts
@@ -23,7 +23,7 @@ import {
   workflowRun,
 } from "@intx/db/schema";
 import type { DB, PrincipalKeyStore } from "@intx/db";
-import { loadFrozenGrantSnapshot } from "@intx/db";
+import { loadFrozenGrantSnapshot, resolveFrameSenderKey } from "@intx/db";
 import type { GrantStore } from "@intx/types/authz";
 import {
   assembleSignedContent,
@@ -571,11 +571,21 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
 
     // Stamp the hub-verified principal address (fromAddr, the address the
     // message is signed and addressed under) as the authenticated sender --
-    // never the message's own MIME From.
+    // never the message's own MIME From. Resolve its hub-held key alongside so
+    // the recipient can verify the signature locally against the key the hub
+    // vouches for. Best-effort: a resolution fault degrades to a null key
+    // (logged) rather than 500-ing a trigger whose grants have already been
+    // sent -- verification is shadow-only and must never block the trigger.
+    const authenticatedSenderPublicKey = await resolveFrameSenderKey(
+      db,
+      principalKeyStore,
+      fromAddr,
+    );
     const delivered = sidecarRouter.routeMail(
       address,
       base64,
       fromAddr,
+      authenticatedSenderPublicKey,
       messageId,
     );
     if (!delivered) {

--- a/packages/hub-sessions/src/hub-session-lookups.ts
+++ b/packages/hub-sessions/src/hub-session-lookups.ts
@@ -48,7 +48,9 @@ export function createHubSessionLookups(
 ): Required<
   Omit<
     SidecarLookups,
-    "materializeMailTriggeredRunGrants" | "resyncCredentials"
+    | "materializeMailTriggeredRunGrants"
+    | "resyncCredentials"
+    | "resolveSenderKey"
   >
 > {
   const { db, agentRepoStore } = deps;

--- a/packages/hub-sessions/src/ws/sidecar-events.ts
+++ b/packages/hub-sessions/src/ws/sidecar-events.ts
@@ -263,6 +263,20 @@ export type SidecarLookups = {
     raw: Uint8Array;
   }) => Promise<SidecarMailPersistedRow[]>;
 
+  /** Resolves the hub-held public key an inbound mail's authenticated sender
+   * signs with, hex-encoded, or `null` when the sender has no resolvable key
+   * (a run whose deploy is not yet acked, an address matching no known
+   * principal). The wire layer carries the result on the `mail.inbound` frame
+   * so the recipient verifies the signature locally against the hub-resolved
+   * key rather than the message's own spoofable From. Returns only the key
+   * string, not its source, so the recipient cannot branch on sender kind.
+   *
+   * Best-effort: this NEVER throws. A resolution fault degrades to `null`
+   * (logged at ERROR by the resolver), so a key-resolution problem can never
+   * block mail delivery. The strict, throwing resolver is `resolveSenderKey`
+   * in `@intx/db`. */
+  resolveSenderKey?: (address: string) => Promise<string | null>;
+
   /** Co-writes the `signal_correlation` routing row and the `approval` row
    * for a suspending workflow agent step, in one transaction. Called from
    * the `signal.correlation.register` frame handler after the wire layer has

--- a/packages/hub-sessions/src/ws/sidecar-handler.mail.test.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.mail.test.ts
@@ -42,10 +42,11 @@ describe("SidecarRouter allocation mail durability", () => {
         TEST_IDENTITY.workflowRunAddress,
         "aGVsbG8=",
         TEST_SENDER,
+        null,
       ),
     ).toBe(true);
     expect(
-      router.routeMail("unknown@example.test", "aGVsbG8=", TEST_SENDER),
+      router.routeMail("unknown@example.test", "aGVsbG8=", TEST_SENDER, null),
     ).toBe(false);
   });
 
@@ -63,6 +64,7 @@ describe("SidecarRouter allocation mail durability", () => {
         TEST_IDENTITY.workflowRunAddress,
         "aGVsbG8=",
         TEST_SENDER,
+        null,
         "mid-retry",
       ),
     ).toBe(true);
@@ -89,6 +91,7 @@ describe("SidecarRouter allocation mail durability", () => {
       TEST_IDENTITY.workflowRunAddress,
       "aGk=",
       TEST_SENDER,
+      null,
       "mid-acked",
     );
 
@@ -152,6 +155,7 @@ describe("SidecarRouter allocation mail durability", () => {
       TEST_IDENTITY.workflowRunAddress,
       "b3duZWQ=",
       TEST_SENDER,
+      null,
       "mid-owned",
     );
     router.handleMessage(
@@ -192,6 +196,7 @@ describe("SidecarRouter allocation mail durability", () => {
       TEST_IDENTITY.workflowRunAddress,
       "ZHJvcA==",
       TEST_SENDER,
+      null,
       "mid-drop",
     );
     await new Promise((resolve) => setTimeout(resolve, 80));
@@ -214,7 +219,12 @@ describe("SidecarRouter allocation mail durability", () => {
       TEST_IDENTITY.workflowRunAddress,
     ]);
 
-    router.routeMail(TEST_IDENTITY.workflowRunAddress, "eXk=", TEST_SENDER);
+    router.routeMail(
+      TEST_IDENTITY.workflowRunAddress,
+      "eXk=",
+      TEST_SENDER,
+      null,
+    );
     await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(framesOfType(ws, "mail.inbound")).toHaveLength(1);
@@ -232,6 +242,7 @@ describe("SidecarRouter allocation mail durability", () => {
       TEST_IDENTITY.workflowRunAddress,
       "cmV0YWluZWQ=",
       TEST_SENDER,
+      null,
       "mid-retained",
     );
     router.handleClose(first);
@@ -260,6 +271,7 @@ describe("SidecarRouter allocation mail durability", () => {
       TEST_IDENTITY.workflowRunAddress,
       "ZXhwaXJlZA==",
       TEST_SENDER,
+      null,
       "mid-expired",
     );
     router.handleClose(first);
@@ -309,6 +321,41 @@ describe("SidecarRouter allocation mail durability", () => {
       "run.grants",
       "mail.inbound",
     ]);
+  });
+
+  test("dispatched inbound mail carries the hub-resolved sender key", async () => {
+    const hexKey = "bb".repeat(32);
+    const resolvedFor: string[] = [];
+    const router = createAllocatedRouter({
+      lookups: {
+        async resolveSenderKey(address) {
+          resolvedFor.push(address);
+          return hexKey;
+        },
+      },
+    });
+    const ws = await connectAllocated(router, [
+      TEST_IDENTITY.workflowRunAddress,
+    ]);
+
+    await router.sendWorkflowRunDispatchToAllocation(
+      TEST_TARGET,
+      TEST_IDENTITY.workflowRunAddress,
+      TEST_IDENTITY.anchorRunId,
+      [],
+      "dHJpZ2dlcg==",
+      TEST_SENDER,
+      "mid-key",
+    );
+
+    // The dispatch path resolves the key from the persisted sender, never the
+    // MIME From, and stamps it on the redelivered frame.
+    expect(resolvedFor).toEqual([TEST_SENDER]);
+    const inbound = framesOfType(ws, "mail.inbound").filter(
+      (frame) => frame["messageId"] === "mid-key",
+    );
+    expect(inbound).toHaveLength(1);
+    expect(inbound[0]?.["authenticatedSenderPublicKey"]).toBe(hexKey);
   });
 });
 
@@ -459,6 +506,67 @@ describe("SidecarRouter workflow-trigger mail gating", () => {
     // (`From: sender@example.test`) -- value-level independence, not just
     // equality to the gate value.
     expect(inbound[0]?.["authenticatedSender"]).not.toBe("sender@example.test");
+  });
+
+  test("relayed inbound mail carries the hub-resolved sender key", async () => {
+    const hexKey = "aa".repeat(32);
+    const resolvedFor: string[] = [];
+    const router = createAllocatedRouter({
+      lookups: {
+        async resolveSenderKey(address) {
+          resolvedFor.push(address);
+          return hexKey;
+        },
+      },
+    });
+    const ws = await connectAllocated(router, [
+      TEST_IDENTITY.workflowRunAddress,
+    ]);
+
+    router.handleMessage(
+      ws,
+      JSON.stringify({
+        type: "mail.outbound",
+        senderAddress: TEST_IDENTITY.workflowRunAddress,
+        rawMessage,
+        recipients: [TEST_IDENTITY.workflowRunAddress],
+      }),
+    );
+    await tick();
+
+    // The key is resolved from the hub-verified sender, never the MIME From.
+    expect(resolvedFor).toEqual([TEST_IDENTITY.workflowRunAddress]);
+    const inbound = framesOfType(ws, "mail.inbound");
+    expect(inbound).toHaveLength(1);
+    expect(inbound[0]?.["authenticatedSenderPublicKey"]).toBe(hexKey);
+  });
+
+  test("inbound mail carries a null sender key when unresolvable", async () => {
+    const router = createAllocatedRouter({
+      lookups: {
+        async resolveSenderKey() {
+          return null;
+        },
+      },
+    });
+    const ws = await connectAllocated(router, [
+      TEST_IDENTITY.workflowRunAddress,
+    ]);
+
+    router.handleMessage(
+      ws,
+      JSON.stringify({
+        type: "mail.outbound",
+        senderAddress: TEST_IDENTITY.workflowRunAddress,
+        rawMessage,
+        recipients: [TEST_IDENTITY.workflowRunAddress],
+      }),
+    );
+    await tick();
+
+    const inbound = framesOfType(ws, "mail.inbound");
+    expect(inbound).toHaveLength(1);
+    expect(inbound[0]?.["authenticatedSenderPublicKey"]).toBeNull();
   });
 
   test("drops mail.outbound whose sender the connection does not own", async () => {

--- a/packages/hub-sessions/src/ws/sidecar-handler.test.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.test.ts
@@ -222,6 +222,7 @@ describe("SidecarRouter allocation routing", () => {
         identity.workflowRunAddress,
         "aGVsbG8=",
         "sender@example.test",
+        null,
         "message-1",
       ),
     ).toBe(true);

--- a/packages/hub-sessions/src/ws/sidecar-handler.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.ts
@@ -192,6 +192,7 @@ export type SidecarRouter = {
     agentAddress: string,
     rawMessage: string,
     authenticatedSender: string,
+    authenticatedSenderPublicKey: string | null,
     messageId?: string,
     runGrants?: { runId: string; stepGrants: RunGrantsFrame["stepGrants"] },
   ): boolean;
@@ -1398,6 +1399,14 @@ export function createSidecarRouter(
     rawMessage: string,
     authenticatedSender: string,
   ): Promise<"routed" | "unrouted" | "failed-closed"> {
+    // Resolve the sender's hub-held key once for either delivery branch. A
+    // missing resolver or an unresolvable sender yields null; the recipient
+    // logs the mail as unverifiable and admits it (shadow), so this never
+    // blocks delivery.
+    const authenticatedSenderPublicKey =
+      lookups.resolveSenderKey !== undefined
+        ? await lookups.resolveSenderKey(authenticatedSender)
+        : null;
     if (
       lookups.materializeMailTriggeredRunGrants !== undefined &&
       isRunAddress(recipient)
@@ -1447,6 +1456,7 @@ export function createSidecarRouter(
           recipient,
           rawMessage,
           authenticatedSender,
+          authenticatedSenderPublicKey,
           messageId,
           { runId, stepGrants: result.stepGrants },
         )
@@ -1459,7 +1469,12 @@ export function createSidecarRouter(
       // authorize. No run is committed here, so no ack handshake is needed.
     }
 
-    return routeMail(recipient, rawMessage, authenticatedSender)
+    return routeMail(
+      recipient,
+      rawMessage,
+      authenticatedSender,
+      authenticatedSenderPublicKey,
+    )
       ? "routed"
       : "unrouted";
   }
@@ -2377,6 +2392,7 @@ export function createSidecarRouter(
     agentAddress: string,
     rawMessage: string,
     authenticatedSender: string,
+    authenticatedSenderPublicKey: string | null,
     messageId?: string,
     runGrants?: { runId: string; stepGrants: RunGrantsFrame["stepGrants"] },
   ): boolean {
@@ -2386,6 +2402,10 @@ export function createSidecarRouter(
     // the frame as the hub-verified sender of record, so a recipient can take
     // the sender from it rather than the forgeable `From`; no consumer reads
     // it yet.
+    //
+    // `authenticatedSenderPublicKey` is the caller's hub-resolved key for that
+    // sender (null when unresolvable), carried alongside so the recipient
+    // verifies the signature locally against the hub-vouched key.
     //
     // Carry the hub-minted messageId on the frame so the sidecar's durable-
     // receipt ack (`mail.inbound.ack`) keys on the same id the hub tracks, and
@@ -2398,6 +2418,7 @@ export function createSidecarRouter(
       agentAddress,
       rawMessage,
       authenticatedSender,
+      authenticatedSenderPublicKey,
       ...(messageId !== undefined ? { messageId } : {}),
     };
     const ws = addressIndex.get(agentAddress);
@@ -2480,11 +2501,23 @@ export function createSidecarRouter(
     // authenticatedSender is the sender persisted at enqueue on the dispatch
     // row (the triggering principal's hub-verified address); the caller reads
     // it from that row. It is never the message's MIME From.
+    //
+    // Resolve its key here, at dispatch (redelivery) time, from that persisted
+    // address -- so the frame reflects the sender's current hub-held key. A
+    // run sender's deployment key is immutable once acked; a user sender's key
+    // rotating mid-flight would leave the fixed signed bytes checked against
+    // the new key, which the recipient logs as unverifiable. Null when
+    // unresolvable (no resolver wired, or the sender has no durable key).
+    const authenticatedSenderPublicKey =
+      lookups.resolveSenderKey !== undefined
+        ? await lookups.resolveSenderKey(authenticatedSender)
+        : null;
     const frame: HubFrame = {
       type: "mail.inbound",
       agentAddress,
       rawMessage,
       authenticatedSender,
+      authenticatedSenderPublicKey,
       messageId,
     };
     conn.send(frame);

--- a/packages/hub-sessions/src/ws/sidecar-handler.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.ts
@@ -2400,12 +2400,14 @@ export function createSidecarRouter(
     // value (the ownership-gated sender of a relayed mail, or the triggering
     // principal's address) -- never the message's own MIME `From`. It rides
     // the frame as the hub-verified sender of record, so a recipient can take
-    // the sender from it rather than the forgeable `From`; no consumer reads
-    // it yet.
+    // the sender from it rather than the forgeable `From`. The recipient's
+    // shadow signature check reads it as the sender of record, but only to log
+    // a verdict -- it does not gate delivery.
     //
     // `authenticatedSenderPublicKey` is the caller's hub-resolved key for that
-    // sender (null when unresolvable), carried alongside so the recipient
-    // verifies the signature locally against the hub-vouched key.
+    // sender (null when unresolvable), carried alongside so the recipient's
+    // shadow check verifies the signature against the hub-vouched key and logs
+    // a verdict; it does not gate delivery.
     //
     // Carry the hub-minted messageId on the frame so the sidecar's durable-
     // receipt ack (`mail.inbound.ack`) keys on the same id the hub tracks, and

--- a/packages/mailbox/src/fetch.test.ts
+++ b/packages/mailbox/src/fetch.test.ts
@@ -1,10 +1,12 @@
 import { describe, test, expect } from "bun:test";
+import type { CryptoProvider } from "@intx/types/runtime";
 import {
   createInMemoryMailboxStore,
   executeSearch,
   fetchHeaders,
   fetchStructure,
   fetchPart,
+  fetchFull,
   type MailboxStore,
   type StoredEnvelope,
 } from "./index";
@@ -214,5 +216,27 @@ describe("async fetch projections route through readRaw", () => {
     await expect(
       fetchHeaders({ uid: 42, mailbox: "INBOX" }, store),
     ).rejects.toThrow(/not found/);
+  });
+
+  test("fetchFull propagates a sender whose getPublicKey throws", async () => {
+    // A CryptoProvider that cannot produce its own public key is a local
+    // fault, not a bad signature: the error surfaces rather than being
+    // masked as a signature status. The key is resolved for every inbound
+    // from a known sender, so even this non-signed message reaches it.
+    const store = createInMemoryMailboxStore();
+    const uid = store.append(rawMessage("Hello", "b"), envelopeFor(), []);
+
+    const brokenSender: CryptoProvider = {
+      sign: () => Promise.reject(new Error("unused")),
+      signSSH: () => Promise.reject(new Error("unused")),
+      verify: () => Promise.resolve(false),
+      getPublicKey: () => {
+        throw new Error("no public key");
+      },
+    };
+
+    await expect(
+      fetchFull({ uid, mailbox: "INBOX" }, store, () => brokenSender),
+    ).rejects.toThrow(/no public key/);
   });
 });

--- a/packages/mailbox/src/fetch.ts
+++ b/packages/mailbox/src/fetch.ts
@@ -22,7 +22,7 @@ import {
   extractAttachments,
 } from "@intx/mime";
 import { buildMessageHeaders } from "./headers";
-import { verifyDetachedSignature } from "@intx/crypto";
+import { verifyMimeSignature } from "./verify-signature";
 
 const MessagePayload = type({
   type: InterchangeType,
@@ -188,42 +188,7 @@ async function verifyMessageSignature(
     return "unknown";
   }
 
-  try {
-    const { headers, bodyOffset } = parseHeaderSection(raw);
-    const body = raw.slice(bodyOffset);
-    const contentType = headers.get("content-type") ?? "";
-
-    if (!contentType.toLowerCase().includes("multipart/signed")) {
-      return "missing";
-    }
-
-    const boundary = extractBoundary(contentType);
-    if (boundary === undefined) return "missing";
-
-    const parts = parseMultipart(body, boundary);
-    if (parts.length < 2) return "missing";
-
-    const signedContentBytes = parts[0]!;
-    const sigPartBytes = parts[1]!;
-    const sigPart = parseMimePart(sigPartBytes);
-
-    if (
-      !sigPart.contentType.toLowerCase().includes("application/pgp-signature")
-    ) {
-      return "missing";
-    }
-
-    const publicKey = senderCrypto.getPublicKey();
-    const valid = await verifyDetachedSignature(
-      signedContentBytes,
-      sigPart.body,
-      publicKey,
-    );
-
-    return valid ? "valid" : "invalid";
-  } catch {
-    return "invalid";
-  }
+  return verifyMimeSignature(raw, senderCrypto.getPublicKey());
 }
 
 function buildStructure(body: Uint8Array, contentType: string): BodyStructure {

--- a/packages/mailbox/src/index.ts
+++ b/packages/mailbox/src/index.ts
@@ -9,3 +9,4 @@ export { executeSearch } from "./search";
 export { executeThread } from "./thread";
 export { fetchHeaders, fetchStructure, fetchPart, fetchFull } from "./fetch";
 export { buildMessageHeaders } from "./headers";
+export { verifyMimeSignature } from "./verify-signature";

--- a/packages/mailbox/src/verify-signature.test.ts
+++ b/packages/mailbox/src/verify-signature.test.ts
@@ -1,0 +1,102 @@
+import { describe, test, expect } from "bun:test";
+import { generateKeyPair, createEd25519Crypto } from "@intx/crypto";
+import {
+  assembleSignedContent,
+  assembleMessage,
+  createDetachedSignatureFromProvider,
+  generateMessageId,
+  type MessageHeaders,
+} from "@intx/mime";
+import { verifyMimeSignature } from "./verify-signature";
+
+function conversationHeaders(): MessageHeaders {
+  return {
+    from: "alpha@test.interchange",
+    to: ["beta@test.interchange"],
+    cc: undefined,
+    date: new Date("2026-01-15T12:00:00Z"),
+    messageId: generateMessageId("alpha@test.interchange"),
+    subject: undefined,
+    inReplyTo: undefined,
+    references: undefined,
+    mimeVersion: "1.0",
+    interchangeType: "conversation.message",
+    interchangeCorrelationId: undefined,
+    interchangeTenantId: undefined,
+    interchangeAgentId: undefined,
+    interchangeSessionId: undefined,
+    interchangeOfferingId: undefined,
+    interchangeSchemaVersion: undefined,
+    traceparent: undefined,
+    tracestate: undefined,
+  };
+}
+
+/** Build a validly-signed `multipart/signed` conversation message. */
+async function signedMessage(
+  crypto: Awaited<ReturnType<typeof makeCrypto>>,
+  text: string,
+): Promise<Uint8Array> {
+  const content = assembleSignedContent({ kind: "conversation", text });
+  const sig = await createDetachedSignatureFromProvider(content, crypto);
+  return assembleMessage(conversationHeaders(), content, sig);
+}
+
+async function makeCrypto() {
+  return createEd25519Crypto(await generateKeyPair());
+}
+
+describe("verifyMimeSignature", () => {
+  test("returns valid for a message signed by the given key", async () => {
+    const crypto = await makeCrypto();
+    const raw = await signedMessage(crypto, "hello world");
+
+    const status = await verifyMimeSignature(raw, crypto.getPublicKey());
+    expect(status).toBe("valid");
+  });
+
+  test("returns invalid when checked against a different key", async () => {
+    const signer = await makeCrypto();
+    const other = await makeCrypto();
+    const raw = await signedMessage(signer, "hello world");
+
+    const status = await verifyMimeSignature(raw, other.getPublicKey());
+    expect(status).toBe("invalid");
+  });
+
+  test("returns invalid, not a throw, for a corrupt signature part", async () => {
+    // Shadow verification must never let a malformed signature escape as an
+    // exception: a corrupt `application/pgp-signature` part is a verdict
+    // ("invalid"), not an error the caller has to catch.
+    const crypto = await makeCrypto();
+    const content = assembleSignedContent({
+      kind: "conversation",
+      text: "hello world",
+    });
+    const raw = assembleMessage(
+      conversationHeaders(),
+      content,
+      new TextEncoder().encode("not a valid pgp signature block"),
+    );
+
+    const status = await verifyMimeSignature(raw, crypto.getPublicKey());
+    expect(status).toBe("invalid");
+  });
+
+  test("returns missing for a message that is not multipart/signed", async () => {
+    const crypto = await makeCrypto();
+    const raw = new TextEncoder().encode(
+      [
+        "From: alpha@test.interchange",
+        "To: beta@test.interchange",
+        "Subject: plain",
+        "Content-Type: text/plain",
+        "",
+        "not signed",
+      ].join("\r\n"),
+    );
+
+    const status = await verifyMimeSignature(raw, crypto.getPublicKey());
+    expect(status).toBe("missing");
+  });
+});

--- a/packages/mailbox/src/verify-signature.ts
+++ b/packages/mailbox/src/verify-signature.ts
@@ -1,0 +1,67 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion -- MIME multipart parsing with bounds checks */
+import {
+  parseHeaderSection,
+  parseMimePart,
+  extractBoundary,
+  parseMultipart,
+} from "@intx/mime";
+import { verifyDetachedSignature } from "@intx/crypto";
+
+/**
+ * Verify a PGP/MIME `multipart/signed` message against a public key.
+ *
+ * Extracts the signed-content part and the detached
+ * `application/pgp-signature` part from the raw message bytes, then checks
+ * the signature with `verifyDetachedSignature`.
+ *
+ * - `valid` — the detached signature verified against `publicKey`
+ * - `invalid` — the signature check failed, or the message could not be
+ *   parsed as a signed message
+ * - `missing` — the message is not `multipart/signed`, or carries no
+ *   `application/pgp-signature` part
+ *
+ * `raw` must be the original, unmodified message bytes: the signature is
+ * recomputed over the exact canonical bytes of the signed part, so a
+ * re-serialized message will not verify. `publicKey` is the raw Ed25519
+ * public key bytes, as returned by `CryptoProvider.getPublicKey()`.
+ */
+export async function verifyMimeSignature(
+  raw: Uint8Array,
+  publicKey: Uint8Array,
+): Promise<"valid" | "invalid" | "missing"> {
+  try {
+    const { headers, bodyOffset } = parseHeaderSection(raw);
+    const body = raw.slice(bodyOffset);
+    const contentType = headers.get("content-type") ?? "";
+
+    if (!contentType.toLowerCase().includes("multipart/signed")) {
+      return "missing";
+    }
+
+    const boundary = extractBoundary(contentType);
+    if (boundary === undefined) return "missing";
+
+    const parts = parseMultipart(body, boundary);
+    if (parts.length < 2) return "missing";
+
+    const signedContentBytes = parts[0]!;
+    const sigPartBytes = parts[1]!;
+    const sigPart = parseMimePart(sigPartBytes);
+
+    if (
+      !sigPart.contentType.toLowerCase().includes("application/pgp-signature")
+    ) {
+      return "missing";
+    }
+
+    const valid = await verifyDetachedSignature(
+      signedContentBytes,
+      sigPart.body,
+      publicKey,
+    );
+
+    return valid ? "valid" : "invalid";
+  } catch {
+    return "invalid";
+  }
+}

--- a/packages/types/src/sidecar.ts
+++ b/packages/types/src/sidecar.ts
@@ -234,9 +234,9 @@ export type SignalCorrelationRegisterAckFrame =
  * itself verified -- the ownership-gated sender of a relayed mail, the
  * address persisted at enqueue for a durable dispatch, or the triggering
  * principal's address for hub-originated mail -- NEVER from the message's
- * own (spoofable) MIME `From`. No consumer reads it yet; it is carried so a
- * recipient can take the sender of record from this hub-verified value
- * rather than the forgeable `From`.
+ * own (spoofable) MIME `From`. The recipient's shadow signature check takes
+ * the sender of record from this hub-verified value rather than the forgeable
+ * `From`, but only to log a verdict -- it does not gate delivery.
  *
  * `authenticatedSenderPublicKey` is the hub-resolved public key of
  * `authenticatedSender`, hex-encoded (the raw 32-byte Ed25519 key). The hub
@@ -245,7 +245,9 @@ export type SignalCorrelationRegisterAckFrame =
  * key the hub vouches for rather than one derived from the message. It is
  * `null` when the sender has no resolvable key -- a run whose deploy is not
  * yet acked, or an address that matches no known principal -- a legitimate
- * "unverifiable sender" state, not an error. No consumer reads it yet.
+ * "unverifiable sender" state, not an error. The recipient's shadow signature
+ * check reads it to verify the message and log a verdict, but does not gate
+ * delivery.
  */
 export const MailInboundFrame = type({
   type: "'mail.inbound'",

--- a/packages/types/src/sidecar.ts
+++ b/packages/types/src/sidecar.ts
@@ -237,12 +237,22 @@ export type SignalCorrelationRegisterAckFrame =
  * own (spoofable) MIME `From`. No consumer reads it yet; it is carried so a
  * recipient can take the sender of record from this hub-verified value
  * rather than the forgeable `From`.
+ *
+ * `authenticatedSenderPublicKey` is the hub-resolved public key of
+ * `authenticatedSender`, hex-encoded (the raw 32-byte Ed25519 key). The hub
+ * resolves it from its own durable key stores at the frame's construction
+ * site, so a recipient can verify the message's signature locally against the
+ * key the hub vouches for rather than one derived from the message. It is
+ * `null` when the sender has no resolvable key -- a run whose deploy is not
+ * yet acked, or an address that matches no known principal -- a legitimate
+ * "unverifiable sender" state, not an error. No consumer reads it yet.
  */
 export const MailInboundFrame = type({
   type: "'mail.inbound'",
   agentAddress: "string",
   rawMessage: "string",
   authenticatedSender: "string",
+  authenticatedSenderPublicKey: "string | null",
   "messageId?": "string",
 });
 export type MailInboundFrame = typeof MailInboundFrame.infer;

--- a/tests/db/sender-key-resolver.test.ts
+++ b/tests/db/sender-key-resolver.test.ts
@@ -11,6 +11,7 @@ import {
   auditSenderKeys,
   createPrincipalKeyStore,
   resolveSenderKey,
+  resolveFrameSenderKey,
   type PrincipalKeyStore,
 } from "@intx/db";
 import { tenant as tenantTable } from "@intx/db/schema";
@@ -245,6 +246,39 @@ describe.skipIf(!harnessDbEnvAvailable())("resolveSenderKey (real DB)", () => {
     await expect(
       resolveSenderKey(h.db, store, "usr_keyless@keyless.localhost"),
     ).rejects.toThrow(/no active key/);
+  });
+
+  test("resolveFrameSenderKey returns the key, and degrades a fault to null", async () => {
+    // A resolvable sender yields its hex key. A resolution FAULT -- here a
+    // keyless principal, the INTR-164 break that makes resolveSenderKey throw --
+    // degrades to null instead, so a shadow-verification fault never blocks mail
+    // delivery.
+    await seedTenant("tnt_frame", "frame.localhost");
+    await seedPrincipal(h.db, {
+      id: "prn_frame_ok",
+      tenantId: "tnt_frame",
+      kind: "user",
+      refId: "usr_ok",
+      status: "active",
+    });
+    const publicKey = await store.generate("prn_frame_ok");
+    expect(
+      await resolveFrameSenderKey(h.db, store, "usr_ok@frame.localhost"),
+    ).toBe(publicKey);
+
+    await seedPrincipal(h.db, {
+      id: "prn_frame_keyless",
+      tenantId: "tnt_frame",
+      kind: "user",
+      refId: "usr_keyless2",
+      status: "active",
+    });
+    await expect(
+      resolveSenderKey(h.db, store, "usr_keyless2@frame.localhost"),
+    ).rejects.toThrow(/no active key/);
+    expect(
+      await resolveFrameSenderKey(h.db, store, "usr_keyless2@frame.localhost"),
+    ).toBeNull();
   });
 
   test("audit: reports no unresolved senders when every sender has a key", async () => {

--- a/tests/hub-agent/lib/deploy-flow-env.ts
+++ b/tests/hub-agent/lib/deploy-flow-env.ts
@@ -1863,7 +1863,7 @@ export async function fireMailTrigger(
   // signed-under address as the authenticated sender. This fixture reuses
   // that same address as the MIME From, so it is not a From-independence
   // check.
-  const delivered = env.hub.router.routeMail(address, base64, from);
+  const delivered = env.hub.router.routeMail(address, base64, from, null);
   if (!delivered) {
     throw new Error(
       `fireMailTrigger: routeMail returned false for ${address}; address is not routable on the hub`,

--- a/tests/workflow-deploy/mail-edge-cases.test.ts
+++ b/tests/workflow-deploy/mail-edge-cases.test.ts
@@ -467,6 +467,7 @@ describe.skipIf(!harnessDbEnvAvailable())("mail-handling edge cases", () => {
       ctx.deploymentMailAddress,
       base64,
       "edge@integration.interchange",
+      null,
       messageId,
     );
     expect(delivered).toBe(true);
@@ -658,6 +659,7 @@ async function routeRaw(
     address,
     base64,
     "user@integration.interchange",
+    null,
   );
   if (!delivered) {
     throw new Error(


### PR DESCRIPTION
## Summary

- Inbound mail is signature-verified recipient-side at the sidecar's
  `mail.inbound` ingress, in SHADOW mode: the verdict is logged and every
  message is admitted — nothing is rejected yet.
- The check is keyed on the hub-stamped `authenticatedSender` (never the
  spoofable MIME `From`), against a hub-resolved sender key delivered on the
  frame. It logs a two-axis verdict — `signature` (valid|invalid|missing|
  unknown|error) and `fromMatch` (match|mismatch|unchecked) — so a valid
  signature carried under a forged `From` is caught as a mismatch.
- A shared MIME signature-verify helper is extracted for reuse. The frame
  carries the hub-resolved key (nullable), resolved via a helper that degrades
  a resolver throw to a null key plus a distinct ERROR log, so a shadow-only,
  verification-optional field can never block delivery on any producer path.

## Verification

- `make all` passes on the implementation (unit + workflow-deploy + core, 0
  failures); the final comment-only amend passed build + lint; CI re-runs the
  full suite on this PR.
- Verified end-to-end at the real hub-link `mail.inbound` WS ingress: a
  validly-signed frame logs `valid/match`, a tampered signature logs `invalid`,
  an unresolvable sender logs `unknown`, and a valid signature under a forged
  `From` logs `valid/mismatch` — all admitted (shadow).
- The new `hub-agent` -> `@intx/mailbox`/`@intx/mime` dependency is acyclic.

This is the SHADOW stage of INTR-512 — it logs and admits, never rejects. The
enforce flip (reject on bad/absent signature, with a drain-before-flip) is a
follow-up PR on the same issue, gated on a clean shadow observation.

Part of INTR-512
