### PR TITLE
refactor(hub-api): collapse route response metadata into shared jsonResponse helper

### DIFF
--- a/packages/hub-api/src/openapi.ts
+++ b/packages/hub-api/src/openapi.ts
@@ -63,4 +63,27 @@ export function resolver(
   } as ResolverResult;
 }
 
+/**
+ * Builds a single OpenAPI response object whose body is a JSON document
+ * described by the given arktype schema. Collapses the repeated
+ * `content: { "application/json": { schema: resolver(...) } }` wrapper
+ * that every route's `responses` map carries.
+ *
+ * Uses the raw hono-openapi resolver (not the `$ref`-rewriting wrapper
+ * above): the docs generator matches response schemas against full JSON
+ * schemas, so a response schema must stay expanded.
+ */
+export function jsonResponse(
+  description: string,
+  schema: Parameters<typeof baseResolver>[0],
+): {
+  description: string;
+  content: { "application/json": { schema: ResolverResult } };
+} {
+  return {
+    description,
+    content: { "application/json": { schema: baseResolver(schema) } },
+  };
+}
+
 export { describeRoute, validator };

--- a/packages/hub-api/src/routes/agent-data.ts
+++ b/packages/hub-api/src/routes/agent-data.ts
@@ -1,16 +1,17 @@
 import { Hono } from "hono";
-import { describeRoute, resolver } from "hono-openapi";
+import { describeRoute } from "hono-openapi";
 import {
   FileEntry,
+  ErrorResponse,
   FileContent,
   HistoryEntry,
   CommitDetail,
   BranchInfo,
-  ErrorResponse,
 } from "@intx/types";
 
 import type { AppEnv } from "../context";
 import { errorResponse } from "../error-response";
+import { jsonResponse } from "../openapi";
 
 export function createAgentDataRoutes(): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
@@ -21,20 +22,8 @@ export function createAgentDataRoutes(): Hono<AppEnv> {
       tags: ["Agent Data"],
       summary: "List files in agent working directory",
       responses: {
-        200: {
-          description: "File listing",
-          content: {
-            "application/json": {
-              schema: resolver(FileEntry.array()),
-            },
-          },
-        },
-        404: {
-          description: "Agent not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("File listing", FileEntry.array()),
+        404: jsonResponse("Agent not found", ErrorResponse),
       },
     }),
     (c) => errorResponse(c, "not_implemented", "Not implemented"),
@@ -47,18 +36,8 @@ export function createAgentDataRoutes(): Hono<AppEnv> {
       summary: "Read a file from agent storage",
       description: "Reads a file by path from the agent's local storage.",
       responses: {
-        200: {
-          description: "File content",
-          content: {
-            "application/json": { schema: resolver(FileContent) },
-          },
-        },
-        404: {
-          description: "File or agent not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("File content", FileContent),
+        404: jsonResponse("File or agent not found", ErrorResponse),
       },
     }),
     (c) => errorResponse(c, "not_implemented", "Not implemented"),
@@ -72,14 +51,7 @@ export function createAgentDataRoutes(): Hono<AppEnv> {
       description:
         "Returns the agent's change history with commit messages and timestamps.",
       responses: {
-        200: {
-          description: "History entries",
-          content: {
-            "application/json": {
-              schema: resolver(HistoryEntry.array()),
-            },
-          },
-        },
+        200: jsonResponse("History entries", HistoryEntry.array()),
       },
     }),
     (c) => errorResponse(c, "not_implemented", "Not implemented"),
@@ -93,18 +65,8 @@ export function createAgentDataRoutes(): Hono<AppEnv> {
       description:
         "Returns the files changed in a specific commit with additions/deletions counts.",
       responses: {
-        200: {
-          description: "Commit details",
-          content: {
-            "application/json": { schema: resolver(CommitDetail) },
-          },
-        },
-        404: {
-          description: "Commit not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Commit details", CommitDetail),
+        404: jsonResponse("Commit not found", ErrorResponse),
       },
     }),
     (c) => errorResponse(c, "not_implemented", "Not implemented"),
@@ -117,14 +79,7 @@ export function createAgentDataRoutes(): Hono<AppEnv> {
       summary: "List branches",
       description: "Lists branches in the agent's data repository.",
       responses: {
-        200: {
-          description: "List of branches",
-          content: {
-            "application/json": {
-              schema: resolver(BranchInfo.array()),
-            },
-          },
-        },
+        200: jsonResponse("List of branches", BranchInfo.array()),
       },
     }),
     (c) => errorResponse(c, "not_implemented", "Not implemented"),
@@ -141,12 +96,7 @@ export function createAgentDataRoutes(): Hono<AppEnv> {
         204: {
           description: "Data restored",
         },
-        404: {
-          description: "Commit not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        404: jsonResponse("Commit not found", ErrorResponse),
       },
     }),
     (c) => errorResponse(c, "not_implemented", "Not implemented"),

--- a/packages/hub-api/src/routes/approvals.ts
+++ b/packages/hub-api/src/routes/approvals.ts
@@ -1,7 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import type { Context } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import { authorize } from "@intx/authz";
 import type { DB, ApprovalStore, SignalCorrelationStore } from "@intx/db";
