### PR TITLE
Refresh cached sender keys on sidecar reconnect

### DIFF
--- a/apps/sidecar/src/agent-key-registration-lifecycle.test.ts
+++ b/apps/sidecar/src/agent-key-registration-lifecycle.test.ts
@@ -252,7 +252,11 @@ describe("agent signing-key registration lifecycle on the host transport", () =>
       } as unknown as Parameters<
         typeof createSidecarDeployRouter
       >[0]["keyStore"],
-      senderKeyCache: { get: () => undefined, put: async () => undefined },
+      senderKeyCache: {
+        get: () => undefined,
+        put: async () => undefined,
+        addresses: () => [],
+      },
       transport,
       repoStore,
       signingKeySeed: keyPair.privateKey,

--- a/apps/sidecar/src/agent-key-registration-lifecycle.test.ts
+++ b/apps/sidecar/src/agent-key-registration-lifecycle.test.ts
@@ -256,6 +256,7 @@ describe("agent signing-key registration lifecycle on the host transport", () =>
         get: () => undefined,
         put: async () => undefined,
         addresses: () => [],
+        rotatableAddresses: () => [],
       },
       transport,
       repoStore,

--- a/apps/sidecar/src/index.ts
+++ b/apps/sidecar/src/index.ts
@@ -14,7 +14,7 @@ import {
   createSidecarOrchestrator,
   type HubLink,
 } from "@intx/hub-agent";
-import { hexEncode } from "@intx/types";
+import { hexDecode, hexEncode } from "@intx/types";
 import { createAgentRepoStore } from "@intx/hub-sessions";
 import { createTarballCache } from "@intx/tool-packaging";
 
