### PR TITLE
INTR - 350 - Reduce validator memory by constructing unions once

### DIFF
--- a/packages/inference-discovery/src/catalog/intent.ts
+++ b/packages/inference-discovery/src/catalog/intent.ts
@@ -44,18 +44,20 @@ const FollowUp = type({
 // response_format, Gemini's responseSchema; Anthropic does not
 // receive a structured-output request because its adapter rejects
 // the field at the marshaling boundary).
-const ResponseFormatIntent = type({
-  kind: "'text'",
-})
-  .or({
+const ResponseFormatIntent = type.or(
+  {
+    kind: "'text'",
+  },
+  {
     kind: "'json'",
-  })
-  .or({
+  },
+  {
     kind: "'json-schema'",
     name: "string",
     schema: "unknown",
     "strict?": "boolean",
-  });
+  },
+);
 
 export const CapabilityIntent = type({
   prompt: "string",

--- a/packages/inference/src/providers/anthropic.ts
+++ b/packages/inference/src/providers/anthropic.ts
@@ -570,12 +570,15 @@ const MessageStart = type({
 const MessageStop = type({ type: "'message_stop'" });
 const Ping = type({ type: "'ping'" });
 
-const AnthropicSSEEvent = ContentBlockDelta.or(ContentBlockStart)
-  .or(ContentBlockStop)
-  .or(MessageDelta)
-  .or(MessageStart)
-  .or(MessageStop)
-  .or(Ping);
+const AnthropicSSEEvent = type.or(
+  ContentBlockDelta,
+  ContentBlockStart,
+  ContentBlockStop,
+  MessageDelta,
+  MessageStart,
+  MessageStop,
+  Ping,
+);
 
 // Maps Anthropic's wire usage object onto the internal TokenUsage. Anthropic
 // never reports a distinct thinking-token count, so `thinking` is always 0.

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -881,7 +881,9 @@ const MediaSourceUrl = type({
   url: "string",
 });
 
-export const MediaSource = MediaSourceBase64.or(MediaSourceFileReference).or(
+export const MediaSource = type.or(
+  MediaSourceBase64,
+  MediaSourceFileReference,
   MediaSourceUrl,
 );
 export type MediaSource = typeof MediaSource.infer;
@@ -1166,28 +1168,29 @@ const ToolResultBlock = type({
   // SafetyRatingBlocks (safety signals annotate model/request
   // filtering), and not CodeExecution blocks (server-side code
   // execution is a distinct lifecycle from the user-tool round-trip).
-  content: TextBlock.or(ImageBlock)
-    .or(AudioBlock)
-    .or(VideoBlock)
-    .or(DocumentBlock)
+  content: type
+    .or(TextBlock, ImageBlock, AudioBlock, VideoBlock, DocumentBlock)
     .array(),
   "detail?": "unknown",
   "isError?": "boolean",
 });
 
-export const ContentBlock = TextBlock.or(ThinkingBlock)
-  .or(RedactedThinkingBlock)
-  .or(RefusalBlock)
-  .or(ImageBlock)
-  .or(AudioBlock)
-  .or(VideoBlock)
-  .or(DocumentBlock)
-  .or(CitationBlock)
-  .or(SafetyRatingBlock)
-  .or(CodeExecutionRequestBlock)
-  .or(CodeExecutionResultBlock)
-  .or(ToolCallBlock)
-  .or(ToolResultBlock);
+export const ContentBlock = type.or(
+  TextBlock,
+  ThinkingBlock,
+  RedactedThinkingBlock,
+  RefusalBlock,
+  ImageBlock,
+  AudioBlock,
+  VideoBlock,
+  DocumentBlock,
+  CitationBlock,
+  SafetyRatingBlock,
+  CodeExecutionRequestBlock,
+  CodeExecutionResultBlock,
+  ToolCallBlock,
+  ToolResultBlock,
+);
 export type ContentBlock = typeof ContentBlock.infer;
 
 /**
@@ -1303,12 +1306,13 @@ const WireInboundMessage = type({
  *
  * (INFERENCE.md § Event Protocol)
  */
-export const InferenceEvent = type({
-  type: "'inference.start'",
-  seq: "number",
-  data: { model: "string" },
-})
-  .or({
+export const InferenceEvent = type.or(
+  {
+    type: "'inference.start'",
+    seq: "number",
+    data: { model: "string" },
+  },
+  {
     type: "'inference.thinking.delta'",
     seq: "number",
     data: {
@@ -1316,18 +1320,18 @@ export const InferenceEvent = type({
       partial: PartialMessage,
       "index?": "number",
     },
-  })
-  .or({
+  },
+  {
     type: "'inference.block.signature'",
     seq: "number",
     data: { signature: "string", "index?": "number" },
-  })
-  .or({
+  },
+  {
     type: "'inference.thinking.redacted'",
     seq: "number",
     data: { redactedThinking: RedactedThinkingBlock, "index?": "number" },
-  })
-  .or({
+  },
+  {
     type: "'inference.text.delta'",
     seq: "number",
     data: {
@@ -1335,8 +1339,8 @@ export const InferenceEvent = type({
       partial: PartialMessage,
       "index?": "number",
     },
-  })
-  .or({
+  },
+  {
     type: "'inference.refusal.delta'",
     seq: "number",
     data: {
@@ -1344,8 +1348,8 @@ export const InferenceEvent = type({
       partial: PartialMessage,
       "index?": "number",
     },
-  })
-  .or({
+  },
+  {
     type: "'inference.tool_call.start'",
     seq: "number",
     data: {
@@ -1354,8 +1358,8 @@ export const InferenceEvent = type({
       partial: PartialMessage,
       "index?": "number",
     },
-  })
-  .or({
+  },
+  {
     type: "'inference.tool_call.delta'",
     seq: "number",
     data: {
@@ -1364,8 +1368,8 @@ export const InferenceEvent = type({
       partial: PartialMessage,
       "index?": "number",
     },
-  })
-  .or({
+  },
+  {
     type: "'inference.tool_call.end'",
     seq: "number",
     data: {
@@ -1375,13 +1379,13 @@ export const InferenceEvent = type({
       partial: PartialMessage,
       "index?": "number",
     },
-  })
-  .or({
+  },
+  {
     type: "'inference.usage'",
     seq: "number",
     data: { usage: TokenUsage, source: LastCycleSource },
-  })
-  .or({
+  },
+  {
     type: "'inference.done'",
     seq: "number",
     data: {
@@ -1390,13 +1394,13 @@ export const InferenceEvent = type({
       source: LastCycleSource,
       "pacingDelayMs?": "number",
     },
-  })
-  .or({
+  },
+  {
     type: "'inference.error'",
     seq: "number",
     data: { error: InferenceError, partial: PartialMessage },
-  })
-  .or({
+  },
+  {
     type: "'inference.retry'",
     seq: "number",
     data: {
@@ -1404,8 +1408,8 @@ export const InferenceEvent = type({
       delayMs: "number",
       previousError: InferenceError,
     },
-  })
-  .or({
+  },
+  {
     type: "'inference.citation'",
     seq: "number",
     // `index`, when present, names the source content block (typically
@@ -1417,8 +1421,8 @@ export const InferenceEvent = type({
     // `content[]` and consumers attribute them to the nearest
     // preceding TextBlock per the CitationBlock docstring.
     data: { citation: CitationBlock, "index?": "number" },
-  })
-  .or({
+  },
+  {
     type: "'inference.safety_rating'",
     seq: "number",
     // Prompt-level structured safety signal (observed Gemini
@@ -1426,13 +1430,13 @@ export const InferenceEvent = type({
     // capture has zero candidates. Harness appends the block to the
     // finalized turn's `content[]`.
     data: { safetyRating: SafetyRatingBlock },
-  })
-  .or({
+  },
+  {
     type: "'inference.code_execution.start'",
     seq: "number",
     data: { request: CodeExecutionRequestBlock, "index?": "number" },
-  })
-  .or({
+  },
+  {
     type: "'inference.code_execution.delta'",
     seq: "number",
     // requestId correlates fragments back to the originating
@@ -1447,13 +1451,13 @@ export const InferenceEvent = type({
       codeFragment: "string",
       "index?": "number",
     },
-  })
-  .or({
+  },
+  {
     type: "'inference.code_execution.result'",
     seq: "number",
     data: { result: CodeExecutionResultBlock, "index?": "number" },
-  })
-  .or({
+  },
+  {
     type: "'inference.image_output'",
     seq: "number",
     // Fires mid-stream when an adapter finalizes an image-output
@@ -1464,28 +1468,28 @@ export const InferenceEvent = type({
     // ~1MB inline blobs); consumers that subscribe to this event
     // should treat it as a non-trivial transport size.
     data: { image: ImageBlock, "index?": "number" },
-  })
-  .or({
+  },
+  {
     type: "'tool.start'",
     seq: "number",
     data: { call: ToolCall },
-  })
-  .or({
+  },
+  {
     type: "'tool.update'",
     seq: "number",
     data: { callId: "string", partial: "string" },
-  })
-  .or({
+  },
+  {
     type: "'tool.done'",
     seq: "number",
     data: { result: ToolResult },
-  })
-  .or({
+  },
+  {
     type: "'message.queued'",
     seq: "number",
     data: { message: WireInboundMessage },
-  })
-  .or({
+  },
+  {
     type: "'message.run.started'",
     seq: "number",
     data: {
@@ -1493,8 +1497,8 @@ export const InferenceEvent = type({
       messageRunId: "string",
       receivedAt: "number",
     },
-  })
-  .or({
+  },
+  {
     type: "'message.run.ended'",
     seq: "number",
     data: {
@@ -1506,23 +1510,23 @@ export const InferenceEvent = type({
         "kind?": "string",
       },
     },
-  })
-  .or({
+  },
+  {
     type: "'message.correlated'",
     seq: "number",
     data: { message: WireInboundMessage, correlationId: "string" },
-  })
-  .or({
+  },
+  {
     type: "'connector.reply'",
     seq: "number",
     data: { content: "string", "checkpointHash?": "string" },
-  })
-  .or({
+  },
+  {
     type: "'reactor.start'",
     seq: "number",
     data: "object",
-  })
-  .or({
+  },
+  {
     type: "'reactor.gate.blocked'",
     seq: "number",
     data: {
@@ -1531,50 +1535,51 @@ export const InferenceEvent = type({
       "correlationId?": "string",
       "approvalSnapshot?": ApprovalSnapshot,
     },
-  })
-  .or({
+  },
+  {
     type: "'reactor.gate.cleared'",
     seq: "number",
     data: {
       gateId: "string",
       reason: type.enumerated("resolved", "timeout", "shutdown"),
     },
-  })
-  .or({
+  },
+  {
     type: "'reactor.done'",
     seq: "number",
     data: "object",
-  })
-  .or({
+  },
+  {
     type: "'reactor.error'",
     seq: "number",
     data: { error: "string", fatal: "boolean" },
-  })
-  .or({
+  },
+  {
     type: "'fork.created'",
     seq: "number",
     data: { forkId: "string", parentId: "string", mode: ForkMode },
-  })
-  .or({
+  },
+  {
     type: "'fork.done'",
     seq: "number",
     data: { forkId: "string", "result?": "unknown" },
-  })
-  .or({
+  },
+  {
     type: "'fork.error'",
     seq: "number",
     data: { forkId: "string", error: "string" },
-  })
-  .or({
+  },
+  {
     type: "'fork.aborted'",
     seq: "number",
     data: { forkId: "string" },
-  })
-  .or({
+  },
+  {
     type: /^custom\./,
     seq: "number",
     data: "Record<string, unknown>",
-  });
+  },
+);
 // The TypeScript type is defined manually rather than inferred from the
 // validator because the `custom.*` variant uses a regex pattern which
 // arktype infers as `string`. A bare `string` in the discriminant position

--- a/packages/types/src/sessions.ts
+++ b/packages/types/src/sessions.ts
@@ -96,35 +96,37 @@ export type MailResponse = typeof MailResponse.infer;
 // needs to locate and explain the rejection, alongside a human-readable
 // `message`. This is the wire contract for the route's attachment 400s; the
 // route handler is the single producer.
-export const AttachmentError = type({
-  code: "'oversize_attachment'",
-  message: "string",
-  attachmentIndex: "number",
-  byteLength: "number",
-  limitBytes: "number",
-})
-  .or({
+export const AttachmentError = type.or(
+  {
+    code: "'oversize_attachment'",
+    message: "string",
+    attachmentIndex: "number",
+    byteLength: "number",
+    limitBytes: "number",
+  },
+  {
     code: "'disallowed_mime_type'",
     message: "string",
     attachmentIndex: "number",
     mimeType: "string",
-  })
-  .or({
+  },
+  {
     code: "'invalid_attachment_name'",
     message: "string",
     attachmentIndex: "number",
-  })
-  .or({
+  },
+  {
     code: "'malformed_base64'",
     message: "string",
     attachmentIndex: "number",
-  })
-  .or({
+  },
+  {
     code: "'oversize_total'",
     message: "string",
     totalBytes: "number",
     limitBytes: "number",
-  });
+  },
+);
 export type AttachmentError = typeof AttachmentError.infer;
 
 export const AttachmentErrorResponse = type({ error: AttachmentError });

--- a/packages/types/src/sidecar.ts
+++ b/packages/types/src/sidecar.ts
@@ -967,42 +967,48 @@ export type WorkflowProbeErrorFrame = typeof WorkflowProbeErrorFrame.infer;
 // ---------------------------------------------------------------------------
 
 /** All frame types the sidecar sends to the hub. */
-export const SidecarFrame = RegisterFrame.or(ReconnectFrame)
-  .or(AgentDeployAckFrame)
-  .or(AgentErrorFrame)
-  .or(MailOutboundFrame)
-  .or(AgentEventFrame)
-  .or(ConnectorStateChangedFrame)
-  .or(PingFrame)
-  .or(SessionAckFrame)
-  .or(SessionErrorFrame)
-  .or(AgentUndeployAckFrame)
-  .or(SignalCorrelationRegisterFrame)
-  .or(PackPushFrame)
-  .or(PackDoneFrame)
-  .or(PackAckFrame)
-  .or(PackRejectFrame)
-  .or(MailInboundAckFrame)
-  .or(WorkflowProbeResultFrame)
-  .or(WorkflowProbeErrorFrame);
+export const SidecarFrame = type.or(
+  RegisterFrame,
+  ReconnectFrame,
+  AgentDeployAckFrame,
+  AgentErrorFrame,
+  MailOutboundFrame,
+  AgentEventFrame,
+  ConnectorStateChangedFrame,
+  PingFrame,
+  SessionAckFrame,
+  SessionErrorFrame,
+  AgentUndeployAckFrame,
+  SignalCorrelationRegisterFrame,
+  PackPushFrame,
+  PackDoneFrame,
+  PackAckFrame,
+  PackRejectFrame,
+  MailInboundAckFrame,
+  WorkflowProbeResultFrame,
+  WorkflowProbeErrorFrame,
+);
 export type SidecarFrame = typeof SidecarFrame.infer;
 
 /** All frame types the hub sends to the sidecar. */
-export const HubFrame = MailInboundFrame.or(AgentDeployFrame)
-  .or(AgentUndeployFrame)
-  .or(PongFrame)
-  .or(SourcesUpdateFrame)
-  .or(CredentialsUpdateFrame)
-  .or(PackPushFrame)
-  .or(PackDoneFrame)
-  .or(PackAckFrame)
-  .or(PackRejectFrame)
-  .or(SyncRequestFrame)
-  .or(SignalDeliverFrame)
-  .or(RunGrantsFrame)
-  .or(SignalCorrelationRegisterAckFrame)
-  .or(DrainDeliverFrame)
-  .or(WorkflowProbeRequestFrame);
+export const HubFrame = type.or(
+  MailInboundFrame,
+  AgentDeployFrame,
+  AgentUndeployFrame,
+  PongFrame,
+  SourcesUpdateFrame,
+  CredentialsUpdateFrame,
+  PackPushFrame,
+  PackDoneFrame,
+  PackAckFrame,
+  PackRejectFrame,
+  SyncRequestFrame,
+  SignalDeliverFrame,
+  RunGrantsFrame,
+  SignalCorrelationRegisterAckFrame,
+  DrainDeliverFrame,
+  WorkflowProbeRequestFrame,
+);
 export type HubFrame = typeof HubFrame.infer;
 
 /** Any frame on the wire, regardless of direction. */

--- a/packages/workflow-host/src/ipc/control-channel.ts
+++ b/packages/workflow-host/src/ipc/control-channel.ts
@@ -199,7 +199,7 @@ export type MailboxNotifyHeaders = typeof MailboxNotifyHeaders.infer;
  * union and not by widening the envelope shape. Inference events
  * NEVER appear here; they ride the event channel.
  */
-export const ControlPayload = type(
+export const ControlPayload = type.or(
   {
     type: "'trigger.fire'",
     data: {
@@ -216,7 +216,6 @@ export const ControlPayload = type(
       payload: "unknown",
     },
   },
-  "|",
   {
     type: "'signal.deliver'",
     data: {
@@ -233,20 +232,19 @@ export const ControlPayload = type(
       payload: "unknown",
     },
   },
-)
-  .or({
+  {
     type: "'drain'",
     data: {
       deadlineMs: "number",
     },
-  })
-  .or({
+  },
+  {
     type: "'shutdown'",
     data: {
       reason: "string",
     },
-  })
-  .or({
+  },
+  {
     type: "'grants-updated'",
     data: {
       /**
@@ -268,12 +266,12 @@ export const ControlPayload = type(
        */
       "stepHashes?": "Record<string, string>",
     },
-  })
-  .or({
+  },
+  {
     type: "'sources-updated'",
     data: SourcesUpdatedData,
-  })
-  .or({
+  },
+  {
     // Refreshed credential material for the deployment's inference sources and
     // tools. The child MERGES this into its in-memory cell (see
     // `mergeCredentialDelivery`): `delivery.materials` upsert by credentialId
@@ -291,8 +289,8 @@ export const ControlPayload = type(
       delivery: CredentialDelivery,
       "revoke?": "string[]",
     },
-  })
-  .or({
+  },
+  {
     type: "'ready'",
     data: {
       childPid: "number",
@@ -304,8 +302,8 @@ export const ControlPayload = type(
        */
       childPublicKey: "string",
     },
-  })
-  .or({
+  },
+  {
     // Child-initiated request to recycle the workflow-process. The
     // child emits this when its own self-check decides it needs to be
     // recycled (an internal consistency error it can't recover from,
@@ -319,8 +317,8 @@ export const ControlPayload = type(
     data: {
       reason: "string",
     },
-  })
-  .or({
+  },
+  {
     // Child-initiated `writeTreePreservingPrefix` request. The child
     // does not hold a substrate write authority for the workflow-run
     // repo (single-writer at the ref tip belongs to the supervisor);
@@ -343,8 +341,8 @@ export const ControlPayload = type(
       preservePrefix: "string > 0",
       message: "string > 0",
     },
-  })
-  .or({
+  },
+  {
     // Supervisor-initiated request for the child's merge bytes. Fired
     // from inside the supervisor's `writeTreePreservingPrefix` merge
     // callback while the per-repo lock is held; the child receives the
@@ -361,8 +359,8 @@ export const ControlPayload = type(
         contentBase64: "string",
       }).array(),
     },
-  })
-  .or({
+  },
+  {
     // Child's merge result. `requestId` correlates with the
     // `substrate.write.request` that started the write; the supervisor
     // resumes its merge callback with the supplied entries (or
@@ -385,8 +383,8 @@ export const ControlPayload = type(
         },
       ),
     },
-  })
-  .or({
+  },
+  {
     // Supervisor's terminal reply to a child's `substrate.write.request`.
     // The `requestId` echoes the child's allocated correlation id so
     // the child's pending-id map resolves the awaiter. A successful
@@ -410,8 +408,8 @@ export const ControlPayload = type(
         },
       ),
     },
-  })
-  .or({
+  },
+  {
     // Child-initiated outbound-mail request (OUTBOUND half of mailbox
     // ownership, §3a). The workflow-process child never holds the
     // agent's signing key and never calls `transport.send` itself. When
@@ -437,8 +435,8 @@ export const ControlPayload = type(
       "mailbox?": "string",
       message: OutboundMessagePayload,
     },
-  })
-  .or({
+  },
+  {
     // Supervisor's terminal reply to a child's `outbound.message`. The
     // `requestId` echoes the child's correlation id so the child's
     // pending mail-tool awaiter resolves. A successful send surfaces the
@@ -462,8 +460,8 @@ export const ControlPayload = type(
         },
       ),
     },
-  })
-  .or({
+  },
+  {
     // Child-initiated terminal-run notification. The workflow-process
     // child emits this when one of its runs reaches a terminal phase
     // (`RunCompleted`, `RunFailed`, `RunCancelled`) so the supervisor's
@@ -489,8 +487,8 @@ export const ControlPayload = type(
         message: "string",
       },
     },
-  })
-  .or({
+  },
+  {
     // Child-initiated control-plane suspension notification. The
     // workflow-process child emits this when a workflow agent step parks
     // on a reserved `signalName(correlationId)` channel (`env.onPark`),
@@ -514,8 +512,8 @@ export const ControlPayload = type(
       // process boundary. Optional: only an ask-rail suspension carries one.
       "snapshot?": BoundedApprovalSnapshot,
     },
-  })
-  .or({
+  },
+  {
     // Supervisor-initiated request: enumerate the child's currently-parked
     // approval correlations. The supervisor fires this after a
     // re-establishment (child respawn, or hub-link reconnect fanned out to
@@ -530,8 +528,8 @@ export const ControlPayload = type(
     data: {
       requestId: "string > 0",
     },
-  })
-  .or({
+  },
+  {
     // Child's reply to `parked-correlations.request`. Each entry mirrors
     // `park.notify`'s data -- the child-supplied half of a
     // `SuspensionRegistration` the supervisor stamps its deployment identity
@@ -553,8 +551,8 @@ export const ControlPayload = type(
         "snapshot?": BoundedApprovalSnapshot,
       }).array(),
     },
-  })
-  .or({
+  },
+  {
     // Child reports self-discovered runs after reconnect or recycle.
     // The supervisor seeds its cohort tracking from these runIds so
     // drain accumulators and dispatch routing account for runs the
@@ -563,8 +561,8 @@ export const ControlPayload = type(
     data: {
       runIds: type("string > 0").array(),
     },
-  })
-  .or({
+  },
+  {
     // Supervisor-to-child one-way notification that new mail landed in a
     // deployment mailbox (INBOUND half of mailbox ownership, §3b). One-way
     // like `grants-updated`/`sources-updated`: no correlation id, no response.
@@ -582,8 +580,8 @@ export const ControlPayload = type(
       uid: "number >= 1",
       headers: MailboxNotifyHeaders,
     },
-  })
-  .or({
+  },
+  {
     // Child-initiated mailbox-mutation request (INBOUND half of mailbox
     // ownership, §3b). The supervisor is the sole writer to the
     // workflow-run mailbox: a step agent reads its INBOX locally but
@@ -616,8 +614,8 @@ export const ControlPayload = type(
         op: "'expunge'",
       },
     ),
-  })
-  .or({
+  },
+  {
     // Supervisor's terminal reply to a child's `mailbox.mutate.request`.
     // The `requestId` echoes the child's correlation id so the child's
     // pending mail-tool awaiter resolves. The reply is sent only after
@@ -643,7 +641,8 @@ export const ControlPayload = type(
         },
       ),
     },
-  });
+  },
+);
 
 export type ControlPayload = typeof ControlPayload.infer;
 


### PR DESCRIPTION
Long ArkType `.or()` chains compile intermediate unions during module initialization, increasing startup memory. Replace ten chains with single `type.or(...)` calls across shared types, workflow control messages, Anthropic streaming events, and discovery response formats.

The rewrite preserves branch definitions, tool-result array validation, and the manual `InferenceEvent` type used for `custom.*` narrowing. JIT validation remains enabled.

Fresh-process import measurements show approximately 166–176 MiB lower RSS on the workflow-child and sidecar wiring paths:

| Import path    |    Before |     After | Reduction |
| -------------- | --------: | --------: | --------: |
| Workflow child | 510.4 MiB | 344.5 MiB | 165.9 MiB |
| Sidecar wiring | 532.3 MiB | 356.3 MiB | 176.0 MiB |

Compared with the shared-types-only version measured in the same run, the additional IPC, Anthropic, and discovery rewrites saved another 25.2 MiB on the workflow-child path and 23.6 MiB on sidecar wiring.

Measurements are medians of three fresh-process runs per variant on macOS arm64 with Bun 1.3.9 and ArkType 2.2.0. They cover module imports.

Validation:

- `make all` passed: 8,252 tests passed, with two live API tests skipped.
- The focused suites passed: 162 tests for shared types and 117 for IPC, Anthropic, and discovery. Generated API documentation passed its freshness check.
- Before/after comparisons preserved inferred input/output types and exported schemas, including metadata and supported JSON Schema output.