@@ -16,10 +16,10 @@ import type {
 } from "@intx/hub-sessions";
 import {
   ApprovalResponse,
+  ErrorResponse,
   ApprovalDecision,
   ApproveAction,
   RejectAction,
-  ErrorResponse,
   isSidecarAllocationDispatchable,
   paginatedSchema,
   signalName,
@@ -43,6 +43,7 @@ import {
   paginatedResponse,
   parsePageParams,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 
 type ParsedApproval = ReturnType<typeof parseApprovalRow>;
 
@@ -404,20 +405,14 @@ export function createApprovalRoutes(
         "Returns pending approval requests within this tenant, newest first.",
       parameters: [...pageParameters],
       responses: {
-        200: {
-          description: "List of pending approvals",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(ApprovalResponse)),
-            },
-          },
-        },
-        403: {
-          description: "Caller lacks the tenant-wide approval grant",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse(
+          "List of pending approvals",
+          paginatedSchema(ApprovalResponse),
+        ),
+        403: jsonResponse(
+          "Caller lacks the tenant-wide approval grant",
+          ErrorResponse,
+        ),
       },
     }),
     async (c) => {
@@ -482,24 +477,9 @@ export function createApprovalRoutes(
       description:
         "Returns the approver-facing tool snapshot, status, and originating deployment for one approval.",
       responses: {
-        200: {
-          description: "Approval details",
-          content: {
-            "application/json": { schema: resolver(ApprovalResponse) },
-          },
-        },
-        403: {
-          description: "Caller lacks the approval grant",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        404: {
-          description: "Approval not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Approval details", ApprovalResponse),
+        403: jsonResponse("Caller lacks the approval grant", ErrorResponse),
+        404: jsonResponse("Approval not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -546,37 +526,20 @@ export function createApprovalRoutes(
       description:
         "Approves the pending action. Scope 'once' authorizes only this suspended call. Scope 'always' additionally records a standing approval, so the same tool is not asked again for the rest of this run.",
       responses: {
-        200: {
-          description: "Action approved",
-          content: {
-            "application/json": { schema: resolver(ApprovalResponse) },
-          },
-        },
-        404: {
-          description: "Approval not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        403: {
-          description: "Approver lacks the approval resolve grant",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        409: {
-          description:
-            "Approval already resolved (takes precedence on retries), workflow run no longer running, or workflow deployment unavailable",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        503: {
-          description: "Durable workflow dispatch unavailable",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Action approved", ApprovalResponse),
+        404: jsonResponse("Approval not found", ErrorResponse),
+        403: jsonResponse(
+          "Approver lacks the approval resolve grant",
+          ErrorResponse,
+        ),
+        409: jsonResponse(
+          "Approval already resolved (takes precedence on retries), workflow run no longer running, or workflow deployment unavailable",
+          ErrorResponse,
+        ),
+        503: jsonResponse(
+          "Durable workflow dispatch unavailable",
+          ErrorResponse,
+        ),
       },
     }),
     validator("json", ApproveAction),
@@ -607,37 +570,20 @@ export function createApprovalRoutes(
       description:
         "Rejects the pending action. An optional message provides feedback to the agent. Scope 'once' (the default) rejects only this call; scope 'always' additionally records a standing rejection, setting the tool to a standing deny so it is blocked without asking again for the rest of this run.",
       responses: {
-        200: {
-          description: "Action rejected",
-          content: {
-            "application/json": { schema: resolver(ApprovalResponse) },
-          },
-        },
-        404: {
-          description: "Approval not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        403: {
-          description: "Approver lacks the approval resolve grant",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        409: {
-          description:
-            "Approval already resolved (takes precedence on retries), workflow run no longer running, or workflow deployment unavailable",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        503: {
-          description: "Durable workflow dispatch unavailable",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Action rejected", ApprovalResponse),
+        404: jsonResponse("Approval not found", ErrorResponse),
+        403: jsonResponse(
+          "Approver lacks the approval resolve grant",
+          ErrorResponse,
+        ),
+        409: jsonResponse(
+          "Approval already resolved (takes precedence on retries), workflow run no longer running, or workflow deployment unavailable",
+          ErrorResponse,
+        ),
+        503: jsonResponse(
+          "Durable workflow dispatch unavailable",
+          ErrorResponse,
+        ),
       },
     }),
     validator("json", RejectAction),

--- a/packages/hub-api/src/routes/assets.ts
+++ b/packages/hub-api/src/routes/assets.ts
@@ -26,7 +26,7 @@
 
 import { and, eq } from "drizzle-orm";
 import { Hono, type Context } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 import { type } from "arktype";
 
 import ssri from "ssri";
@@ -55,8 +55,8 @@ import type { RepoAction, RepoKind } from "@intx/types/sidecar";
 import type { ConditionRegistry, GrantStore } from "@intx/types/authz";
 import {
   AssetResponse,
-  AssetWithOriginResponse,
   ErrorResponse,
+  AssetWithOriginResponse,
 } from "@intx/types";
 
 import type { TenantEnv } from "../context";
@@ -79,6 +79,7 @@ import {
   makeUploadPackStore,
   resolveAuthzVerdict,
 } from "./git-user-principal";
+import { jsonResponse } from "../openapi";
 
 const log = getLogger(["hub", "assets"]);
 
@@ -295,14 +296,7 @@ export function createAssetRoutes({
         },
       ],
       responses: {
-        200: {
-          description: "List of assets",
-          content: {
-            "application/json": {
-              schema: resolver(AssetWithOriginResponse.array()),
-            },
-          },
-        },
+        200: jsonResponse("List of assets", AssetWithOriginResponse.array()),
       },
     }),
     async (c) => {
@@ -356,18 +350,8 @@ export function createAssetRoutes({
       description:
         "Returns asset metadata. Resolves through the tenant hierarchy: assets declared on the tenant or any ancestor are visible. Sibling-tenant assets return 404 so callers cannot probe for cross-tenant existence.",
       responses: {
-        200: {
-          description: "Asset metadata",
-          content: {
-            "application/json": { schema: resolver(AssetResponse) },
-          },
-        },
-        404: {
-          description: "Asset not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Asset metadata", AssetResponse),
+        404: jsonResponse("Asset not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -392,24 +376,9 @@ export function createAssetRoutes({
       description:
         "Inserts an asset row and initializes the backing git repository with a hub-signed genesis commit and the asset-route .gitignore body.",
       responses: {
-        201: {
-          description: "Asset created",
-          content: {
-            "application/json": { schema: resolver(AssetResponseSchema) },
-          },
-        },
-        400: {
-          description: "Validation error",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        409: {
-          description: "Asset already exists",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Asset created", AssetResponseSchema),
+        400: jsonResponse("Validation error", ErrorResponse),
+        409: jsonResponse("Asset already exists", ErrorResponse),
       },
     }),
     validator("json", CreateAsset),
@@ -565,24 +534,12 @@ export function createAssetRoutes({
       description:
         "Commits raw tarball bytes at tarballs/<filename> in the package-registry asset's git tree. Overwrites permitted. The kind handler validates the tarball's package.json before the commit is accepted.",
       responses: {
-        200: {
-          description: "Tarball stored",
-          content: {
-            "application/json": { schema: resolver(TarballPutResponse) },
-          },
-        },
-        400: {
-          description: "Invalid filename or rejected content",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        404: {
-          description: "Asset not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Tarball stored", TarballPutResponse),
+        400: jsonResponse(
+          "Invalid filename or rejected content",
+          ErrorResponse,
+        ),
+        404: jsonResponse("Asset not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -706,18 +663,8 @@ export function createAssetRoutes({
       description:
         "Returns the current set of tarballs under tarballs/ for the package-registry asset, with size and SRI integrity for each entry.",
       responses: {
-        200: {
-          description: "Tarball list",
-          content: {
-            "application/json": { schema: resolver(TarballListResponse) },
-          },
-        },
-        404: {
-          description: "Asset not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Tarball list", TarballListResponse),
+        404: jsonResponse("Asset not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -768,24 +715,9 @@ export function createAssetRoutes({
       description:
         "Removes the named tarball from the package-registry asset and commits the resulting tree. Returns 404 if the asset or filename does not exist.",
       responses: {
-        200: {
-          description: "Tarball removed",
-          content: {
-            "application/json": { schema: resolver(TarballDeleteResponse) },
-          },
-        },
-        400: {
-          description: "Invalid filename",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        404: {
-          description: "Asset or filename not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Tarball removed", TarballDeleteResponse),
+        400: jsonResponse("Invalid filename", ErrorResponse),
+        404: jsonResponse("Asset or filename not found", ErrorResponse),
       },
     }),
     async (c) => {

--- a/packages/hub-api/src/routes/credentials.ts
+++ b/packages/hub-api/src/routes/credentials.ts
@@ -1,6 +1,6 @@
 import { eq, and, isNull } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import { credential, grant as grantTable, provider } from "@intx/db/schema";
 import {
@@ -11,9 +11,9 @@ import {
 import type { DB } from "@intx/db";
 import {
   CreateCredential,
+  ErrorResponse,
   UpdateCredential,
   CredentialResponse,
-  ErrorResponse,
   paginatedSchema,
   credentialAad,
 } from "@intx/types";
@@ -33,6 +33,7 @@ import {
   paginatedResponse,
   pageParameters,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 import {
   pushCredentialRevoke,
   pushSourceUpdates,
@@ -91,14 +92,10 @@ export function createCredentialRoutes({
         ...pageParameters,
       ],
       responses: {
-        200: {
-          description: "List of credentials",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(CredentialResponse)),
-            },
-          },
-        },
+        200: jsonResponse(
+          "List of credentials",
+          paginatedSchema(CredentialResponse),
+        ),
       },
     }),
     async (c) => {
@@ -143,30 +140,13 @@ export function createCredentialRoutes({
       description:
         "Stores a credential (API key, OAuth token, etc.). The secret is stored securely and never returned in subsequent reads. A provider must be specified.",
       responses: {
-        201: {
-          description: "Credential stored",
-          content: {
-            "application/json": { schema: resolver(CredentialResponse) },
-          },
-        },
-        400: {
-          description: "Validation error",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        404: {
-          description: "Provider not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        409: {
-          description: "Credential name already exists in this tenant",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Credential stored", CredentialResponse),
+        400: jsonResponse("Validation error", ErrorResponse),
+        404: jsonResponse("Provider not found", ErrorResponse),
+        409: jsonResponse(
+          "Credential name already exists in this tenant",
+          ErrorResponse,
+        ),
       },
     }),
     validator("json", CreateCredential),
@@ -279,18 +259,8 @@ export function createCredentialRoutes({
       description:
         "Resolves a credential by name, walking the tenant hierarchy. Returns metadata only (no secret). Useful for discovering which credential an agent would get.",
       responses: {
-        200: {
-          description: "Credential metadata",
-          content: {
-            "application/json": { schema: resolver(CredentialResponse) },
-          },
-        },
-        404: {
-          description: "Credential not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Credential metadata", CredentialResponse),
+        404: jsonResponse("Credential not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -316,18 +286,8 @@ export function createCredentialRoutes({
       description:
         "Returns credential metadata. The secret is never included. Supports hierarchy-aware access.",
       responses: {
-        200: {
-          description: "Credential metadata",
-          content: {
-            "application/json": { schema: resolver(CredentialResponse) },
-          },
-        },
-        404: {
-          description: "Credential not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Credential metadata", CredentialResponse),
+        404: jsonResponse("Credential not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -359,18 +319,8 @@ export function createCredentialRoutes({
       summary: "Rotate or update a credential",
       description: "Only credentials owned by this tenant can be updated.",
       responses: {
-        200: {
-          description: "Credential updated",
-          content: {
-            "application/json": { schema: resolver(CredentialResponse) },
-          },
-        },
-        404: {
-          description: "Credential not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Credential updated", CredentialResponse),
+        404: jsonResponse("Credential not found", ErrorResponse),
       },
     }),
     validator("json", UpdateCredential),
@@ -462,18 +412,11 @@ export function createCredentialRoutes({
         204: {
           description: "Credential revoked",
         },
-        404: {
-          description: "Credential not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        409: {
-          description: "Credential is in use by a model provider",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        404: jsonResponse("Credential not found", ErrorResponse),
+        409: jsonResponse(
+          "Credential is in use by a model provider",
+          ErrorResponse,
+        ),
       },
     }),
     async (c) => {

--- a/packages/hub-api/src/routes/git-tokens.ts
+++ b/packages/hub-api/src/routes/git-tokens.ts
@@ -1,6 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 import { type } from "arktype";
 
 import { sha256 } from "@intx/crypto";
@@ -17,7 +17,7 @@ import {
 } from "@intx/hub-common";
 import { getLogger } from "@intx/log";
 import type { RepoAction } from "@intx/types/sidecar";
-import { base64urlEncode, ErrorResponse, paginatedSchema } from "@intx/types";
+import { base64urlEncode, paginatedSchema, ErrorResponse } from "@intx/types";
 
 import { unauthorizedResponse, type AppEnv, type TenantEnv } from "../context";
 import { errorResponse } from "../error-response";
@@ -30,6 +30,7 @@ import {
   paginatedResponse,
   parsePageParams,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 
 const log = getLogger(["hub", "git-token"]);
 
@@ -337,14 +338,10 @@ export function createTenantGitTokenRoutes({
         'Lists service tokens (`kind: "svc"`) bound to this tenant. Secrets are never returned; the plaintext is shown only at mint time.',
       parameters: [...pageParameters],
       responses: {
-        200: {
-          description: "List of git tokens",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(GitTokenSummary)),
-            },
-          },
-        },
+        200: jsonResponse(
+          "List of git tokens",
+          paginatedSchema(GitTokenSummary),
+        ),
       },
     }),
     async (c) => {
@@ -387,18 +384,8 @@ export function createTenantGitTokenRoutes({
       description:
         'Mints a service token (`kind: "svc"`) bound to the requesting tenant. The plaintext secret is returned exactly once in the response and is never persisted in plaintext.',
       responses: {
-        201: {
-          description: "Token minted",
-          content: {
-            "application/json": { schema: resolver(GitTokenMintResponse) },
-          },
-        },
-        400: {
-          description: "Validation error",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Token minted", GitTokenMintResponse),
+        400: jsonResponse("Validation error", ErrorResponse),
       },
     }),
     validator("json", CreateTenantGitToken),
@@ -464,12 +451,7 @@ export function createTenantGitTokenRoutes({
         "Soft-revokes a tenant-bound git token by setting `revokedAt`. The row is retained for audit.",
       responses: {
         204: { description: "Token revoked" },
-        404: {
-          description: "Token not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        404: jsonResponse("Token not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -527,20 +509,11 @@ export function createMeGitTokenRoutes({
         'Lists the authenticated user\'s personal access tokens (`kind: "pat"`). Secrets are never returned; the plaintext is shown only at mint time.',
       parameters: [...pageParameters],
       responses: {
-        200: {
-          description: "List of git tokens",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(GitTokenSummary)),
-            },
-          },
-        },
-        401: {
-          description: "Not authenticated",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse(
+          "List of git tokens",
+          paginatedSchema(GitTokenSummary),
+        ),
+        401: jsonResponse("Not authenticated", ErrorResponse),
       },
     }),
     async (c) => {
@@ -588,24 +561,9 @@ export function createMeGitTokenRoutes({
       description:
         'Mints a personal access token (`kind: "pat"`) for the authenticated user. The plaintext secret is returned exactly once in the response. An optional `tenantId` restricts the token to a single tenant.',
       responses: {
-        201: {
-          description: "Token minted",
-          content: {
-            "application/json": { schema: resolver(GitTokenMintResponse) },
-          },
-        },
-        400: {
-          description: "Validation error",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        401: {
-          description: "Not authenticated",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Token minted", GitTokenMintResponse),
+        400: jsonResponse("Validation error", ErrorResponse),
+        401: jsonResponse("Not authenticated", ErrorResponse),
       },
     }),
     validator("json", CreateMeGitToken),
@@ -660,18 +618,11 @@ export function createMeGitTokenRoutes({
         "Soft-revokes a personal access token by setting `revokedAt`. Only the owning user may revoke their own tokens.",
       responses: {
         204: { description: "Token revoked" },
-        401: {
-          description: "Not authenticated",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        404: {
-          description: "Token not found or not owned by the authenticated user",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        401: jsonResponse("Not authenticated", ErrorResponse),
+        404: jsonResponse(
+          "Token not found or not owned by the authenticated user",
+          ErrorResponse,
+        ),
       },
     }),
     async (c) => {

--- a/packages/hub-api/src/routes/grants.ts
+++ b/packages/hub-api/src/routes/grants.ts
@@ -1,6 +1,6 @@
 import { eq, and } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import { authorize } from "@intx/authz";
 import { grant, principal } from "@intx/db/schema";
@@ -9,11 +9,11 @@ import type { DB } from "@intx/db";
 import type { ConditionRegistry, GrantStore } from "@intx/types/authz";
 import {
   CreateGrant,
+  ErrorResponse,
   UpdateGrant,
   GrantResponse,
   EvaluateRequest,
   EvaluateResult,
-  ErrorResponse,
   paginatedSchema,
 } from "@intx/types";
 
@@ -31,6 +31,7 @@ import {
   paginatedResponse,
   pageParameters,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 
 type ResolvedNames = {
   roleNames: Map<string, string>;
@@ -157,14 +158,7 @@ export function createGrantRoutes({
         ...pageParameters,
       ],
       responses: {
-        200: {
-          description: "List of grants",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(GrantResponse)),
-            },
-          },
-        },
+        200: jsonResponse("List of grants", paginatedSchema(GrantResponse)),
       },
     }),
     async (c) => {
@@ -216,18 +210,8 @@ export function createGrantRoutes({
       description:
         "Creates a grant targeting either a role or a principal directly. Exactly one of roleId or principalId must be provided.",
       responses: {
-        201: {
-          description: "Grant created",
-          content: {
-            "application/json": { schema: resolver(GrantResponse) },
-          },
-        },
-        400: {
-          description: "Validation error",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Grant created", GrantResponse),
+        400: jsonResponse("Validation error", ErrorResponse),
       },
     }),
     validator("json", CreateGrant),
@@ -270,18 +254,8 @@ export function createGrantRoutes({
       tags: ["Grants"],
       summary: "Get grant details",
       responses: {
-        200: {
-          description: "Grant details",
-          content: {
-            "application/json": { schema: resolver(GrantResponse) },
-          },
-        },
-        404: {
-          description: "Grant not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Grant details", GrantResponse),
+        404: jsonResponse("Grant not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -308,18 +282,8 @@ export function createGrantRoutes({
       summary: "Update a grant",
       description: "Update effect, conditions, or expiry on an existing grant.",
       responses: {
-        200: {
-          description: "Grant updated",
-          content: {
-            "application/json": { schema: resolver(GrantResponse) },
-          },
-        },
-        404: {
-          description: "Grant not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Grant updated", GrantResponse),
+        404: jsonResponse("Grant not found", ErrorResponse),
       },
     }),
     validator("json", UpdateGrant),
@@ -360,12 +324,7 @@ export function createGrantRoutes({
         204: {
           description: "Grant revoked",
         },
-        404: {
-          description: "Grant not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        404: jsonResponse("Grant not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -410,18 +369,8 @@ export function createEvaluateRoutes({
       description:
         "Evaluates what would happen if a principal attempted an operation. Returns the resolved effect and all matching grants. Useful for debugging authorization.",
       responses: {
-        200: {
-          description: "Evaluation result",
-          content: {
-            "application/json": { schema: resolver(EvaluateResult) },
-          },
-        },
-        404: {
-          description: "Principal not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Evaluation result", EvaluateResult),
+        404: jsonResponse("Principal not found", ErrorResponse),
       },
     }),
     validator("json", EvaluateRequest),

--- a/packages/hub-api/src/routes/me.ts
+++ b/packages/hub-api/src/routes/me.ts
@@ -1,17 +1,17 @@
 import { type SQL, eq, and, inArray, isNotNull, isNull } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver } from "hono-openapi";
+import { describeRoute } from "hono-openapi";
 
 import { principal, workflowDefinition, workflowRun } from "@intx/db/schema";
 import { parsePrincipalRow } from "@intx/db";
 import type { DB } from "@intx/db";
 import {
   UserProfile,
+  ErrorResponse,
   PrincipalSummary,
   WorkflowRunSummary,
   SessionSummary,
   ApprovalSummary,
-  ErrorResponse,
   paginatedSchema,
 } from "@intx/types";
 
@@ -24,6 +24,7 @@ import {
   paginatedResponse,
   pageParameters,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 
 export type CreateMeRoutesDeps = {
   db: DB["db"];
@@ -38,18 +39,8 @@ export function createMeRoutes({ db }: CreateMeRoutesDeps): Hono<AppEnv> {
       tags: ["User"],
       summary: "Get current user profile",
       responses: {
-        200: {
-          description: "User profile",
-          content: {
-            "application/json": { schema: resolver(UserProfile) },
-          },
-        },
-        401: {
-          description: "Not authenticated",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("User profile", UserProfile),
+        401: jsonResponse("Not authenticated", ErrorResponse),
       },
     }),
     (c) => {
@@ -78,20 +69,11 @@ export function createMeRoutes({ db }: CreateMeRoutesDeps): Hono<AppEnv> {
         "Returns all of the authenticated user's principals across tenants, with tenant name, roles, and status in each.",
       parameters: [...pageParameters],
       responses: {
-        200: {
-          description: "List of principals across tenants",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(PrincipalSummary)),
-            },
-          },
-        },
-        401: {
-          description: "Not authenticated",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse(
+          "List of principals across tenants",
+          paginatedSchema(PrincipalSummary),
+        ),
+        401: jsonResponse("Not authenticated", ErrorResponse),
       },
     }),
     async (c) => {
@@ -185,14 +167,10 @@ export function createMeRoutes({ db }: CreateMeRoutesDeps): Hono<AppEnv> {
         "Aggregates running workflow runs from all tenants the user belongs to. Each result is tagged with tenantId.",
       parameters: [...pageParameters],
       responses: {
-        200: {
-          description: "Runs across tenants",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(WorkflowRunSummary)),
-            },
-          },
-        },
+        200: jsonResponse(
+          "Runs across tenants",
+          paginatedSchema(WorkflowRunSummary),
+        ),
       },
     }),
     async (c) => {
@@ -284,14 +262,7 @@ export function createMeRoutes({ db }: CreateMeRoutesDeps): Hono<AppEnv> {
       description:
         "Aggregates active sessions from all tenants the user belongs to. Each result is tagged with tenantId.",
       responses: {
-        200: {
-          description: "Sessions across tenants",
-          content: {
-            "application/json": {
-              schema: resolver(SessionSummary.array()),
-            },
-          },
-        },
+        200: jsonResponse("Sessions across tenants", SessionSummary.array()),
       },
     }),
     (_c) => {
@@ -308,14 +279,7 @@ export function createMeRoutes({ db }: CreateMeRoutesDeps): Hono<AppEnv> {
       description:
         "Aggregates pending approval requests from all tenants the user belongs to. Each result is tagged with tenantId.",
       responses: {
-        200: {
-          description: "Approvals across tenants",
-          content: {
-            "application/json": {
-              schema: resolver(ApprovalSummary.array()),
-            },
-          },
-        },
+        200: jsonResponse("Approvals across tenants", ApprovalSummary.array()),
       },
     }),
     (_c) => {

--- a/packages/hub-api/src/routes/model-offerings.ts
+++ b/packages/hub-api/src/routes/model-offerings.ts
@@ -1,6 +1,6 @@
 import { eq, and } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import {
   model,
@@ -12,11 +12,11 @@ import type { DB } from "@intx/db";
 import { parseModelOfferingRow } from "@intx/db";
 import {
   CreateModelOffering,
+  ErrorResponse,
   UpdateModelOffering,
   CreatePricingRow,
   ModelOfferingResponse,
   PricingRowResponse,
-  ErrorResponse,
   paginatedSchema,
 } from "@intx/types";
 import {
@@ -38,6 +38,7 @@ import {
   paginatedResponse,
   pageParameters,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 
 export function formatModelOffering(row: typeof modelOffering.$inferSelect) {
   // Validate the row once so the jsonb `quirks` is narrowed from `unknown`
@@ -103,14 +104,10 @@ export function createModelOfferingRoutes({
         "Lists the model offerings created directly on this tenant. Offerings inherited from ancestor tenants are not included; use the model discovery endpoint to see the resolved catalog.",
       parameters: [...pageParameters],
       responses: {
-        200: {
-          description: "List of model offerings",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(ModelOfferingResponse)),
-            },
-          },
-        },
+        200: jsonResponse(
+          "List of model offerings",
+          paginatedSchema(ModelOfferingResponse),
+        ),
       },
     }),
     async (c) => {
@@ -147,24 +144,15 @@ export function createModelOfferingRoutes({
       description:
         "Pairs a tenant-owned model with a tenant-owned provider. To offer an inherited model or provider, first create a tenant-local copy of it (shadowing).",
       responses: {
-        201: {
-          description: "Offering created",
-          content: {
-            "application/json": { schema: resolver(ModelOfferingResponse) },
-          },
-        },
-        404: {
-          description: "Model or provider not found in this tenant",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        409: {
-          description: "Offering already exists for this model and provider",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Offering created", ModelOfferingResponse),
+        404: jsonResponse(
+          "Model or provider not found in this tenant",
+          ErrorResponse,
+        ),
+        409: jsonResponse(
+          "Offering already exists for this model and provider",
+          ErrorResponse,
+        ),
       },
     }),
     validator("json", CreateModelOffering),
@@ -247,18 +235,8 @@ export function createModelOfferingRoutes({
       tags: ["Catalog"],
       summary: "Get a model offering",
       responses: {
-        200: {
-          description: "Offering details",
-          content: {
-            "application/json": { schema: resolver(ModelOfferingResponse) },
-          },
-        },
-        404: {
-          description: "Offering not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Offering details", ModelOfferingResponse),
+        404: jsonResponse("Offering not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -284,18 +262,8 @@ export function createModelOfferingRoutes({
       tags: ["Catalog"],
       summary: "Update a model offering",
       responses: {
-        200: {
-          description: "Offering updated",
-          content: {
-            "application/json": { schema: resolver(ModelOfferingResponse) },
-          },
-        },
-        404: {
-          description: "Offering not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Offering updated", ModelOfferingResponse),
+        404: jsonResponse("Offering not found", ErrorResponse),
       },
     }),
     validator("json", UpdateModelOffering),
@@ -348,12 +316,7 @@ export function createModelOfferingRoutes({
         "Removes the offering and its pricing history. Running instances resolved through it fail over to the next eligible source.",
       responses: {
         204: { description: "Offering removed" },
-        404: {
-          description: "Offering not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        404: jsonResponse("Offering not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -390,20 +353,8 @@ export function createModelOfferingRoutes({
       description:
         "Returns the full append-only pricing history for an offering, every currency and effective-from date, newest first.",
       responses: {
-        200: {
-          description: "Pricing rows",
-          content: {
-            "application/json": {
-              schema: resolver(PricingRowResponse.array()),
-            },
-          },
-        },
-        404: {
-          description: "Offering not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Pricing rows", PricingRowResponse.array()),
+        404: jsonResponse("Offering not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -437,31 +388,16 @@ export function createModelOfferingRoutes({
       description:
         "Appends a pricing row. Pricing is append-only: a price change inserts a new row with a later effective-from rather than editing an existing one, so historical cost attribution stays accurate.",
       responses: {
-        201: {
-          description: "Pricing row created",
-          content: {
-            "application/json": { schema: resolver(PricingRowResponse) },
-          },
-        },
-        400: {
-          description: "effectiveFrom is not a valid timestamp",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        404: {
-          description: "Offering not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        409: {
-          description:
-            "A pricing row already exists for this currency and effective-from",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Pricing row created", PricingRowResponse),
+        400: jsonResponse(
+          "effectiveFrom is not a valid timestamp",
+          ErrorResponse,
+        ),
+        404: jsonResponse("Offering not found", ErrorResponse),
+        409: jsonResponse(
+          "A pricing row already exists for this currency and effective-from",
+          ErrorResponse,
+        ),
       },
     }),
     validator("json", CreatePricingRow),

--- a/packages/hub-api/src/routes/model-providers.ts
+++ b/packages/hub-api/src/routes/model-providers.ts
@@ -1,15 +1,15 @@
 import { eq, and, ne } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import { modelProvider } from "@intx/db/schema";
 import { resolveTenantOwnedCredentialById } from "@intx/db";
 import type { DB } from "@intx/db";
 import {
   CreateModelProvider,
+  ErrorResponse,
   UpdateModelProvider,
   ModelProviderResponse,
-  ErrorResponse,
   paginatedSchema,
 } from "@intx/types";
 import {
@@ -31,6 +31,7 @@ import {
   paginatedResponse,
   pageParameters,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 
 export function formatModelProvider(row: typeof modelProvider.$inferSelect) {
   return {
@@ -72,14 +73,10 @@ export function createModelProviderRoutes({
         "Lists the model providers created directly on this tenant. Providers inherited from ancestor tenants are not included.",
       parameters: [...pageParameters],
       responses: {
-        200: {
-          description: "List of model providers",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(ModelProviderResponse)),
-            },
-          },
-        },
+        200: jsonResponse(
+          "List of model providers",
+          paginatedSchema(ModelProviderResponse),
+        ),
       },
     }),
     async (c) => {
@@ -116,30 +113,16 @@ export function createModelProviderRoutes({
       description:
         "Registers an inference endpoint authenticated by exactly one of a credential or a wallet. Supplying both or neither is rejected.",
       responses: {
-        201: {
-          description: "Provider created",
-          content: {
-            "application/json": { schema: resolver(ModelProviderResponse) },
-          },
-        },
-        400: {
-          description: "Exactly one of credentialId or walletId is required",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        404: {
-          description: "Credential not found in this tenant",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        409: {
-          description: "Provider name already exists in this tenant",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Provider created", ModelProviderResponse),
+        400: jsonResponse(
+          "Exactly one of credentialId or walletId is required",
+          ErrorResponse,
+        ),
+        404: jsonResponse("Credential not found in this tenant", ErrorResponse),
+        409: jsonResponse(
+          "Provider name already exists in this tenant",
+          ErrorResponse,
+        ),
       },
     }),
     validator("json", CreateModelProvider),
@@ -241,18 +224,8 @@ export function createModelProviderRoutes({
       tags: ["Catalog"],
       summary: "Get a model provider",
       responses: {
-        200: {
-          description: "Provider details",
-          content: {
-            "application/json": { schema: resolver(ModelProviderResponse) },
-          },
-        },
-        404: {
-          description: "Provider not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Provider details", ModelProviderResponse),
+        404: jsonResponse("Provider not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -280,24 +253,12 @@ export function createModelProviderRoutes({
       description:
         "Updates a provider's name, base URL, or disabled flag. Changing the authentication binding is not supported; delete and recreate the provider to repoint it.",
       responses: {
-        200: {
-          description: "Provider updated",
-          content: {
-            "application/json": { schema: resolver(ModelProviderResponse) },
-          },
-        },
-        404: {
-          description: "Provider not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        409: {
-          description: "Provider name already exists in this tenant",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Provider updated", ModelProviderResponse),
+        404: jsonResponse("Provider not found", ErrorResponse),
+        409: jsonResponse(
+          "Provider name already exists in this tenant",
+          ErrorResponse,
+        ),
       },
     }),
     validator("json", UpdateModelProvider),
@@ -363,12 +324,7 @@ export function createModelProviderRoutes({
         "Removes the provider and cascades to the offerings that reference it. Running instances resolved through those offerings fail over to the next eligible source.",
       responses: {
         204: { description: "Provider removed" },
-        404: {
-          description: "Provider not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        404: jsonResponse("Provider not found", ErrorResponse),
       },
     }),
     async (c) => {

--- a/packages/hub-api/src/routes/models.ts
+++ b/packages/hub-api/src/routes/models.ts
@@ -1,16 +1,16 @@
 import { eq, and, inArray } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import { model, modelPricing } from "@intx/db/schema";
 import { listVisibleOfferings, resolveActivePrice } from "@intx/db";
 import type { DB, ModelPricingRow, ResolvedOffering } from "@intx/db";
 import {
   CreateModel,
+  ErrorResponse,
   UpdateModel,
   ModelResponse,
   ModelInfo,
-  ErrorResponse,
   paginatedSchema,
 } from "@intx/types";
 import {
@@ -33,6 +33,7 @@ import {
   pageParameters,
 } from "../pagination";
 import { formatPricingRow } from "./model-offerings";
+import { jsonResponse } from "../openapi";
 
 export function formatModel(row: typeof model.$inferSelect) {
   return {
@@ -72,14 +73,7 @@ export function createModelCatalogRoutes({
         "Lists the models created directly on this tenant. Models inherited from ancestor tenants are not included; use the model discovery endpoint to see the resolved catalog.",
       parameters: [...pageParameters],
       responses: {
-        200: {
-          description: "List of models",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(ModelResponse)),
-            },
-          },
-        },
+        200: jsonResponse("List of models", paginatedSchema(ModelResponse)),
       },
     }),
     async (c) => {
@@ -112,18 +106,11 @@ export function createModelCatalogRoutes({
       description:
         "Creates a tenant-local model. Reusing the canonical name of an inherited model shadows that model for this tenant and its descendants.",
       responses: {
-        201: {
-          description: "Model created",
-          content: {
-            "application/json": { schema: resolver(ModelResponse) },
-          },
-        },
-        409: {
-          description: "A model with this canonical name already exists",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Model created", ModelResponse),
+        409: jsonResponse(
+          "A model with this canonical name already exists",
+          ErrorResponse,
+        ),
       },
     }),
     validator("json", CreateModel),
@@ -178,18 +165,8 @@ export function createModelCatalogRoutes({
       tags: ["Catalog"],
       summary: "Get a model",
       responses: {
-        200: {
-          description: "Model details",
-          content: {
-            "application/json": { schema: resolver(ModelResponse) },
-          },
-        },
-        404: {
-          description: "Model not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Model details", ModelResponse),
+        404: jsonResponse("Model not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -212,18 +189,8 @@ export function createModelCatalogRoutes({
       tags: ["Catalog"],
       summary: "Update a model",
       responses: {
-        200: {
-          description: "Model updated",
-          content: {
-            "application/json": { schema: resolver(ModelResponse) },
-          },
-        },
-        404: {
-          description: "Model not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Model updated", ModelResponse),
+        404: jsonResponse("Model not found", ErrorResponse),
       },
     }),
     validator("json", UpdateModel),
@@ -269,12 +236,7 @@ export function createModelCatalogRoutes({
         "Removes the model and cascades to the offerings that reference it. Running instances resolved through those offerings fail over to the next eligible source.",
       responses: {
         204: { description: "Model removed" },
-        404: {
-          description: "Model not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        404: jsonResponse("Model not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -393,12 +355,7 @@ export function createModelDiscoveryRoutes({
       description:
         "Returns the tenant's resolved catalog: every model visible after applying inheritance, shadowing, and disable suppression, broken down by the providers that offer it with each offering's active price per currency.",
       responses: {
-        200: {
-          description: "Resolved models",
-          content: {
-            "application/json": { schema: resolver(ModelInfo.array()) },
-          },
-        },
+        200: jsonResponse("Resolved models", ModelInfo.array()),
       },
     }),
     async (c) => {

--- a/packages/hub-api/src/routes/oauth-clients.ts
+++ b/packages/hub-api/src/routes/oauth-clients.ts
@@ -1,15 +1,15 @@
 import { eq, and } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import { oauthClient, provider } from "@intx/db/schema";
 import { getAncestorChain, parseOAuthClientRow } from "@intx/db";
 import type { DB } from "@intx/db";
 import {
   CreateOAuthClient,
+  ErrorResponse,
   UpdateOAuthClient,
   OAuthClientResponse,
-  ErrorResponse,
   paginatedSchema,
   credentialAad,
 } from "@intx/types";
@@ -28,6 +28,7 @@ import {
   paginatedResponse,
   pageParameters,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 
 function formatOAuthClient(row: typeof oauthClient.$inferSelect) {
   const parsed = parseOAuthClientRow(row);
@@ -67,14 +68,10 @@ export function createOAuthClientRoutes({
         "Lists OAuth client registrations for the tenant. Secrets are never returned.",
       parameters: [...pageParameters],
       responses: {
-        200: {
-          description: "List of OAuth clients",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(OAuthClientResponse)),
-            },
-          },
-        },
+        200: jsonResponse(
+          "List of OAuth clients",
+          paginatedSchema(OAuthClientResponse),
+        ),
       },
     }),
     async (c) => {
@@ -112,31 +109,13 @@ export function createOAuthClientRoutes({
       description:
         "Registers an OAuth client (client_id/client_secret) for a provider. The provider must exist in the tenant or its ancestors.",
       responses: {
-        201: {
-          description: "OAuth client registered",
-          content: {
-            "application/json": { schema: resolver(OAuthClientResponse) },
-          },
-        },
-        400: {
-          description: "Validation error",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        404: {
-          description: "Provider not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        409: {
-          description:
-            "OAuth client already exists for this provider in this tenant",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("OAuth client registered", OAuthClientResponse),
+        400: jsonResponse("Validation error", ErrorResponse),
+        404: jsonResponse("Provider not found", ErrorResponse),
+        409: jsonResponse(
+          "OAuth client already exists for this provider in this tenant",
+          ErrorResponse,
+        ),
       },
     }),
     validator("json", CreateOAuthClient),
@@ -207,18 +186,8 @@ export function createOAuthClientRoutes({
       summary: "Get OAuth client details",
       description: "Returns OAuth client metadata. Secrets are never included.",
       responses: {
-        200: {
-          description: "OAuth client details",
-          content: {
-            "application/json": { schema: resolver(OAuthClientResponse) },
-          },
-        },
-        404: {
-          description: "OAuth client not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("OAuth client details", OAuthClientResponse),
+        404: jsonResponse("OAuth client not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -247,18 +216,8 @@ export function createOAuthClientRoutes({
       tags: ["OAuth Clients"],
       summary: "Update an OAuth client registration",
       responses: {
-        200: {
-          description: "OAuth client updated",
-          content: {
-            "application/json": { schema: resolver(OAuthClientResponse) },
-          },
-        },
-        404: {
-          description: "OAuth client not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("OAuth client updated", OAuthClientResponse),
+        404: jsonResponse("OAuth client not found", ErrorResponse),
       },
     }),
     validator("json", UpdateOAuthClient),
@@ -308,12 +267,7 @@ export function createOAuthClientRoutes({
       summary: "Remove an OAuth client registration",
       responses: {
         204: { description: "OAuth client removed" },
-        404: {
-          description: "OAuth client not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        404: jsonResponse("OAuth client not found", ErrorResponse),
       },
     }),
     async (c) => {

--- a/packages/hub-api/src/routes/observability.ts
+++ b/packages/hub-api/src/routes/observability.ts
@@ -1,15 +1,16 @@
 import { Hono } from "hono";
-import { describeRoute, resolver } from "hono-openapi";
+import { describeRoute } from "hono-openapi";
 import {
   LogEntry,
+  ErrorResponse,
   MetricsResponse,
   TraceResponse,
   SpanResponse,
-  ErrorResponse,
 } from "@intx/types";
 
 import type { AppEnv } from "../context";
 import { errorResponse } from "../error-response";
+import { jsonResponse } from "../openapi";
 
 export function createObservabilityRoutes(): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
@@ -31,20 +32,8 @@ export function createObservabilityRoutes(): Hono<AppEnv> {
         { name: "endTime", in: "query", schema: { type: "string" } },
       ],
       responses: {
-        200: {
-          description: "Log entries",
-          content: {
-            "application/json": {
-              schema: resolver(LogEntry.array()),
-            },
-          },
-        },
-        404: {
-          description: "Agent not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Log entries", LogEntry.array()),
+        404: jsonResponse("Agent not found", ErrorResponse),
       },
     }),
     (c) => errorResponse(c, "not_implemented", "Not implemented"),
@@ -58,18 +47,8 @@ export function createObservabilityRoutes(): Hono<AppEnv> {
       description:
         "Returns throughput, latency, error rates, token usage, and cost metrics.",
       responses: {
-        200: {
-          description: "Agent metrics",
-          content: {
-            "application/json": { schema: resolver(MetricsResponse) },
-          },
-        },
-        404: {
-          description: "Agent not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Agent metrics", MetricsResponse),
+        404: jsonResponse("Agent not found", ErrorResponse),
       },
     }),
     (c) => errorResponse(c, "not_implemented", "Not implemented"),
@@ -90,14 +69,7 @@ export function createObservabilityRoutes(): Hono<AppEnv> {
         { name: "endTime", in: "query", schema: { type: "string" } },
       ],
       responses: {
-        200: {
-          description: "List of traces",
-          content: {
-            "application/json": {
-              schema: resolver(SpanResponse.array()),
-            },
-          },
-        },
+        200: jsonResponse("List of traces", SpanResponse.array()),
       },
     }),
     (c) => errorResponse(c, "not_implemented", "Not implemented"),
@@ -110,18 +82,8 @@ export function createObservabilityRoutes(): Hono<AppEnv> {
       summary: "Get a full trace",
       description: "Returns all spans in a trace across agent boundaries.",
       responses: {
-        200: {
-          description: "Trace with spans",
-          content: {
-            "application/json": { schema: resolver(TraceResponse) },
-          },
-        },
-        404: {
-          description: "Trace not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Trace with spans", TraceResponse),
+        404: jsonResponse("Trace not found", ErrorResponse),
       },
     }),
     (c) => errorResponse(c, "not_implemented", "Not implemented"),

--- a/packages/hub-api/src/routes/offerings.ts
+++ b/packages/hub-api/src/routes/offerings.ts
@@ -1,15 +1,15 @@
 import { eq, and, ilike } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import { offering, workflowDefinition } from "@intx/db/schema";
 import { parseOfferingRow } from "@intx/db";
 import type { DB } from "@intx/db";
 import {
   CreateOffering,
+  ErrorResponse,
   UpdateOffering,
   OfferingDetail,
-  ErrorResponse,
   paginatedSchema,
 } from "@intx/types";
 
@@ -26,6 +26,7 @@ import {
   paginatedResponse,
   pageParameters,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 
 export function formatOffering(
   row: typeof offering.$inferSelect,
@@ -71,14 +72,7 @@ export function createOfferingRoutes({
         ...pageParameters,
       ],
       responses: {
-        200: {
-          description: "List of offerings",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(OfferingDetail)),
-            },
-          },
-        },
+        200: jsonResponse("List of offerings", paginatedSchema(OfferingDetail)),
       },
     }),
     async (c) => {
@@ -135,24 +129,9 @@ export function createOfferingRoutes({
       description:
         "Registers an offering for a workflow definition. The definition must belong to the tenant.",
       responses: {
-        201: {
-          description: "Offering registered",
-          content: {
-            "application/json": { schema: resolver(OfferingDetail) },
-          },
-        },
-        400: {
-          description: "Validation error",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        404: {
-          description: "Workflow definition not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Offering registered", OfferingDetail),
+        400: jsonResponse("Validation error", ErrorResponse),
+        404: jsonResponse("Workflow definition not found", ErrorResponse),
       },
     }),
     validator("json", CreateOffering),
@@ -207,18 +186,8 @@ export function createOfferingRoutes({
       description:
         "Returns pricing, definition info, and request/response type information.",
       responses: {
-        200: {
-          description: "Offering details",
-          content: {
-            "application/json": { schema: resolver(OfferingDetail) },
-          },
-        },
-        404: {
-          description: "Offering not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Offering details", OfferingDetail),
+        404: jsonResponse("Offering not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -251,18 +220,8 @@ export function createOfferingRoutes({
       tags: ["Discovery"],
       summary: "Update an offering",
       responses: {
-        200: {
-          description: "Offering updated",
-          content: {
-            "application/json": { schema: resolver(OfferingDetail) },
-          },
-        },
-        404: {
-          description: "Offering not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Offering updated", OfferingDetail),
+        404: jsonResponse("Offering not found", ErrorResponse),
       },
     }),
     validator("json", UpdateOffering),
@@ -310,12 +269,7 @@ export function createOfferingRoutes({
         204: {
           description: "Offering removed",
         },
-        404: {
-          description: "Offering not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        404: jsonResponse("Offering not found", ErrorResponse),
       },
     }),
     async (c) => {

--- a/packages/hub-api/src/routes/principals.ts
+++ b/packages/hub-api/src/routes/principals.ts
@@ -1,15 +1,15 @@
 import { eq, ne, and } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import { principal, principalRole, role, user } from "@intx/db/schema";
 import { createPrincipalStore, parsePrincipalRow } from "@intx/db";
 import type { DB, PrincipalKeyStore } from "@intx/db";
 import {
   PrincipalResponse,
+  ErrorResponse,
   UpdatePrincipal,
   InviteMember,
-  ErrorResponse,
   paginatedSchema,
 } from "@intx/types";
 
@@ -27,6 +27,7 @@ import {
   paginatedResponse,
   pageParameters,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 
 type ResolvedIdentity = { displayName: string; email?: string };
 
@@ -131,14 +132,10 @@ export function createPrincipalRoutes({
         ...pageParameters,
       ],
       responses: {
-        200: {
-          description: "List of principals",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(PrincipalResponse)),
-            },
-          },
-        },
+        200: jsonResponse(
+          "List of principals",
+          paginatedSchema(PrincipalResponse),
+        ),
       },
     }),
     async (c) => {
@@ -232,18 +229,8 @@ export function createPrincipalRoutes({
       description:
         "Returns principal details including kind, status, assigned roles, and effective grants.",
       responses: {
-        200: {
-          description: "Principal details",
-          content: {
-            "application/json": { schema: resolver(PrincipalResponse) },
-          },
-        },
-        404: {
-          description: "Principal not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Principal details", PrincipalResponse),
+        404: jsonResponse("Principal not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -275,18 +262,8 @@ export function createPrincipalRoutes({
       summary: "Update principal status",
       description: "Activate, suspend, or deactivate a principal.",
       responses: {
-        200: {
-          description: "Principal updated",
-          content: {
-            "application/json": { schema: resolver(PrincipalResponse) },
-          },
-        },
-        403: {
-          description: "Insufficient grants",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Principal updated", PrincipalResponse),
+        403: jsonResponse("Insufficient grants", ErrorResponse),
       },
     }),
     validator("json", UpdatePrincipal),
@@ -329,12 +306,7 @@ export function createPrincipalRoutes({
         204: {
           description: "Principal removed",
         },
-        403: {
-          description: "Insufficient grants",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        403: jsonResponse("Insufficient grants", ErrorResponse),
       },
     }),
     async (c) => {
@@ -386,18 +358,8 @@ export function createInviteRoutes({
       description:
         "Invites a user by email. Creates a principal with invited status and optionally assigns a role.",
       responses: {
-        201: {
-          description: "Invitation sent",
-          content: {
-            "application/json": { schema: resolver(PrincipalResponse) },
-          },
-        },
-        400: {
-          description: "Validation error",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Invitation sent", PrincipalResponse),
+        400: jsonResponse("Validation error", ErrorResponse),
       },
     }),
     validator("json", InviteMember),

--- a/packages/hub-api/src/routes/providers.ts
+++ b/packages/hub-api/src/routes/providers.ts
@@ -1,15 +1,15 @@
 import { eq, and } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import { provider } from "@intx/db/schema";
 import { getAncestorChain, parseProviderRow } from "@intx/db";
 import type { DB } from "@intx/db";
 import {
   CreateProvider,
+  ErrorResponse,
   UpdateProvider,
   ProviderResponse,
-  ErrorResponse,
   paginatedSchema,
 } from "@intx/types";
 
@@ -26,6 +26,7 @@ import {
   paginatedResponse,
   pageParameters,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 
 function formatProvider(row: typeof provider.$inferSelect) {
   const parsed = parseProviderRow(row);
@@ -73,14 +74,10 @@ export function createProviderRoutes({
         ...pageParameters,
       ],
       responses: {
-        200: {
-          description: "List of providers",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(ProviderResponse)),
-            },
-          },
-        },
+        200: jsonResponse(
+          "List of providers",
+          paginatedSchema(ProviderResponse),
+        ),
       },
     }),
     async (c) => {
@@ -137,24 +134,12 @@ export function createProviderRoutes({
       description:
         "Defines a new service provider for the tenant. The plugin field determines how Interchange integrates with the service.",
       responses: {
-        201: {
-          description: "Provider created",
-          content: {
-            "application/json": { schema: resolver(ProviderResponse) },
-          },
-        },
-        400: {
-          description: "Validation error",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        409: {
-          description: "Provider name already exists in this tenant",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Provider created", ProviderResponse),
+        400: jsonResponse("Validation error", ErrorResponse),
+        409: jsonResponse(
+          "Provider name already exists in this tenant",
+          ErrorResponse,
+        ),
       },
     }),
     validator("json", CreateProvider),
@@ -208,18 +193,8 @@ export function createProviderRoutes({
       tags: ["Providers"],
       summary: "Get provider details",
       responses: {
-        200: {
-          description: "Provider details",
-          content: {
-            "application/json": { schema: resolver(ProviderResponse) },
-          },
-        },
-        404: {
-          description: "Provider not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Provider details", ProviderResponse),
+        404: jsonResponse("Provider not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -251,18 +226,8 @@ export function createProviderRoutes({
       summary: "Update a provider definition",
       description: "Only providers owned by this tenant can be updated.",
       responses: {
-        200: {
-          description: "Provider updated",
-          content: {
-            "application/json": { schema: resolver(ProviderResponse) },
-          },
-        },
-        404: {
-          description: "Provider not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Provider updated", ProviderResponse),
+        404: jsonResponse("Provider not found", ErrorResponse),
       },
     }),
     validator("json", UpdateProvider),
@@ -309,12 +274,7 @@ export function createProviderRoutes({
       description: "Only providers owned by this tenant can be removed.",
       responses: {
         204: { description: "Provider removed" },
-        404: {
-          description: "Provider not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        404: jsonResponse("Provider not found", ErrorResponse),
       },
     }),
     async (c) => {

--- a/packages/hub-api/src/routes/roles.ts
+++ b/packages/hub-api/src/routes/roles.ts
@@ -1,14 +1,14 @@
 import { eq, and } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import { role, principalRole, principal } from "@intx/db/schema";
 import type { DB } from "@intx/db";
 import {
   CreateRole,
+  ErrorResponse,
   UpdateRole,
   RoleResponse,
-  ErrorResponse,
   paginatedSchema,
 } from "@intx/types";
 
@@ -25,6 +25,7 @@ import {
   paginatedResponse,
   pageParameters,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 
 function formatRole(row: typeof role.$inferSelect) {
   return {
@@ -59,14 +60,7 @@ export function createRoleRoutes({
         "Lists both system roles (owner, admin, member) and custom roles.",
       parameters: [...pageParameters],
       responses: {
-        200: {
-          description: "List of roles",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(RoleResponse)),
-            },
-          },
-        },
+        200: jsonResponse("List of roles", paginatedSchema(RoleResponse)),
       },
     }),
     async (c) => {
@@ -98,18 +92,8 @@ export function createRoleRoutes({
       tags: ["Roles"],
       summary: "Create a custom role",
       responses: {
-        201: {
-          description: "Role created",
-          content: {
-            "application/json": { schema: resolver(RoleResponse) },
-          },
-        },
-        400: {
-          description: "Validation error",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Role created", RoleResponse),
+        400: jsonResponse("Validation error", ErrorResponse),
       },
     }),
     validator("json", CreateRole),
@@ -145,18 +129,8 @@ export function createRoleRoutes({
       summary: "Get role details",
       description: "Returns role details including attached grants.",
       responses: {
-        200: {
-          description: "Role details",
-          content: {
-            "application/json": { schema: resolver(RoleResponse) },
-          },
-        },
-        404: {
-          description: "Role not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Role details", RoleResponse),
+        404: jsonResponse("Role not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -184,18 +158,8 @@ export function createRoleRoutes({
       description:
         "Update name or description. System roles cannot be modified.",
       responses: {
-        200: {
-          description: "Role updated",
-          content: {
-            "application/json": { schema: resolver(RoleResponse) },
-          },
-        },
-        403: {
-          description: "Cannot modify system role",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Role updated", RoleResponse),
+        403: jsonResponse("Cannot modify system role", ErrorResponse),
       },
     }),
     validator("json", UpdateRole),
@@ -245,18 +209,8 @@ export function createRoleRoutes({
         204: {
           description: "Role deleted",
         },
-        400: {
-          description: "Role still assigned to principals",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        403: {
-          description: "Cannot delete system role",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        400: jsonResponse("Role still assigned to principals", ErrorResponse),
+        403: jsonResponse("Cannot delete system role", ErrorResponse),
       },
     }),
     async (c) => {
@@ -320,12 +274,7 @@ export function createRoleAssignRoutes({
         204: {
           description: "Role assigned",
         },
-        404: {
-          description: "Principal or role not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        404: jsonResponse("Principal or role not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -379,12 +328,7 @@ export function createRoleAssignRoutes({
         204: {
           description: "Role removed",
         },
-        404: {
-          description: "Assignment not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        404: jsonResponse("Assignment not found", ErrorResponse),
       },
     }),
     async (c) => {

--- a/packages/hub-api/src/routes/runs.ts
+++ b/packages/hub-api/src/routes/runs.ts
@@ -1,7 +1,7 @@
 import { eq, and, inArray, isNotNull } from "drizzle-orm";
 import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import {
   offering,
@@ -16,13 +16,13 @@ import { extractPartByPath } from "@intx/mime";
 
 import {
   WorkflowRunResponse,
+  ErrorResponse,
   WorkflowRunHealth,
   RunAuthorizationResponse,
   RunApprovalsResponse,
   OfferingDetail,
   SendMessage,
   MailResponse,
-  ErrorResponse,
   paginatedSchema,
 } from "@intx/types";
 import {
@@ -64,6 +64,7 @@ import {
   paginatedResponse,
   pageParameters,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 
 // Stop and mail history are not yet wired onto a workflow (anchor) run. They
 // were built for the retired folded-launch surface and need genuinely new
@@ -262,14 +263,7 @@ export function createRunRoutes({
         ...pageParameters,
       ],
       responses: {
-        200: {
-          description: "List of runs",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(WorkflowRunResponse)),
-            },
-          },
-        },
+        200: jsonResponse("List of runs", paginatedSchema(WorkflowRunResponse)),
       },
     }),
     async (c) => {
@@ -349,24 +343,9 @@ export function createRunRoutes({
           description: "Blob bytes",
           content: { "application/octet-stream": {} },
         },
-        400: {
-          description: "Invalid blob ID",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        403: {
-          description: "Forbidden",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        404: {
-          description: "Blob not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        400: jsonResponse("Invalid blob ID", ErrorResponse),
+        403: jsonResponse("Forbidden", ErrorResponse),
+        404: jsonResponse("Blob not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -463,18 +442,8 @@ export function createRunRoutes({
       description:
         "Returns workflow run state including status, public key, and sidecar assignment.",
       responses: {
-        200: {
-          description: "Run detail",
-          content: {
-            "application/json": { schema: resolver(WorkflowRunResponse) },
-          },
-        },
-        404: {
-          description: "Run not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Run detail", WorkflowRunResponse),
+        404: jsonResponse("Run not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -518,20 +487,8 @@ export function createRunRoutes({
       description:
         "Returns the run's effective authorization floor: its committed grants and their resolved effects. A standing 'always' approval mutates the tool's committed grant in place at resolve time (approve-always sets allow, reject-always sets deny), so a standing-resolved tool reads that effect directly here. This is the floor the runtime enforces, so the view mirrors what the run can do. Complete for the source-ref deploy lineage (the shipping pipeline); a pinned-tool deploy's sidecar-injected ask floor is not reflected here.",
       responses: {
-        200: {
-          description: "Run authorization",
-          content: {
-            "application/json": {
-              schema: resolver(RunAuthorizationResponse),
-            },
-          },
-        },
-        404: {
-          description: "Run not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Run authorization", RunAuthorizationResponse),
+        404: jsonResponse("Run not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -573,18 +530,8 @@ export function createRunRoutes({
       description:
         "Returns the run's approval decisions, newest first, across every status. The tools an operator turned into standing approvals are the entries with scope 'always' and status 'approved'.",
       responses: {
-        200: {
-          description: "Run approvals",
-          content: {
-            "application/json": { schema: resolver(RunApprovalsResponse) },
-          },
-        },
-        404: {
-          description: "Run not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Run approvals", RunApprovalsResponse),
+        404: jsonResponse("Run not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -610,24 +557,9 @@ export function createRunRoutes({
       description:
         "Returns liveness and readiness for a live run. Liveness reflects whether the run's sidecar connection is active. Readiness reflects whether the run has an active event collector and can process work.",
       responses: {
-        200: {
-          description: "Health status",
-          content: {
-            "application/json": { schema: resolver(WorkflowRunHealth) },
-          },
-        },
-        404: {
-          description: "Run not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        410: {
-          description: "Run stopped",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Health status", WorkflowRunHealth),
+        404: jsonResponse("Run not found", ErrorResponse),
+        410: jsonResponse("Run stopped", ErrorResponse),
       },
     }),
     async (c) => {
@@ -664,20 +596,8 @@ export function createRunRoutes({
       description:
         "Returns the offerings associated with the run's workflow definition. These represent the capabilities the run can provide.",
       responses: {
-        200: {
-          description: "List of offerings",
-          content: {
-            "application/json": {
-              schema: resolver(OfferingDetail.array()),
-            },
-          },
-        },
-        404: {
-          description: "Run not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("List of offerings", OfferingDetail.array()),
+        404: jsonResponse("Run not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -724,24 +644,9 @@ export function createRunRoutes({
         204: {
           description: "Run stopped",
         },
-        404: {
-          description: "Run not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        409: {
-          description: "Run already stopped",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        502: {
-          description: "Sidecar unavailable",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        404: jsonResponse("Run not found", ErrorResponse),
+        409: jsonResponse("Run already stopped", ErrorResponse),
+        502: jsonResponse("Sidecar unavailable", ErrorResponse),
       },
     }),
     async (c) => {
@@ -764,24 +669,9 @@ export function createRunRoutes({
       description:
         "Returns the run's committed, seq-ordered event log (RunStarted, StepStarted, StepCompleted, SignalAwaited, RunCompleted, etc.). The full log is returned on every call; a client polling for live updates deduplicates on seq. A run that has not been triggered yet returns an empty list.",
       responses: {
-        200: {
-          description: "Seq-ordered run events",
-          content: {
-            "application/json": { schema: resolver(WorkflowRunEventsResponse) },
-          },
-        },
-        404: {
-          description: "Run not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        503: {
-          description: "Run event log unavailable",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Seq-ordered run events", WorkflowRunEventsResponse),
+        404: jsonResponse("Run not found", ErrorResponse),
+        503: jsonResponse("Run event log unavailable", ErrorResponse),
       },
     }),
     async (c) => serveRunEvents(c, c.req.param("runId")),
@@ -796,46 +686,24 @@ export function createRunRoutes({
       description:
         "Delivers a fresh signed conversation message to the run, firing it through the run's workflow-native Trigger path. The first accepted message fires the run; while it remains live, later messages may resume its onTrigger input. A terminal run cannot be fired again. The returned messageId identifies this trigger occurrence.",
       responses: {
-        202: {
-          description: "Trigger accepted for delivery",
-          content: {
-            "application/json": {
-              schema: resolver(WorkflowRunTriggerResponse),
-            },
-          },
-        },
-        400: {
-          description:
-            "Attachment validation error. Each variant carries a structured code (oversize_attachment, disallowed_mime_type, malformed_base64, oversize_total) with the offending index and limits. A malformed request body that fails SendMessage validation returns the generic error shape instead.",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        404: {
-          description: "Run not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        409: {
-          description:
-            "Run address is not routable, its allocation is no longer active, or the run is terminal",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        413: {
-          description: "Request body exceeds the maximum allowed size",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        503: {
-          description: "Run trigger substrate unavailable",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        202: jsonResponse(
+          "Trigger accepted for delivery",
+          WorkflowRunTriggerResponse,
+        ),
+        400: jsonResponse(
+          "Attachment validation error. Each variant carries a structured code (oversize_attachment, disallowed_mime_type, malformed_base64, oversize_total) with the offending index and limits. A malformed request body that fails SendMessage validation returns the generic error shape instead.",
+          ErrorResponse,
+        ),
+        404: jsonResponse("Run not found", ErrorResponse),
+        409: jsonResponse(
+          "Run address is not routable, its allocation is no longer active, or the run is terminal",
+          ErrorResponse,
+        ),
+        413: jsonResponse(
+          "Request body exceeds the maximum allowed size",
+          ErrorResponse,
+        ),
+        503: jsonResponse("Run trigger substrate unavailable", ErrorResponse),
       },
     }),
     bodyLimit({
@@ -892,20 +760,8 @@ export function createRunRoutes({
         "Returns parsed JMAP Email objects in reverse chronological order. Cursor-paginated.",
       parameters: [...pageParameters],
       responses: {
-        200: {
-          description: "List of mail",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(MailResponse)),
-            },
-          },
-        },
-        404: {
-          description: "Run not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("List of mail", paginatedSchema(MailResponse)),
+        404: jsonResponse("Run not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -926,24 +782,9 @@ export function createRunRoutes({
       description:
         "Returns the run's step and lifecycle events in seq order -- the same committed event log the events route serves, presented as the run's turns. A run that has not been triggered yet returns an empty list.",
       responses: {
-        200: {
-          description: "Seq-ordered run events",
-          content: {
-            "application/json": { schema: resolver(WorkflowRunEventsResponse) },
-          },
-        },
-        404: {
-          description: "Run not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        503: {
-          description: "Run event log unavailable",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Seq-ordered run events", WorkflowRunEventsResponse),
+        404: jsonResponse("Run not found", ErrorResponse),
+        503: jsonResponse("Run event log unavailable", ErrorResponse),
       },
     }),
     async (c) => serveRunEvents(c, c.req.param("runId")),

--- a/packages/hub-api/src/routes/tenant-federation.ts
+++ b/packages/hub-api/src/routes/tenant-federation.ts
@@ -1,13 +1,13 @@
 import { eq, and } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import { federationTrust, tenant } from "@intx/db/schema";
 import type { DB } from "@intx/db";
 import {
   FederationTrust,
-  CreateFederationTrust,
   ErrorResponse,
+  CreateFederationTrust,
   paginatedSchema,
 } from "@intx/types";
 
@@ -22,6 +22,7 @@ import {
   paginatedResponse,
   pageParameters,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 
 export type CreateTenantFederationRoutesDeps = {
   db: DB["db"];
@@ -39,14 +40,10 @@ export function createTenantFederationRoutes({
       summary: "List federation trust relationships",
       parameters: [...pageParameters],
       responses: {
-        200: {
-          description: "Federation trusts",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(FederationTrust)),
-            },
-          },
-        },
+        200: jsonResponse(
+          "Federation trusts",
+          paginatedSchema(FederationTrust),
+        ),
       },
     }),
     async (c) => {
@@ -105,18 +102,8 @@ export function createTenantFederationRoutes({
       description:
         "Creates a trust relationship with another tenant for cross-tenant agent discovery and interaction.",
       responses: {
-        201: {
-          description: "Trust established",
-          content: {
-            "application/json": { schema: resolver(FederationTrust) },
-          },
-        },
-        400: {
-          description: "Validation error",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Trust established", FederationTrust),
+        400: jsonResponse("Validation error", ErrorResponse),
       },
     }),
     validator("json", CreateFederationTrust),
@@ -175,12 +162,7 @@ export function createTenantFederationRoutes({
         204: {
           description: "Trust revoked",
         },
-        404: {
-          description: "Trust not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        404: jsonResponse("Trust not found", ErrorResponse),
       },
     }),
     async (c) => {

--- a/packages/hub-api/src/routes/tenants.ts
+++ b/packages/hub-api/src/routes/tenants.ts
@@ -1,20 +1,21 @@
 import { eq, and, sql } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import { tenant, principal, role, principalRole, grant } from "@intx/db/schema";
 import { createPrincipalStore, parseTenantRow } from "@intx/db";
 import type { DB, PrincipalKeyStore } from "@intx/db";
 import {
   CreateTenant,
+  ErrorResponse,
   UpdateTenant,
   TenantResponse,
-  ErrorResponse,
 } from "@intx/types";
 
 import { unauthorizedResponse, type AppEnv } from "../context";
 import { errorResponse } from "../error-response";
 import { first, ts } from "../format";
+import { jsonResponse } from "../openapi";
 import { generateId } from "@intx/hub-common";
 
 const SYSTEM_ROLES = ["owner", "admin", "member"] as const;
@@ -53,18 +54,8 @@ export function createTenantRoutes({
       description:
         "Creates a new tenant. The authenticated user becomes the owner with a principal and default owner role.",
       responses: {
-        201: {
-          description: "Tenant created",
-          content: {
-            "application/json": { schema: resolver(TenantResponse) },
-          },
-        },
-        400: {
-          description: "Validation error",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Tenant created", TenantResponse),
+        400: jsonResponse("Validation error", ErrorResponse),
       },
     }),
     validator("json", CreateTenant),
@@ -229,24 +220,9 @@ export function createTenantRoutes({
       tags: ["Tenants"],
       summary: "Get tenant details",
       responses: {
-        200: {
-          description: "Tenant details",
-          content: {
-            "application/json": { schema: resolver(TenantResponse) },
-          },
-        },
-        403: {
-          description: "Not a member of this tenant",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        404: {
-          description: "Tenant not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Tenant details", TenantResponse),
+        403: jsonResponse("Not a member of this tenant", ErrorResponse),
+        404: jsonResponse("Tenant not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -286,18 +262,8 @@ export function createTenantRoutes({
       summary: "Update tenant config",
       description: "Requires admin or higher grant within the tenant.",
       responses: {
-        200: {
-          description: "Tenant updated",
-          content: {
-            "application/json": { schema: resolver(TenantResponse) },
-          },
-        },
-        403: {
-          description: "Insufficient grants",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Tenant updated", TenantResponse),
+        403: jsonResponse("Insufficient grants", ErrorResponse),
       },
     }),
     validator("json", UpdateTenant),

--- a/packages/hub-api/src/routes/wallets.ts
+++ b/packages/hub-api/src/routes/wallets.ts
@@ -1,16 +1,16 @@
 import { eq, and } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import { wallet, transaction } from "@intx/db/schema";
 import { parseWalletRow, parseTransactionRow } from "@intx/db";
 import type { DB } from "@intx/db";
 import {
   CreateWallet,
+  ErrorResponse,
   UpdateWallet,
   WalletResponse,
   TransactionResponse,
-  ErrorResponse,
   paginatedSchema,
 } from "@intx/types";
 
@@ -28,6 +28,7 @@ import {
   paginatedResponse,
   pageParameters,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 
 function formatWallet(row: typeof wallet.$inferSelect) {
   const parsed = parseWalletRow(row);
@@ -80,14 +81,7 @@ export function createWalletRoutes({
       summary: "List wallets in the tenant",
       parameters: [...pageParameters],
       responses: {
-        200: {
-          description: "List of wallets",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(WalletResponse)),
-            },
-          },
-        },
+        200: jsonResponse("List of wallets", paginatedSchema(WalletResponse)),
       },
     }),
     async (c) => {
@@ -121,18 +115,8 @@ export function createWalletRoutes({
       description:
         "Creates a wallet with the specified payment backend and currency. Access for agents is managed through grants.",
       responses: {
-        201: {
-          description: "Wallet created",
-          content: {
-            "application/json": { schema: resolver(WalletResponse) },
-          },
-        },
-        400: {
-          description: "Validation error",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        201: jsonResponse("Wallet created", WalletResponse),
+        400: jsonResponse("Validation error", ErrorResponse),
       },
     }),
     validator("json", CreateWallet),
@@ -170,18 +154,8 @@ export function createWalletRoutes({
       summary: "Get wallet details",
       description: "Returns wallet details including current balance.",
       responses: {
-        200: {
-          description: "Wallet details",
-          content: {
-            "application/json": { schema: resolver(WalletResponse) },
-          },
-        },
-        404: {
-          description: "Wallet not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Wallet details", WalletResponse),
+        404: jsonResponse("Wallet not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -207,18 +181,8 @@ export function createWalletRoutes({
       tags: ["Wallets"],
       summary: "Update wallet config",
       responses: {
-        200: {
-          description: "Wallet updated",
-          content: {
-            "application/json": { schema: resolver(WalletResponse) },
-          },
-        },
-        404: {
-          description: "Wallet not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Wallet updated", WalletResponse),
+        404: jsonResponse("Wallet not found", ErrorResponse),
       },
     }),
     validator("json", UpdateWallet),
@@ -255,18 +219,11 @@ export function createWalletRoutes({
         204: {
           description: "Wallet deactivated",
         },
-        404: {
-          description: "Wallet not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        409: {
-          description: "Wallet is in use by a model provider",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        404: jsonResponse("Wallet not found", ErrorResponse),
+        409: jsonResponse(
+          "Wallet is in use by a model provider",
+          ErrorResponse,
+        ),
       },
     }),
     async (c) => {
@@ -334,14 +291,10 @@ export function createWalletRoutes({
         ...pageParameters,
       ],
       responses: {
-        200: {
-          description: "List of transactions",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(TransactionResponse)),
-            },
-          },
-        },
+        200: jsonResponse(
+          "List of transactions",
+          paginatedSchema(TransactionResponse),
+        ),
       },
     }),
     async (c) => {

--- a/packages/hub-api/src/routes/workflow-definitions.ts
+++ b/packages/hub-api/src/routes/workflow-definitions.ts
@@ -1,6 +1,6 @@
 import { eq, and } from "drizzle-orm";
 import { Hono } from "hono";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 
 import { workflowDefinition, workflowDefinitionVersion } from "@intx/db/schema";
 import {
@@ -11,9 +11,9 @@ import {
 import type { DB } from "@intx/db";
 import {
   WorkflowDefinitionVersion,
+  ErrorResponse,
   WorkflowDefinitionResponse,
   WorkflowRollbackRequest,
-  ErrorResponse,
   paginatedSchema,
 } from "@intx/types";
 
@@ -29,6 +29,7 @@ import {
   paginatedResponse,
   pageParameters,
 } from "../pagination";
+import { jsonResponse } from "../openapi";
 
 export type CreateWorkflowDefinitionRoutesDeps = {
   db: DB["db"];
@@ -52,14 +53,10 @@ export function createWorkflowDefinitionRoutes({
         "Lists the workflow definitions for the tenant, most recent first.",
       parameters: [...pageParameters],
       responses: {
-        200: {
-          description: "List of workflow definitions",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(WorkflowDefinitionResponse)),
-            },
-          },
-        },
+        200: jsonResponse(
+          "List of workflow definitions",
+          paginatedSchema(WorkflowDefinitionResponse),
+        ),
       },
     }),
     async (c) => {
@@ -113,20 +110,11 @@ export function createWorkflowDefinitionRoutes({
       description: "Lists all versions of a workflow definition with status.",
       parameters: [...pageParameters],
       responses: {
-        200: {
-          description: "List of versions",
-          content: {
-            "application/json": {
-              schema: resolver(paginatedSchema(WorkflowDefinitionVersion)),
-            },
-          },
-        },
-        404: {
-          description: "Definition not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse(
+          "List of versions",
+          paginatedSchema(WorkflowDefinitionVersion),
+        ),
+        404: jsonResponse("Definition not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -197,26 +185,9 @@ export function createWorkflowDefinitionRoutes({
       description:
         "Activates the specified version and stops the current one; repoints currentVersion.",
       responses: {
-        200: {
-          description: "Rollback applied",
-          content: {
-            "application/json": {
-              schema: resolver(WorkflowDefinitionResponse),
-            },
-          },
-        },
-        400: {
-          description: "Invalid version",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
-        404: {
-          description: "Definition not found",
-          content: {
-            "application/json": { schema: resolver(ErrorResponse) },
-          },
-        },
+        200: jsonResponse("Rollback applied", WorkflowDefinitionResponse),
+        400: jsonResponse("Invalid version", ErrorResponse),
+        404: jsonResponse("Definition not found", ErrorResponse),
       },
     }),
     validator("json", WorkflowRollbackRequest),

--- a/packages/hub-api/src/routes/workflows.ts
+++ b/packages/hub-api/src/routes/workflows.ts
@@ -2,7 +2,7 @@ import { and, desc, eq, isNotNull } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
-import { describeRoute, resolver, validator } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 import { type } from "arktype";
 
 import {
@@ -20,8 +20,8 @@ import {
 import type { GrantStore } from "@intx/types/authz";
 import {
   correlationIdFromSignalName,
-  deriveWorkflowRunId,
   ErrorResponse,
+  deriveWorkflowRunId,
   isSidecarAllocationDispatchable,
   SendMessage,
   WorkflowDeploymentResponse,
@@ -62,6 +62,7 @@ import {
   MAX_MAIL_BODY_BYTES,
   WorkflowRunTriggerResponse,
 } from "../workflow-run-trigger";
+import { jsonResponse } from "../openapi";
 
 // Request body for the general workflow deploy. The definition is CODE-SOURCED:
 // `source` names where its bytes come from and `entry` the `interchange.workflow`
@@ -241,31 +242,20 @@ export function createWorkflowRoutes({
       description:
         "Installs, probes, gates, and freezes a code-sourced workflow definition from its `source`/`entry`, then creates a pending provisioned deployment. Provisioning continues asynchronously; the response returns the deployment record.",
       responses: {
-        201: {
-          description: "Workflow deployment accepted for provisioning",
-          content: {
-            "application/json": {
-              schema: resolver(WorkflowDeploymentResponse),
-            },
-          },
-        },
-        404: {
-          description: "Workflow asset not found",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
-        409: {
-          description:
-            "Workflow definition or source offering chain invalid, workflow provisioning unavailable, or provisioner selection failed",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
-        500: {
-          description: "Deployment projection row missing after preparation",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
-        502: {
-          description: "Sidecar unavailable",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
+        201: jsonResponse(
+          "Workflow deployment accepted for provisioning",
+          WorkflowDeploymentResponse,
+        ),
+        404: jsonResponse("Workflow asset not found", ErrorResponse),
+        409: jsonResponse(
+          "Workflow definition or source offering chain invalid, workflow provisioning unavailable, or provisioner selection failed",
+          ErrorResponse,
+        ),
+        500: jsonResponse(
+          "Deployment projection row missing after preparation",
+          ErrorResponse,
+        ),
+        502: jsonResponse("Sidecar unavailable", ErrorResponse),
       },
     }),
     validator("json", DeployWorkflow),
@@ -388,14 +378,10 @@ export function createWorkflowRoutes({
       description:
         "Lists the workflow deployments for the tenant, most recent first.",
       responses: {
-        200: {
-          description: "List of workflow deployments",
-          content: {
-            "application/json": {
-              schema: resolver(WorkflowDeploymentResponse.array()),
-            },
-          },
-        },
+        200: jsonResponse(
+          "List of workflow deployments",
+          WorkflowDeploymentResponse.array(),
+        ),
       },
     }),
     async (c) => {
@@ -451,28 +437,20 @@ export function createWorkflowRoutes({
         202: {
           description: "Signal accepted for delivery",
         },
-        400: {
-          description:
-            "Reserved signal name or a runId that is not the deployment's addressable run",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
-        404: {
-          description: "Workflow deployment not found",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
-        409: {
-          description:
-            "Workflow run has not started, is terminal, its deployment allocation is no longer active, or the signalId conflicts with a previously accepted payload",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
-        502: {
-          description: "Sidecar unavailable",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
-        503: {
-          description: "Durable workflow dispatch unavailable",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
+        400: jsonResponse(
+          "Reserved signal name or a runId that is not the deployment's addressable run",
+          ErrorResponse,
+        ),
+        404: jsonResponse("Workflow deployment not found", ErrorResponse),
+        409: jsonResponse(
+          "Workflow run has not started, is terminal, its deployment allocation is no longer active, or the signalId conflicts with a previously accepted payload",
+          ErrorResponse,
+        ),
+        502: jsonResponse("Sidecar unavailable", ErrorResponse),
+        503: jsonResponse(
+          "Durable workflow dispatch unavailable",
+          ErrorResponse,
+        ),
       },
     }),
     validator("json", DeliverSignal),
@@ -691,36 +669,27 @@ export function createWorkflowRoutes({
       description:
         "Delivers a fresh signed conversation message to the deployment's stable top-level run. The first accepted message fires that run; while it remains live, later messages may resume its onTrigger input. A terminal deployment run cannot be fired again. The returned messageId identifies this trigger occurrence.",
       responses: {
-        202: {
-          description: "Trigger accepted for delivery",
-          content: {
-            "application/json": {
-              schema: resolver(WorkflowRunTriggerResponse),
-            },
-          },
-        },
-        400: {
-          description:
-            "Attachment validation error. Each variant carries a structured code (oversize_attachment, disallowed_mime_type, malformed_base64, oversize_total) with the offending index and limits. A malformed request body that fails SendMessage validation returns the generic error shape instead.",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
-        404: {
-          description: "Workflow deployment not found",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
-        409: {
-          description:
-            "Deployment address is not routable, its allocation is no longer active, or its top-level run is terminal",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
-        413: {
-          description: "Request body exceeds the maximum allowed size",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
-        503: {
-          description: "Durable workflow dispatch unavailable",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
+        202: jsonResponse(
+          "Trigger accepted for delivery",
+          WorkflowRunTriggerResponse,
+        ),
+        400: jsonResponse(
+          "Attachment validation error. Each variant carries a structured code (oversize_attachment, disallowed_mime_type, malformed_base64, oversize_total) with the offending index and limits. A malformed request body that fails SendMessage validation returns the generic error shape instead.",
+          ErrorResponse,
+        ),
+        404: jsonResponse("Workflow deployment not found", ErrorResponse),
+        409: jsonResponse(
+          "Deployment address is not routable, its allocation is no longer active, or its top-level run is terminal",
+          ErrorResponse,
+        ),
+        413: jsonResponse(
+          "Request body exceeds the maximum allowed size",
+          ErrorResponse,
+        ),
+        503: jsonResponse(
+          "Durable workflow dispatch unavailable",
+          ErrorResponse,
+        ),
       },
     }),
     bodyLimit({
@@ -754,18 +723,8 @@ export function createWorkflowRoutes({
       description:
         "Lists the run ids present in the deployment's workflow-run event log. Returns an empty list when no run has committed events yet.",
       responses: {
-        200: {
-          description: "List of run ids",
-          content: {
-            "application/json": {
-              schema: resolver(WorkflowRunListResponse),
-            },
-          },
-        },
-        404: {
-          description: "Workflow deployment not found",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
+        200: jsonResponse("List of run ids", WorkflowRunListResponse),
+        404: jsonResponse("Workflow deployment not found", ErrorResponse),
       },
     }),
     async (c) => {
@@ -793,18 +752,8 @@ export function createWorkflowRoutes({
       description:
         "Returns the seq-ordered event projection (RunStarted, StepStarted, StepCompleted, SignalAwaited, RunCompleted, etc.) for a single run. The full event log is returned in ascending seq order; an unknown run returns an empty list.",
       responses: {
-        200: {
-          description: "Seq-ordered run events",
-          content: {
-            "application/json": {
-              schema: resolver(WorkflowRunEventsResponse),
-            },
-          },
-        },
-        404: {
-          description: "Workflow deployment not found",
-          content: { "application/json": { schema: resolver(ErrorResponse) } },
-        },
+        200: jsonResponse("Seq-ordered run events", WorkflowRunEventsResponse),
+        404: jsonResponse("Workflow deployment not found", ErrorResponse),
       },
     }),
     async (c) => {


### PR DESCRIPTION
# Summary                                                                                                                   
                                                                                                                           
 Introduces a shared jsonResponse(description, schema) helper in packages/hub-api/src/openapi.ts and migrates all 22 route 
 files to use it, replacing the repeated                                                                                   
                                                                                                                           
 ```ts                                                                                                                     
   {                                                                                                                       
     description: "...",                                                                                                   
     content: { "application/json": { schema: resolver(...) } }                                                            
   }                                                                                                                       
 ```                                                                                                                       
                                                                                                                           
 wrapper that every route's responses map had.                                                                         
                                                                                                                           
 ## Motivation                                                                                                                
                                                                                                                           
 Every route in the hub API described its responses with the same boilerplate; a description string plus a nested         
 content/application/json/schema object wrapping an arktype schema. This made route definitions noisy and made response structure changes touch every file with 4–7 lines of overhead per response.                                                   
                                                                                                                           
 ## Changes                                                                                                                   
                                                                                                                           
 - New: jsonResponse() in packages/hub-api/src/openapi.ts builds a single OpenAPI response object for a JSON body        
   described by an arktype schema.                                                                                         
 - Migrated: all 22 route files under packages/hub-api/src/routes/ (runs, workflows, approvals, model-offerings,           
   model-providers, models, assets, credentials, grants, roles, principals, tenants, tenant-federation, wallets,           
   offers/offerings, me, agent-data, git-tokens, oauth-clients, observability, providers).                                 
 - Net change: +496 / −1591 lines.                                                                                         
                                                                                                                           
 ## Design notes                                                                                                              
                                                                                                                           
 - jsonResponse deliberately calls the raw hono-openapi resolver (baseResolver) rather than the $ref-rewriting resolver    
   wrapper. The docs generator (bin/gen-api-docs.ts / make docs) matches response schemas against full JSON schemas, so    
   response schemas must stay expanded; using the rewriting wrapper would break generated docs/API.md.                     
 - Behavior-preserving: the emitted OpenAPI spec (GET /openapi.json and docs/API.md) is unchanged; only the                
   route-definition source changes. validator imports are kept where still used for request validation.  