@@ -449,6 +449,13 @@ const orchestrator = createSidecarOrchestrator({
     verifySSHSig: verifySSHSignature,
   },
   resolveSenderCrypto,
+  // Write peer of `resolveSenderCrypto`: an inbound `sender.key.refresh` frame
+  // re-pushes a rotated sender key here. Decode the hex and persist through the
+  // same cache the read side serves from; `put` owns the 32-byte length check
+  // and `hexDecode` owns hex validity, so both faults surface to the link's
+  // handler rather than being masked here.
+  cacheSenderKey: (address, publicKey) =>
+    senderKeyCache.put(address, hexDecode(publicKey)),
   mailInboundRouter: multistepMailRouter,
   signalInboundRouter: multistepSignalRouter,
   drainInboundRouter: multistepDrainRouter,

--- a/apps/sidecar/src/index.ts
+++ b/apps/sidecar/src/index.ts
@@ -478,6 +478,13 @@ const orchestrator = createSidecarOrchestrator({
     }
     return sidecarDeployRouter.activeAddresses();
   },
+  // Report the sidecar's cached rotatable senders on every (re)connect so the
+  // hub re-resolves each current key and re-pushes it, catching a rotation that
+  // landed while the sidecar was disconnected. The cache owns the "only user
+  // senders rotate" filter (a run sender's key is the immutable
+  // workflow_run.public_key); the link stays source-opaque and reports whatever
+  // this returns.
+  getCachedSenderAddresses: () => senderKeyCache.rotatableAddresses(),
   // When the hub-link re-announces a deployment address in an authenticated
   // reconnect, re-drive any workflow-run pack the disconnect cancelled. The
   // link fires this AFTER sending the reconnect frame, so the hub routes the

--- a/apps/sidecar/src/workflow-host-wiring-deploy-failure.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring-deploy-failure.test.ts
@@ -130,7 +130,11 @@ describe("deploy-failure registry leak", () => {
         typeof createSidecarDeployRouter
       >[0]["sessions"],
       keyStore: stubKeyStore(),
-      senderKeyCache: { get: () => undefined, put: async () => undefined },
+      senderKeyCache: {
+        get: () => undefined,
+        put: async () => undefined,
+        addresses: () => [],
+      },
       transport,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- an unsupported frame throws before any repoStore usage
       repoStore: {} as Parameters<
@@ -214,7 +218,11 @@ describe("deploy-failure registry leak", () => {
     const router = createSidecarDeployRouter({
       sessions,
       keyStore,
-      senderKeyCache: { get: () => undefined, put: async () => undefined },
+      senderKeyCache: {
+        get: () => undefined,
+        put: async () => undefined,
+        addresses: () => [],
+      },
       transport,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub: only getRepoDir + writeTree are exercised before the spawn-time failure
       repoStore: repoStoreStub as RepoStore,
@@ -368,7 +376,11 @@ describe("deploy-failure registry leak", () => {
     const router = createSidecarDeployRouter({
       sessions,
       keyStore,
-      senderKeyCache: { get: () => undefined, put: async () => undefined },
+      senderKeyCache: {
+        get: () => undefined,
+        put: async () => undefined,
+        addresses: () => [],
+      },
       transport,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub: only getRepoDir + writeTree are exercised before the spawn-time failure
       repoStore: repoStoreStub as RepoStore,

--- a/apps/sidecar/src/workflow-host-wiring-deploy-failure.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring-deploy-failure.test.ts
@@ -134,6 +134,7 @@ describe("deploy-failure registry leak", () => {
         get: () => undefined,
         put: async () => undefined,
         addresses: () => [],
+        rotatableAddresses: () => [],
       },
       transport,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- an unsupported frame throws before any repoStore usage
@@ -222,6 +223,7 @@ describe("deploy-failure registry leak", () => {
         get: () => undefined,
         put: async () => undefined,
         addresses: () => [],
+        rotatableAddresses: () => [],
       },
       transport,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub: only getRepoDir + writeTree are exercised before the spawn-time failure
@@ -380,6 +382,7 @@ describe("deploy-failure registry leak", () => {
         get: () => undefined,
         put: async () => undefined,
         addresses: () => [],
+        rotatableAddresses: () => [],
       },
       transport,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test stub: only getRepoDir + writeTree are exercised before the spawn-time failure

--- a/apps/sidecar/src/workflow-host-wiring-undeploy-supervisor.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring-undeploy-supervisor.test.ts
@@ -263,7 +263,11 @@ describe("createSidecarDeployRouter multi-step undeploy shuts the supervisor dow
       } as unknown as Parameters<
         typeof createSidecarDeployRouter
       >[0]["keyStore"],
-      senderKeyCache: { get: () => undefined, put: async () => undefined },
+      senderKeyCache: {
+        get: () => undefined,
+        put: async () => undefined,
+        addresses: () => [],
+      },
       transport,
       repoStore,
       signingKeySeed: keyPair.privateKey,

--- a/apps/sidecar/src/workflow-host-wiring-undeploy-supervisor.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring-undeploy-supervisor.test.ts
@@ -267,6 +267,7 @@ describe("createSidecarDeployRouter multi-step undeploy shuts the supervisor dow
         get: () => undefined,
         put: async () => undefined,
         addresses: () => [],
+        rotatableAddresses: () => [],
       },
       transport,
       repoStore,

--- a/apps/sidecar/src/workflow-host-wiring.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring.test.ts
@@ -260,6 +260,7 @@ describe("createSidecarDeployRouter provision-step (no-spawn) mode", () => {
         get: () => undefined,
         put: async () => undefined,
         addresses: () => [],
+        rotatableAddresses: () => [],
       },
       transport,
       repoStore,
@@ -859,6 +860,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
         get: () => undefined,
         put: async () => undefined,
         addresses: () => [],
+        rotatableAddresses: () => [],
       },
       transport,
       repoStore,
@@ -1549,6 +1551,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
         puts.push({ address, grantsExisted });
       },
       addresses: () => [],
+      rotatableAddresses: () => [],
     };
 
     const { grantsRouter, agentAddress, anchorRunId, tempBase } =
@@ -1598,6 +1601,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
         throw new Error("sender-key disk full");
       },
       addresses: () => [],
+      rotatableAddresses: () => [],
     };
 
     const { grantsRouter, agentAddress, anchorRunId, tempBase } =
@@ -1646,6 +1650,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
         puts.push(address);
       },
       addresses: () => [],
+      rotatableAddresses: () => [],
     };
 
     const { grantsRouter, agentAddress, anchorRunId, tempBase } =

--- a/apps/sidecar/src/workflow-host-wiring.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring.test.ts
@@ -256,7 +256,11 @@ describe("createSidecarDeployRouter provision-step (no-spawn) mode", () => {
       } as unknown as Parameters<
         typeof createSidecarDeployRouter
       >[0]["keyStore"],
-      senderKeyCache: { get: () => undefined, put: async () => undefined },
+      senderKeyCache: {
+        get: () => undefined,
+        put: async () => undefined,
+        addresses: () => [],
+      },
       transport,
       repoStore,
       signingKeySeed: keyPair.privateKey,
@@ -854,6 +858,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
       senderKeyCache: opts.senderKeyCache ?? {
         get: () => undefined,
         put: async () => undefined,
+        addresses: () => [],
       },
       transport,
       repoStore,
@@ -1543,6 +1548,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
             .catch(() => false));
         puts.push({ address, grantsExisted });
       },
+      addresses: () => [],
     };
 
     const { grantsRouter, agentAddress, anchorRunId, tempBase } =
@@ -1591,6 +1597,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
       put: async () => {
         throw new Error("sender-key disk full");
       },
+      addresses: () => [],
     };
 
     const { grantsRouter, agentAddress, anchorRunId, tempBase } =
@@ -1638,6 +1645,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
       put: async (address: string) => {
         puts.push(address);
       },
+      addresses: () => [],
     };
 
     const { grantsRouter, agentAddress, anchorRunId, tempBase } =

--- a/packages/hub-agent/src/sender-crypto.test.ts
+++ b/packages/hub-agent/src/sender-crypto.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "bun:test";
+import { isRunAddress } from "@intx/types";
 
 import {
   createPublicKeyCrypto,
@@ -18,6 +19,7 @@ function stubCache(entries: Record<string, Uint8Array>): SenderKeyCache {
     get: (address) => map.get(address),
     put: async () => undefined,
     addresses: () => [...map.keys()],
+    rotatableAddresses: () => [...map.keys()].filter((a) => !isRunAddress(a)),
   };
 }
 

--- a/packages/hub-agent/src/sender-crypto.test.ts
+++ b/packages/hub-agent/src/sender-crypto.test.ts
@@ -17,6 +17,7 @@ function stubCache(entries: Record<string, Uint8Array>): SenderKeyCache {
   return {
     get: (address) => map.get(address),
     put: async () => undefined,
+    addresses: () => [...map.keys()],
   };
 }
 

--- a/packages/hub-agent/src/sender-key-cache.test.ts
+++ b/packages/hub-agent/src/sender-key-cache.test.ts
@@ -145,6 +145,37 @@ describe("SenderKeyCache", () => {
     expect(cache.get("short@example.com")).toBeUndefined();
   });
 
+  test("reports exactly the addresses it holds a key for", async () => {
+    const dataDir = await tempDir();
+    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    await cache.put("alice@a.example", makeKey(5));
+    await cache.put("bob@b.example", makeKey(9));
+
+    expect([...cache.addresses()].sort()).toEqual([
+      "alice@a.example",
+      "bob@b.example",
+    ]);
+  });
+
+  test("reports no addresses for a freshly constructed cache", async () => {
+    const dataDir = await tempDir();
+    // No keyring dir exists yet, so loadFromDisk finds nothing: the cold-start
+    // path the reconnect reporter hits before any key has been cached.
+    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    expect(cache.addresses()).toEqual([]);
+  });
+
+  test("returns a snapshot a later put does not retroactively mutate", async () => {
+    const dataDir = await tempDir();
+    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    await cache.put("alice@a.example", makeKey(5));
+
+    const snapshot = cache.addresses();
+    await cache.put("bob@b.example", makeKey(9));
+
+    expect(snapshot).toEqual(["alice@a.example"]);
+  });
+
   test("a failed durable write leaves no in-memory entry", async () => {
     const dataDir = await tempDir();
     const cache = await createSenderKeyCache({

--- a/packages/hub-agent/src/sender-key-cache.test.ts
+++ b/packages/hub-agent/src/sender-key-cache.test.ts
@@ -157,6 +157,23 @@ describe("SenderKeyCache", () => {
     ]);
   });
 
+  test("reports only rotatable (non-run) addresses for the reconnect report", async () => {
+    const dataDir = await tempDir();
+    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    await cache.put("usr_alice@tenant.example", makeKey(5));
+    await cache.put("run_job1@tenant.example", makeKey(9));
+    await cache.put("usr_bob@tenant.example", makeKey(13));
+
+    // A run sender's key is the immutable workflow_run.public_key, so only the
+    // user senders are worth re-resolving on reconnect.
+    expect([...cache.rotatableAddresses()].sort()).toEqual([
+      "usr_alice@tenant.example",
+      "usr_bob@tenant.example",
+    ]);
+    // The unfiltered snapshot still carries every cached address.
+    expect(cache.addresses()).toHaveLength(3);
+  });
+
   test("reports no addresses for a freshly constructed cache", async () => {
     const dataDir = await tempDir();
     // No keyring dir exists yet, so loadFromDisk finds nothing: the cold-start

--- a/packages/hub-agent/src/sender-key-cache.ts
+++ b/packages/hub-agent/src/sender-key-cache.ts
@@ -27,7 +27,7 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 import { type } from "arktype";
 import { getLogger } from "@intx/log";
-import { hasCode, hexDecode, hexEncode } from "@intx/types";
+import { hasCode, hexDecode, hexEncode, isRunAddress } from "@intx/types";
 
 const logger = getLogger(["interchange", "hub-agent", "sender-key-cache"]);
 
@@ -78,6 +78,17 @@ export type SenderKeyCache = {
    * hub-side rather than trusting the cached (possibly stale) one.
    */
   addresses(): string[];
+  /**
+   * The cached addresses whose key can rotate: `addresses()` minus run
+   * addresses. A run address resolves to the immutable
+   * `workflow_run.public_key`, so its cached key never changes; a user sender
+   * resolves to a hub principal key that can rotate. The reconnect reporter
+   * sends exactly this set so the hub re-resolves only the senders whose key
+   * could have changed while the sidecar was disconnected. This is a
+   * work-saving filter, not a trust boundary -- the hub resolves every reported
+   * address on its own.
+   */
+  rotatableAddresses(): string[];
 };
 
 export async function createSenderKeyCache(
@@ -149,6 +160,10 @@ export async function createSenderKeyCache(
     return [...keys.keys()];
   }
 
+  function rotatableAddresses(): string[] {
+    return addresses().filter((address) => !isRunAddress(address));
+  }
+
   async function put(address: string, publicKey: Uint8Array): Promise<void> {
     if (publicKey.length !== ED25519_PUBLIC_KEY_BYTES) {
       throw new Error(
@@ -166,5 +181,5 @@ export async function createSenderKeyCache(
 
   await loadFromDisk();
 
-  return { get, put, addresses };
+  return { get, put, addresses, rotatableAddresses };
 }

--- a/packages/hub-agent/src/sender-key-cache.ts
+++ b/packages/hub-agent/src/sender-key-cache.ts
@@ -69,6 +69,15 @@ export type SenderKeyCache = {
    * resolves.
    */
   put(address: string, publicKey: Uint8Array): Promise<void>;
+  /**
+   * A snapshot of every address the cache currently holds a key for. Returns a
+   * fresh array, decoupled from the backing map, so a later `put` does not
+   * change an array a caller is still holding -- the reported set stays stable
+   * across an `await`. The cache reports addresses only; the key values stay
+   * inside because the refresh-on-reconnect flow re-resolves each current key
+   * hub-side rather than trusting the cached (possibly stale) one.
+   */
+  addresses(): string[];
 };
 
 export async function createSenderKeyCache(
@@ -136,6 +145,10 @@ export async function createSenderKeyCache(
     return keys.get(address);
   }
 
+  function addresses(): string[] {
+    return [...keys.keys()];
+  }
+
   async function put(address: string, publicKey: Uint8Array): Promise<void> {
     if (publicKey.length !== ED25519_PUBLIC_KEY_BYTES) {
       throw new Error(
@@ -153,5 +166,5 @@ export async function createSenderKeyCache(
 
   await loadFromDisk();
 
-  return { get, put };
+  return { get, put, addresses };
 }

--- a/packages/hub-agent/src/sidecar-orchestrator-probe.test.ts
+++ b/packages/hub-agent/src/sidecar-orchestrator-probe.test.ts
@@ -171,6 +171,7 @@ describe("createSidecarOrchestrator workflow-probe threading", () => {
         verifySSHSig: verifySSHSignature,
       },
       resolveSenderCrypto: () => undefined,
+      cacheSenderKey: async () => undefined,
       createDeployRouter: () => ({
         deploy: () => Promise.resolve({ publicKey: "aa".repeat(32) }),
       }),

--- a/packages/hub-agent/src/sidecar-orchestrator.ts
+++ b/packages/hub-agent/src/sidecar-orchestrator.ts
@@ -109,6 +109,13 @@ export type SidecarOrchestratorConfig = {
    */
   resolveSenderCrypto: (address: string) => CryptoProvider | undefined;
   /**
+   * Persists the hub-vouched public key for a sender address. The host builds
+   * it over the same sender-key cache as `resolveSenderCrypto` and the
+   * orchestrator forwards it unchanged to `createHubLink`, where an inbound
+   * `sender.key.refresh` frame drives it.
+   */
+  cacheSenderKey: (address: string, publicKey: string) => Promise<void>;
+  /**
    * Host-injected `DeployRouter` factory. The orchestrator calls it
    * once after `sessions` and `keyStore` are constructed; the
    * returned router routes every `agent.deploy` frame on the link.
@@ -229,6 +236,7 @@ export function createSidecarOrchestrator(
     transport,
     cryptoOps,
     resolveSenderCrypto,
+    cacheSenderKey,
     createDeployRouter,
     mailInboundRouter,
     signalInboundRouter,
@@ -320,6 +328,7 @@ export function createSidecarOrchestrator(
     sessions,
     keyStore,
     resolveSenderCrypto,
+    cacheSenderKey,
     deployRouter,
     applyWorkflowRunPack,
     ...(mailInboundRouter !== undefined ? { mailInboundRouter } : {}),

--- a/packages/hub-agent/src/sidecar-orchestrator.ts
+++ b/packages/hub-agent/src/sidecar-orchestrator.ts
@@ -192,6 +192,14 @@ export type SidecarOrchestratorConfig = {
    */
   getWorkflowAddresses?: () => string[];
   /**
+   * Returns the rotatable (non-run) sender addresses this sidecar holds cached
+   * keys for. Forwarded to the hub link, which reports them on every
+   * (re)connect so the hub re-resolves and re-pushes each key. Production wires
+   * this to the sender-key cache's rotatable view; omitted, the link reports
+   * none.
+   */
+  getCachedSenderAddresses?: () => string[];
+  /**
    * Invoked with the workflow-substrate addresses the link just announced in
    * an authenticated reconnect. Forwarded to the hub link so the workflow-run
    * pack pusher can re-drive a push a disconnect cancelled -- gated on the
@@ -247,6 +255,7 @@ export function createSidecarOrchestrator(
     applyWorkflowRunPack,
     workflowProbeExecutor,
     getWorkflowAddresses,
+    getCachedSenderAddresses,
     onWorkflowAddressesRoutable,
     onWorkflowAddressesUnroutable,
     pingIntervalMs,
@@ -341,6 +350,9 @@ export function createSidecarOrchestrator(
       : {}),
     ...(workflowProbeExecutor !== undefined ? { workflowProbeExecutor } : {}),
     ...(getWorkflowAddresses !== undefined ? { getWorkflowAddresses } : {}),
+    ...(getCachedSenderAddresses !== undefined
+      ? { getCachedSenderAddresses }
+      : {}),
     ...(onWorkflowAddressesRoutable !== undefined
       ? { onWorkflowAddressesRoutable }
       : {}),

--- a/packages/hub-agent/src/ws/hub-link-bootstrap-prune.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-bootstrap-prune.test.ts
@@ -297,6 +297,7 @@ describe("hub-link workflow-run pack bootstrap prune", () => {
       sessions,
       keyStore,
       resolveSenderCrypto: () => undefined,
+      cacheSenderKey: async () => undefined,
       deployRouter: createTestDeployRouter(keyStore),
     });
 

--- a/packages/hub-agent/src/ws/hub-link-mail-router.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-mail-router.test.ts
@@ -100,12 +100,14 @@ function withTestDeployBindings(): {
   keyStore: AgentKeyStore & { registerKey(address: string, kp: KeyPair): void };
   deployRouter: DeployRouter;
   resolveSenderCrypto: () => undefined;
+  cacheSenderKey: () => Promise<void>;
 } {
   const keyStore = createTestKeyStore();
   return {
     keyStore,
     deployRouter: createTestDeployRouter(keyStore),
     resolveSenderCrypto: () => undefined,
+    cacheSenderKey: async () => undefined,
   };
 }
 

--- a/packages/hub-agent/src/ws/hub-link-sender-key-refresh.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-sender-key-refresh.test.ts
@@ -1,0 +1,336 @@
+// Exercises the `sender.key.refresh` arm in `handleMessage`: a hub-pushed
+// key-only refresh drives the source-opaque `cacheSenderKey` write peer and
+// touches nothing else. The frame updates the sidecar's cached sender key; a
+// cache-write fault (transient disk fault or malformed key) is logged at ERROR
+// and swallowed, never wedging the per-connection message chain and never
+// poisoning a run -- there is no run to poison on this address-keyed path.
+//
+// The write is driven through the REAL edge composition the sidecar wires in
+// `index.ts` (`(address, hex) => senderKeyCache.put(address, hexDecode(hex))`)
+// against a real `SenderKeyCache`, so the hex-decode and 32-byte-length
+// boundaries are exercised end to end rather than mocked.
+
+import {
+  describe,
+  test,
+  expect,
+  afterAll,
+  beforeAll,
+  afterEach,
+} from "bun:test";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { Hono } from "hono";
+import { upgradeWebSocket, websocket } from "hono/bun";
+import { createInMemoryTransport } from "@intx/mail-memory";
+import { hexDecode, hexEncode } from "@intx/types";
+import { configureSync, getConfig, resetSync } from "@intx/log";
+
+import { createHubLink, type DeployRouter } from "./hub-link";
+import { createSenderKeyCache } from "../sender-key-cache";
+import type { AgentKeyStore } from "../agent-key-store";
+import type { SessionManager } from "../session-manager";
+
+// ---------------------------------------------------------------------------
+// Minimal link dependencies. The refresh arm touches only `cacheSenderKey`, so
+// the deploy/session/key stubs exist only to satisfy the required config.
+// ---------------------------------------------------------------------------
+
+function createStubKeyStore(): AgentKeyStore {
+  return {
+    async loadOrGenerateKey(address: string) {
+      throw new Error(`No key registered for ${address} in test store`);
+    },
+    recordHubKey: () => undefined,
+    verifyDeployCommit: () => Promise.resolve(true),
+    forgetAgent: () => undefined,
+  };
+}
+
+function createStubDeployRouter(): DeployRouter {
+  return {
+    async deploy() {
+      return { publicKey: "aa".repeat(32) };
+    },
+  };
+}
+
+function createStubSessionManager(): SessionManager {
+  return {
+    initRepo: () => Promise.resolve(),
+    applyDeployPack: () => Promise.resolve(),
+    applyAssetPack: () => Promise.resolve(),
+    createStatePack: () =>
+      Promise.resolve({
+        pack: new Uint8Array([1, 2, 3]),
+        commitSha: "abc123",
+        ref: "refs/heads/main",
+      }),
+    deleteAgentDir: () => Promise.resolve(),
+    getAddresses: () => [],
+    getSessionId: () => undefined,
+  };
+}
+
+async function writeFileDurable(
+  filePath: string,
+  contents: string,
+): Promise<void> {
+  await fs.writeFile(filePath, contents);
+}
+
+const tempDirs: string[] = [];
+
+async function tempDir(): Promise<string> {
+  const d = await fs.mkdtemp(
+    path.join(os.tmpdir(), "sender-key-refresh-test-"),
+  );
+  tempDirs.push(d);
+  return d;
+}
+
+afterEach(async () => {
+  const dirs = tempDirs.splice(0);
+  await Promise.all(
+    dirs.map((d) => fs.rm(d, { recursive: true, force: true })),
+  );
+});
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 2000,
+): Promise<void> {
+  const start = Date.now();
+  while (!(await predicate())) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+    }
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test server: relays raw hub->sidecar frames to the connected link. It
+// captures the server-side send handle so a test can push an arbitrary frame;
+// the client's message listener is attached synchronously at socket creation,
+// so the handle being set means the link is ready to receive.
+// ---------------------------------------------------------------------------
+
+type ServerSend = (frame: unknown) => void;
+
+function startTestServer(): {
+  server: ReturnType<typeof Bun.serve>;
+  awaitSend: () => Promise<ServerSend>;
+} {
+  let send: ServerSend | null = null;
+
+  const app = new Hono();
+  app.get(
+    "/ws",
+    upgradeWebSocket(() => ({
+      onOpen(_evt, ws) {
+        send = (frame) => ws.send(JSON.stringify(frame));
+      },
+      onClose() {
+        send = null;
+      },
+    })),
+  );
+
+  const server = Bun.serve({ fetch: app.fetch, websocket, port: 0 });
+
+  async function awaitSend(): Promise<ServerSend> {
+    await waitFor(() => send !== null);
+    const captured = send;
+    if (captured === null) throw new Error("server send handle disappeared");
+    return captured;
+  }
+
+  return { server, awaitSend };
+}
+
+const env = startTestServer();
+
+afterAll(async () => {
+  await env.server.stop(true);
+});
+
+type CapturedLog = {
+  category: readonly string[];
+  level: string;
+  message: readonly unknown[];
+};
+
+const capturedLogs: CapturedLog[] = [];
+const savedLogConfig = getConfig();
+
+beforeAll(() => {
+  configureSync({
+    reset: true,
+    sinks: {
+      capture: (record) => {
+        capturedLogs.push({
+          category: record.category,
+          level: record.level,
+          message: record.message,
+        });
+      },
+    },
+    loggers: [
+      { category: [], lowestLevel: "debug", sinks: ["capture"] },
+      {
+        category: ["logtape", "meta"],
+        lowestLevel: "warning",
+        sinks: ["capture"],
+      },
+    ],
+  });
+});
+
+afterAll(() => {
+  if (savedLogConfig) {
+    configureSync({ reset: true, ...savedLogConfig });
+  } else {
+    resetSync();
+  }
+});
+
+function refreshErrors(): string[] {
+  return capturedLogs
+    .filter(
+      (r) =>
+        r.level === "error" &&
+        r.message.join("").includes("sender.key.refresh"),
+    )
+    .map((r) => r.message.join(""));
+}
+
+function createTestLink(
+  cacheSenderKey: (address: string, publicKey: string) => Promise<void>,
+  sidecarId: string,
+) {
+  return createHubLink({
+    hubURL: `ws://localhost:${env.server.port}/ws`,
+    sidecarId,
+    token: "test-token",
+    transport: createInMemoryTransport(),
+    sessions: createStubSessionManager(),
+    keyStore: createStubKeyStore(),
+    resolveSenderCrypto: () => undefined,
+    cacheSenderKey,
+    deployRouter: createStubDeployRouter(),
+  });
+}
+
+function makeKey(seed: number): Uint8Array {
+  const key = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) key[i] = (seed + i) & 0xff;
+  return key;
+}
+
+describe("hub-link sender.key.refresh", () => {
+  beforeAll(() => {
+    capturedLogs.length = 0;
+  });
+
+  test("updates the cache with the refreshed key through the real edge", async () => {
+    const dataDir = await tempDir();
+    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const client = createTestLink(
+      (address, publicKey) => cache.put(address, hexDecode(publicKey)),
+      "sc-refresh-ok",
+    );
+
+    client.connect();
+    try {
+      const send = await env.awaitSend();
+      const address = "usr_alice@tenant.example";
+      const key = makeKey(11);
+      send({ type: "sender.key.refresh", address, publicKey: hexEncode(key) });
+
+      await waitFor(() => cache.get(address) !== undefined);
+      expect(cache.get(address)).toEqual(key);
+      expect(refreshErrors()).toHaveLength(0);
+    } finally {
+      client.close();
+    }
+  });
+
+  test("a cache-write fault is logged and does not wedge later frames", async () => {
+    capturedLogs.length = 0;
+    let calls = 0;
+    const recorded: string[] = [];
+    const cacheSenderKey = async (address: string) => {
+      calls += 1;
+      // Transient fault on the first write; the second must still be processed,
+      // proving the swallowed throw did not wedge the message chain.
+      if (calls === 1) throw new Error("sender-key disk full");
+      recorded.push(address);
+    };
+    const client = createTestLink(cacheSenderKey, "sc-refresh-fault");
+
+    client.connect();
+    try {
+      const send = await env.awaitSend();
+      const key = hexEncode(makeKey(3));
+      send({
+        type: "sender.key.refresh",
+        address: "usr_faulty@tenant.example",
+        publicKey: key,
+      });
+      send({
+        type: "sender.key.refresh",
+        address: "usr_second@tenant.example",
+        publicKey: key,
+      });
+
+      await waitFor(() => recorded.length > 0);
+      expect(recorded).toEqual(["usr_second@tenant.example"]);
+      expect(calls).toBe(2);
+      const errors = refreshErrors();
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("usr_faulty@tenant.example");
+    } finally {
+      client.close();
+    }
+  });
+
+  test("a wrong-length key is rejected without partially updating the cache", async () => {
+    capturedLogs.length = 0;
+    const dataDir = await tempDir();
+    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const client = createTestLink(
+      (address, publicKey) => cache.put(address, hexDecode(publicKey)),
+      "sc-refresh-badkey",
+    );
+
+    client.connect();
+    try {
+      const send = await env.awaitSend();
+      const badAddress = "usr_short@tenant.example";
+      // A 31-byte key: hexDecode succeeds but put's length guard throws.
+      send({
+        type: "sender.key.refresh",
+        address: badAddress,
+        publicKey: hexEncode(new Uint8Array(31)),
+      });
+
+      await waitFor(() => refreshErrors().length > 0);
+      expect(cache.get(badAddress)).toBeUndefined();
+
+      // The link survived the malformed frame: a following valid frame caches.
+      const goodAddress = "usr_good@tenant.example";
+      const goodKey = makeKey(7);
+      send({
+        type: "sender.key.refresh",
+        address: goodAddress,
+        publicKey: hexEncode(goodKey),
+      });
+      await waitFor(() => cache.get(goodAddress) !== undefined);
+      expect(cache.get(goodAddress)).toEqual(goodKey);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/packages/hub-agent/src/ws/hub-link-sender-key-refresh.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-sender-key-refresh.test.ts
@@ -1,14 +1,20 @@
-// Exercises the `sender.key.refresh` arm in `handleMessage`: a hub-pushed
-// key-only refresh drives the source-opaque `cacheSenderKey` write peer and
-// touches nothing else. The frame updates the sidecar's cached sender key; a
-// cache-write fault (transient disk fault or malformed key) is logged at ERROR
-// and swallowed, never wedging the per-connection message chain and never
-// poisoning a run -- there is no run to poison on this address-keyed path.
+// Exercises both halves of the sender-key refresh feature's hub-link surface:
 //
-// The write is driven through the REAL edge composition the sidecar wires in
-// `index.ts` (`(address, hex) => senderKeyCache.put(address, hexDecode(hex))`)
-// against a real `SenderKeyCache`, so the hex-decode and 32-byte-length
-// boundaries are exercised end to end rather than mocked.
+//   1. REPORT (on connect): the link announces the sidecar's cached rotatable
+//      senders on its register/reconnect frame, read from the
+//      `getCachedSenderAddresses` callback. Reported on BOTH frame types and
+//      omitted when empty.
+//   2. RECEIVE (`sender.key.refresh` arm in `handleMessage`): a hub-pushed
+//      key-only refresh drives the source-opaque `cacheSenderKey` write peer
+//      and touches nothing else. A cache-write fault (transient disk fault or
+//      malformed key) is logged at ERROR and swallowed, never wedging the
+//      per-connection message chain and never poisoning a run -- there is no
+//      run to poison on this address-keyed path.
+//
+// The receive path is driven through the REAL edge composition the sidecar
+// wires in `index.ts` (`(address, hex) => senderKeyCache.put(address,
+// hexDecode(hex))`) against a real `SenderKeyCache`, so the hex-decode and
+// 32-byte-length boundaries are exercised end to end rather than mocked.
 
 import {
   describe,
@@ -23,8 +29,10 @@ import path from "node:path";
 import os from "node:os";
 import { Hono } from "hono";
 import { upgradeWebSocket, websocket } from "hono/bun";
+import { type } from "arktype";
 import { createInMemoryTransport } from "@intx/mail-memory";
 import { hexDecode, hexEncode } from "@intx/types";
+import { RegisterFrame, ReconnectFrame } from "@intx/types/sidecar";
 import { configureSync, getConfig, resetSync } from "@intx/log";
 
 import { createHubLink, type DeployRouter } from "./hub-link";
@@ -111,19 +119,34 @@ async function waitFor(
 }
 
 // ---------------------------------------------------------------------------
-// Test server: relays raw hub->sidecar frames to the connected link. It
+// Test server: relays raw hub->sidecar frames to the connected link and records
+// the sidecar->hub frames the link sends (its register/reconnect handshake). It
 // captures the server-side send handle so a test can push an arbitrary frame;
 // the client's message listener is attached synchronously at socket creation,
 // so the handle being set means the link is ready to receive.
 // ---------------------------------------------------------------------------
 
 type ServerSend = (frame: unknown) => void;
+type HandshakeFrame = RegisterFrame | ReconnectFrame;
+
+// The sidecar sends a register or reconnect frame at handshake (plus pings and
+// pack frames later). Validate each inbound frame against the real
+// register/reconnect schemas; anything else is ignored.
+function parseHandshake(raw: unknown): HandshakeFrame | null {
+  const register = RegisterFrame(raw);
+  if (!(register instanceof type.errors)) return register;
+  const reconnect = ReconnectFrame(raw);
+  if (!(reconnect instanceof type.errors)) return reconnect;
+  return null;
+}
 
 function startTestServer(): {
   server: ReturnType<typeof Bun.serve>;
   awaitSend: () => Promise<ServerSend>;
+  awaitHandshake: (sidecarId: string) => Promise<HandshakeFrame>;
 } {
   let send: ServerSend | null = null;
+  const handshakes: HandshakeFrame[] = [];
 
   const app = new Hono();
   app.get(
@@ -131,6 +154,12 @@ function startTestServer(): {
     upgradeWebSocket(() => ({
       onOpen(_evt, ws) {
         send = (frame) => ws.send(JSON.stringify(frame));
+      },
+      onMessage(evt) {
+        if (typeof evt.data !== "string") return;
+        const raw: unknown = JSON.parse(evt.data);
+        const frame = parseHandshake(raw);
+        if (frame !== null) handshakes.push(frame);
       },
       onClose() {
         send = null;
@@ -147,7 +176,14 @@ function startTestServer(): {
     return captured;
   }
 
-  return { server, awaitSend };
+  async function awaitHandshake(sidecarId: string): Promise<HandshakeFrame> {
+    await waitFor(() => handshakes.some((h) => h.sidecarId === sidecarId));
+    const frame = handshakes.find((h) => h.sidecarId === sidecarId);
+    if (frame === undefined) throw new Error("handshake frame disappeared");
+    return frame;
+  }
+
+  return { server, awaitSend, awaitHandshake };
 }
 
 const env = startTestServer();
@@ -209,6 +245,10 @@ function refreshErrors(): string[] {
 function createTestLink(
   cacheSenderKey: (address: string, publicKey: string) => Promise<void>,
   sidecarId: string,
+  report?: {
+    getWorkflowAddresses?: () => string[];
+    getCachedSenderAddresses?: () => string[];
+  },
 ) {
   return createHubLink({
     hubURL: `ws://localhost:${env.server.port}/ws`,
@@ -220,8 +260,16 @@ function createTestLink(
     resolveSenderCrypto: () => undefined,
     cacheSenderKey,
     deployRouter: createStubDeployRouter(),
+    ...(report?.getWorkflowAddresses !== undefined
+      ? { getWorkflowAddresses: report.getWorkflowAddresses }
+      : {}),
+    ...(report?.getCachedSenderAddresses !== undefined
+      ? { getCachedSenderAddresses: report.getCachedSenderAddresses }
+      : {}),
   });
 }
+
+const noopCacheSenderKey = async () => undefined;
 
 function makeKey(seed: number): Uint8Array {
   const key = new Uint8Array(32);
@@ -329,6 +377,61 @@ describe("hub-link sender.key.refresh", () => {
       });
       await waitFor(() => cache.get(goodAddress) !== undefined);
       expect(cache.get(goodAddress)).toEqual(goodKey);
+    } finally {
+      client.close();
+    }
+  });
+});
+
+describe("hub-link cached-sender report on connect", () => {
+  test("a register frame carries the reported cached senders", async () => {
+    const reported = ["usr_alice@tenant.example", "usr_bob@tenant.example"];
+    const client = createTestLink(noopCacheSenderKey, "sc-report-register", {
+      // No workflow addresses -> the link sends a register frame.
+      getWorkflowAddresses: () => [],
+      getCachedSenderAddresses: () => reported,
+    });
+
+    client.connect();
+    try {
+      const frame = await env.awaitHandshake("sc-report-register");
+      expect(frame.type).toBe("register");
+      expect(frame.cachedSenderAddresses).toEqual(reported);
+    } finally {
+      client.close();
+    }
+  });
+
+  test("a reconnect frame carries the reported cached senders", async () => {
+    const reported = ["usr_carol@tenant.example"];
+    const client = createTestLink(noopCacheSenderKey, "sc-report-reconnect", {
+      // A restored workflow address -> the link sends a reconnect frame; the
+      // cached-sender report must ride it too, not only the register path.
+      getWorkflowAddresses: () => ["run_deployment@tenant.example"],
+      getCachedSenderAddresses: () => reported,
+    });
+
+    client.connect();
+    try {
+      const frame = await env.awaitHandshake("sc-report-reconnect");
+      expect(frame.type).toBe("reconnect");
+      expect(frame.cachedSenderAddresses).toEqual(reported);
+    } finally {
+      client.close();
+    }
+  });
+
+  test("an empty report omits the field from the frame", async () => {
+    const client = createTestLink(noopCacheSenderKey, "sc-report-empty", {
+      getWorkflowAddresses: () => [],
+      getCachedSenderAddresses: () => [],
+    });
+
+    client.connect();
+    try {
+      const frame = await env.awaitHandshake("sc-report-empty");
+      expect(frame.type).toBe("register");
+      expect(frame.cachedSenderAddresses).toBeUndefined();
     } finally {
       client.close();
     }

--- a/packages/hub-agent/src/ws/hub-link-sender-key-rotation.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-sender-key-rotation.test.ts
@@ -1,0 +1,306 @@
+// End-to-end proof of INTR-520: a user-principal sender key that rotates while
+// a sidecar is disconnected is reconciled into the sidecar's SenderKeyCache when
+// it reconnects. This exercises the whole loop against real components -- a real
+// HubLink, a real SenderKeyCache, and a real hub-side createSidecarRouter -- so
+// the pieces the per-commit unit tests cover in isolation are proven to compose:
+//
+//   1. The sidecar reports its cached rotatable senders on the reconnect frame.
+//   2. The hub re-resolves each reported sender's CURRENT key (a per-call DB
+//      lookup, so it sees the rotation) and pushes a sender.key.refresh.
+//   3. The sidecar applies the pushed key to its cache.
+//
+// The reconnecting sidecar loads its cache cold from the same data dir the first
+// connection persisted to, modelling a real drop-and-reconnect where the cache
+// survives on disk. The reconnect connect carries a restored workflow address so
+// it emits a genuine `reconnect` frame (not `register`), pinning both hub
+// handshake paths to this behavior.
+
+import { describe, test, expect, afterEach } from "bun:test";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { Hono } from "hono";
+import { upgradeWebSocket, websocket } from "hono/bun";
+import {
+  createSidecarRouter,
+  type SidecarAuthenticator,
+  type WsHandle,
+} from "@intx/hub-sessions";
+import { createInMemoryTransport } from "@intx/mail-memory";
+import { hexDecode, hexEncode } from "@intx/types";
+
+import { createHubLink, type DeployRouter } from "./hub-link";
+import { createSenderKeyCache } from "../sender-key-cache";
+import type { AgentKeyStore } from "../agent-key-store";
+import type { SessionManager } from "../session-manager";
+
+// ---------------------------------------------------------------------------
+// Minimal link dependencies. The rotation loop touches only the sender cache
+// wiring, so the deploy/session/key stubs exist only to satisfy the config.
+// ---------------------------------------------------------------------------
+
+function createStubKeyStore(): AgentKeyStore {
+  return {
+    async loadOrGenerateKey(address: string) {
+      throw new Error(`No key registered for ${address} in test store`);
+    },
+    recordHubKey: () => undefined,
+    verifyDeployCommit: () => Promise.resolve(true),
+    forgetAgent: () => undefined,
+  };
+}
+
+function createStubDeployRouter(): DeployRouter {
+  return {
+    async deploy() {
+      return { publicKey: "aa".repeat(32) };
+    },
+  };
+}
+
+function createStubSessionManager(): SessionManager {
+  return {
+    initRepo: () => Promise.resolve(),
+    applyDeployPack: () => Promise.resolve(),
+    applyAssetPack: () => Promise.resolve(),
+    createStatePack: () =>
+      Promise.resolve({
+        pack: new Uint8Array([1, 2, 3]),
+        commitSha: "abc123",
+        ref: "refs/heads/main",
+      }),
+    deleteAgentDir: () => Promise.resolve(),
+    getAddresses: () => [],
+    getSessionId: () => undefined,
+  };
+}
+
+async function writeFileDurable(
+  filePath: string,
+  contents: string,
+): Promise<void> {
+  await fs.writeFile(filePath, contents);
+}
+
+const tempDirs: string[] = [];
+
+async function tempDir(): Promise<string> {
+  const d = await fs.mkdtemp(path.join(os.tmpdir(), "sender-key-rotation-"));
+  tempDirs.push(d);
+  return d;
+}
+
+afterEach(async () => {
+  const dirs = tempDirs.splice(0);
+  await Promise.all(
+    dirs.map((d) => fs.rm(d, { recursive: true, force: true })),
+  );
+});
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 2000,
+): Promise<void> {
+  const start = Date.now();
+  while (!(await predicate())) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+    }
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+function makeKey(seed: number): Uint8Array {
+  const key = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) key[i] = (seed + i) & 0xff;
+  return key;
+}
+
+// ---------------------------------------------------------------------------
+// Test server: a real createSidecarRouter behind a ws server. It fences the
+// reporting sidecar's allocation and pins its workflow address from the
+// handshake frame (mirroring the production allocation-authenticated flow), and
+// records the handshake frame types so the test can assert a real reconnect.
+// ---------------------------------------------------------------------------
+
+type AllocatedIdentity = Extract<
+  Awaited<ReturnType<SidecarAuthenticator>>,
+  { kind: "allocated" }
+>;
+
+function startRotationServer(
+  resolveSenderKey: (address: string) => Promise<string | null>,
+) {
+  const observedHandshakes: string[] = [];
+  // Memoize one mutable identity per sidecarId so the handshake frame can pin
+  // its workflow address before authentication reads it back (mirroring the
+  // production allocation-authenticated reconnect flow).
+  const identities = new Map<string, AllocatedIdentity>();
+  function ensureIdentity(sidecarId: string): AllocatedIdentity {
+    const existing = identities.get(sidecarId);
+    if (existing !== undefined) return existing;
+    const identity: AllocatedIdentity = {
+      kind: "allocated",
+      sidecarId,
+      allocationId: `allocation-${sidecarId}`,
+      tenantId: "tenant-test",
+      anchorRunId: `anchor-${sidecarId}`,
+      workflowRunAddress: "workflow",
+      generation: 1,
+    };
+    identities.set(sidecarId, identity);
+    return identity;
+  }
+
+  const router = createSidecarRouter({
+    authenticateSidecar: async ({ sidecarId }) => ensureIdentity(sidecarId),
+    validateSidecarIdentity: async () => true,
+    hubPublicKey: "a".repeat(64),
+    requestTimeoutMs: 5000,
+    lookups: { resolveSenderKey },
+  });
+
+  function prepareHandshake(data: string): void {
+    const raw: unknown = JSON.parse(data);
+    if (
+      typeof raw !== "object" ||
+      raw === null ||
+      !("type" in raw) ||
+      (raw.type !== "register" && raw.type !== "reconnect") ||
+      !("sidecarId" in raw) ||
+      typeof raw.sidecarId !== "string"
+    ) {
+      return;
+    }
+    observedHandshakes.push(raw.type);
+    router.fenceAllocation(`allocation-${raw.sidecarId}`, 1);
+    const identity = ensureIdentity(raw.sidecarId);
+    const addresses =
+      "agentAddresses" in raw && Array.isArray(raw.agentAddresses)
+        ? raw.agentAddresses
+        : [];
+    if (addresses.length === 1 && typeof addresses[0] === "string") {
+      // The identity's workflowRunAddress is readonly on the type; the
+      // production allocation flow pins it from the frame the same way.
+      Object.assign(identity, { workflowRunAddress: addresses[0] });
+    }
+  }
+
+  const app = new Hono();
+  app.get(
+    "/ws",
+    upgradeWebSocket(() => {
+      let handle: WsHandle;
+      return {
+        onOpen(_evt, ws) {
+          handle = {
+            send: (data: string) => ws.send(data),
+            close: () => ws.close(),
+          };
+          router.handleOpen(handle);
+        },
+        onMessage(evt) {
+          if (typeof evt.data !== "string") return;
+          prepareHandshake(evt.data);
+          router.handleMessage(handle, evt.data);
+        },
+        onClose() {
+          router.handleClose(handle);
+        },
+      };
+    }),
+  );
+
+  const server = Bun.serve({ fetch: app.fetch, websocket, port: 0 });
+  return { server, router, observedHandshakes };
+}
+
+describe("hub-link sender-key rotation on reconnect", () => {
+  test("a key rotated during the offline window lands in the cache on reconnect", async () => {
+    const sender = "usr_sender@tenant.example";
+    const oldKey = makeKey(1);
+    const newKey = makeKey(2);
+    let currentKey = hexEncode(oldKey);
+    const { server, router, observedHandshakes } = startRotationServer(
+      (address) => Promise.resolve(address === sender ? currentKey : null),
+    );
+
+    const dataDir = await tempDir();
+    const sidecarId = "sc-rotation";
+    const hubURL = `ws://localhost:${server.port}/ws`;
+
+    try {
+      // The sidecar already holds the sender's OLD key before it ever connects.
+      const seedCache = await createSenderKeyCache({
+        dataDir,
+        writeFileDurable,
+      });
+      await seedCache.put(sender, oldKey);
+
+      // First connection: a live session that will drop. It reports the cached
+      // sender and the hub pushes the still-current OLD key (a no-op refresh).
+      const firstCache = await createSenderKeyCache({
+        dataDir,
+        writeFileDurable,
+      });
+      const first = createHubLink({
+        hubURL,
+        sidecarId,
+        token: "test-token",
+        transport: createInMemoryTransport(),
+        sessions: createStubSessionManager(),
+        keyStore: createStubKeyStore(),
+        resolveSenderCrypto: () => undefined,
+        cacheSenderKey: (address, publicKey) =>
+          firstCache.put(address, hexDecode(publicKey)),
+        deployRouter: createStubDeployRouter(),
+        getCachedSenderAddresses: () => firstCache.rotatableAddresses(),
+      });
+      first.connect();
+      await waitFor(() => router.getConnectedSidecars().includes(sidecarId));
+      first.close();
+      await waitFor(() => !router.getConnectedSidecars().includes(sidecarId));
+
+      // The key rotates hub-side while the sidecar is disconnected.
+      currentKey = hexEncode(newKey);
+
+      // The sidecar reconnects, cold-loading its cache from the same data dir.
+      // A restored workflow address makes this a genuine `reconnect` frame.
+      const reconnectCache = await createSenderKeyCache({
+        dataDir,
+        writeFileDurable,
+      });
+      expect(reconnectCache.get(sender)).toEqual(oldKey);
+      const workflowAddress = "run_deploy@tenant.example";
+      const second = createHubLink({
+        hubURL,
+        sidecarId,
+        token: "test-token",
+        transport: createInMemoryTransport(),
+        sessions: createStubSessionManager(),
+        keyStore: createStubKeyStore(),
+        resolveSenderCrypto: () => undefined,
+        cacheSenderKey: (address, publicKey) =>
+          reconnectCache.put(address, hexDecode(publicKey)),
+        deployRouter: createStubDeployRouter(),
+        getWorkflowAddresses: () => [workflowAddress],
+        getCachedSenderAddresses: () => reconnectCache.rotatableAddresses(),
+      });
+      second.connect();
+      try {
+        // The refresh push is fire-and-forget, so poll for the cache to update.
+        await waitFor(() => {
+          const held = reconnectCache.get(sender);
+          return held !== undefined && held[0] === newKey[0];
+        });
+        expect(reconnectCache.get(sender)).toEqual(newKey);
+        expect(reconnectCache.get(sender)).not.toEqual(oldKey);
+        expect(observedHandshakes).toContain("reconnect");
+      } finally {
+        second.close();
+      }
+    } finally {
+      await server.stop(true);
+    }
+  });
+});

--- a/packages/hub-agent/src/ws/hub-link.test.ts
+++ b/packages/hub-agent/src/ws/hub-link.test.ts
@@ -157,14 +157,16 @@ function withTestDeployBindings(): {
   keyStore: AgentKeyStore & { registerKey(address: string, kp: KeyPair): void };
   deployRouter: DeployRouter;
   resolveSenderCrypto: () => undefined;
+  cacheSenderKey: () => Promise<void>;
 } {
   const keyStore = createTestKeyStore();
   return {
     keyStore,
     deployRouter: createTestDeployRouter(keyStore),
     // These tests do not exercise the inbound signature compare, so the shadow
-    // resolves no cached key.
+    // resolves no cached key and the refresh sink is a no-op.
     resolveSenderCrypto: () => undefined,
+    cacheSenderKey: async () => undefined,
   };
 }
 import type { KeyPair } from "@intx/types/runtime";
@@ -787,6 +789,7 @@ describe("sidecar↔hub integration", () => {
       sessions,
       keyStore,
       resolveSenderCrypto: () => undefined,
+      cacheSenderKey: async () => undefined,
       deployRouter: createTestDeployRouter(keyStore),
     });
 

--- a/packages/hub-agent/src/ws/hub-link.ts
+++ b/packages/hub-agent/src/ws/hub-link.ts
@@ -26,6 +26,7 @@ import {
   RepoId,
   type SignalDeliverFrame,
   type RunGrantsFrame,
+  type SenderKeyRefreshFrame,
   type SignalCorrelationRegisterFrame,
   type SignalCorrelationRegisterAckFrame,
   type DrainDeliverFrame,
@@ -511,6 +512,17 @@ export type HubLinkConfig = {
    */
   resolveSenderCrypto: (address: string) => CryptoProvider | undefined;
   /**
+   * Persists the hub-vouched public key for a sender address, overwriting any
+   * previously cached key. The link calls it on an inbound `sender.key.refresh`
+   * frame, passing the frame's hex-encoded key through unchanged. Source-opaque,
+   * the write peer of `resolveSenderCrypto`: the host builds it over the
+   * sidecar's sender-key cache (decode the hex, `put` the bytes) so the link
+   * never touches key material or decoding. Required, not optional, because its
+   * read peer is required and every composition that runs the link already holds
+   * the same cache.
+   */
+  cacheSenderKey: (address: string, publicKey: string) => Promise<void>;
+  /**
    * Routes every inbound `agent.deploy` frame. Production wiring
    * supplies a router that stages each deploy through the workflow-run
    * substrate: a provision-step frame primes a per-step repo, and a
@@ -703,6 +715,7 @@ export function createHubLink(config: HubLinkConfig): HubLink {
     sessions,
     keyStore,
     resolveSenderCrypto,
+    cacheSenderKey,
     deployRouter,
     mailInboundRouter,
     signalInboundRouter,
@@ -1223,6 +1236,34 @@ export function createHubLink(config: HubLinkConfig): HubLink {
     }
   }
 
+  async function handleSenderKeyRefresh(
+    frame: SenderKeyRefreshFrame,
+  ): Promise<void> {
+    // Address-keyed and cross-run: it caches one sender's current key and
+    // touches no run, so unlike `run.grants` a fault here has no run to poison.
+    // Swallow it after logging at ERROR -- there is no reply channel and the
+    // link must never wedge. A malformed key (bad hex, wrong length) is simply
+    // dropped. A transient cache-write fault is louder than it looks: the
+    // sidecar keeps the STALE key and verifies this sender's mail against it
+    // until the next reconnect re-pushes, so this push is best-effort, not
+    // delivery-guaranteed.
+    //
+    // Awaited inline on the message chain, NOT detached the way the
+    // `mail.inbound` durable write is: the co-resident `run.grants` handler also
+    // caches sender keys on this same chain, so serializing the refresh write
+    // keeps last-write-wins deterministic against a concurrent grants write for
+    // the same address. The fan-out is bounded (one frame per rotatable cached
+    // sender, once per reconnect), so the head-of-line cost stays far short of
+    // the heartbeat window; a detached write would trade that determinism for
+    // latency this low-volume path does not need.
+    try {
+      await cacheSenderKey(frame.address, frame.publicKey);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error`sender.key.refresh cache write failed for ${frame.address}: ${msg}`;
+    }
+  }
+
   async function handleSourcesUpdate(frame: SourcesUpdateFrame): Promise<void> {
     // `sources.update` is request/ack (the hub awaits a reply within its
     // request timeout), so every path answers `session.ack` or
@@ -1544,6 +1585,9 @@ export function createHubLink(config: HubLinkConfig): HubLink {
         break;
       case "run.grants":
         await handleRunGrants(frame);
+        break;
+      case "sender.key.refresh":
+        await handleSenderKeyRefresh(frame);
         break;
       case "drain.deliver":
         await handleDrainDeliver(frame);

--- a/packages/hub-agent/src/ws/hub-link.ts
+++ b/packages/hub-agent/src/ws/hub-link.ts
@@ -617,6 +617,19 @@ export type HubLinkConfig = {
    */
   getWorkflowAddresses?: () => string[];
   /**
+   * Returns the rotatable (non-run) sender addresses this sidecar holds cached
+   * keys for. Read at each (re)connect and reported on the register/reconnect
+   * frame so the Hub re-resolves and re-pushes each key, catching a rotation
+   * that landed while the sidecar was disconnected.
+   *
+   * Optional with an empty default, UNLIKE the required `cacheSenderKey`: this
+   * is a report-path reader whose empty result is a legitimate steady state (no
+   * cached senders, or a host with no sender substrate), the same shape as
+   * `getWorkflowAddresses`. `cacheSenderKey` sits on the receive path a sidecar
+   * must always be able to serve, so it is required; this one is not.
+   */
+  getCachedSenderAddresses?: () => string[];
+  /**
    * Invoked after the allocation-authenticated reconnect frame is written.
    * The Hub serializes that frame ahead of later pack frames on the same
    * socket, so the workflow-run pack pusher can safely re-drive a cancelled
@@ -726,6 +739,7 @@ export function createHubLink(config: HubLinkConfig): HubLink {
     applyWorkflowRunPack,
     workflowProbeExecutor = defaultWorkflowProbeExecutor,
     getWorkflowAddresses = () => [],
+    getCachedSenderAddresses = () => [],
     onWorkflowAddressesRoutable,
     onWorkflowAddressesUnroutable,
     pingIntervalMs = DEFAULT_PING_INTERVAL_MS,
@@ -1662,12 +1676,21 @@ export function createHubLink(config: HubLinkConfig): HubLink {
       // reconnect would expose a false empty inventory and let allocation
       // reconciliation restore Hub state over the live workflow.
       const restoredAddresses = getWorkflowAddresses();
+      // Report the sidecar's cached rotatable senders on both frames: the
+      // register-vs-reconnect choice turns on workflow-address presence, so a
+      // sidecar with cached senders but no restored workflow substrate still
+      // announces them on a register frame. Omit the field when empty to honor
+      // its additive-optional wire shape.
+      const cachedSenderAddresses = getCachedSenderAddresses();
+      const senderReport =
+        cachedSenderAddresses.length > 0 ? { cachedSenderAddresses } : {};
       if (restoredAddresses.length === 0) {
         completeHandshake(connection, {
           type: "register",
           sidecarId,
           token,
           agentAddresses: [],
+          ...senderReport,
         });
       } else {
         completeHandshake(connection, {
@@ -1675,6 +1698,7 @@ export function createHubLink(config: HubLinkConfig): HubLink {
           sidecarId,
           token,
           agentAddresses: restoredAddresses,
+          ...senderReport,
         });
       }
     });

--- a/packages/hub-sessions/src/ws/sidecar-events.ts
+++ b/packages/hub-sessions/src/ws/sidecar-events.ts
@@ -263,13 +263,16 @@ export type SidecarLookups = {
     raw: Uint8Array;
   }) => Promise<SidecarMailPersistedRow[]>;
 
-  /** Resolves the hub-held public key an inbound mail's authenticated sender
-   * signs with, hex-encoded, or `null` when the sender has no resolvable key
-   * (a run whose deploy is not yet acked, an address matching no known
-   * principal). The wire layer carries the result on the `mail.inbound` frame
-   * so the recipient verifies the signature locally against the hub-resolved
-   * key rather than the message's own spoofable From. Returns only the key
-   * string, not its source, so the recipient cannot branch on sender kind.
+  /** Resolves the hub-held public key a sender address signs with, hex-encoded,
+   * or `null` when the sender has no resolvable key (a run whose deploy is not
+   * yet acked, an address matching no known principal). Two consumers share it:
+   * the `mail.inbound` frame carries the result so a recipient verifies the
+   * signature locally against the hub-resolved key rather than the message's own
+   * spoofable From; and the register/reconnect handler re-resolves each cached
+   * sender the sidecar reports, pushing a `sender.key.refresh` so a key that
+   * rotated during the offline window reaches the sidecar cache. Returns only
+   * the key string, not its source, so the recipient cannot branch on sender
+   * kind.
    *
    * Best-effort: this NEVER throws. A resolution fault degrades to `null`
    * (logged at ERROR by the resolver), so a key-resolution problem can never

--- a/packages/hub-sessions/src/ws/sidecar-handler.test.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.test.ts
@@ -80,23 +80,59 @@ function createAllocatedRouter(
   return router;
 }
 
+function createSenderKeyRouter(
+  resolveSenderKey: (address: string) => Promise<string | null>,
+) {
+  const router = createSidecarRouter({
+    authenticateSidecar: async () => identity,
+    validateSidecarIdentity: async () => true,
+    hubPublicKey: "a".repeat(64),
+    requestTimeoutMs: 500,
+    lookups: { resolveSenderKey },
+  });
+  router.fenceAllocation(identity.allocationId, identity.generation);
+  return router;
+}
+
 async function connect(
   router: ReturnType<typeof createSidecarRouter>,
   agentAddresses: string[] = [],
+  handshake: {
+    frameType?: "register" | "reconnect";
+    cachedSenderAddresses?: string[];
+  } = {},
 ) {
   const ws = createMockWs();
   router.handleOpen(ws);
   router.handleMessage(
     ws,
     JSON.stringify({
-      type: "register",
+      type: handshake.frameType ?? "register",
       sidecarId: identity.sidecarId,
       token: "token",
       agentAddresses,
+      ...(handshake.cachedSenderAddresses !== undefined
+        ? { cachedSenderAddresses: handshake.cachedSenderAddresses }
+        : {}),
     }),
   );
   await tick();
   return ws;
+}
+
+async function waitForFrame(
+  ws: ReturnType<typeof createMockWs>,
+  predicate: (frame: Record<string, unknown>) => boolean,
+  tries = 25,
+): Promise<Record<string, unknown>> {
+  for (let attempt = 0; attempt < tries; attempt += 1) {
+    for (const raw of ws.sent) {
+      const frame: Record<string, unknown> = JSON.parse(raw);
+      if (predicate(frame)) return frame;
+    }
+    await tick();
+  }
+  throw new Error("expected frame was never sent");
 }
 
 describe("SidecarRouter allocation routing", () => {
@@ -147,6 +183,92 @@ describe("SidecarRouter allocation routing", () => {
 
     expect(ws.closed).toBe(false);
     expect(resynced).toEqual([runAddress]);
+  });
+
+  test("pushes a sender-key refresh for each reported cached sender", async () => {
+    const key = "ab".repeat(32);
+    const resolved: string[] = [];
+    const router = createSenderKeyRouter((address) => {
+      resolved.push(address);
+      return Promise.resolve(address === "usr_alice@exclusive" ? key : null);
+    });
+    const ws = await connect(router, [], {
+      cachedSenderAddresses: ["usr_alice@exclusive"],
+    });
+
+    const frame = await waitForFrame(
+      ws,
+      (f) => f.type === "sender.key.refresh",
+    );
+    expect(frame).toEqual({
+      type: "sender.key.refresh",
+      address: "usr_alice@exclusive",
+      publicKey: key,
+    });
+    expect(resolved).toEqual(["usr_alice@exclusive"]);
+  });
+
+  test("pushes the refresh on the reconnect path too", async () => {
+    const key = "cd".repeat(32);
+    const router = createSenderKeyRouter(() => Promise.resolve(key));
+    const ws = await connect(router, [], {
+      frameType: "reconnect",
+      cachedSenderAddresses: ["usr_carol@exclusive"],
+    });
+
+    const frame = await waitForFrame(
+      ws,
+      (f) => f.type === "sender.key.refresh",
+    );
+    expect(frame.address).toBe("usr_carol@exclusive");
+    expect(frame.publicKey).toBe(key);
+  });
+
+  test("skips a reported sender that resolves to no key", async () => {
+    const resolved: string[] = [];
+    const router = createSenderKeyRouter((address) => {
+      resolved.push(address);
+      return Promise.resolve(null);
+    });
+    const ws = await connect(router, [], {
+      cachedSenderAddresses: ["usr_ghost@exclusive"],
+    });
+    // Let the detached resync task run to completion.
+    await tick();
+    await tick();
+
+    // The resolver ran (the path executed) but nothing was pushed.
+    expect(resolved).toEqual(["usr_ghost@exclusive"]);
+    const refreshes = ws.sent
+      .map((raw): Record<string, unknown> => JSON.parse(raw))
+      .filter((f) => f.type === "sender.key.refresh");
+    expect(refreshes).toEqual([]);
+  });
+
+  test("skips a run address in the report without resolving it", async () => {
+    const key = "ef".repeat(32);
+    const resolved: string[] = [];
+    const router = createSenderKeyRouter((address) => {
+      resolved.push(address);
+      return Promise.resolve(key);
+    });
+    const ws = await connect(router, [], {
+      cachedSenderAddresses: ["run_job1@exclusive", "usr_bob@exclusive"],
+    });
+
+    await waitForFrame(
+      ws,
+      (f) =>
+        f.type === "sender.key.refresh" && f.address === "usr_bob@exclusive",
+    );
+    // The run address is filtered before resolution; only the user sender is
+    // resolved and refreshed.
+    expect(resolved).toEqual(["usr_bob@exclusive"]);
+    const refreshed = ws.sent
+      .map((raw): Record<string, unknown> => JSON.parse(raw))
+      .filter((f) => f.type === "sender.key.refresh")
+      .map((f) => f.address);
+    expect(refreshed).toEqual(["usr_bob@exclusive"]);
   });
 
   test("deploys only through the exact allocation target", async () => {

--- a/packages/hub-sessions/src/ws/sidecar-handler.test.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.test.ts
@@ -1,9 +1,18 @@
-import { describe, expect, test } from "bun:test";
+import {
+  describe,
+  expect,
+  test,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "bun:test";
 
 import { deriveWorkflowRunRepoId } from "@intx/workflow-deploy";
+import { configureSync, getConfig, resetSync } from "@intx/log";
 
 import {
   createSidecarRouter,
+  MAX_RESYNC_SENDER_ADDRESSES,
   type SidecarAuthIdentity,
   type WsHandle,
 } from "./sidecar-handler";
@@ -426,5 +435,111 @@ describe("SidecarRouter allocation routing", () => {
 
     expect(ws.closed).toBe(true);
     expect(await router.isAllocatedSidecarReady(target)).toBe(false);
+  });
+});
+
+type CapturedLog = {
+  category: readonly string[];
+  level: string;
+  message: readonly unknown[];
+};
+
+async function waitUntil(predicate: () => boolean, tries = 200): Promise<void> {
+  for (let attempt = 0; attempt < tries; attempt += 1) {
+    if (predicate()) return;
+    await tick();
+  }
+  throw new Error("condition was not met in time");
+}
+
+describe("SidecarRouter sender-key resync cap", () => {
+  const capturedLogs: CapturedLog[] = [];
+  let savedLogConfig: ReturnType<typeof getConfig>;
+
+  beforeAll(() => {
+    savedLogConfig = getConfig();
+    configureSync({
+      reset: true,
+      sinks: {
+        capture: (record) => {
+          capturedLogs.push({
+            category: record.category,
+            level: record.level,
+            message: record.message,
+          });
+        },
+      },
+      loggers: [
+        { category: [], lowestLevel: "debug", sinks: ["capture"] },
+        {
+          category: ["logtape", "meta"],
+          lowestLevel: "warning",
+          sinks: ["capture"],
+        },
+      ],
+    });
+  });
+
+  afterAll(() => {
+    if (savedLogConfig) {
+      configureSync({ reset: true, ...savedLogConfig });
+    } else {
+      resetSync();
+    }
+  });
+
+  beforeEach(() => {
+    capturedLogs.length = 0;
+  });
+
+  function capWarnings(): string[] {
+    return capturedLogs
+      .filter(
+        (r) =>
+          r.level === "warning" && r.message.join("").includes("resync cap"),
+      )
+      .map((r) => r.message.join(""));
+  }
+
+  function refreshAddresses(ws: ReturnType<typeof createMockWs>): unknown[] {
+    return ws.sent
+      .map((raw): Record<string, unknown> => JSON.parse(raw))
+      .filter((f) => f.type === "sender.key.refresh")
+      .map((f) => f.address);
+  }
+
+  test("resolves and refreshes every reported sender under the cap", async () => {
+    const key = "ab".repeat(32);
+    const router = createSenderKeyRouter(() => Promise.resolve(key));
+    const senders = ["usr_a@exclusive", "usr_b@exclusive", "usr_c@exclusive"];
+    const ws = await connect(router, [], { cachedSenderAddresses: senders });
+
+    await waitUntil(() => refreshAddresses(ws).length === senders.length);
+    expect([...refreshAddresses(ws)].sort()).toEqual([...senders].sort());
+    expect(capWarnings()).toEqual([]);
+  });
+
+  test("caps an over-large reported set and warns", async () => {
+    const key = "cd".repeat(32);
+    const router = createSenderKeyRouter(() => Promise.resolve(key));
+    const reported = Array.from(
+      { length: MAX_RESYNC_SENDER_ADDRESSES + 1 },
+      (_, i) => `usr_s${String(i)}@exclusive`,
+    );
+    // The cap runs on the de-duped set, so a generator collision would silently
+    // hollow the test; assert distinctness before the behavioral checks.
+    expect(new Set(reported).size).toBe(MAX_RESYNC_SENDER_ADDRESSES + 1);
+
+    const ws = await connect(router, [], { cachedSenderAddresses: reported });
+    await waitUntil(
+      () => refreshAddresses(ws).length >= MAX_RESYNC_SENDER_ADDRESSES,
+    );
+    // Let any erroneous extra send settle, then confirm the cap held exactly.
+    await tick();
+    expect(refreshAddresses(ws)).toHaveLength(MAX_RESYNC_SENDER_ADDRESSES);
+
+    const warnings = capWarnings();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain(String(MAX_RESYNC_SENDER_ADDRESSES + 1));
   });
 });

--- a/packages/hub-sessions/src/ws/sidecar-handler.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.ts
@@ -993,14 +993,16 @@ export function createSidecarRouter(
     switch (frame.type) {
       case "register": {
         const agentAddresses = frame.agentAddresses;
+        const cachedSenderAddresses = frame.cachedSenderAddresses ?? [];
         return authenticateHandshake(ws, frame, (identity) =>
-          handleRegister(ws, identity, agentAddresses),
+          handleRegister(ws, identity, agentAddresses, cachedSenderAddresses),
         );
       }
       case "reconnect": {
         const agentAddresses = frame.agentAddresses;
+        const cachedSenderAddresses = frame.cachedSenderAddresses ?? [];
         return authenticateHandshake(ws, frame, (identity) =>
-          handleReconnect(ws, identity, agentAddresses),
+          handleReconnect(ws, identity, agentAddresses, cachedSenderAddresses),
         );
       }
       case "agent.deploy.ack":
@@ -1194,6 +1196,7 @@ export function createSidecarRouter(
     ws: WsHandle,
     identity: SidecarAuthIdentity,
     agentAddresses: string[],
+    cachedSenderAddresses: string[],
   ): Promise<void> {
     if (allocationFences.get(identity.allocationId) !== identity.generation) {
       logger.warn`Rejected allocated sidecar ${identity.sidecarId}: allocation ${identity.allocationId} generation ${String(identity.generation)} is not fenced as current`;
@@ -1287,6 +1290,40 @@ export function createSidecarRouter(
         resyncCredentials(address);
       }
     }
+    // Reconcile the sidecar's cached sender keys, closing the offline window: a
+    // user-principal key that rotated while the sidecar was disconnected is
+    // re-resolved and pushed back now, so the recipient stops verifying that
+    // sender's mail against a stale key. Only allocated sidecars host a sender
+    // cache worth refreshing. Resolve and push SEQUENTIALLY in one detached
+    // task: registration is never blocked, and a large cache cannot fan out
+    // into one concurrent DB query per reported sender on every reconnect.
+    const resolveSenderKey = lookups.resolveSenderKey;
+    if (identity.kind === "allocated" && resolveSenderKey !== undefined) {
+      const rotatableSenders = new Set(cachedSenderAddresses);
+      void (async () => {
+        for (const address of rotatableSenders) {
+          // The sidecar already reports only non-run senders, but do not trust
+          // the report: a run sender's key is the immutable
+          // workflow_run.public_key and never needs a refresh, so skip it here
+          // too rather than couple correctness to the sidecar's filter.
+          if (isRunAddress(address)) continue;
+          // Best-effort: a deleted or unresolvable sender resolves to null (the
+          // resolver logs a genuine fault at ERROR itself), so skip it and never
+          // fail the reconnect over one sender.
+          const publicKey = await resolveSenderKey(address);
+          if (publicKey !== null) {
+            conn.send({ type: "sender.key.refresh", address, publicKey });
+          }
+        }
+      })().catch((cause) => {
+        // resolveSenderKey never throws, but conn.send (JSON.stringify + the
+        // socket write) can throw synchronously once the sidecar is gone. That
+        // means the connection left, so stop -- the remaining sends would fail
+        // the same way.
+        const message = cause instanceof Error ? cause.message : String(cause);
+        logger.warn`Sender-key resync for sidecar ${identity.sidecarId} stopped: ${message}`;
+      });
+    }
     logger.info`Provisioned sidecar ${identity.sidecarId} registered for allocation ${identity.allocationId} generation ${String(identity.generation)}`;
     await notifyAllocationWaiters(identity.allocationId);
     if (identity.kind === "allocated") {
@@ -1301,16 +1338,28 @@ export function createSidecarRouter(
     ws: WsHandle,
     identity: SidecarAuthIdentity,
     agentAddresses: string[],
+    cachedSenderAddresses: string[],
   ): Promise<void> {
-    await handleAllocatedRegister(ws, identity, agentAddresses);
+    await handleAllocatedRegister(
+      ws,
+      identity,
+      agentAddresses,
+      cachedSenderAddresses,
+    );
   }
 
   async function handleReconnect(
     ws: WsHandle,
     identity: SidecarAuthIdentity,
     agentAddresses: string[],
+    cachedSenderAddresses: string[],
   ): Promise<void> {
-    await handleAllocatedRegister(ws, identity, agentAddresses);
+    await handleAllocatedRegister(
+      ws,
+      identity,
+      agentAddresses,
+      cachedSenderAddresses,
+    );
   }
 
   async function handleMailOutbound(

--- a/packages/hub-sessions/src/ws/sidecar-handler.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.ts
@@ -464,6 +464,19 @@ const DEFAULT_PING_TIMEOUT_MS = 60_000;
 const DEFAULT_MAIL_ACK_RETRY_INTERVAL_MS = 10_000;
 const DEFAULT_MAIL_ACK_MAX_RETRIES = 5;
 
+// The hub re-resolves and re-pushes a key for each rotatable sender a sidecar
+// reports on (re)connect. A legitimate sidecar caches keys for tens, maybe low
+// hundreds of distinct user senders, so this cap sits well above ten times that
+// ceiling: it NEVER truncates a real report -- dropping a genuine sender would
+// leave its key stale, the exact failure this refresh exists to prevent. It
+// bounds only a hostile or buggy sidecar, since a compromised authenticated
+// sidecar could otherwise report an unbounded set and drive that many sequential
+// DB resolves on every reconnect. The cap lives in the handler, not on the
+// arktype frame schema, on purpose: rejecting an over-cap frame at parse would
+// fail the whole reconnect (a hard outage) rather than degrade gracefully to a
+// bounded refresh.
+export const MAX_RESYNC_SENDER_ADDRESSES = 2048;
+
 export function createSidecarRouter(
   config: SidecarRouterConfig,
 ): SidecarRouter & SidecarAllocationRouter {
@@ -1300,8 +1313,19 @@ export function createSidecarRouter(
     const resolveSenderKey = lookups.resolveSenderKey;
     if (identity.kind === "allocated" && resolveSenderKey !== undefined) {
       const rotatableSenders = new Set(cachedSenderAddresses);
+      // Resolve-don't-trust applied to input SIZE: bound the reported set before
+      // acting on it. Run addresses count toward the cap by design -- the
+      // isRunAddress skip below is inside the loop, so the iteration, and thus
+      // the DB resolves, can never exceed the cap regardless of the run/non-run
+      // mix. Over the cap, refresh the first MAX_RESYNC_SENDER_ADDRESSES and log
+      // the overflow so a misbehaving sidecar is detectable.
+      let sendersToResync = [...rotatableSenders];
+      if (sendersToResync.length > MAX_RESYNC_SENDER_ADDRESSES) {
+        logger.warn`Sidecar ${identity.sidecarId} reported ${String(sendersToResync.length)} cached sender addresses on allocation ${identity.allocationId} generation ${String(identity.generation)}, over the ${String(MAX_RESYNC_SENDER_ADDRESSES)} resync cap; refreshing the first ${String(MAX_RESYNC_SENDER_ADDRESSES)} and ignoring the rest`;
+        sendersToResync = sendersToResync.slice(0, MAX_RESYNC_SENDER_ADDRESSES);
+      }
       void (async () => {
-        for (const address of rotatableSenders) {
+        for (const address of sendersToResync) {
           // The sidecar already reports only non-run senders, but do not trust
           // the report: a run sender's key is the immutable
           // workflow_run.public_key and never needs a refresh, so skip it here

--- a/packages/types/src/sidecar.ts
+++ b/packages/types/src/sidecar.ts
@@ -35,6 +35,13 @@ export const RegisterFrame = type({
   sidecarId: "string",
   token: "string",
   agentAddresses: "string[]",
+  // The rotatable (non-run) sender addresses this sidecar holds cached keys
+  // for. The hub re-resolves each current key and re-pushes it on a
+  // `sender.key.refresh`, so a user-principal rotation that landed while the
+  // sidecar was disconnected reaches its cache. Additive-optional and omitted
+  // when empty: a sidecar with no cached senders (or a pre-upgrade one) sends
+  // no field, and the hub treats absence as "nothing to refresh".
+  "cachedSenderAddresses?": "string[]",
 });
 export type RegisterFrame = typeof RegisterFrame.infer;
 
@@ -48,6 +55,12 @@ export const ReconnectFrame = type({
   sidecarId: "string",
   token: "string",
   agentAddresses: "string[]",
+  // The rotatable (non-run) sender addresses this sidecar holds cached keys
+  // for; see `RegisterFrame`. Carried on both frames because the register vs
+  // reconnect choice turns on workflow-address presence, not sender-cache
+  // presence -- a sidecar that restored no workflow substrate still reports its
+  // cached senders on a register frame. Additive-optional, omitted when empty.
+  "cachedSenderAddresses?": "string[]",
 });
 export type ReconnectFrame = typeof ReconnectFrame.infer;
 

--- a/packages/types/src/sidecar.ts
+++ b/packages/types/src/sidecar.ts
@@ -334,6 +334,34 @@ export const RunGrantsFrame = type({
 export type RunGrantsFrame = typeof RunGrantsFrame.infer;
 
 /**
+ * Re-push the current public key the hub vouches for a cached sender, keyed by
+ * the sender's `address`. `publicKey` is the hex-encoded raw 32-byte Ed25519
+ * key, exactly as `SenderIdentity` carries it. The sidecar overwrites its cached
+ * key for `address` and touches nothing else -- no grants, no per-run state.
+ *
+ * The hub sends one per rotatable sender the sidecar reported on (re)connect,
+ * after re-resolving the sender's current key: a user-principal rotation that
+ * happened while the sidecar was disconnected lands on the sidecar this way.
+ *
+ * It is a dedicated frame rather than a reuse of two shapes it resembles.
+ * Not `SenderIdentity` (whose shape it currently matches): that type is a fact
+ * embedded in `run.grants`, so composing it would couple this command's wire
+ * contract to a grants-owned type. Not `run.grants`: a rotated key is
+ * address-keyed and cross-run, whereas grants are run-keyed, and routing this
+ * through the grants barrier would poison a healthy idle run on a transient
+ * cache-write fault and do a per-run durable write for a change that alters no
+ * grants. One address per frame keeps each key's cache write independently
+ * fallible -- a fault on one sender never fails the refresh of another -- which
+ * is the property a batched frame would give up.
+ */
+export const SenderKeyRefreshFrame = type({
+  type: "'sender.key.refresh'",
+  address: "string",
+  publicKey: "string",
+});
+export type SenderKeyRefreshFrame = typeof SenderKeyRefreshFrame.infer;
+
+/**
  * Deliver a workflow-host drain control payload to a multi-step
  * deployment's supervisor. The hub forwards the frame to the sidecar
  * that hosts the deployment named by `agentAddress` (the
@@ -1013,6 +1041,7 @@ export const HubFrame = type.or(
   SyncRequestFrame,
   SignalDeliverFrame,
   RunGrantsFrame,
+  SenderKeyRefreshFrame,
   SignalCorrelationRegisterAckFrame,
   DrainDeliverFrame,
   WorkflowProbeRequestFrame,

--- a/tests/workflow-deploy/boot-restore.bench.ts
+++ b/tests/workflow-deploy/boot-restore.bench.ts
@@ -379,7 +379,11 @@ async function buildRouter(args: {
       }),
       forgetAgent: () => undefined,
     } as unknown as Parameters<typeof createSidecarDeployRouter>[0]["keyStore"],
-    senderKeyCache: { get: () => undefined, put: async () => undefined },
+    senderKeyCache: {
+      get: () => undefined,
+      put: async () => undefined,
+      addresses: () => [],
+    },
     transport: args.transport,
     repoStore,
     signingKeySeed: signingKeyPair.privateKey,

--- a/tests/workflow-deploy/boot-restore.bench.ts
+++ b/tests/workflow-deploy/boot-restore.bench.ts
@@ -383,6 +383,7 @@ async function buildRouter(args: {
       get: () => undefined,
       put: async () => undefined,
       addresses: () => [],
+      rotatableAddresses: () => [],
     },
     transport: args.transport,
     repoStore,


### PR DESCRIPTION
## Summary

- On (re)connect the sidecar reports the sender addresses it has cached; the
  hub re-resolves each sender's current key and pushes the refreshed key back,
  so a user-principal key that rotated while the sidecar was disconnected no
  longer leaves a stale cached key (which would reject legitimate mail once
  verification enforces).
- The refresh rides a dedicated key-only frame that updates the sidecar's cache
  via `SenderKeyCache.put` alone — no grants rewrite, so a transient write fault
  logs at ERROR but never poisons a run.
- Only rotatable (user) senders are reported; the hub re-resolves every reported
  address itself rather than trusting the sidecar's filter, and caps the set it
  will resync so a hostile sidecar cannot drive unbounded resolution.

## Verification

- Lint, `tsc -b --noEmit --force`, the admin-ui bundle, and the full unit suite
  pass. The new behavior is covered by unit and integration tests that run in
  the unit suite: the key-only refresh handler (fault-swallowed, no poison,
  wrong-length rejected), the resolve-don't-trust hub resync across both the
  register and reconnect paths, the resync cap (over-cap truncates and warns,
  under-cap refreshes all), and the rotated-key reconnect end to end — a real
  `HubLink` + real `SenderKeyCache` + a cold-load-from-disk round trip.
- The real-process `test-workflow` end-to-end suite (the workflow-deploy
  reconnect tests) runs in CI as the authoritative end-to-end gate.

Closes INTR-520
