### PR TITLE
Verify inbound mail against a co-delivered sender-key cache

### DIFF
--- a/apps/sidecar/src/agent-key-registration-lifecycle.test.ts
+++ b/apps/sidecar/src/agent-key-registration-lifecycle.test.ts
@@ -252,6 +252,7 @@ describe("agent signing-key registration lifecycle on the host transport", () =>
       } as unknown as Parameters<
         typeof createSidecarDeployRouter
       >[0]["keyStore"],
+      senderKeyCache: { get: () => undefined, put: async () => undefined },
       transport,
       repoStore,
       signingKeySeed: keyPair.privateKey,

--- a/apps/sidecar/src/index.ts
+++ b/apps/sidecar/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from "@intx/crypto";
 import {
   createSenderKeyCache,
+  createSenderCryptoResolver,
   createSidecarOrchestrator,
   type HubLink,
 } from "@intx/hub-agent";
@@ -245,6 +246,12 @@ const senderKeyCache = await createSenderKeyCache({
     writeFileAtomicDurable(filePath, contents, { mode: 0o600 }),
 });
 
+// The read side of the same cache: the inbound signature shadow resolves a
+// sender address to the crypto that verifies its mail. Built here at the edge
+// so the hub link stays source-opaque -- it resolves address -> crypto without
+// holding the cache or knowing where the key came from.
+const resolveSenderCrypto = createSenderCryptoResolver(senderKeyCache);
+
 // The deploy router records `(runId -> agentAddress)` here on
 // every inbound `agent.deploy`; the facade resolves the mapping when
 // firing the pack push so the outbound frames carry the right
