### PR TITLE
Open the hub database to any pg driver and drop hub-agent's dead deps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -330,7 +330,6 @@
       "devDependencies": {
         "@intx/crypto": "workspace:*",
         "@intx/hub-sessions": "workspace:*",
-        "@intx/test-harness": "workspace:*",
         "hono": "catalog:",
       },
     },

--- a/bun.lock
+++ b/bun.lock
@@ -316,7 +316,6 @@
       "name": "@intx/hub-agent",
       "version": "0.3.0",
       "dependencies": {
-        "@intx/harness": "workspace:*",
         "@intx/log": "workspace:*",
         "@intx/mail-memory": "workspace:*",
         "@intx/mailbox": "workspace:*",

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,9 +1,39 @@
 import { type } from "arktype";
+import type { ExtractTablesWithRelations } from "drizzle-orm";
+import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 import { drizzle } from "drizzle-orm/postgres-js";
 
 import { DBConfig } from "./config";
 import { createConnection } from "./connection";
 import * as schema from "./schema";
+
+/**
+ * A drizzle database over the hub schema, typed against the driver-agnostic
+ * `PgDatabase` base rather than a single driver. `createDB` builds one over
+ * postgres-js; a caller can equally build one over pglite -- `drizzle(handle,
+ * { schema })` from `drizzle-orm/pglite`, with the schema re-exported from
+ * `@intx/db/schema` -- and pass it to the store factories. The required
+ * `$client` keeps a bare `PgTransaction` unassignable (a transaction carries no
+ * `$client`), so a parameter typed against this still rejects a tx where only a
+ * top-level database belongs.
+ */
+export type AnyPgDatabase = PgDatabase<
+  PgQueryResultHKT,
+  typeof schema,
+  ExtractTablesWithRelations<typeof schema>
+> & { $client: unknown };
+
+/**
+ * The hub database handle: the database itself, plus `transaction` and
+ * `close`. `createDB` returns the postgres-js instantiation, but the handle is
+ * typed against `AnyPgDatabase` so the stores accept any pg driver -- a
+ * caller-built pglite database included.
+ */
+export interface DB {
+  db: AnyPgDatabase;
+  transaction: AnyPgDatabase["transaction"];
+  close: () => Promise<void>;
+}
 
 export function createDB(raw: unknown) {
   const config = DBConfig(raw);
@@ -21,7 +51,12 @@ export function createDB(raw: unknown) {
   };
 }
 
-export type DB = ReturnType<typeof createDB>;
+// `createDB` returns the concrete postgres-js handle so its own callers keep
+// the driver's precise result types (e.g. a typed `db.execute`). This assures
+// at the definition site that the concrete handle still satisfies `DB`, the
+// driver-agnostic contract the stores consume.
+const _createDBReturnsDB: (raw: unknown) => DB = createDB;
+void _createDBReturnsDB;
 
 /**
  * A handle that can execute queries: either the top-level `db` or a

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,9 @@
-export { createDB, type DB, type DBExecutor } from "./client";
+export {
+  createDB,
+  type AnyPgDatabase,
+  type DB,
+  type DBExecutor,
+} from "./client";
 export {
   pgErrorCode,
   PG_UNIQUE_VIOLATION,

--- a/packages/hub-agent/package.json
+++ b/packages/hub-agent/package.json
@@ -31,7 +31,6 @@
   "devDependencies": {
     "@intx/crypto": "workspace:*",
     "@intx/hub-sessions": "workspace:*",
-    "@intx/test-harness": "workspace:*",
     "hono": "catalog:"
   },
   "files": [

--- a/packages/hub-agent/package.json
+++ b/packages/hub-agent/package.json
@@ -17,7 +17,6 @@
     }
   },
   "dependencies": {
-    "@intx/harness": "workspace:*",
     "@intx/log": "workspace:*",
     "@intx/mail-memory": "workspace:*",
     "@intx/mailbox": "workspace:*",

--- a/tests/db/workflow-run-pack-fencing.test.ts
+++ b/tests/db/workflow-run-pack-fencing.test.ts
@@ -15,7 +15,6 @@ import path from "node:path";
 import { eq, sql } from "drizzle-orm";
 
 import { generateKeyPair } from "@intx/crypto";
-import type { DBExecutor } from "@intx/db";
 import { sidecarAllocation } from "@intx/db/schema";
 import {
   createAgentRepoStore,
@@ -118,7 +117,11 @@ describe.skipIf(!harnessDbEnvAvailable())(
       );
     }
 
-    async function getBackendPid(tx: DBExecutor): Promise<number> {
+    // The concrete postgres transaction the harness hands to a `transaction`
+    // callback, so raw `tx.execute` keeps its typed rows.
+    type HarnessTx = Parameters<Parameters<TestDb["db"]["transaction"]>[0]>[0];
+
+    async function getBackendPid(tx: HarnessTx): Promise<number> {
       const rows = await tx.execute(
         sql`select pg_backend_pid()::integer as pid`,
       );

--- a/tests/lib/db-harness.ts
+++ b/tests/lib/db-harness.ts
@@ -9,13 +9,7 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 
-import {
-  createDB,
-  dropSchema,
-  runMigrations,
-  type DB,
-  type DBConfig,
-} from "@intx/db";
+import { createDB, dropSchema, runMigrations, type DBConfig } from "@intx/db";
 import { sql } from "drizzle-orm";
 
 import { REPO_ROOT, optionalKey, parseEnvFileSync, requireKey } from "./env";
@@ -93,7 +87,11 @@ export function randomSchemaName(): string {
  * grants are needed and no hub subprocess is involved.
  */
 export type TestDb = {
-  db: DB["db"];
+  // The harness always builds a postgres-js database, so pin `db` to the
+  // concrete type `createDB` returns rather than the driver-agnostic `DB["db"]`.
+  // That keeps raw `db.execute` results typed for the postgres-only tests that
+  // read rows off `pg_*` queries.
+  db: ReturnType<typeof createDB>["db"];
   schema: string;
   reset: () => Promise<void>;
   close: () => Promise<void>;


### PR DESCRIPTION
## Summary

- Remove two dead dependencies from the published `@intx/hub-agent`: an
  unused `@intx/test-harness` devDependency (it points at the `tests/` tree,
  so it breaks `bun install` for a consumer that vendors only `packages/*`)
  and an unused `@intx/harness` runtime dependency.
- Type the hub database against the driver-agnostic `PgDatabase` base
  intersected with a required `$client`, so the store factories accept a
  database built on any drizzle pg driver — a caller-built pglite database
  included — while a bare transaction is still rejected. `createDB` still
  returns the concrete postgres-js handle, and `@intx/db` gains no pglite
  dependency.

## Verification

- `make all` passes (build, lint, full-graph type-check, and tests exit clean).
- A `packages/*`-only vendored subset resolves `bun install` without the
  `tests/` tree, since the dependency pointing there is gone.
- Type-level: a pglite database from `drizzle(handle, { schema })` is
  assignable to the store-facing type; a transaction is not. Runtime execution
  of the stores over pglite is not exercised here — that needs a pglite
  dependency this branch deliberately omits.

Closes INTR-521