@@ -441,6 +448,7 @@ const orchestrator = createSidecarOrchestrator({
     generateKeyPair,
     verifySSHSig: verifySSHSignature,
   },
+  resolveSenderCrypto,
   mailInboundRouter: multistepMailRouter,
   signalInboundRouter: multistepSignalRouter,
   drainInboundRouter: multistepDrainRouter,

--- a/apps/sidecar/src/index.ts
+++ b/apps/sidecar/src/index.ts
@@ -8,7 +8,11 @@ import {
   generateKeyPair,
   verifySSHSignature,
 } from "@intx/crypto";
-import { createSidecarOrchestrator, type HubLink } from "@intx/hub-agent";
+import {
+  createSenderKeyCache,
+  createSidecarOrchestrator,
+  type HubLink,
+} from "@intx/hub-agent";
 import { hexEncode } from "@intx/types";
 import { createAgentRepoStore } from "@intx/hub-sessions";
 import { createTarballCache } from "@intx/tool-packaging";
@@ -49,6 +53,7 @@ import { createWorkflowClosureMaterializer } from "./workflow-closure-materializ
 import { MAX_INLINE_ASSET_PAYLOAD_BYTES } from "./source-asset-delivery";
 import { createWorkflowProbeExecutor } from "./workflow-probe-handler";
 import { loadOrMintSidecarKeypair } from "./signing-keypair";
+import { writeFileAtomicDurable } from "./atomic-write";
 
 await setup();
 
@@ -225,6 +230,19 @@ const sidecarSigningKey = await loadOrMintSidecarKeypair(SIDECAR_SIGNING_DIR);
 const agentRepoStore = createAgentRepoStore({
   dataDir,
   signingKey: sidecarSigningKey,
+});
+
+// Cache of the hub-vouched public keys of senders this sidecar's deployments
+// are authorized to receive mail from. The grants handler writes each key the
+// hub co-delivers on a `run.grants` frame; the recipient's inbound-mail verify
+// reads it back. The keyring is loaded here at boot so a restart keeps every
+// previously-cached key. The durable-write primitive is injected so the cache
+// write is atomic and fsynced -- at least as durable as the run-grants write it
+// gates -- while the cache itself stays in @intx/hub-agent.
+const senderKeyCache = await createSenderKeyCache({
+  dataDir,
+  writeFileDurable: (filePath, contents) =>
+    writeFileAtomicDurable(filePath, contents, { mode: 0o600 }),
 });
 
 // The deploy router records `(runId -> agentAddress)` here on
@@ -505,6 +523,7 @@ const orchestrator = createSidecarOrchestrator({
     const router = createSidecarDeployRouter({
       sessions,
       keyStore,
+      senderKeyCache,
       transport,
       repoStore: wrappedRepoStore,
       signingKeySeed: sidecarSigningKey.privateKey,

--- a/apps/sidecar/src/workflow-host-wiring-deploy-failure.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring-deploy-failure.test.ts
@@ -130,6 +130,7 @@ describe("deploy-failure registry leak", () => {
         typeof createSidecarDeployRouter
       >[0]["sessions"],
       keyStore: stubKeyStore(),
+      senderKeyCache: { get: () => undefined, put: async () => undefined },
       transport,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- an unsupported frame throws before any repoStore usage
       repoStore: {} as Parameters<
@@ -213,6 +214,7 @@ describe("deploy-failure registry leak", () => {
     const router = createSidecarDeployRouter({
       sessions,
       keyStore,
+      senderKeyCache: { get: () => undefined, put: async () => undefined },
       transport,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub: only getRepoDir + writeTree are exercised before the spawn-time failure
       repoStore: repoStoreStub as RepoStore,
@@ -366,6 +368,7 @@ describe("deploy-failure registry leak", () => {
     const router = createSidecarDeployRouter({
       sessions,
       keyStore,
+      senderKeyCache: { get: () => undefined, put: async () => undefined },
       transport,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub: only getRepoDir + writeTree are exercised before the spawn-time failure
       repoStore: repoStoreStub as RepoStore,

--- a/apps/sidecar/src/workflow-host-wiring-undeploy-supervisor.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring-undeploy-supervisor.test.ts
@@ -263,6 +263,7 @@ describe("createSidecarDeployRouter multi-step undeploy shuts the supervisor dow
       } as unknown as Parameters<
         typeof createSidecarDeployRouter
       >[0]["keyStore"],
+      senderKeyCache: { get: () => undefined, put: async () => undefined },
       transport,
       repoStore,
       signingKeySeed: keyPair.privateKey,

--- a/apps/sidecar/src/workflow-host-wiring.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring.test.ts
@@ -256,6 +256,7 @@ describe("createSidecarDeployRouter provision-step (no-spawn) mode", () => {
       } as unknown as Parameters<
         typeof createSidecarDeployRouter
       >[0]["keyStore"],
+      senderKeyCache: { get: () => undefined, put: async () => undefined },
       transport,
       repoStore,
       signingKeySeed: keyPair.privateKey,
@@ -709,6 +710,14 @@ describe("createSidecarDeployRouter multi-step branch", () => {
     multistepSubstrateEnv?: Record<string, string>;
     multistepMailRouter?: MultistepMailRouter;
     multistepGrantsRouter?: MultistepGrantsRouter;
+    /**
+     * Injectable sender-key cache. The co-delivery tests pass a spy (or a
+     * throwing stub) to observe the grants handler's cache write; omitted, a
+     * no-op cache satisfies the dependency without persisting anything.
+     */
+    senderKeyCache?: Parameters<
+      typeof createSidecarDeployRouter
+    >[0]["senderKeyCache"];
     multistepSourcesRouter?: MultistepSourcesRouter;
     registerDeployment?: (args: {
       runId: string;
@@ -842,6 +851,10 @@ describe("createSidecarDeployRouter multi-step branch", () => {
       } as unknown as Parameters<
         typeof createSidecarDeployRouter
       >[0]["keyStore"],
+      senderKeyCache: opts.senderKeyCache ?? {
+        get: () => undefined,
+        put: async () => undefined,
+      },
       transport,
       repoStore,
       signingKeySeed: keyPair.privateKey,
@@ -1415,6 +1428,255 @@ describe("createSidecarDeployRouter multi-step branch", () => {
 
     // Teardown.
     void supervisorToChild;
+  });
+
+  // Deploy a multi-step deployment through the full spawn/ready handshake so
+  // the deploy router installs its grants handler, then hand back the pieces a
+  // co-delivery test needs to route a `run.grants` frame and inspect the write.
+  async function deployMultistepForGrants(
+    definitionId: string,
+    senderKeyCache: Parameters<
+      typeof createSidecarDeployRouter
+    >[0]["senderKeyCache"],
+  ): Promise<{
+    grantsRouter: MultistepGrantsRouter;
+    agentAddress: string;
+    anchorRunId: string;
+    tempBase: string;
+  }> {
+    const childIpcKeyPair = await generateKeyPair();
+    const supervisorToChild = createMemoryNdjsonStream();
+    const childToSupervisor = createMemoryNdjsonStream();
+    const eventChildToSupervisor = createMemoryFrameStream();
+    let resolveExit: ((code: number) => void) | undefined;
+    const exited = new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    });
+    let observedEnv: Record<string, string> | undefined;
+    const spawner: SubprocessSpawner = ({ env }) => {
+      observedEnv = env;
+      return {
+        pid: 9124,
+        controlWriter: supervisorToChild.writer,
+        controlReader: childToSupervisor.reader,
+        eventReader: eventChildToSupervisor.reader,
+        kill: () => {
+          childToSupervisor.close();
+          eventChildToSupervisor.close();
+          resolveExit?.(0);
+        },
+        exited,
+      };
+    };
+
+    const grantsRouter = createMultistepGrantsRouter();
+    const { router, tempBase } = await buildMultistepFixture({
+      spawner,
+      multistepGrantsRouter: grantsRouter,
+      senderKeyCache,
+    });
+
+    const definition = {
+      id: definitionId,
+      triggers: [{ type: "manual" }],
+      stepOrder: ["step-1", "step-2"],
+      steps: { "step-1": { kind: "step" }, "step-2": { kind: "step" } },
+    };
+    const frame = makeMultistepFrame({
+      definition,
+      sources: defaultMultistepSources(),
+    });
+    const deployPromise = router.deploy(frame);
+
+    while (observedEnv === undefined) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    const channelId = observedEnv.IPC_CHANNEL_ID;
+    if (channelId === undefined) {
+      throw new Error("IPC_CHANNEL_ID not set in spawn-time env");
+    }
+    const childSender = createControlChannelSender({
+      privateKeySeed: childIpcKeyPair.privateKey,
+      channelId,
+      writer: {
+        write(line: string) {
+          childToSupervisor.inject(line);
+          return Promise.resolve();
+        },
+      },
+    });
+    await childSender.send({
+      type: "ready",
+      data: {
+        childPid: 9124,
+        childPublicKey: hexEncode(childIpcKeyPair.publicKey),
+      },
+    });
+    await deployPromise;
+    void supervisorToChild;
+
+    return {
+      grantsRouter,
+      agentAddress: frame.agentAddress,
+      anchorRunId: deriveDeploymentId(frame.agentAddress),
+      tempBase,
+    };
+  }
+
+  test("caches each co-delivered sender key before the run's grants land", async () => {
+    // The grants handler must cache the sender key BEFORE writing grants.json,
+    // so a durable grant is never missing the key its recipient verifies
+    // against. The spy records whether grants.json already exists when its
+    // `put` runs; it must not.
+    // A holder the spy reads at `put` time; its path is filled in only once the
+    // deploy resolves the run's on-disk location, so it starts empty.
+    const grantsFileRef: { path: string | undefined } = { path: undefined };
+    const puts: { address: string; grantsExisted: boolean }[] = [];
+    const senderKeyCache = {
+      get: () => undefined,
+      put: async (address: string) => {
+        const grantsExisted =
+          grantsFileRef.path !== undefined &&
+          (await fs
+            .stat(grantsFileRef.path)
+            .then(() => true)
+            .catch(() => false));
+        puts.push({ address, grantsExisted });
+      },
+    };
+
+    const { grantsRouter, agentAddress, anchorRunId, tempBase } =
+      await deployMultistepForGrants("wf-sender-key-order", senderKeyCache);
+
+    const runId = "run-codeliver";
+    const grantsFilePath = path.join(
+      tempBase,
+      "workflow-run",
+      anchorRunId,
+      "runs",
+      runId,
+      "grants.json",
+    );
+    grantsFileRef.path = grantsFilePath;
+    const routed = await grantsRouter.tryRoute({
+      type: "run.grants",
+      agentAddress,
+      runId,
+      stepGrants: [],
+      senderIdentities: [
+        {
+          address: "sender@peer.example",
+          publicKey: hexEncode(new Uint8Array(32)),
+        },
+      ],
+    });
+
+    expect(routed).toBe(true);
+    expect(puts).toEqual([
+      { address: "sender@peer.example", grantsExisted: false },
+    ]);
+    const grantsLanded = await fs
+      .stat(grantsFilePath)
+      .then(() => true)
+      .catch(() => false);
+    expect(grantsLanded).toBe(true);
+  });
+
+  test("a sender-key cache-write failure fails the run's grants", async () => {
+    // The cache write gates the grants write: if the key cannot be cached, the
+    // run must not start under a grant whose sender the recipient cannot
+    // verify. The handler's throw propagates and grants.json never lands.
+    const senderKeyCache = {
+      get: () => undefined,
+      put: async () => {
+        throw new Error("sender-key disk full");
+      },
+    };
+
+    const { grantsRouter, agentAddress, anchorRunId, tempBase } =
+      await deployMultistepForGrants("wf-sender-key-fault", senderKeyCache);
+
+    const runId = "run-cache-fault";
+    await expect(
+      grantsRouter.tryRoute({
+        type: "run.grants",
+        agentAddress,
+        runId,
+        stepGrants: [],
+        senderIdentities: [
+          {
+            address: "sender@peer.example",
+            publicKey: hexEncode(new Uint8Array(32)),
+          },
+        ],
+      }),
+    ).rejects.toThrow("sender-key disk full");
+
+    const grantsFilePath = path.join(
+      tempBase,
+      "workflow-run",
+      anchorRunId,
+      "runs",
+      runId,
+      "grants.json",
+    );
+    const grantsLanded = await fs
+      .stat(grantsFilePath)
+      .then(() => true)
+      .catch(() => false);
+    expect(grantsLanded).toBe(false);
+  });
+
+  test("skips a malformed co-delivered key without failing the run's grants", async () => {
+    // A malformed key is a hub-side defect, keyless from the sidecar's view.
+    // Unlike a disk fault it must NOT poison the run -- otherwise a persistently
+    // bad key would wedge the run on every replay. The valid siblings still
+    // cache and the grants still land.
+    const puts: string[] = [];
+    const senderKeyCache = {
+      get: () => undefined,
+      put: async (address: string) => {
+        puts.push(address);
+      },
+    };
+
+    const { grantsRouter, agentAddress, anchorRunId, tempBase } =
+      await deployMultistepForGrants("wf-sender-key-malformed", senderKeyCache);
+
+    const runId = "run-malformed";
+    const routed = await grantsRouter.tryRoute({
+      type: "run.grants",
+      agentAddress,
+      runId,
+      stepGrants: [],
+      senderIdentities: [
+        // Wrong length: valid hex, but 16 bytes rather than 32.
+        {
+          address: "bad@peer.example",
+          publicKey: hexEncode(new Uint8Array(16)),
+        },
+        {
+          address: "good@peer.example",
+          publicKey: hexEncode(new Uint8Array(32)),
+        },
+      ],
+    });
+
+    expect(routed).toBe(true);
+    expect(puts).toEqual(["good@peer.example"]);
+    const grantsFilePath = path.join(
+      tempBase,
+      "workflow-run",
+      anchorRunId,
+      "runs",
+      runId,
+      "grants.json",
+    );
+    const grantsLanded = await fs
+      .stat(grantsFilePath)
+      .then(() => true)
+      .catch(() => false);
+    expect(grantsLanded).toBe(true);
   });
 
   test("does not register a multistepMailRouter handler if spawn rejects", async () => {

--- a/apps/sidecar/src/workflow-host-wiring.ts
+++ b/apps/sidecar/src/workflow-host-wiring.ts
@@ -26,6 +26,7 @@ import type {
   AgentKeyStore,
   DeployRouter,
   DeployRouterResult,
+  SenderKeyCache,
   SessionManager,
 } from "@intx/hub-agent";
 import {
@@ -49,7 +50,12 @@ import {
   type SuspensionRegistration,
   type WorkflowSupervisor,
 } from "@intx/workflow-host";
-import { hexEncode, type CredentialCipher, type SignalKind } from "@intx/types";
+import {
+  hexDecode,
+  hexEncode,
+  type CredentialCipher,
+  type SignalKind,
+} from "@intx/types";
 import {
   parseInferenceEvent,
   type ApprovalSnapshot,
@@ -95,6 +101,9 @@ import {
 import { readRunGrants, runGrantsPath } from "./run-grants";
 
 const logger = getLogger(["interchange", "sidecar", "workflow-host-wiring"]);
+
+// A raw Ed25519 public key is 32 bytes.
+const ED25519_PUBLIC_KEY_BYTES = 32;
 
 /**
  * Project an run address into the substrate-safe id of its
@@ -1010,6 +1019,13 @@ export interface SidecarDeployRouter extends DeployRouter {
 export function createSidecarDeployRouter(deps: {
   sessions: SessionManager;
   keyStore: AgentKeyStore;
+  /**
+   * Cache of hub-vouched sender public keys. The grants handler writes each
+   * co-delivered `senderIdentities` entry here before the run's grants land,
+   * so a durable grant is never missing the key its recipient needs to verify
+   * the sender's inbound mail.
+   */
+  senderKeyCache: SenderKeyCache;
   transport: HubTransport;
   repoStore: RepoStore;
   signingKeySeed: Uint8Array;
@@ -1941,6 +1957,31 @@ export function createSidecarDeployRouter(deps: {
       // machinery still takes them.
       deps.multistepGrantsRouter?.register(spec.agentAddress, async (args) => {
         try {
+          // Cache the co-delivered sender keys BEFORE the grants file lands, so
+          // "grant durable" implies "key durable": a cache-write fault falls
+          // into the catch below and poisons the run rather than starting it
+          // with a grant whose sender the recipient cannot verify. A malformed
+          // key is a hub-side defect that is keyless from here, so skip it and
+          // cache the valid ones (no weaker than the hub having omitted it)
+          // rather than wedge the run on every replay -- but log it at ERROR,
+          // naming the address and reason, so the hub bug surfaces loudly
+          // instead of being silently dropped.
+          for (const identity of args.senderIdentities ?? []) {
+            let publicKey: Uint8Array;
+            try {
+              publicKey = hexDecode(identity.publicKey);
+            } catch (cause) {
+              const message =
+                cause instanceof Error ? cause.message : String(cause);
+              logger.error`Skipping unparseable sender key for ${identity.address} on run ${args.runId}: ${message}`;
+              continue;
+            }
+            if (publicKey.length !== ED25519_PUBLIC_KEY_BYTES) {
+              logger.error`Skipping wrong-length sender key for ${identity.address} on run ${args.runId}: got ${String(publicKey.length)} bytes`;
+              continue;
+            }
+            await deps.senderKeyCache.put(identity.address, publicKey);
+          }
           await writeStepGrants({
             repoStore: deps.repoStore,
             anchorRunId: runId,
@@ -1950,9 +1991,9 @@ export function createSidecarDeployRouter(deps: {
             runId: args.runId,
           });
         } catch (cause) {
-          // The per-run grants file did not land. Poison the runId so the
-          // grants barrier fails the run instead of starting it under the
-          // deploy-time grant set, then re-throw so the hub-link logs the
+          // A sender-key or per-run grants write did not land. Poison the runId
+          // so the grants barrier fails the run instead of starting it under
+          // the deploy-time grant set, then re-throw so the hub-link logs the
           // durable-write failure loudly.
           poisonedRunIds.add(args.runId);
           throw cause;

--- a/apps/sidecar/src/workflow-run-pack-client.ts
+++ b/apps/sidecar/src/workflow-run-pack-client.ts
@@ -18,7 +18,7 @@ import { type } from "arktype";
 import { getLogger } from "@intx/log";
 import { SourcesUpdatedData } from "@intx/workflow-host";
 import type { InferenceSource } from "@intx/types/runtime";
-import { CredentialDelivery } from "@intx/types/sidecar";
+import { CredentialDelivery, type SenderIdentity } from "@intx/types/sidecar";
 import type {
   RepoId,
   RepoStore,
@@ -292,10 +292,16 @@ export function createMultistepSignalRouter(): MultistepSignalRouter {
  * `runs/<runId>/events/` subtree. The write is awaited so the frame's FIFO
  * completion means the grants are durable on disk before the next frame is
  * processed.
+ *
+ * `senderIdentities` carries the run's authorized senders' hub-vouched keys,
+ * co-delivered on the same `run.grants` frame. The handler caches each one
+ * before the grants write, so a grant that lands durably is never missing the
+ * key its recipient needs to verify the sender's mail.
  */
 export type MultistepGrantsHandler = (args: {
   runId: string;
   stepGrants: readonly unknown[];
+  senderIdentities?: readonly SenderIdentity[];
 }) => Promise<void>;
 
 /**
@@ -321,6 +327,7 @@ export type MultistepGrantsRouter = {
     agentAddress: string;
     runId: string;
     stepGrants: readonly unknown[];
+    senderIdentities?: readonly SenderIdentity[];
   }): Promise<boolean>;
 };
 
@@ -336,7 +343,13 @@ export function createMultistepGrantsRouter(): MultistepGrantsRouter {
     async tryRoute(frame) {
       const handler = handlers.get(frame.agentAddress);
       if (handler === undefined) return false;
-      await handler({ runId: frame.runId, stepGrants: frame.stepGrants });
+      await handler({
+        runId: frame.runId,
+        stepGrants: frame.stepGrants,
+        ...(frame.senderIdentities !== undefined
+          ? { senderIdentities: frame.senderIdentities }
+          : {}),
+      });
       return true;
     },
   };

--- a/packages/hub-agent/src/index.ts
+++ b/packages/hub-agent/src/index.ts
@@ -13,6 +13,10 @@ export {
   type SenderKeyCache,
   type SenderKeyCacheDeps,
 } from "./sender-key-cache";
+export {
+  createPublicKeyCrypto,
+  createSenderCryptoResolver,
+} from "./sender-crypto";
 export type { HarnessBuilder } from "./harness-builder";
 export {
   createSessionManager,

--- a/packages/hub-agent/src/index.ts
+++ b/packages/hub-agent/src/index.ts
@@ -8,6 +8,11 @@ export {
   type AgentKeyStore,
   type AgentKeyStoreDeps,
 } from "./agent-key-store";
+export {
+  createSenderKeyCache,
+  type SenderKeyCache,
+  type SenderKeyCacheDeps,
+} from "./sender-key-cache";
 export type { HarnessBuilder } from "./harness-builder";
 export {
   createSessionManager,

--- a/packages/hub-agent/src/sender-crypto.test.ts
+++ b/packages/hub-agent/src/sender-crypto.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect } from "bun:test";
+
+import {
+  createPublicKeyCrypto,
+  createSenderCryptoResolver,
+} from "./sender-crypto";
+import type { SenderKeyCache } from "./sender-key-cache";
+
+function makeKey(seed: number): Uint8Array {
+  const key = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) key[i] = (seed + i) & 0xff;
+  return key;
+}
+
+function stubCache(entries: Record<string, Uint8Array>): SenderKeyCache {
+  const map = new Map(Object.entries(entries));
+  return {
+    get: (address) => map.get(address),
+    put: async () => undefined,
+  };
+}
+
+describe("createPublicKeyCrypto", () => {
+  test("reports the wrapped public key", () => {
+    const key = makeKey(1);
+    expect(createPublicKeyCrypto(key).getPublicKey()).toBe(key);
+  });
+
+  test("refuses to sign without a private key", async () => {
+    const crypto = createPublicKeyCrypto(makeKey(2));
+    await expect(crypto.sign(new Uint8Array([1]))).rejects.toThrow(
+      /public-key-only/,
+    );
+    await expect(crypto.signSSH("payload")).rejects.toThrow(/public-key-only/);
+  });
+
+  test("refuses to verify (callers use verifyMimeSignature over the key)", async () => {
+    const crypto = createPublicKeyCrypto(makeKey(3));
+    await expect(
+      crypto.verify(new Uint8Array([1]), new Uint8Array([2]), makeKey(3)),
+    ).rejects.toThrow(/public-key-only/);
+  });
+});
+
+describe("createSenderCryptoResolver", () => {
+  test("wraps the cached key for a known sender", () => {
+    const key = makeKey(4);
+    const resolve = createSenderCryptoResolver(
+      stubCache({ "sender@peer.example": key }),
+    );
+    const crypto = resolve("sender@peer.example");
+    expect(crypto).toBeDefined();
+    expect(crypto?.getPublicKey()).toBe(key);
+  });
+
+  test("returns undefined for a sender with no cached key", () => {
+    const resolve = createSenderCryptoResolver(stubCache({}));
+    expect(resolve("unknown@peer.example")).toBeUndefined();
+  });
+});

--- a/packages/hub-agent/src/sender-crypto.ts
+++ b/packages/hub-agent/src/sender-crypto.ts
@@ -1,0 +1,58 @@
+// Read side of the sender-key cache: resolve a sender address to the crypto
+// the inbound-mail verify seam consumes.
+//
+// The mailbox verify seam is typed as `(address) => CryptoProvider | undefined`
+// (`fetchFull`'s `getCrypto`), and it uses only the provider's public key --
+// it reads `getPublicKey()` and hands the bytes to `verifyMimeSignature`. The
+// cache holds a foreign sender's PUBLIC key alone, so the provider it wraps can
+// answer `getPublicKey()` but cannot sign or verify with a private key it does
+// not have. Those methods throw rather than return a wrong or empty answer.
+
+import type { CryptoProvider } from "@intx/types/runtime";
+
+import type { SenderKeyCache } from "./sender-key-cache";
+
+const NO_PRIVATE_KEY =
+  "public-key-only crypto holds no private key; verify an inbound signature " +
+  "with verifyMimeSignature over getPublicKey() bytes";
+
+/**
+ * Wrap a raw Ed25519 public key as a `CryptoProvider` that can only report the
+ * key. `getPublicKey` returns the bytes; `sign`, `signSSH`, and `verify` throw,
+ * because none of them can be answered from a public key alone. This is the
+ * shape the mailbox verify seam expects for a sender whose key the hub vouches
+ * for but whose private key this process never holds.
+ */
+export function createPublicKeyCrypto(publicKey: Uint8Array): CryptoProvider {
+  return {
+    getPublicKey() {
+      return publicKey;
+    },
+    async sign() {
+      throw new Error(NO_PRIVATE_KEY);
+    },
+    async signSSH() {
+      throw new Error(NO_PRIVATE_KEY);
+    },
+    async verify() {
+      throw new Error(NO_PRIVATE_KEY);
+    },
+  };
+}
+
+/**
+ * Build a resolver that maps a sender address to a public-key-only
+ * `CryptoProvider`, or `undefined` when the cache holds no key for it. The
+ * signature matches the mailbox verify seam's `getCrypto`, so the resolver is a
+ * drop-in source of the sender's verification key. `undefined` is the seam's
+ * defined "no key for this address" sentinel, not a swallowed failure.
+ */
+export function createSenderCryptoResolver(
+  cache: SenderKeyCache,
+): (address: string) => CryptoProvider | undefined {
+  return (address) => {
+    const publicKey = cache.get(address);
+    if (publicKey === undefined) return undefined;
+    return createPublicKeyCrypto(publicKey);
+  };
+}

--- a/packages/hub-agent/src/sender-key-cache.test.ts
+++ b/packages/hub-agent/src/sender-key-cache.test.ts
@@ -1,0 +1,163 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { hexEncode } from "@intx/types";
+
+import { createSenderKeyCache } from "./sender-key-cache";
+
+const tempDirs: string[] = [];
+
+async function tempDir(): Promise<string> {
+  const d = await fs.mkdtemp(path.join(os.tmpdir(), "sender-key-cache-test-"));
+  tempDirs.push(d);
+  return d;
+}
+
+afterEach(async () => {
+  const dirs = tempDirs.splice(0);
+  await Promise.all(
+    dirs.map((d) => fs.rm(d, { recursive: true, force: true })),
+  );
+});
+
+// A plain durable write is enough for the cache's own logic; the atomicity and
+// fsync of the production primitive are orthogonal to what these tests assert.
+async function writeFileDurable(
+  filePath: string,
+  contents: string,
+): Promise<void> {
+  await fs.writeFile(filePath, contents);
+}
+
+function makeKey(seed: number): Uint8Array {
+  const key = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) key[i] = (seed + i) & 0xff;
+  return key;
+}
+
+const senderKeysDir = (dataDir: string) => path.join(dataDir, "sender-keys");
+
+describe("SenderKeyCache", () => {
+  test("caches a key and reads it back keyed on the full address", async () => {
+    const dataDir = await tempDir();
+    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+
+    const address = "run_abc@tenant.example.com";
+    await cache.put(address, makeKey(3));
+
+    expect(cache.get(address)).toEqual(makeKey(3));
+    // The domain-qualified address is the key; a bare local part is a miss.
+    expect(cache.get("run_abc")).toBeUndefined();
+  });
+
+  test("returns undefined for an unknown sender", async () => {
+    const dataDir = await tempDir();
+    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    expect(cache.get("nobody@example.com")).toBeUndefined();
+  });
+
+  test("survives a restart by loading the keyring from disk", async () => {
+    const dataDir = await tempDir();
+    const first = await createSenderKeyCache({ dataDir, writeFileDurable });
+    await first.put("alice@a.example", makeKey(5));
+    await first.put("bob@b.example", makeKey(9));
+
+    const restarted = await createSenderKeyCache({ dataDir, writeFileDurable });
+    expect(restarted.get("alice@a.example")).toEqual(makeKey(5));
+    expect(restarted.get("bob@b.example")).toEqual(makeKey(9));
+  });
+
+  test("keeps addresses that collide under lossy sanitization distinct", async () => {
+    // "a.b@c.example" and "a_b@c.example" both flatten to one filename under
+    // the AgentKeyStore sanitize scheme; the injective hex filename must not.
+    const dataDir = await tempDir();
+    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    await cache.put("a.b@c.example", makeKey(1));
+    await cache.put("a_b@c.example", makeKey(2));
+
+    expect(cache.get("a.b@c.example")).toEqual(makeKey(1));
+    expect(cache.get("a_b@c.example")).toEqual(makeKey(2));
+
+    const files = await fs.readdir(senderKeysDir(dataDir));
+    expect(files).toHaveLength(2);
+
+    const restarted = await createSenderKeyCache({ dataDir, writeFileDurable });
+    expect(restarted.get("a.b@c.example")).toEqual(makeKey(1));
+    expect(restarted.get("a_b@c.example")).toEqual(makeKey(2));
+  });
+
+  test("the latest write for an address wins", async () => {
+    const dataDir = await tempDir();
+    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    await cache.put("rotator@example.com", makeKey(4));
+    await cache.put("rotator@example.com", makeKey(8));
+
+    expect(cache.get("rotator@example.com")).toEqual(makeKey(8));
+    const restarted = await createSenderKeyCache({ dataDir, writeFileDurable });
+    expect(restarted.get("rotator@example.com")).toEqual(makeKey(8));
+  });
+
+  test("skips a corrupt file on load without dropping the other keys", async () => {
+    const dataDir = await tempDir();
+    const good = await createSenderKeyCache({ dataDir, writeFileDurable });
+    await good.put("good@example.com", makeKey(6));
+
+    const dir = senderKeysDir(dataDir);
+    // A validly-named file whose contents are not a valid envelope.
+    const corruptName = hexEncode(new TextEncoder().encode("corrupt@example"));
+    await fs.writeFile(path.join(dir, corruptName), "{ not json");
+    // A stray temp file the way a crashed atomic write would leave one.
+    await fs.writeFile(path.join(dir, "leftover.tmp.123.abcd"), "junk");
+
+    const restarted = await createSenderKeyCache({ dataDir, writeFileDurable });
+    expect(restarted.get("good@example.com")).toEqual(makeKey(6));
+    expect(restarted.get("corrupt@example")).toBeUndefined();
+  });
+
+  test("skips a file whose envelope address does not match its filename", async () => {
+    const dataDir = await tempDir();
+    await createSenderKeyCache({ dataDir, writeFileDurable });
+    const dir = senderKeysDir(dataDir);
+    await fs.mkdir(dir, { recursive: true });
+    // File named for address A but carrying address B: a tamper/corruption the
+    // filename/envelope cross-check must reject rather than serve under A.
+    const nameForA = hexEncode(new TextEncoder().encode("a@example.com"));
+    await fs.writeFile(
+      path.join(dir, nameForA),
+      JSON.stringify({
+        address: "b@example.com",
+        publicKey: hexEncode(makeKey(2)),
+      }),
+    );
+
+    const restarted = await createSenderKeyCache({ dataDir, writeFileDurable });
+    expect(restarted.get("a@example.com")).toBeUndefined();
+    expect(restarted.get("b@example.com")).toBeUndefined();
+  });
+
+  test("rejects a wrong-length key at put", async () => {
+    const dataDir = await tempDir();
+    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    await expect(
+      cache.put("short@example.com", new Uint8Array(16)),
+    ).rejects.toThrow(/32/);
+    expect(cache.get("short@example.com")).toBeUndefined();
+  });
+
+  test("a failed durable write leaves no in-memory entry", async () => {
+    const dataDir = await tempDir();
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable: async () => {
+        throw new Error("disk full");
+      },
+    });
+    await expect(cache.put("faulty@example.com", makeKey(7))).rejects.toThrow(
+      "disk full",
+    );
+    // Memory is only updated after the durable write lands, so a failed write
+    // must not leave a phantom key that a restart would not reproduce.
+    expect(cache.get("faulty@example.com")).toBeUndefined();
+  });
+});

--- a/packages/hub-agent/src/sender-key-cache.ts
+++ b/packages/hub-agent/src/sender-key-cache.ts
@@ -1,0 +1,157 @@
+// Local cache of the public keys the hub vouches for, keyed by sender
+// address.
+//
+// A recipient sidecar verifies an inbound mail signature against the key
+// the hub resolved for the message's authenticated sender. The hub
+// co-delivers that key on the `run.grants` barrier (see the
+// `senderIdentities` field on `RunGrantsFrame`); this cache is where the
+// sidecar retains it so verification works locally and keeps working
+// while the sidecar is disconnected from the hub.
+//
+// Peer to AgentKeyStore, but for a different custody role: AgentKeyStore
+// holds this sidecar's OWN agents' key pairs, whereas this cache holds
+// FOREIGN senders' public keys only. There is no private material here.
+//
+// The hub owns key freshness -- it re-pushes a rotated key on the next
+// grant or reconnect -- so the cache has no TTL, generation, or eviction.
+// A second entry for an address overwrites the first; the latest push
+// wins.
+//
+// The whole keyring is loaded into memory at construction, so `get` is a
+// synchronous memory read on the inbound-verify path and a restart sees
+// every previously-cached key. The on-disk filename is the hex-encoded
+// address bytes: an injective, reversible handle, so two addresses never
+// collide onto one file the way the lossy `sanitizeAddress` scheme would.
+
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { type } from "arktype";
+import { getLogger } from "@intx/log";
+import { hasCode, hexDecode, hexEncode } from "@intx/types";
+
+const logger = getLogger(["interchange", "hub-agent", "sender-key-cache"]);
+
+// A raw Ed25519 public key is 32 bytes.
+const ED25519_PUBLIC_KEY_BYTES = 32;
+
+const SENDER_KEYS_DIR_NAME = "sender-keys";
+
+// The on-disk envelope carries the address alongside the key so a loaded
+// file is self-describing and a filename/content mismatch is detectable.
+const StoredSenderKey = type({
+  address: "string",
+  publicKey: "string",
+});
+
+export type SenderKeyCacheDeps = {
+  dataDir: string;
+  /**
+   * Durably persist `contents` at `path` (atomic replace + fsync). Injected
+   * so the cache's write is at least as durable as the run-grants write it
+   * gates, without this package depending on the sidecar app that owns the
+   * durable-write primitive.
+   */
+  writeFileDurable: (path: string, contents: string) => Promise<void>;
+};
+
+export type SenderKeyCache = {
+  /**
+   * The cached public key for `address`, or `undefined` when none is known.
+   * A synchronous memory read: the keyring is loaded at construction and
+   * every `put` updates memory, so the map is authoritative for this
+   * single-process sidecar.
+   */
+  get(address: string): Uint8Array | undefined;
+  /**
+   * Cache `publicKey` for `address`, persisting it durably before returning.
+   * Throws if the durable write fails, so a caller that gates a downstream
+   * durable write on this one can rely on "this key is on disk" once it
+   * resolves.
+   */
+  put(address: string, publicKey: Uint8Array): Promise<void>;
+};
+
+export async function createSenderKeyCache(
+  deps: SenderKeyCacheDeps,
+): Promise<SenderKeyCache> {
+  const { dataDir, writeFileDurable } = deps;
+  const dir = path.join(dataDir, SENDER_KEYS_DIR_NAME);
+  const keys = new Map<string, Uint8Array>();
+
+  function keyPath(address: string): string {
+    return path.join(dir, hexEncode(new TextEncoder().encode(address)));
+  }
+
+  async function loadFromDisk(): Promise<void> {
+    let entries: string[];
+    try {
+      entries = await fsp.readdir(dir);
+    } catch (err: unknown) {
+      // A fresh sidecar has no keyring dir yet; that is an empty cache, not a
+      // fault. Any other failure (EACCES, EIO, ...) must surface rather than
+      // silently start with no cached keys.
+      if (hasCode(err) && err.code === "ENOENT") return;
+      throw err;
+    }
+    for (const entry of entries) {
+      const loaded = await loadEntry(entry);
+      if (loaded !== null) keys.set(loaded.address, loaded.publicKey);
+    }
+  }
+
+  async function loadEntry(
+    entry: string,
+  ): Promise<{ address: string; publicKey: Uint8Array } | null> {
+    // A crashed atomic write can leave a `<name>.tmp.<pid>.<rand>` file; its
+    // name is not valid hex, so decoding the filename rejects it below. A
+    // corrupt or mismatched file is logged and skipped rather than failing the
+    // whole load -- one bad entry must not deny the sidecar its other keys.
+    try {
+      const filenameAddress = new TextDecoder().decode(hexDecode(entry));
+      const raw = await fsp.readFile(path.join(dir, entry), "utf8");
+      const parsed = StoredSenderKey(JSON.parse(raw));
+      if (parsed instanceof type.errors) {
+        throw new Error(`envelope invalid: ${parsed.summary}`);
+      }
+      if (parsed.address !== filenameAddress) {
+        throw new Error(
+          `filename address ${filenameAddress} does not match envelope address ${parsed.address}`,
+        );
+      }
+      const publicKey = hexDecode(parsed.publicKey);
+      if (publicKey.length !== ED25519_PUBLIC_KEY_BYTES) {
+        throw new Error(
+          `expected a ${ED25519_PUBLIC_KEY_BYTES}-byte key, got ${publicKey.length}`,
+        );
+      }
+      return { address: parsed.address, publicKey };
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      logger.error`Skipping unreadable sender-key file ${entry}: ${message}`;
+      return null;
+    }
+  }
+
+  function get(address: string): Uint8Array | undefined {
+    return keys.get(address);
+  }
+
+  async function put(address: string, publicKey: Uint8Array): Promise<void> {
+    if (publicKey.length !== ED25519_PUBLIC_KEY_BYTES) {
+      throw new Error(
+        `refusing to cache a ${publicKey.length}-byte key for ${address}; expected ${ED25519_PUBLIC_KEY_BYTES}`,
+      );
+    }
+    const contents = JSON.stringify({
+      address,
+      publicKey: hexEncode(publicKey),
+    });
+    await fsp.mkdir(dir, { recursive: true });
+    await writeFileDurable(keyPath(address), contents);
+    keys.set(address, publicKey);
+  }
+
+  await loadFromDisk();
+
+  return { get, put };
+}

--- a/packages/hub-agent/src/sidecar-orchestrator-probe.test.ts
+++ b/packages/hub-agent/src/sidecar-orchestrator-probe.test.ts
@@ -170,6 +170,7 @@ describe("createSidecarOrchestrator workflow-probe threading", () => {
         generateKeyPair,
         verifySSHSig: verifySSHSignature,
       },
+      resolveSenderCrypto: () => undefined,
       createDeployRouter: () => ({
         deploy: () => Promise.resolve({ publicKey: "aa".repeat(32) }),
       }),

--- a/packages/hub-agent/src/sidecar-orchestrator.ts
+++ b/packages/hub-agent/src/sidecar-orchestrator.ts
@@ -16,6 +16,7 @@ import type { HubTransport } from "@intx/mail-memory";
 import type { SignalKind } from "@intx/types";
 import type {
   ApprovalSnapshot,
+  CryptoProvider,
   InferenceEvent,
   KeyPair,
 } from "@intx/types/runtime";
@@ -100,6 +101,13 @@ export type SidecarOrchestratorConfig = {
   dataDir: string;
   transport: HubTransport;
   cryptoOps: SidecarCryptoOps;
+  /**
+   * Resolves a sender address to the crypto that verifies its inbound mail.
+   * The host builds this over the sidecar's sender-key cache and the
+   * orchestrator forwards it unchanged to `createHubLink`, where the inbound
+   * signature shadow uses it.
+   */
+  resolveSenderCrypto: (address: string) => CryptoProvider | undefined;
   /**
    * Host-injected `DeployRouter` factory. The orchestrator calls it
    * once after `sessions` and `keyStore` are constructed; the
@@ -220,6 +228,7 @@ export function createSidecarOrchestrator(
     dataDir,
     transport,
     cryptoOps,
+    resolveSenderCrypto,
     createDeployRouter,
     mailInboundRouter,
     signalInboundRouter,
@@ -310,6 +319,7 @@ export function createSidecarOrchestrator(
     transport,
     sessions,
     keyStore,
+    resolveSenderCrypto,
     deployRouter,
     applyWorkflowRunPack,
     ...(mailInboundRouter !== undefined ? { mailInboundRouter } : {}),

--- a/packages/hub-agent/src/ws/hub-link-bootstrap-prune.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-bootstrap-prune.test.ts
@@ -296,6 +296,7 @@ describe("hub-link workflow-run pack bootstrap prune", () => {
       transport,
       sessions,
       keyStore,
+      resolveSenderCrypto: () => undefined,
       deployRouter: createTestDeployRouter(keyStore),
     });
 

--- a/packages/hub-agent/src/ws/hub-link-mail-router.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-mail-router.test.ts
@@ -39,7 +39,7 @@ import {
   verifySSHSignature,
   createEd25519Crypto,
 } from "@intx/crypto";
-import { hexDecode, hexEncode } from "@intx/types";
+import { hexDecode } from "@intx/types";
 import {
   assembleSignedContent,
   assembleMessage,
@@ -50,6 +50,7 @@ import {
 import { configureSync, getConfig, resetSync } from "@intx/log";
 
 import { createHubLink, type DeployRouter } from "./hub-link";
+import { createPublicKeyCrypto } from "../sender-crypto";
 import type { AgentKeyStore } from "../agent-key-store";
 import type { SessionManager } from "../session-manager";
 
@@ -98,11 +99,13 @@ function createTestDeployRouter(keyStore: AgentKeyStore): DeployRouter {
 function withTestDeployBindings(): {
   keyStore: AgentKeyStore & { registerKey(address: string, kp: KeyPair): void };
   deployRouter: DeployRouter;
+  resolveSenderCrypto: () => undefined;
 } {
   const keyStore = createTestKeyStore();
   return {
     keyStore,
     deployRouter: createTestDeployRouter(keyStore),
+    resolveSenderCrypto: () => undefined,
   };
 }
 
@@ -332,7 +335,6 @@ describe("hub-link mail.inbound throwing router", () => {
           deploymentAddress,
           encoded,
           "user@integration.interchange",
-          null,
         ),
       ).toBe(true);
 
@@ -345,7 +347,6 @@ describe("hub-link mail.inbound throwing router", () => {
           deploymentAddress,
           encoded,
           "user@integration.interchange",
-          null,
         ),
       ).toBe(true);
 
@@ -459,6 +460,9 @@ describe("hub-link mail.inbound signature shadow", () => {
       deploymentAddress: string;
       routed: Uint8Array[];
     }) => Promise<void>,
+    resolveSenderCrypto?: Parameters<
+      typeof createHubLink
+    >[0]["resolveSenderCrypto"],
   ): Promise<void> {
     const transport = createInMemoryTransport();
     const sessions = createMockSessionManager();
@@ -482,6 +486,7 @@ describe("hub-link mail.inbound signature shadow", () => {
       transport,
       sessions,
       ...bindings,
+      ...(resolveSenderCrypto !== undefined ? { resolveSenderCrypto } : {}),
       mailInboundRouter,
       getWorkflowAddresses: () => [deploymentAddress],
     });
@@ -500,7 +505,10 @@ describe("hub-link mail.inbound signature shadow", () => {
     }
   }
 
-  test("a validly-signed frame logs a valid/match verdict and is admitted", async () => {
+  test("a signature the cached key verifies logs valid/match and is admitted", async () => {
+    // The cache resolves the sender's real key, so the recipient verifies the
+    // signature locally and logs valid/match. The resolver returns the key (not
+    // the () => undefined default), so this exercises the populated-cache path.
     const sender = "external@remote.interchange";
     const crypto = createEd25519Crypto(await generateKeyPair());
     const raw = await makeSignedMail(crypto, sender);
@@ -509,12 +517,7 @@ describe("hub-link mail.inbound signature shadow", () => {
       "shadowvalid",
       async ({ deploymentAddress, routed }) => {
         expect(
-          env.router.routeMail(
-            deploymentAddress,
-            base64Encode(raw),
-            sender,
-            hexEncode(crypto.getPublicKey()),
-          ),
+          env.router.routeMail(deploymentAddress, base64Encode(raw), sender),
         ).toBe(true);
 
         await waitFor(() => shadowVerdicts().length > 0);
@@ -525,10 +528,14 @@ describe("hub-link mail.inbound signature shadow", () => {
         await waitFor(() => routed.length > 0);
         expect(routed).toHaveLength(1);
       },
+      (address) =>
+        address === sender
+          ? createPublicKeyCrypto(crypto.getPublicKey())
+          : undefined,
     );
   });
 
-  test("a tampered signature logs invalid and is still admitted", async () => {
+  test("a signature the cached key does not verify logs invalid and is still admitted", async () => {
     const sender = "external@remote.interchange";
     const signer = createEd25519Crypto(await generateKeyPair());
     const other = createEd25519Crypto(await generateKeyPair());
@@ -537,15 +544,10 @@ describe("hub-link mail.inbound signature shadow", () => {
     await withConnectedLink(
       "shadowbad",
       async ({ deploymentAddress, routed }) => {
-        // The hub stamps a key that does not match the signer, so the recipient
-        // verdict is invalid -- but shadow admits it anyway.
+        // The cache holds a key that did not sign the message, so the verdict
+        // is invalid -- but shadow admits it anyway.
         expect(
-          env.router.routeMail(
-            deploymentAddress,
-            base64Encode(raw),
-            sender,
-            hexEncode(other.getPublicKey()),
-          ),
+          env.router.routeMail(deploymentAddress, base64Encode(raw), sender),
         ).toBe(true);
 
         await waitFor(() => shadowVerdicts().length > 0);
@@ -553,24 +555,25 @@ describe("hub-link mail.inbound signature shadow", () => {
         await waitFor(() => routed.length > 0);
         expect(routed).toHaveLength(1);
       },
+      (address) =>
+        address === sender
+          ? createPublicKeyCrypto(other.getPublicKey())
+          : undefined,
     );
   });
 
-  test("a null sender key logs unknown and is still admitted", async () => {
+  test("a cache miss logs unknown and is still admitted", async () => {
     const sender = "external@remote.interchange";
     const crypto = createEd25519Crypto(await generateKeyPair());
     const raw = await makeSignedMail(crypto, sender);
 
     await withConnectedLink(
-      "shadownull",
+      "shadowmiss",
       async ({ deploymentAddress, routed }) => {
+        // The default resolver returns undefined (empty cache), so there is no
+        // key to verify against -- a quiet unknown, and still admitted.
         expect(
-          env.router.routeMail(
-            deploymentAddress,
-            base64Encode(raw),
-            sender,
-            null,
-          ),
+          env.router.routeMail(deploymentAddress, base64Encode(raw), sender),
         ).toBe(true);
 
         await waitFor(() => shadowVerdicts().length > 0);
@@ -591,12 +594,7 @@ describe("hub-link mail.inbound signature shadow", () => {
       "shadowforge",
       async ({ deploymentAddress, routed }) => {
         expect(
-          env.router.routeMail(
-            deploymentAddress,
-            base64Encode(raw),
-            stamp,
-            hexEncode(crypto.getPublicKey()),
-          ),
+          env.router.routeMail(deploymentAddress, base64Encode(raw), stamp),
         ).toBe(true);
 
         await waitFor(() => shadowVerdicts().length > 0);
@@ -606,6 +604,10 @@ describe("hub-link mail.inbound signature shadow", () => {
         await waitFor(() => routed.length > 0);
         expect(routed).toHaveLength(1);
       },
+      (address) =>
+        address === stamp
+          ? createPublicKeyCrypto(crypto.getPublicKey())
+          : undefined,
     );
   });
 });

--- a/packages/hub-agent/src/ws/hub-link.test.ts
+++ b/packages/hub-agent/src/ws/hub-link.test.ts
@@ -156,11 +156,15 @@ function createTestDeployRouter(keyStore: AgentKeyStore): DeployRouter {
 function withTestDeployBindings(): {
   keyStore: AgentKeyStore & { registerKey(address: string, kp: KeyPair): void };
   deployRouter: DeployRouter;
+  resolveSenderCrypto: () => undefined;
 } {
   const keyStore = createTestKeyStore();
   return {
     keyStore,
     deployRouter: createTestDeployRouter(keyStore),
+    // These tests do not exercise the inbound signature compare, so the shadow
+    // resolves no cached key.
+    resolveSenderCrypto: () => undefined,
   };
 }
 import type { KeyPair } from "@intx/types/runtime";
@@ -782,6 +786,7 @@ describe("sidecar↔hub integration", () => {
       transport,
       sessions,
       keyStore,
+      resolveSenderCrypto: () => undefined,
       deployRouter: createTestDeployRouter(keyStore),
     });
 
@@ -1164,7 +1169,6 @@ describe("sidecar↔hub integration", () => {
         deploymentAddress,
         encoded,
         "user@integration.interchange",
-        null,
       );
       expect(accepted).toBe(true);
 

--- a/packages/hub-agent/src/ws/hub-link.ts
+++ b/packages/hub-agent/src/ws/hub-link.ts
@@ -44,7 +44,11 @@ import {
 } from "./register-acker";
 import { shadowVerifyInboundSignature } from "./inbound-signature-shadow";
 import { base64Decode, base64Encode } from "@intx/types";
-import type { ApprovalSnapshot, InferenceEvent } from "@intx/types/runtime";
+import type {
+  ApprovalSnapshot,
+  CryptoProvider,
+  InferenceEvent,
+} from "@intx/types/runtime";
 
 import type { AgentKeyStore } from "../agent-key-store";
 import type { SessionManager } from "../session-manager";
@@ -498,6 +502,15 @@ export type HubLinkConfig = {
    */
   keyStore: AgentKeyStore;
   /**
+   * Resolves a sender address to the crypto whose public key verifies that
+   * sender's inbound mail, or `undefined` when no key is known. The inbound
+   * signature shadow uses it to check each frame's signature against the key a
+   * local cache holds, beside the check against the key the hub stamped on the
+   * frame. Source-opaque by design: the link never learns whether the key came
+   * from a local cache or a relayed foreign key.
+   */
+  resolveSenderCrypto: (address: string) => CryptoProvider | undefined;
+  /**
    * Routes every inbound `agent.deploy` frame. Production wiring
    * supplies a router that stages each deploy through the workflow-run
    * substrate: a provision-step frame primes a per-step repo, and a
@@ -689,6 +702,7 @@ export function createHubLink(config: HubLinkConfig): HubLink {
     transport,
     sessions,
     keyStore,
+    resolveSenderCrypto,
     deployRouter,
     mailInboundRouter,
     signalInboundRouter,
@@ -1436,13 +1450,15 @@ export function createHubLink(config: HubLinkConfig): HubLink {
         // sender, so it is outside this path.
         void Promise.resolve()
           .then(() =>
-            shadowVerifyInboundSignature({
-              raw: rawBytes,
-              authenticatedSender: frame.authenticatedSender,
-              authenticatedSenderPublicKey: frame.authenticatedSenderPublicKey,
-              messageId: frame.messageId,
-              agentAddress: frame.agentAddress,
-            }),
+            shadowVerifyInboundSignature(
+              {
+                raw: rawBytes,
+                authenticatedSender: frame.authenticatedSender,
+                messageId: frame.messageId,
+                agentAddress: frame.agentAddress,
+              },
+              resolveSenderCrypto,
+            ),
           )
           .catch((cause: unknown) => {
             const msg = cause instanceof Error ? cause.message : String(cause);

--- a/packages/hub-agent/src/ws/inbound-signature-shadow.test.ts
+++ b/packages/hub-agent/src/ws/inbound-signature-shadow.test.ts
@@ -7,9 +7,10 @@ import {
   generateMessageId,
   type MessageHeaders,
 } from "@intx/mime";
-import { hexEncode } from "@intx/types";
+import type { CryptoProvider } from "@intx/types/runtime";
 
 import { shadowVerifyInboundSignature } from "./inbound-signature-shadow";
+import { createPublicKeyCrypto } from "../sender-crypto";
 
 const AGENT_ADDRESS = "run_anchor@tenant.example";
 
@@ -51,42 +52,59 @@ async function signedMessage(
   return assembleMessage(headersFrom(from), content, sig);
 }
 
-function hexKey(crypto: Awaited<ReturnType<typeof makeCrypto>>): string {
-  return hexEncode(crypto.getPublicKey());
+/**
+ * A resolver that hands back `crypto`'s public key for `sender` and misses
+ * (returns undefined) for anyone else -- the cache the recipient verifies
+ * against.
+ */
+function cacheFor(
+  sender: string,
+  crypto: Awaited<ReturnType<typeof makeCrypto>>,
+): (address: string) => CryptoProvider | undefined {
+  return (address) =>
+    address === sender
+      ? createPublicKeyCrypto(crypto.getPublicKey())
+      : undefined;
 }
 
+const emptyCache = (): undefined => undefined;
+
 describe("shadowVerifyInboundSignature", () => {
-  test("valid signature whose From matches the stamp: valid/match", async () => {
+  test("signature the cached key verifies, From matches: valid/match", async () => {
     const sender = "alpha@test.interchange";
     const crypto = await makeCrypto();
     const raw = await signedMessage(crypto, sender);
 
-    const verdict = await shadowVerifyInboundSignature({
-      raw,
-      authenticatedSender: sender,
-      authenticatedSenderPublicKey: hexKey(crypto),
-      messageId: "mid-valid",
-      agentAddress: AGENT_ADDRESS,
-    });
+    const verdict = await shadowVerifyInboundSignature(
+      {
+        raw,
+        authenticatedSender: sender,
+        messageId: "mid-valid",
+        agentAddress: AGENT_ADDRESS,
+      },
+      cacheFor(sender, crypto),
+    );
 
     expect(verdict.signature).toBe("valid");
     expect(verdict.fromMatch).toBe("match");
     expect(verdict.messageFrom).toBe(sender);
   });
 
-  test("signature against a different key: invalid, From unchecked", async () => {
+  test("signature against a different cached key: invalid, From unchecked", async () => {
     const sender = "alpha@test.interchange";
     const signer = await makeCrypto();
     const other = await makeCrypto();
     const raw = await signedMessage(signer, sender);
 
-    const verdict = await shadowVerifyInboundSignature({
-      raw,
-      authenticatedSender: sender,
-      authenticatedSenderPublicKey: hexKey(other),
-      messageId: "mid-invalid",
-      agentAddress: AGENT_ADDRESS,
-    });
+    const verdict = await shadowVerifyInboundSignature(
+      {
+        raw,
+        authenticatedSender: sender,
+        messageId: "mid-invalid",
+        agentAddress: AGENT_ADDRESS,
+      },
+      cacheFor(sender, other),
+    );
 
     expect(verdict.signature).toBe("invalid");
     // A From-binding is only meaningful atop a valid signature.
@@ -107,105 +125,133 @@ describe("shadowVerifyInboundSignature", () => {
       ].join("\r\n"),
     );
 
-    const verdict = await shadowVerifyInboundSignature({
-      raw,
-      authenticatedSender: sender,
-      authenticatedSenderPublicKey: hexKey(crypto),
-      messageId: "mid-missing",
-      agentAddress: AGENT_ADDRESS,
-    });
+    const verdict = await shadowVerifyInboundSignature(
+      {
+        raw,
+        authenticatedSender: sender,
+        messageId: "mid-missing",
+        agentAddress: AGENT_ADDRESS,
+      },
+      cacheFor(sender, crypto),
+    );
 
     expect(verdict.signature).toBe("missing");
     expect(verdict.fromMatch).toBe("unchecked");
   });
 
   test("valid signature under a forged From: valid/mismatch", async () => {
-    // The message is genuinely signed by `signer`'s key (so the hub stamps
-    // `signer`'s address + key), but its visible From claims a different
-    // sender. A valid signature over a borrowed display identity is the
-    // forgery this binding catches.
+    // The message is genuinely signed by `crypto` (the key the cache holds for
+    // the stamped `signer`), but its visible From claims a different sender. A
+    // valid signature over a borrowed display identity is the forgery this
+    // binding catches.
     const signer = "alpha@test.interchange";
     const forgedFrom = "victim@test.interchange";
     const crypto = await makeCrypto();
     const raw = await signedMessage(crypto, forgedFrom);
 
-    const verdict = await shadowVerifyInboundSignature({
-      raw,
-      authenticatedSender: signer,
-      authenticatedSenderPublicKey: hexKey(crypto),
-      messageId: "mid-forged",
-      agentAddress: AGENT_ADDRESS,
-    });
+    const verdict = await shadowVerifyInboundSignature(
+      {
+        raw,
+        authenticatedSender: signer,
+        messageId: "mid-forged",
+        agentAddress: AGENT_ADDRESS,
+      },
+      cacheFor(signer, crypto),
+    );
 
     expect(verdict.signature).toBe("valid");
     expect(verdict.fromMatch).toBe("mismatch");
     expect(verdict.messageFrom).toBe(forgedFrom);
   });
 
-  test("null sender key: unknown, admitted", async () => {
+  test("cache miss: unknown, admitted", async () => {
     const sender = "alpha@test.interchange";
     const crypto = await makeCrypto();
     const raw = await signedMessage(crypto, sender);
 
-    const verdict = await shadowVerifyInboundSignature({
-      raw,
-      authenticatedSender: sender,
-      authenticatedSenderPublicKey: null,
-      messageId: "mid-null",
-      agentAddress: AGENT_ADDRESS,
-    });
+    const verdict = await shadowVerifyInboundSignature(
+      {
+        raw,
+        authenticatedSender: sender,
+        messageId: "mid-miss",
+        agentAddress: AGENT_ADDRESS,
+      },
+      emptyCache,
+    );
 
     expect(verdict.signature).toBe("unknown");
     expect(verdict.fromMatch).toBe("unchecked");
   });
 
-  test("malformed hex key degrades to a distinct error verdict", async () => {
+  test("a resolver that throws degrades to error, not a crash", async () => {
+    // The resolver call is inside the verify's try, so a throw is contained as
+    // a distinct `error` verdict rather than escaping and being mis-logged as a
+    // mail-path crash.
     const sender = "alpha@test.interchange";
     const crypto = await makeCrypto();
     const raw = await signedMessage(crypto, sender);
 
-    const verdict = await shadowVerifyInboundSignature({
-      raw,
-      authenticatedSender: sender,
-      authenticatedSenderPublicKey: "not-hex",
-      messageId: "mid-badhex",
-      agentAddress: AGENT_ADDRESS,
-    });
+    const verdict = await shadowVerifyInboundSignature(
+      {
+        raw,
+        authenticatedSender: sender,
+        messageId: "mid-resolver-fault",
+        agentAddress: AGENT_ADDRESS,
+      },
+      () => {
+        throw new Error("resolver boom");
+      },
+    );
 
     expect(verdict.signature).toBe("error");
     expect(verdict.fromMatch).toBe("unchecked");
   });
 
-  test("well-formed hex of the wrong length is an error, not a crash", async () => {
+  test("an unreadable cached key degrades to error, not a crash", async () => {
     const sender = "alpha@test.interchange";
     const crypto = await makeCrypto();
     const raw = await signedMessage(crypto, sender);
+    // A provider whose getPublicKey throws -- the verify path must contain it
+    // as a distinct `error` verdict rather than crash the mail path.
+    const faulty: CryptoProvider = {
+      getPublicKey() {
+        throw new Error("cached key unreadable");
+      },
+      sign: () => Promise.reject(new Error("verify-only")),
+      signSSH: () => Promise.reject(new Error("verify-only")),
+      verify: () => Promise.reject(new Error("verify-only")),
+    };
 
-    const verdict = await shadowVerifyInboundSignature({
-      raw,
-      authenticatedSender: sender,
-      // 16 bytes of valid hex -- half an Ed25519 key.
-      authenticatedSenderPublicKey: "ab".repeat(16),
-      messageId: "mid-shortkey",
-      agentAddress: AGENT_ADDRESS,
-    });
+    const verdict = await shadowVerifyInboundSignature(
+      {
+        raw,
+        authenticatedSender: sender,
+        messageId: "mid-key-fault",
+        agentAddress: AGENT_ADDRESS,
+      },
+      () => faulty,
+    );
 
     expect(verdict.signature).toBe("error");
+    expect(verdict.fromMatch).toBe("unchecked");
   });
 
   test("a display-name From still binds to the stamp addr-spec", async () => {
     // extractAddrSpec strips the display name, so `Alpha <a@b>` binds to the
     // bare stamp `a@b` without a false mismatch.
+    const sender = "alpha@test.interchange";
     const crypto = await makeCrypto();
     const raw = await signedMessage(crypto, "Alpha <alpha@test.interchange>");
 
-    const verdict = await shadowVerifyInboundSignature({
-      raw,
-      authenticatedSender: "alpha@test.interchange",
-      authenticatedSenderPublicKey: hexKey(crypto),
-      messageId: "mid-display",
-      agentAddress: AGENT_ADDRESS,
-    });
+    const verdict = await shadowVerifyInboundSignature(
+      {
+        raw,
+        authenticatedSender: sender,
+        messageId: "mid-display",
+        agentAddress: AGENT_ADDRESS,
+      },
+      cacheFor(sender, crypto),
+    );
 
     expect(verdict.signature).toBe("valid");
     expect(verdict.fromMatch).toBe("match");
@@ -217,19 +263,22 @@ describe("shadowVerifyInboundSignature", () => {
     // forgery verdict -- that would poison the corpus (and later drop
     // legitimate mail under enforcement). extractAddrSpec rejects the two-@
     // input; the binding degrades to unchecked while the signature stands.
+    const sender = "alpha@test.interchange";
     const crypto = await makeCrypto();
     const raw = await signedMessage(
       crypto,
       "alpha@test.interchange, beta@test.interchange",
     );
 
-    const verdict = await shadowVerifyInboundSignature({
-      raw,
-      authenticatedSender: "alpha@test.interchange",
-      authenticatedSenderPublicKey: hexKey(crypto),
-      messageId: "mid-multi",
-      agentAddress: AGENT_ADDRESS,
-    });
+    const verdict = await shadowVerifyInboundSignature(
+      {
+        raw,
+        authenticatedSender: sender,
+        messageId: "mid-multi",
+        agentAddress: AGENT_ADDRESS,
+      },
+      cacheFor(sender, crypto),
+    );
 
     expect(verdict.signature).toBe("valid");
     expect(verdict.fromMatch).toBe("unchecked");
@@ -238,16 +287,19 @@ describe("shadowVerifyInboundSignature", () => {
   test("case-variant From still matches the stamp", async () => {
     // extractAddrSpec normalizes to lowercase, so an upper-case From binds to a
     // lower-case stamp without a false mismatch.
+    const sender = "alpha@test.interchange";
     const crypto = await makeCrypto();
     const raw = await signedMessage(crypto, "Alpha@Test.Interchange");
 
-    const verdict = await shadowVerifyInboundSignature({
-      raw,
-      authenticatedSender: "alpha@test.interchange",
-      authenticatedSenderPublicKey: hexKey(crypto),
-      messageId: "mid-case",
-      agentAddress: AGENT_ADDRESS,
-    });
+    const verdict = await shadowVerifyInboundSignature(
+      {
+        raw,
+        authenticatedSender: sender,
+        messageId: "mid-case",
+        agentAddress: AGENT_ADDRESS,
+      },
+      cacheFor(sender, crypto),
+    );
 
     expect(verdict.signature).toBe("valid");
     expect(verdict.fromMatch).toBe("match");

--- a/packages/hub-agent/src/ws/inbound-signature-shadow.ts
+++ b/packages/hub-agent/src/ws/inbound-signature-shadow.ts
@@ -1,5 +1,5 @@
 import { getLogger } from "@intx/log";
-import { hexDecode } from "@intx/types";
+import type { CryptoProvider } from "@intx/types/runtime";
 import { verifyMimeSignature } from "@intx/mailbox";
 import { parseHeaderSection, extractAddrSpec } from "@intx/mime";
 
@@ -10,18 +10,15 @@ const logger = getLogger([
   "inbound-signature-shadow",
 ]);
 
-// A raw Ed25519 public key is 32 bytes; the hub stamps it hex-encoded on the
-// frame.
-const ED25519_PUBLIC_KEY_BYTES = 32;
-
 /**
  * The two-axis verdict of shadow-verifying one inbound mail frame.
  *
  * `signature` reuses the `SignatureStatus` vocabulary --
  * `valid | invalid | missing | unknown` -- with an added `error` for a fault in
- * the verifier itself (a malformed key, an unparseable sender). It answers: does
- * the message's detached signature verify against the key the hub resolved for
- * `authenticatedSender`?
+ * the verifier itself (verify throwing, an unparseable sender). It answers: does
+ * the message's detached signature verify against the key the recipient's local
+ * cache holds for `authenticatedSender`? `unknown` means the cache holds no key
+ * for the sender, so there is nothing to verify against.
  *
  * `fromMatch` is an orthogonal axis: given a VALID signature, does the message's
  * visible `From` bind to `authenticatedSender`? A valid signature over a `From`
@@ -45,51 +42,61 @@ export type InboundSignatureVerdict = {
 export type InboundSignatureShadowInput = {
   raw: Uint8Array;
   authenticatedSender: string;
-  authenticatedSenderPublicKey: string | null;
   messageId: string | undefined;
   agentAddress: string;
 };
 
 /**
- * Verify an inbound mail frame's signature against the hub-resolved sender key
- * and LOG the verdict. Shadow only: this NEVER rejects delivery and NEVER
- * throws -- the caller runs it beside an unconditional admit. Returns the
- * verdict so a caller (or a test) can read it without scraping the log.
+ * Verify an inbound mail frame's signature against the key the recipient's
+ * local cache holds for `authenticatedSender` and LOG the verdict. The key is
+ * resolved through `resolveSenderCrypto` -- the cache-backed source populated by
+ * the hub's co-delivery on the run's grants barrier -- so the recipient verifies
+ * locally against the key the hub vouched for, never a key travelling on the
+ * message itself.
  *
- * A fault in the verifier (malformed key, unparseable sender) degrades to an
- * `error` verdict logged at ERROR -- surfaced loudly and kept distinct from the
- * ordinary `unknown` of an unresolvable sender, which stays a quiet `info`.
+ * Shadow only: this NEVER rejects delivery and NEVER throws -- the caller runs
+ * it beside an unconditional admit. Returns the verdict so a caller (or a test)
+ * can read it without scraping the log.
+ *
+ * A cache miss is a quiet `unknown` (an expected, benign state -- see below),
+ * not a fault. A genuine fault (the resolver throwing, the cached key being
+ * unreadable, or the verify throwing) degrades to an `error` verdict logged at
+ * ERROR -- surfaced loudly and kept distinct from `unknown`.
  */
 export async function shadowVerifyInboundSignature(
   input: InboundSignatureShadowInput,
+  resolveSenderCrypto: (address: string) => CryptoProvider | undefined,
 ): Promise<InboundSignatureVerdict> {
-  const { raw, authenticatedSender, authenticatedSenderPublicKey } = input;
-
-  if (authenticatedSenderPublicKey === null) {
-    // No hub-resolved key: an unresolvable sender (a run whose deploy is not yet
-    // acked, an address matching no principal). Nothing to verify against; the
-    // mail is admitted as an unverifiable sender. Not a fault -- a quiet
-    // `unknown`.
-    return logVerdict(
-      {
-        signature: "unknown",
-        fromMatch: "unchecked",
-        authenticatedSender,
-        messageFrom: null,
-      },
-      input,
-    );
-  }
+  const { raw, authenticatedSender } = input;
 
   let verdict: InboundSignatureVerdict;
   try {
-    const key = hexDecode(authenticatedSenderPublicKey);
-    if (key.length !== ED25519_PUBLIC_KEY_BYTES) {
-      throw new Error(
-        `expected a ${ED25519_PUBLIC_KEY_BYTES}-byte Ed25519 key, got ${key.length}`,
+    // Resolve and read the cached key inside the try so ANY fault -- the
+    // resolver throwing, `getPublicKey` throwing, or the verify throwing --
+    // is contained as a single `error` verdict rather than escaping. This is
+    // what keeps the "never throws" contract true.
+    const crypto = resolveSenderCrypto(authenticatedSender);
+    if (crypto === undefined) {
+      // Cache miss: the local keyring holds no key for this sender, so there
+      // is nothing to verify against. Expected for a sender whose key was
+      // never co-delivered (a run authorized before this shipped, relayed mail
+      // with no preceding grant co-delivery) or was unresolvable, or a
+      // rotation the cache has not yet refreshed. The mail is admitted as an
+      // unverifiable sender -- a quiet `unknown`, keyed by `authenticatedSender`
+      // in the log so the observation window stays legible.
+      return logVerdict(
+        {
+          signature: "unknown",
+          fromMatch: "unchecked",
+          authenticatedSender,
+          messageFrom: null,
+        },
+        input,
       );
     }
-    const signature = await verifyMimeSignature(raw, key);
+    // The cached key is raw bytes, already validated 32-byte Ed25519 at cache
+    // write/load time, so it feeds `verifyMimeSignature` directly.
+    const signature = await verifyMimeSignature(raw, crypto.getPublicKey());
     verdict = {
       signature,
       fromMatch: "unchecked",

--- a/packages/hub-api/src/routes/approvals.ts
+++ b/packages/hub-api/src/routes/approvals.ts
@@ -75,10 +75,14 @@ async function propagateRunGrantsToSidecar(
     );
     // A run with no committed per-run grants has nothing to push.
     if (committed === null) return;
+    // A standing-grant refresh carries no inbound sender, so there is no sender
+    // key to co-deliver on this barrier; the sender's key rides the run.grants
+    // frame that its triggering mail pushed.
     const delivered = deps.sidecarRouter.sendRunGrants(
       approval.agentAddress,
       approval.runId,
       committed.stepGrants,
+      undefined,
     );
     if (!delivered) {
       log.warn`standing grant for run ${approval.runId} not pushed: deployment ${approval.agentAddress} is not routable; the next dispatch re-establishes it`;

--- a/packages/hub-api/src/routes/workflows.test.ts
+++ b/packages/hub-api/src/routes/workflows.test.ts
@@ -494,7 +494,6 @@ type RouteMailCall = {
   address: string;
   rawMessage: string;
   authenticatedSender: string;
-  authenticatedSenderPublicKey: string | null;
 };
 type RunGrantsCall = {
   address: string;
@@ -520,17 +519,11 @@ function createMockSidecarRouter(
     handleOpen: () => notImpl("handleOpen"),
     handleMessage: () => notImpl("handleMessage"),
     handleClose: () => notImpl("handleClose"),
-    routeMail: (
-      address,
-      rawMessage,
-      authenticatedSender,
-      authenticatedSenderPublicKey,
-    ) => {
+    routeMail: (address, rawMessage, authenticatedSender) => {
       routeMailCalls.push({
         address,
         rawMessage,
         authenticatedSender,
-        authenticatedSenderPublicKey,
       });
       sendOrder.push({ kind: "mail", address });
       return routeMailResult;
@@ -1692,10 +1685,6 @@ describe("POST /workflows/:anchorRunId/mail", () => {
     // authenticated sender (fromAddr = principal.refId@tenant.domain), not
     // anything parsed from the message body.
     expect(call.authenticatedSender).toBe(`${USER_ID}@${DOMAIN}`);
-    // The trigger resolves the authenticated sender's hub-held key and stamps
-    // it on the frame so the recipient can verify the signature. The mock key
-    // store mints this canned hex key for the triggering principal.
-    expect(call.authenticatedSenderPublicKey).toBe("ab".repeat(32));
     // The wire payload is base64-encoded MIME carrying the body text.
     const decoded = new TextDecoder().decode(base64Decode(call.rawMessage));
     expect(decoded).toContain("kick off");
@@ -1705,10 +1694,11 @@ describe("POST /workflows/:anchorRunId/mail", () => {
   });
 
   test("routes the trigger mail even when the sender key cannot be resolved", async () => {
-    // The frame sender key is shadow-only and nullable, so a resolution fault
-    // (here a misconfigured key store whose getPublicKey throws) must degrade to
-    // null rather than fail the trigger. Otherwise the fault would strand a run
-    // whose grants (sent before the mail) have already gone out.
+    // The sender key is co-delivered best-effort for shadow verification, so a
+    // resolution fault (here a misconfigured key store whose getPublicKey
+    // throws) must degrade to omitting it rather than fail the trigger.
+    // Otherwise the fault would strand a run whose grants (sent before the
+    // mail) have already gone out.
     const routeMailCalls: RouteMailCall[] = [];
     const throwingKeyStore: PrincipalKeyStore = {
       ...createMockPrincipalKeyStore(),
@@ -1727,11 +1717,10 @@ describe("POST /workflows/:anchorRunId/mail", () => {
       authedPost(`${base()}/${DEPLOYMENT_ID}/mail`, { content: "kick off" }),
     );
 
+    // The resolution fault degrades to omitting the co-delivered key rather
+    // than propagating; the mail still routes so the run is not stranded.
     expect(res.status).toBe(202);
     expect(routeMailCalls).toHaveLength(1);
-    // The resolution fault degrades to a null stamped key rather than
-    // propagating; the mail still routes so the run is not stranded.
-    expect(routeMailCalls[0]?.authenticatedSenderPublicKey).toBeNull();
   });
 
   test("a later trigger occurrence reuses the live run's committed grants", async () => {

--- a/packages/hub-api/src/workflow-run-trigger.ts
+++ b/packages/hub-api/src/workflow-run-trigger.ts
@@ -592,7 +592,6 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
       address,
       base64,
       fromAddr,
-      authenticatedSenderPublicKey,
       messageId,
     );
     if (!delivered) {

--- a/packages/hub-api/src/workflow-run-trigger.ts
+++ b/packages/hub-api/src/workflow-run-trigger.ts
@@ -544,6 +544,24 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
     }
     stepGrants = reserved;
 
+    // Stamp the hub-verified principal address (fromAddr, the address the
+    // message is signed and addressed under) as the authenticated sender --
+    // never the message's own MIME From. Resolve its hub-held key so the
+    // recipient can verify the signature locally against the key the hub
+    // vouches for, and co-deliver it on the run's grants barrier below so the
+    // sender's key rides the same push as the grant. Best-effort: a resolution
+    // fault degrades to a null key (logged) rather than blocking the trigger --
+    // verification is shadow-only. A null key is omitted from the co-delivery.
+    const authenticatedSenderPublicKey = await resolveFrameSenderKey(
+      db,
+      principalKeyStore,
+      fromAddr,
+    );
+    const senderIdentities =
+      authenticatedSenderPublicKey !== null
+        ? [{ address: fromAddr, publicKey: authenticatedSenderPublicKey }]
+        : undefined;
+
     // Send the run's grants BEFORE the trigger mail. Both frames route
     // through the same per-address channel, so same-websocket FIFO
     // ordering guarantees the grants land at the sidecar before the mail
@@ -555,6 +573,7 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
       address,
       runId,
       stepGrants,
+      senderIdentities,
     );
     if (!grantsDelivered) {
       return {
@@ -569,18 +588,6 @@ export function createWorkflowRunTrigger(deps: TriggerWorkflowRunDeps) {
       };
     }
 
-    // Stamp the hub-verified principal address (fromAddr, the address the
-    // message is signed and addressed under) as the authenticated sender --
-    // never the message's own MIME From. Resolve its hub-held key alongside so
-    // the recipient can verify the signature locally against the key the hub
-    // vouches for. Best-effort: a resolution fault degrades to a null key
-    // (logged) rather than 500-ing a trigger whose grants have already been
-    // sent -- verification is shadow-only and must never block the trigger.
-    const authenticatedSenderPublicKey = await resolveFrameSenderKey(
-      db,
-      principalKeyStore,
-      fromAddr,
-    );
     const delivered = sidecarRouter.routeMail(
       address,
       base64,

--- a/packages/hub-sessions/src/ws/sidecar-handler.mail.test.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.mail.test.ts
@@ -357,6 +357,76 @@ describe("SidecarRouter allocation mail durability", () => {
     expect(inbound).toHaveLength(1);
     expect(inbound[0]?.["authenticatedSenderPublicKey"]).toBe(hexKey);
   });
+
+  test("co-delivers the resolved sender key on the dispatched run.grants frame", async () => {
+    const hexKey = "cc".repeat(32);
+    const router = createAllocatedRouter({
+      lookups: {
+        async resolveSenderKey() {
+          return hexKey;
+        },
+      },
+    });
+    const ws = await connectAllocated(router, [
+      TEST_IDENTITY.workflowRunAddress,
+    ]);
+
+    await router.sendWorkflowRunDispatchToAllocation(
+      TEST_TARGET,
+      TEST_IDENTITY.workflowRunAddress,
+      TEST_IDENTITY.anchorRunId,
+      [],
+      "dHJpZ2dlcg==",
+      TEST_SENDER,
+      "mid-codeliver",
+    );
+
+    const grants = framesOfType(ws, "run.grants");
+    expect(grants).toHaveLength(1);
+    expect(grants[0]?.["senderIdentities"]).toEqual([
+      { address: TEST_SENDER, publicKey: hexKey },
+    ]);
+  });
+
+  test("replays the co-delivered sender key on reconnect", async () => {
+    // A sidecar that missed the original dispatch learns the grant only from
+    // the reconnect replay; the co-delivered key must ride that replay too, or
+    // the sidecar would hold a grant for a sender whose key it never cached.
+    const hexKey = "dd".repeat(32);
+    const router = createAllocatedRouter({
+      mailAckRetryIntervalMs: 10_000,
+      disconnectQueueTTLMs: 60_000,
+      lookups: {
+        async resolveSenderKey() {
+          return hexKey;
+        },
+      },
+    });
+    const first = await connectAllocated(router, [
+      TEST_IDENTITY.workflowRunAddress,
+    ]);
+    await router.sendWorkflowRunDispatchToAllocation(
+      TEST_TARGET,
+      TEST_IDENTITY.workflowRunAddress,
+      TEST_IDENTITY.anchorRunId,
+      [],
+      "dHJpZ2dlcg==",
+      TEST_SENDER,
+      "mid-replay-key",
+    );
+    router.handleClose(first);
+
+    const second = await connectAllocated(
+      router,
+      [TEST_IDENTITY.workflowRunAddress],
+      "reconnect",
+    );
+    const grants = framesOfType(second, "run.grants");
+    expect(grants).toHaveLength(1);
+    expect(grants[0]?.["senderIdentities"]).toEqual([
+      { address: TEST_SENDER, publicKey: hexKey },
+    ]);
+  });
 });
 
 describe("SidecarRouter workflow-trigger mail gating", () => {
@@ -406,6 +476,116 @@ describe("SidecarRouter workflow-trigger mail gating", () => {
         )
         .map((frame) => frame["type"]),
     ).toEqual(["run.grants", "mail.inbound"]);
+  });
+
+  test("co-delivers the sender key on the live run.grants frame", async () => {
+    const hexKey = "ee".repeat(32);
+    const router = createAllocatedRouter({
+      lookups: {
+        async materializeMailTriggeredRunGrants() {
+          return { outcome: "materialized", stepGrants: [] };
+        },
+        async resolveSenderKey() {
+          return hexKey;
+        },
+      },
+    });
+    const ws = await connectAllocated(router, [
+      TEST_IDENTITY.workflowRunAddress,
+    ]);
+
+    router.handleMessage(
+      ws,
+      JSON.stringify({
+        type: "mail.outbound",
+        senderAddress: TEST_IDENTITY.workflowRunAddress,
+        rawMessage,
+        recipients: [TEST_IDENTITY.workflowRunAddress],
+      }),
+    );
+    await tick();
+
+    const grants = framesOfType(ws, "run.grants");
+    expect(grants).toHaveLength(1);
+    expect(grants[0]?.["senderIdentities"]).toEqual([
+      { address: TEST_IDENTITY.workflowRunAddress, publicKey: hexKey },
+    ]);
+  });
+
+  test("replays the mail-trigger sender key on reconnect", async () => {
+    // The mail-relay trigger commits a run through the messageId handshake, so
+    // its co-delivered key rides the pending-mail entry, not just the live
+    // send. A sidecar that drops before the ack must still learn the key from
+    // the reconnect replay.
+    const hexKey = "ff".repeat(32);
+    const router = createAllocatedRouter({
+      mailAckRetryIntervalMs: 10_000,
+      disconnectQueueTTLMs: 60_000,
+      lookups: {
+        async materializeMailTriggeredRunGrants() {
+          return { outcome: "materialized", stepGrants: [] };
+        },
+        async resolveSenderKey() {
+          return hexKey;
+        },
+      },
+    });
+    const first = await connectAllocated(router, [
+      TEST_IDENTITY.workflowRunAddress,
+    ]);
+    router.handleMessage(
+      first,
+      JSON.stringify({
+        type: "mail.outbound",
+        senderAddress: TEST_IDENTITY.workflowRunAddress,
+        rawMessage,
+        recipients: [TEST_IDENTITY.workflowRunAddress],
+      }),
+    );
+    await tick();
+    router.handleClose(first);
+
+    const second = await connectAllocated(
+      router,
+      [TEST_IDENTITY.workflowRunAddress],
+      "reconnect",
+    );
+    const grants = framesOfType(second, "run.grants");
+    expect(grants).toHaveLength(1);
+    expect(grants[0]?.["senderIdentities"]).toEqual([
+      { address: TEST_IDENTITY.workflowRunAddress, publicKey: hexKey },
+    ]);
+  });
+
+  test("omits senderIdentities from the run.grants frame when the key is unresolvable", async () => {
+    const router = createAllocatedRouter({
+      lookups: {
+        async materializeMailTriggeredRunGrants() {
+          return { outcome: "materialized", stepGrants: [] };
+        },
+        async resolveSenderKey() {
+          return null;
+        },
+      },
+    });
+    const ws = await connectAllocated(router, [
+      TEST_IDENTITY.workflowRunAddress,
+    ]);
+
+    router.handleMessage(
+      ws,
+      JSON.stringify({
+        type: "mail.outbound",
+        senderAddress: TEST_IDENTITY.workflowRunAddress,
+        rawMessage,
+        recipients: [TEST_IDENTITY.workflowRunAddress],
+      }),
+    );
+    await tick();
+
+    const grants = framesOfType(ws, "run.grants");
+    expect(grants).toHaveLength(1);
+    expect("senderIdentities" in (grants[0] ?? {})).toBe(false);
   });
 
   test("fails a rejected workflow recipient closed", async () => {

--- a/packages/hub-sessions/src/ws/sidecar-handler.mail.test.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.mail.test.ts
@@ -42,11 +42,10 @@ describe("SidecarRouter allocation mail durability", () => {
         TEST_IDENTITY.workflowRunAddress,
         "aGVsbG8=",
         TEST_SENDER,
-        null,
       ),
     ).toBe(true);
     expect(
-      router.routeMail("unknown@example.test", "aGVsbG8=", TEST_SENDER, null),
+      router.routeMail("unknown@example.test", "aGVsbG8=", TEST_SENDER),
     ).toBe(false);
   });
 
@@ -64,7 +63,6 @@ describe("SidecarRouter allocation mail durability", () => {
         TEST_IDENTITY.workflowRunAddress,
         "aGVsbG8=",
         TEST_SENDER,
-        null,
         "mid-retry",
       ),
     ).toBe(true);
@@ -91,7 +89,6 @@ describe("SidecarRouter allocation mail durability", () => {
       TEST_IDENTITY.workflowRunAddress,
       "aGk=",
       TEST_SENDER,
-      null,
       "mid-acked",
     );
 
@@ -155,7 +152,6 @@ describe("SidecarRouter allocation mail durability", () => {
       TEST_IDENTITY.workflowRunAddress,
       "b3duZWQ=",
       TEST_SENDER,
-      null,
       "mid-owned",
     );
     router.handleMessage(
@@ -196,7 +192,6 @@ describe("SidecarRouter allocation mail durability", () => {
       TEST_IDENTITY.workflowRunAddress,
       "ZHJvcA==",
       TEST_SENDER,
-      null,
       "mid-drop",
     );
     await new Promise((resolve) => setTimeout(resolve, 80));
@@ -219,12 +214,7 @@ describe("SidecarRouter allocation mail durability", () => {
       TEST_IDENTITY.workflowRunAddress,
     ]);
 
-    router.routeMail(
-      TEST_IDENTITY.workflowRunAddress,
-      "eXk=",
-      TEST_SENDER,
-      null,
-    );
+    router.routeMail(TEST_IDENTITY.workflowRunAddress, "eXk=", TEST_SENDER);
     await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(framesOfType(ws, "mail.inbound")).toHaveLength(1);
@@ -242,7 +232,6 @@ describe("SidecarRouter allocation mail durability", () => {
       TEST_IDENTITY.workflowRunAddress,
       "cmV0YWluZWQ=",
       TEST_SENDER,
-      null,
       "mid-retained",
     );
     router.handleClose(first);
@@ -271,7 +260,6 @@ describe("SidecarRouter allocation mail durability", () => {
       TEST_IDENTITY.workflowRunAddress,
       "ZXhwaXJlZA==",
       TEST_SENDER,
-      null,
       "mid-expired",
     );
     router.handleClose(first);
@@ -321,41 +309,6 @@ describe("SidecarRouter allocation mail durability", () => {
       "run.grants",
       "mail.inbound",
     ]);
-  });
-
-  test("dispatched inbound mail carries the hub-resolved sender key", async () => {
-    const hexKey = "bb".repeat(32);
-    const resolvedFor: string[] = [];
-    const router = createAllocatedRouter({
-      lookups: {
-        async resolveSenderKey(address) {
-          resolvedFor.push(address);
-          return hexKey;
-        },
-      },
-    });
-    const ws = await connectAllocated(router, [
-      TEST_IDENTITY.workflowRunAddress,
-    ]);
-
-    await router.sendWorkflowRunDispatchToAllocation(
-      TEST_TARGET,
-      TEST_IDENTITY.workflowRunAddress,
-      TEST_IDENTITY.anchorRunId,
-      [],
-      "dHJpZ2dlcg==",
-      TEST_SENDER,
-      "mid-key",
-    );
-
-    // The dispatch path resolves the key from the persisted sender, never the
-    // MIME From, and stamps it on the redelivered frame.
-    expect(resolvedFor).toEqual([TEST_SENDER]);
-    const inbound = framesOfType(ws, "mail.inbound").filter(
-      (frame) => frame["messageId"] === "mid-key",
-    );
-    expect(inbound).toHaveLength(1);
-    expect(inbound[0]?.["authenticatedSenderPublicKey"]).toBe(hexKey);
   });
 
   test("co-delivers the resolved sender key on the dispatched run.grants frame", async () => {
@@ -686,67 +639,6 @@ describe("SidecarRouter workflow-trigger mail gating", () => {
     // (`From: sender@example.test`) -- value-level independence, not just
     // equality to the gate value.
     expect(inbound[0]?.["authenticatedSender"]).not.toBe("sender@example.test");
-  });
-
-  test("relayed inbound mail carries the hub-resolved sender key", async () => {
-    const hexKey = "aa".repeat(32);
-    const resolvedFor: string[] = [];
-    const router = createAllocatedRouter({
-      lookups: {
-        async resolveSenderKey(address) {
-          resolvedFor.push(address);
-          return hexKey;
-        },
-      },
-    });
-    const ws = await connectAllocated(router, [
-      TEST_IDENTITY.workflowRunAddress,
-    ]);
-
-    router.handleMessage(
-      ws,
-      JSON.stringify({
-        type: "mail.outbound",
-        senderAddress: TEST_IDENTITY.workflowRunAddress,
-        rawMessage,
-        recipients: [TEST_IDENTITY.workflowRunAddress],
-      }),
-    );
-    await tick();
-
-    // The key is resolved from the hub-verified sender, never the MIME From.
-    expect(resolvedFor).toEqual([TEST_IDENTITY.workflowRunAddress]);
-    const inbound = framesOfType(ws, "mail.inbound");
-    expect(inbound).toHaveLength(1);
-    expect(inbound[0]?.["authenticatedSenderPublicKey"]).toBe(hexKey);
-  });
-
-  test("inbound mail carries a null sender key when unresolvable", async () => {
-    const router = createAllocatedRouter({
-      lookups: {
-        async resolveSenderKey() {
-          return null;
-        },
-      },
-    });
-    const ws = await connectAllocated(router, [
-      TEST_IDENTITY.workflowRunAddress,
-    ]);
-
-    router.handleMessage(
-      ws,
-      JSON.stringify({
-        type: "mail.outbound",
-        senderAddress: TEST_IDENTITY.workflowRunAddress,
-        rawMessage,
-        recipients: [TEST_IDENTITY.workflowRunAddress],
-      }),
-    );
-    await tick();
-
-    const inbound = framesOfType(ws, "mail.inbound");
-    expect(inbound).toHaveLength(1);
-    expect(inbound[0]?.["authenticatedSenderPublicKey"]).toBeNull();
   });
 
   test("drops mail.outbound whose sender the connection does not own", async () => {

--- a/packages/hub-sessions/src/ws/sidecar-handler.test.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.test.ts
@@ -222,7 +222,6 @@ describe("SidecarRouter allocation routing", () => {
         identity.workflowRunAddress,
         "aGVsbG8=",
         "sender@example.test",
-        null,
         "message-1",
       ),
     ).toBe(true);

--- a/packages/hub-sessions/src/ws/sidecar-handler.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.ts
@@ -191,7 +191,11 @@ export type SidecarRouter = {
     authenticatedSender: string,
     authenticatedSenderPublicKey: string | null,
     messageId?: string,
-    runGrants?: { runId: string; stepGrants: RunGrantsFrame["stepGrants"] },
+    runGrants?: {
+      runId: string;
+      stepGrants: RunGrantsFrame["stepGrants"];
+      senderIdentities?: RunGrantsFrame["senderIdentities"];
+    },
   ): boolean;
   /**
    * Deliver a run's authorization grants to the sidecar hosting the named
@@ -207,11 +211,18 @@ export type SidecarRouter = {
    * `run.grants` then has no queue to ride and this returns `false`. Returns
    * `false` whenever the address is unroutable; the caller keeps any stable-run
    * grant reservation so a later first-delivery attempt reuses it.
+   *
+   * `senderIdentities` co-delivers the run's authorized senders' resolved keys
+   * on the same barrier as the grant, so a recipient that caches from this
+   * frame binds each sender address to the hub-vouched key. The caller passes
+   * `undefined` when there is no sender to co-deliver (a standing-grant refresh)
+   * or the sender has no resolvable key; a null key is never carried.
    */
   sendRunGrants(
     agentAddress: string,
     runId: string,
     stepGrants: RunGrantsFrame["stepGrants"],
+    senderIdentities: RunGrantsFrame["senderIdentities"],
   ): boolean;
   /**
    * Returns the current connector-thread state for the named agent, or
@@ -527,8 +538,14 @@ export function createSidecarRouter(
     // `run.grants` frame AHEAD of the mail so the redelivered trigger lands on
     // a sidecar that has the run's grants, rather than failing its onRunStart
     // barrier closed. Re-materializing at redelivery time is unsafe (it carries
-    // commit/authority semantics); replaying the same bytes is not.
-    runGrants?: { runId: string; stepGrants: RunGrantsFrame["stepGrants"] };
+    // commit/authority semantics); replaying the same bytes is not. The
+    // co-delivered `senderIdentities` ride the same snapshot, so a sidecar that
+    // first learns the grant on the reconnect replay also learns the key.
+    runGrants?: {
+      runId: string;
+      stepGrants: RunGrantsFrame["stepGrants"];
+      senderIdentities?: RunGrantsFrame["senderIdentities"];
+    };
     /** Present for a durable trigger pinned to a provisioned allocation. */
     allocatedTarget?: AllocatedSidecarTarget;
   };
@@ -640,7 +657,11 @@ export function createSidecarRouter(
     agentAddress: string,
     messageId: string,
     frame: HubFrame,
-    runGrants?: { runId: string; stepGrants: RunGrantsFrame["stepGrants"] },
+    runGrants?: {
+      runId: string;
+      stepGrants: RunGrantsFrame["stepGrants"];
+      senderIdentities?: RunGrantsFrame["senderIdentities"];
+    },
     allocatedTarget?: AllocatedSidecarTarget,
   ): void {
     let byId = pendingMail.get(agentAddress);
@@ -678,6 +699,9 @@ export function createSidecarRouter(
       agentAddress: entry.agentAddress,
       runId: entry.runGrants.runId,
       stepGrants: entry.runGrants.stepGrants,
+      ...(entry.runGrants.senderIdentities !== undefined
+        ? { senderIdentities: entry.runGrants.senderIdentities }
+        : {}),
     });
   }
 
@@ -1380,6 +1404,19 @@ export function createSidecarRouter(
       lookups.resolveSenderKey !== undefined
         ? await lookups.resolveSenderKey(authenticatedSender)
         : null;
+    // Co-deliver the sender's resolved key on the run's grants barrier so a
+    // recipient that caches from the `run.grants` frame binds the sender
+    // address to it. A null key is omitted -- never carried -- so the
+    // "authorized-with-a-key implies key cached" invariant holds.
+    const senderIdentities =
+      authenticatedSenderPublicKey !== null
+        ? [
+            {
+              address: authenticatedSender,
+              publicKey: authenticatedSenderPublicKey,
+            },
+          ]
+        : undefined;
     if (
       lookups.materializeMailTriggeredRunGrants !== undefined &&
       isRunAddress(recipient)
@@ -1410,7 +1447,9 @@ export function createSidecarRouter(
         // deployment is unroutable. Do not route the mail that would dispatch
         // it; the grants-only reservation remains the canonical snapshot for a
         // later first-delivery attempt.
-        if (!sendRunGrants(recipient, runId, result.stepGrants)) {
+        if (
+          !sendRunGrants(recipient, runId, result.stepGrants, senderIdentities)
+        ) {
           logger.error`Deployment ${recipient} is not routable for run ${runId}; retaining the unfired run's grant reservation for retry`;
           return "unrouted";
         }
@@ -1431,7 +1470,11 @@ export function createSidecarRouter(
           authenticatedSender,
           authenticatedSenderPublicKey,
           messageId,
-          { runId, stepGrants: result.stepGrants },
+          {
+            runId,
+            stepGrants: result.stepGrants,
+            ...(senderIdentities !== undefined ? { senderIdentities } : {}),
+          },
         )
           ? "routed"
           : "unrouted";
@@ -2312,7 +2355,11 @@ export function createSidecarRouter(
     authenticatedSender: string,
     authenticatedSenderPublicKey: string | null,
     messageId?: string,
-    runGrants?: { runId: string; stepGrants: RunGrantsFrame["stepGrants"] },
+    runGrants?: {
+      runId: string;
+      stepGrants: RunGrantsFrame["stepGrants"];
+      senderIdentities?: RunGrantsFrame["senderIdentities"];
+    },
   ): boolean {
     // `authenticatedSender` is hub-assigned by the caller from a hub-verified
     // value (the ownership-gated sender of a relayed mail, or the triggering
@@ -2367,12 +2414,14 @@ export function createSidecarRouter(
     agentAddress: string,
     runId: string,
     stepGrants: RunGrantsFrame["stepGrants"],
+    senderIdentities: RunGrantsFrame["senderIdentities"],
   ): boolean {
     const frame: HubFrame = {
       type: "run.grants",
       agentAddress,
       runId,
       stepGrants,
+      ...(senderIdentities !== undefined ? { senderIdentities } : {}),
     };
 
     const ws = addressIndex.get(agentAddress);
@@ -2411,13 +2460,6 @@ export function createSidecarRouter(
         `Address ${agentAddress} is not routed on allocation ${target.allocationId}`,
       );
     }
-    const runGrants = { runId, stepGrants };
-    conn.send({
-      type: "run.grants",
-      agentAddress,
-      runId,
-      stepGrants,
-    });
     // authenticatedSender is the sender persisted at enqueue on the dispatch
     // row (the triggering principal's hub-verified address); the caller reads
     // it from that row. It is never the message's MIME From.
@@ -2427,11 +2469,37 @@ export function createSidecarRouter(
     // run sender's deployment key is immutable once acked; a user sender's key
     // rotating mid-flight would leave the fixed signed bytes checked against
     // the new key, which the recipient logs as unverifiable. Null when
-    // unresolvable (no resolver wired, or the sender has no durable key).
+    // unresolvable (no resolver wired, or the sender has no durable key). The
+    // lookup contract (see SidecarLookups.resolveSenderKey) is best-effort and
+    // never throws, so resolving ahead of the run.grants send cannot block it.
     const authenticatedSenderPublicKey =
       lookups.resolveSenderKey !== undefined
         ? await lookups.resolveSenderKey(authenticatedSender)
         : null;
+    // Co-deliver the resolved key on the run's grants barrier, omitting a null
+    // key so it is never cached (see deliverMailToRecipient). The same list
+    // rides the pending-mail entry so the reconnect replay carries it too.
+    const senderIdentities =
+      authenticatedSenderPublicKey !== null
+        ? [
+            {
+              address: authenticatedSender,
+              publicKey: authenticatedSenderPublicKey,
+            },
+          ]
+        : undefined;
+    const runGrants = {
+      runId,
+      stepGrants,
+      ...(senderIdentities !== undefined ? { senderIdentities } : {}),
+    };
+    conn.send({
+      type: "run.grants",
+      agentAddress,
+      runId,
+      stepGrants,
+      ...(senderIdentities !== undefined ? { senderIdentities } : {}),
+    });
     const frame: HubFrame = {
       type: "mail.inbound",
       agentAddress,

--- a/packages/hub-sessions/src/ws/sidecar-handler.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.ts
@@ -189,7 +189,6 @@ export type SidecarRouter = {
     agentAddress: string,
     rawMessage: string,
     authenticatedSender: string,
-    authenticatedSenderPublicKey: string | null,
     messageId?: string,
     runGrants?: {
       runId: string;
@@ -1396,27 +1395,6 @@ export function createSidecarRouter(
     rawMessage: string,
     authenticatedSender: string,
   ): Promise<"routed" | "unrouted" | "failed-closed"> {
-    // Resolve the sender's hub-held key once for either delivery branch. A
-    // missing resolver or an unresolvable sender yields null; the recipient
-    // logs the mail as unverifiable and admits it (shadow), so this never
-    // blocks delivery.
-    const authenticatedSenderPublicKey =
-      lookups.resolveSenderKey !== undefined
-        ? await lookups.resolveSenderKey(authenticatedSender)
-        : null;
-    // Co-deliver the sender's resolved key on the run's grants barrier so a
-    // recipient that caches from the `run.grants` frame binds the sender
-    // address to it. A null key is omitted -- never carried -- so the
-    // "authorized-with-a-key implies key cached" invariant holds.
-    const senderIdentities =
-      authenticatedSenderPublicKey !== null
-        ? [
-            {
-              address: authenticatedSender,
-              publicKey: authenticatedSenderPublicKey,
-            },
-          ]
-        : undefined;
     if (
       lookups.materializeMailTriggeredRunGrants !== undefined &&
       isRunAddress(recipient)
@@ -1443,6 +1421,29 @@ export function createSidecarRouter(
         return "failed-closed";
       }
       if (result.outcome === "materialized") {
+        // Resolve the sender's hub-held key to co-deliver on the run's grants
+        // barrier, so a recipient that caches from the `run.grants` frame binds
+        // the sender address to it and can verify the sender's mail locally. A
+        // missing resolver or an unresolvable sender yields null; a null key is
+        // omitted -- never carried -- so the "authorized-with-a-key implies key
+        // cached" invariant holds, and the recipient logs such mail as
+        // unverifiable and admits it (shadow) rather than blocking delivery.
+        // Resolved only here, inside the run-grants branch that consumes it: a
+        // non-run recipient, a `skip`, or a rejected materialization never pays
+        // for the lookup.
+        const authenticatedSenderPublicKey =
+          lookups.resolveSenderKey !== undefined
+            ? await lookups.resolveSenderKey(authenticatedSender)
+            : null;
+        const senderIdentities =
+          authenticatedSenderPublicKey !== null
+            ? [
+                {
+                  address: authenticatedSender,
+                  publicKey: authenticatedSenderPublicKey,
+                },
+              ]
+            : undefined;
         // Send the run's grants ahead of the mail. A `false` here means the
         // deployment is unroutable. Do not route the mail that would dispatch
         // it; the grants-only reservation remains the canonical snapshot for a
@@ -1468,7 +1469,6 @@ export function createSidecarRouter(
           recipient,
           rawMessage,
           authenticatedSender,
-          authenticatedSenderPublicKey,
           messageId,
           {
             runId,
@@ -1485,12 +1485,7 @@ export function createSidecarRouter(
       // authorize. No run is committed here, so no ack handshake is needed.
     }
 
-    return routeMail(
-      recipient,
-      rawMessage,
-      authenticatedSender,
-      authenticatedSenderPublicKey,
-    )
+    return routeMail(recipient, rawMessage, authenticatedSender)
       ? "routed"
       : "unrouted";
   }
@@ -2353,7 +2348,6 @@ export function createSidecarRouter(
     agentAddress: string,
     rawMessage: string,
     authenticatedSender: string,
-    authenticatedSenderPublicKey: string | null,
     messageId?: string,
     runGrants?: {
       runId: string;
@@ -2366,13 +2360,9 @@ export function createSidecarRouter(
     // principal's address) -- never the message's own MIME `From`. It rides
     // the frame as the hub-verified sender of record, so a recipient can take
     // the sender from it rather than the forgeable `From`. The recipient's
-    // shadow signature check reads it as the sender of record, but only to log
-    // a verdict -- it does not gate delivery.
-    //
-    // `authenticatedSenderPublicKey` is the caller's hub-resolved key for that
-    // sender (null when unresolvable), carried alongside so the recipient's
-    // shadow check verifies the signature against the hub-vouched key and logs
-    // a verdict; it does not gate delivery.
+    // shadow signature check reads it as the sender of record -- resolving the
+    // sender's key from its local cache to verify the signature -- but only to
+    // log a verdict; it does not gate delivery.
     //
     // Carry the hub-minted messageId on the frame so the sidecar's durable-
     // receipt ack (`mail.inbound.ack`) keys on the same id the hub tracks, and
@@ -2385,7 +2375,6 @@ export function createSidecarRouter(
       agentAddress,
       rawMessage,
       authenticatedSender,
-      authenticatedSenderPublicKey,
       ...(messageId !== undefined ? { messageId } : {}),
     };
     const ws = addressIndex.get(agentAddress);
@@ -2465,13 +2454,14 @@ export function createSidecarRouter(
     // it from that row. It is never the message's MIME From.
     //
     // Resolve its key here, at dispatch (redelivery) time, from that persisted
-    // address -- so the frame reflects the sender's current hub-held key. A
-    // run sender's deployment key is immutable once acked; a user sender's key
-    // rotating mid-flight would leave the fixed signed bytes checked against
-    // the new key, which the recipient logs as unverifiable. Null when
-    // unresolvable (no resolver wired, or the sender has no durable key). The
-    // lookup contract (see SidecarLookups.resolveSenderKey) is best-effort and
-    // never throws, so resolving ahead of the run.grants send cannot block it.
+    // address, to co-deliver on the run's grants barrier so the recipient
+    // caches the sender's current hub-held key. A run sender's deployment key
+    // is immutable once acked; a user sender's key rotating mid-flight would
+    // leave the fixed signed bytes checked against the new key, which the
+    // recipient logs as unverifiable. Null when unresolvable (no resolver
+    // wired, or the sender has no durable key). The lookup contract (see
+    // SidecarLookups.resolveSenderKey) is best-effort and never throws, so
+    // resolving ahead of the run.grants send cannot block it.
     const authenticatedSenderPublicKey =
       lookups.resolveSenderKey !== undefined
         ? await lookups.resolveSenderKey(authenticatedSender)
@@ -2505,7 +2495,6 @@ export function createSidecarRouter(
       agentAddress,
       rawMessage,
       authenticatedSender,
-      authenticatedSenderPublicKey,
       messageId,
     };
     conn.send(frame);

--- a/packages/types/src/sidecar.test.ts
+++ b/packages/types/src/sidecar.test.ts
@@ -9,6 +9,7 @@ import {
   MailOutboundFrame,
   PackRejectFrame,
   PackRejectReason,
+  RunGrantsFrame,
   SidecarFrame,
   SignalCorrelationRegisterFrame,
   SourcesUpdateFrame,
@@ -391,5 +392,79 @@ describe("CredentialsUpdateFrame revoke", () => {
   test("a non-string revoke entry is rejected", () => {
     const bad = { ...pureRevoke, revoke: [123] };
     expect(CredentialsUpdateFrame(bad) instanceof type.errors).toBe(true);
+  });
+});
+
+describe("RunGrantsFrame senderIdentities co-delivery", () => {
+  const base = {
+    type: "run.grants" as const,
+    agentAddress: "dep@integration.interchange",
+    runId: "run_1",
+    stepGrants: [],
+  };
+  const identities = [
+    {
+      address: "run_sender@integration.interchange",
+      publicKey: "aa".repeat(32),
+    },
+  ];
+
+  test("the HubFrame union admits a run.grants frame carrying identities", () => {
+    // The sidecar parses inbound frames through the HubFrame union, so the
+    // co-delivered keys must reach the run.grants member and round-trip.
+    const out = HubFrame({ ...base, senderIdentities: identities });
+    if (out instanceof type.errors) {
+      throw new Error(`expected a valid HubFrame: ${out.summary}`);
+    }
+    if (out.type !== "run.grants") {
+      throw new Error(`expected a run.grants frame, got ${out.type}`);
+    }
+    expect(out.senderIdentities).toEqual(identities);
+  });
+
+  test("the HubFrame union rejects a malformed identity entry", () => {
+    // arktype passes undeclared keys through unchanged, so a valid-input
+    // round-trip alone cannot prove the field is declared on the wire path:
+    // it would survive even if senderIdentities were dropped from the schema.
+    // A malformed entry rejected THROUGH the union is the real guard -- were
+    // the field undeclared, the bad entry would ride the union as a harmless
+    // passthrough key and this parse would succeed, silently starving the
+    // recipient's key cache.
+    const bad = {
+      ...base,
+      senderIdentities: [{ address: "run_sender@integration.interchange" }],
+    };
+    expect(HubFrame(bad) instanceof type.errors).toBe(true);
+  });
+
+  test("a frame with no senderIdentities validates and omits the key", () => {
+    const out = RunGrantsFrame(base);
+    if (out instanceof type.errors) {
+      throw new Error(`expected a valid frame: ${out.summary}`);
+    }
+    expect("senderIdentities" in out).toBe(false);
+  });
+
+  test("an identity entry missing its public key is rejected", () => {
+    const bad = {
+      ...base,
+      senderIdentities: [{ address: "run_sender@integration.interchange" }],
+    };
+    expect(RunGrantsFrame(bad) instanceof type.errors).toBe(true);
+  });
+
+  test("an identity entry with a non-string public key is rejected", () => {
+    const bad = {
+      ...base,
+      senderIdentities: [
+        { address: "run_sender@integration.interchange", publicKey: 123 },
+      ],
+    };
+    expect(RunGrantsFrame(bad) instanceof type.errors).toBe(true);
+  });
+
+  test("an identity entry missing its address is rejected", () => {
+    const bad = { ...base, senderIdentities: [{ publicKey: "aa".repeat(32) }] };
+    expect(RunGrantsFrame(bad) instanceof type.errors).toBe(true);
   });
 });

--- a/packages/types/src/sidecar.ts
+++ b/packages/types/src/sidecar.ts
@@ -236,25 +236,14 @@ export type SignalCorrelationRegisterAckFrame =
  * principal's address for hub-originated mail -- NEVER from the message's
  * own (spoofable) MIME `From`. The recipient's shadow signature check takes
  * the sender of record from this hub-verified value rather than the forgeable
- * `From`, but only to log a verdict -- it does not gate delivery.
- *
- * `authenticatedSenderPublicKey` is the hub-resolved public key of
- * `authenticatedSender`, hex-encoded (the raw 32-byte Ed25519 key). The hub
- * resolves it from its own durable key stores at the frame's construction
- * site, so a recipient can verify the message's signature locally against the
- * key the hub vouches for rather than one derived from the message. It is
- * `null` when the sender has no resolvable key -- a run whose deploy is not
- * yet acked, or an address that matches no known principal -- a legitimate
- * "unverifiable sender" state, not an error. The recipient's shadow signature
- * check reads it to verify the message and log a verdict, but does not gate
- * delivery.
+ * `From`, resolves the sender's key from its local cache, and logs a verdict --
+ * it does not gate delivery.
  */
 export const MailInboundFrame = type({
   type: "'mail.inbound'",
   agentAddress: "string",
   rawMessage: "string",
   authenticatedSender: "string",
-  authenticatedSenderPublicKey: "string | null",
   "messageId?": "string",
 });
 export type MailInboundFrame = typeof MailInboundFrame.infer;
@@ -305,8 +294,7 @@ export type SignalDeliverFrame = typeof SignalDeliverFrame.infer;
 
 /**
  * A sender address bound to the public key the hub vouches for. `publicKey`
- * is the hex-encoded raw 32-byte Ed25519 key -- the same encoding as
- * `MailInboundFrame.authenticatedSenderPublicKey`. `address` is the full
+ * is the hex-encoded raw 32-byte Ed25519 key. `address` is the full
  * domain-qualified sender address.
  */
 export const SenderIdentity = type({

--- a/packages/types/src/sidecar.ts
+++ b/packages/types/src/sidecar.ts
@@ -304,6 +304,18 @@ export const SignalDeliverFrame = type({
 export type SignalDeliverFrame = typeof SignalDeliverFrame.infer;
 
 /**
+ * A sender address bound to the public key the hub vouches for. `publicKey`
+ * is the hex-encoded raw 32-byte Ed25519 key -- the same encoding as
+ * `MailInboundFrame.authenticatedSenderPublicKey`. `address` is the full
+ * domain-qualified sender address.
+ */
+export const SenderIdentity = type({
+  address: "string",
+  publicKey: "string",
+});
+export type SenderIdentity = typeof SenderIdentity.infer;
+
+/**
  * Deliver a run's authorization grants to a multi-step deployment's
  * supervisor. The hub forwards the frame to the sidecar that hosts the
  * deployment named by `agentAddress` (the deployment-level mail
@@ -316,12 +328,20 @@ export type SignalDeliverFrame = typeof SignalDeliverFrame.infer;
  * frame's `config.grants` ships, so the run's grants ride the same
  * validated grant encoding as the deploy-time step grants rather than a
  * new one.
+ *
+ * `senderIdentities` carries the resolved public keys of the run's
+ * authorized senders, co-delivered on the same `run.grants` barrier as the
+ * authorization grant so a recipient can bind each sender address to the
+ * key the hub vouches for. A sender with no resolvable key is omitted rather
+ * than carried as null, so every entry has a concrete key. The field is
+ * optional: a producer that does not co-deliver keys omits it entirely.
  */
 export const RunGrantsFrame = type({
   type: "'run.grants'",
   agentAddress: "string",
   runId: "string",
   stepGrants: WireGrantRule.array(),
+  "senderIdentities?": SenderIdentity.array(),
 });
 export type RunGrantsFrame = typeof RunGrantsFrame.infer;
 

--- a/tests/hub-agent/lib/deploy-flow-env.ts
+++ b/tests/hub-agent/lib/deploy-flow-env.ts
@@ -1864,7 +1864,7 @@ export async function fireMailTrigger(
   // signed-under address as the authenticated sender. This fixture reuses
   // that same address as the MIME From, so it is not a From-independence
   // check.
-  const delivered = env.hub.router.routeMail(address, base64, from, null);
+  const delivered = env.hub.router.routeMail(address, base64, from);
   if (!delivered) {
     throw new Error(
       `fireMailTrigger: routeMail returned false for ${address}; address is not routable on the hub`,

--- a/tests/hub-agent/lib/deploy-flow-env.ts
+++ b/tests/hub-agent/lib/deploy-flow-env.ts
@@ -1852,6 +1852,7 @@ export async function fireMailTrigger(
     address,
     runId,
     opts.grants ?? [],
+    undefined,
   );
   if (!grantsDelivered) {
     throw new Error(

--- a/tests/workflow-deploy/boot-restore.bench.ts
+++ b/tests/workflow-deploy/boot-restore.bench.ts
@@ -379,6 +379,7 @@ async function buildRouter(args: {
       }),
       forgetAgent: () => undefined,
     } as unknown as Parameters<typeof createSidecarDeployRouter>[0]["keyStore"],
+    senderKeyCache: { get: () => undefined, put: async () => undefined },
     transport: args.transport,
     repoStore,
     signingKeySeed: signingKeyPair.privateKey,

--- a/tests/workflow-deploy/mail-edge-cases.test.ts
+++ b/tests/workflow-deploy/mail-edge-cases.test.ts
@@ -454,6 +454,7 @@ describe.skipIf(!harnessDbEnvAvailable())("mail-handling edge cases", () => {
       ctx.deploymentMailAddress,
       runId,
       [],
+      undefined,
     );
     expect(grantsDelivered).toBe(true);
     await new Promise((r) => setTimeout(r, 2_000));
@@ -645,7 +646,12 @@ async function routeRaw(
   // runs/<deploymentAddress>/grants.json, regardless of the message's
   // derived messageId.
   const runId = deriveWorkflowRunId(address);
-  const grantsDelivered = env.hub.router.sendRunGrants(address, runId, []);
+  const grantsDelivered = env.hub.router.sendRunGrants(
+    address,
+    runId,
+    [],
+    undefined,
+  );
   if (!grantsDelivered) {
     throw new Error(
       `routeRaw: sendRunGrants returned false for ${address}; address is not routable on the hub`,

--- a/tests/workflow-deploy/mail-edge-cases.test.ts
+++ b/tests/workflow-deploy/mail-edge-cases.test.ts
@@ -468,7 +468,6 @@ describe.skipIf(!harnessDbEnvAvailable())("mail-handling edge cases", () => {
       ctx.deploymentMailAddress,
       base64,
       "edge@integration.interchange",
-      null,
       messageId,
     );
     expect(delivered).toBe(true);
@@ -665,7 +664,6 @@ async function routeRaw(
     address,
     base64,
     "user@integration.interchange",
-    null,
   );
   if (!delivered) {
     throw new Error(


### PR DESCRIPTION
## Summary

- The hub co-delivers each authorized sender's resolved public key on the same
  `run.grants` barrier as the authorization grant (via a required
  `sendRunGrants` parameter, so no push site can silently drop it), and the
  sidecar caches each key in a local disk-backed keyring — written before the
  run's grants file so a durable grant always implies a durable key, and
  eager-loaded at boot so verification survives a restart or disconnection.
- A resolver wraps a cached key as a public-key-only crypto provider matching
  the inbound-mail verify seam.
- The recipient-side inbound-mail signature check verifies each message against
  the cache-resolved sender key and logs the verdict. It is shadow-only: it
  never rejects mail. The interim key that rode on the `mail.inbound` frame is
  removed — the cache is now the recipient's key source.

## Verification

- Lint, `tsc -b --noEmit --force`, the admin-ui production bundle, and the full
  unit suite (7354 tests) pass.
- The recipient verify is covered by unit and real-WS-ingress tests with real
  crypto — valid / invalid / missing / `unknown`-on-cache-miss and both
  fault-containment paths; the cache's write-before-grants durability,
  malformed-key skip, and the co-delivery paths have dedicated tests.
- The real-process `test-workflow` end-to-end suite runs in CI as the
  authoritative integration gate.
- The verify path is fault-contained: a resolver, `getPublicKey`, or verify
  fault degrades to an `error` verdict and never crashes the mail path. A cache
  miss logs `unknown` and admits — expected for grants that predate the cache,
  relayed agent-to-agent mail with no preceding co-delivery, and the
  not-yet-built reconnect key-refresh.

Closes INTR-517
Closes INTR-519
