### PR TITLE
Harden the sidecar control-socket frames and sender-key cache

### DIFF
--- a/apps/hub/src/server.ts
+++ b/apps/hub/src/server.ts
@@ -35,6 +35,7 @@ import {
 } from "@intx/hub-sessions";
 import { generateKeyPair } from "@intx/crypto";
 import { hexEncode } from "@intx/types";
+import { MAX_SIDECAR_FRAME_BYTES } from "@intx/types/sidecar";
 import { upgradeWebSocket, websocket } from "hono/bun";
 import { setup, getLogger } from "@intx/log";
 
@@ -472,9 +473,27 @@ export async function createHubServer({
 
   log.info("Starting server on port {port}", { port });
 
+  // Cap the size of a frame the hub accepts from a sidecar. Bun's default
+  // (~16MB) sits below legitimate frames -- a large mail.outbound would trip it
+  // and Bun would CLOSE the sidecar's control socket, forcing a reconnect. Raise
+  // it above the largest legit received frame so only a genuinely oversized
+  // frame closes the connection. hono types the shared `websocket` handler with
+  // its minimal BunWebSocketHandler interface, which omits Bun's serve-level
+  // `maxPayloadLength`. The explicit `typeof websocket & { maxPayloadLength }`
+  // annotation adds the field with a nameable type -- both halves are portable,
+  // which keeps createHubServer's return type nameable, where an un-annotated
+  // inline spread infers an anonymous intersection that references hono's
+  // internal websocket type and trips TS2742 -- while still type-checking the
+  // option name so a future typo fails to compile rather than silently reverting
+  // to Bun's default.
+  const sidecarWebsocket: typeof websocket & { maxPayloadLength: number } = {
+    ...websocket,
+    maxPayloadLength: MAX_SIDECAR_FRAME_BYTES,
+  };
+
   return {
     fetch: app.fetch,
-    websocket,
+    websocket: sidecarWebsocket,
     port,
     idleTimeout: 0,
   };

--- a/apps/hub/src/server.ts
+++ b/apps/hub/src/server.ts
@@ -5,6 +5,7 @@ import {
   createSidecarAllocationStore,
   createWorkflowRunDispatchStore,
   resolveFrameSenderKey,
+  resolveSenderKey,
 } from "@intx/db";
 import { createEnvKeyCredentialCipher } from "@intx/crypto";
 import { hexDecode, type SidecarCapabilityRule } from "@intx/types";
@@ -245,6 +246,13 @@ export async function createHubServer({
     ),
     resolveSenderKey: (address) =>
       resolveFrameSenderKey(db, principalKeyStore, address),
+    // The strict sibling for reconnect reconciliation: it preserves the strict
+    // resolver's throw (a fault must be kept distinct from a confirmed absence
+    // so the handler evicts only a genuinely deleted sender, never on a fault),
+    // and unwraps the resolution to the hex key the handler pushes.
+    resolveSenderKeyStrict: async (address) =>
+      (await resolveSenderKey(db, principalKeyStore, address))?.publicKey ??
+      null,
   };
 
   const sidecarCredentials = createSidecarCredentialResolver({ db });

--- a/apps/sidecar/src/agent-key-registration-lifecycle.test.ts
+++ b/apps/sidecar/src/agent-key-registration-lifecycle.test.ts
@@ -255,6 +255,7 @@ describe("agent signing-key registration lifecycle on the host transport", () =>
       senderKeyCache: {
         get: () => undefined,
         put: async () => undefined,
+        evict: async () => undefined,
         addresses: () => [],
         rotatableAddresses: () => [],
       },

--- a/apps/sidecar/src/atomic-write.test.ts
+++ b/apps/sidecar/src/atomic-write.test.ts
@@ -3,7 +3,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { writeFileAtomicDurable } from "./atomic-write";
+import {
+  removeFileAtomicDurable,
+  writeFileAtomicDurable,
+} from "./atomic-write";
 
 async function makeDir(): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), "atomic-write-"));
@@ -96,6 +99,45 @@ describe("writeFileAtomicDurable", () => {
       writeFileAtomicDurable(file, "new", { mode: 0o600 }),
     ).rejects.toThrow();
     expect(await listNames(dir)).toEqual(["record.json"]);
+
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+});
+
+describe("removeFileAtomicDurable", () => {
+  test("removes an existing file", async () => {
+    const dir = await makeDir();
+    const file = path.join(dir, "record.json");
+    await fs.writeFile(file, "x");
+
+    await removeFileAtomicDurable(file);
+    expect(await listNames(dir)).toEqual([]);
+
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  test("is a no-op for an already-absent file", async () => {
+    const dir = await makeDir();
+    const file = path.join(dir, "never-existed.json");
+
+    // Idempotent: removing an absent file completes without throwing, so a
+    // re-driven eviction of an already-evicted key is not a fault.
+    await removeFileAtomicDurable(file);
+    expect(await listNames(dir)).toEqual([]);
+
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  test("leaves sibling files untouched", async () => {
+    const dir = await makeDir();
+    const target = path.join(dir, "target.json");
+    const sibling = path.join(dir, "keep.json");
+    await fs.writeFile(target, "gone");
+    await fs.writeFile(sibling, "stay");
+
+    await removeFileAtomicDurable(target);
+    expect(await listNames(dir)).toEqual(["keep.json"]);
+    expect(await fs.readFile(sibling, "utf8")).toBe("stay");
 
     await fs.rm(dir, { recursive: true, force: true });
   });

--- a/apps/sidecar/src/atomic-write.ts
+++ b/apps/sidecar/src/atomic-write.ts
@@ -10,7 +10,7 @@ import { open, rename, unlink } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import { getLogger } from "@intx/log";
-import { hexEncode } from "@intx/types";
+import { hasCode, hexEncode } from "@intx/types";
 
 const logger = getLogger(["interchange", "sidecar", "atomic-write"]);
 
@@ -75,5 +75,38 @@ export async function writeFileAtomicDurable(
     }
   } catch (err) {
     logger.warn`parent-dir fsync failed for ${path}; durability is degraded but the file is renamed and fsynced — ${err instanceof Error ? err.message : String(err)}`;
+  }
+}
+
+/**
+ * Remove `path` durably: unlink it, then fsync the parent directory so the
+ * removal survives a power loss. A raw `unlink` leaves the directory-entry
+ * removal in the OS's delayed-metadata window, so a power loss can resurrect
+ * the file -- for a cache whose on-disk entry is the restore source, a
+ * resurrected entry re-stales the cache. Idempotent: a file already absent is a
+ * completed removal, so ENOENT on the unlink is success.
+ *
+ * The parent-directory fsync mirrors `writeFileAtomicDurable`, including its
+ * degrade: a filesystem that rejects directory fsync (FAT/exFAT, some network
+ * mounts) only weakens durability -- the file is already unlinked -- so that
+ * failure is logged, not thrown. It runs unconditionally so a prior removal
+ * that unlinked but died before the fsync is made durable on the next attempt.
+ */
+export async function removeFileAtomicDurable(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch (err) {
+    if (!(hasCode(err) && err.code === "ENOENT")) throw err;
+  }
+
+  try {
+    const dirHandle = await open(dirname(path), "r");
+    try {
+      await dirHandle.sync();
+    } finally {
+      await dirHandle.close();
+    }
+  } catch (err) {
+    logger.warn`parent-dir fsync failed for ${path}; durability is degraded but the file is unlinked — ${err instanceof Error ? err.message : String(err)}`;
   }
 }

--- a/apps/sidecar/src/index.ts
+++ b/apps/sidecar/src/index.ts
@@ -54,7 +54,10 @@ import { createWorkflowClosureMaterializer } from "./workflow-closure-materializ
 import { MAX_INLINE_ASSET_PAYLOAD_BYTES } from "./source-asset-delivery";
 import { createWorkflowProbeExecutor } from "./workflow-probe-handler";
 import { loadOrMintSidecarKeypair } from "./signing-keypair";
-import { writeFileAtomicDurable } from "./atomic-write";
+import {
+  removeFileAtomicDurable,
+  writeFileAtomicDurable,
+} from "./atomic-write";
 
 await setup();
 
@@ -244,6 +247,7 @@ const senderKeyCache = await createSenderKeyCache({
   dataDir,
   writeFileDurable: (filePath, contents) =>
     writeFileAtomicDurable(filePath, contents, { mode: 0o600 }),
+  removeFileDurable: (filePath) => removeFileAtomicDurable(filePath),
 });
 
 // The read side of the same cache: the inbound signature shadow resolves a
@@ -456,6 +460,9 @@ const orchestrator = createSidecarOrchestrator({
   // handler rather than being masked here.
   cacheSenderKey: (address, publicKey) =>
     senderKeyCache.put(address, hexDecode(publicKey)),
+  // Evicting peer of `cacheSenderKey`: an inbound `sender.key.evict` frame
+  // durably removes a revoked sender's cached key through the same cache.
+  evictSenderKey: (address) => senderKeyCache.evict(address),
   mailInboundRouter: multistepMailRouter,
   signalInboundRouter: multistepSignalRouter,
   drainInboundRouter: multistepDrainRouter,

--- a/apps/sidecar/src/workflow-host-wiring-deploy-failure.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring-deploy-failure.test.ts
@@ -133,6 +133,7 @@ describe("deploy-failure registry leak", () => {
       senderKeyCache: {
         get: () => undefined,
         put: async () => undefined,
+        evict: async () => undefined,
         addresses: () => [],
         rotatableAddresses: () => [],
       },
@@ -222,6 +223,7 @@ describe("deploy-failure registry leak", () => {
       senderKeyCache: {
         get: () => undefined,
         put: async () => undefined,
+        evict: async () => undefined,
         addresses: () => [],
         rotatableAddresses: () => [],
       },
@@ -381,6 +383,7 @@ describe("deploy-failure registry leak", () => {
       senderKeyCache: {
         get: () => undefined,
         put: async () => undefined,
+        evict: async () => undefined,
         addresses: () => [],
         rotatableAddresses: () => [],
       },

--- a/apps/sidecar/src/workflow-host-wiring-undeploy-supervisor.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring-undeploy-supervisor.test.ts
@@ -266,6 +266,7 @@ describe("createSidecarDeployRouter multi-step undeploy shuts the supervisor dow
       senderKeyCache: {
         get: () => undefined,
         put: async () => undefined,
+        evict: async () => undefined,
         addresses: () => [],
         rotatableAddresses: () => [],
       },

--- a/apps/sidecar/src/workflow-host-wiring.test.ts
+++ b/apps/sidecar/src/workflow-host-wiring.test.ts
@@ -259,6 +259,7 @@ describe("createSidecarDeployRouter provision-step (no-spawn) mode", () => {
       senderKeyCache: {
         get: () => undefined,
         put: async () => undefined,
+        evict: async () => undefined,
         addresses: () => [],
         rotatableAddresses: () => [],
       },
@@ -859,6 +860,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
       senderKeyCache: opts.senderKeyCache ?? {
         get: () => undefined,
         put: async () => undefined,
+        evict: async () => undefined,
         addresses: () => [],
         rotatableAddresses: () => [],
       },
@@ -1550,6 +1552,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
             .catch(() => false));
         puts.push({ address, grantsExisted });
       },
+      evict: async () => undefined,
       addresses: () => [],
       rotatableAddresses: () => [],
     };
@@ -1600,6 +1603,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
       put: async () => {
         throw new Error("sender-key disk full");
       },
+      evict: async () => undefined,
       addresses: () => [],
       rotatableAddresses: () => [],
     };
@@ -1649,6 +1653,7 @@ describe("createSidecarDeployRouter multi-step branch", () => {
       put: async (address: string) => {
         puts.push(address);
       },
+      evict: async () => undefined,
       addresses: () => [],
       rotatableAddresses: () => [],
     };

--- a/packages/hub-agent/src/sender-crypto.test.ts
+++ b/packages/hub-agent/src/sender-crypto.test.ts
@@ -18,6 +18,7 @@ function stubCache(entries: Record<string, Uint8Array>): SenderKeyCache {
   return {
     get: (address) => map.get(address),
     put: async () => undefined,
+    evict: async () => undefined,
     addresses: () => [...map.keys()],
     rotatableAddresses: () => [...map.keys()].filter((a) => !isRunAddress(a)),
   };

--- a/packages/hub-agent/src/sender-key-cache.test.ts
+++ b/packages/hub-agent/src/sender-key-cache.test.ts
@@ -30,6 +30,13 @@ async function writeFileDurable(
   await fs.writeFile(filePath, contents);
 }
 
+// The durable-removal counterpart; `force` makes it idempotent like the
+// production `removeFileAtomicDurable`. Its atomicity/fsync are orthogonal to
+// what these tests assert.
+async function removeFileDurable(filePath: string): Promise<void> {
+  await fs.rm(filePath, { force: true });
+}
+
 function makeKey(seed: number): Uint8Array {
   const key = new Uint8Array(32);
   for (let i = 0; i < 32; i++) key[i] = (seed + i) & 0xff;
@@ -41,7 +48,11 @@ const senderKeysDir = (dataDir: string) => path.join(dataDir, "sender-keys");
 describe("SenderKeyCache", () => {
   test("caches a key and reads it back keyed on the full address", async () => {
     const dataDir = await tempDir();
-    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
 
     const address = "run_abc@tenant.example.com";
     await cache.put(address, makeKey(3));
@@ -53,17 +64,29 @@ describe("SenderKeyCache", () => {
 
   test("returns undefined for an unknown sender", async () => {
     const dataDir = await tempDir();
-    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     expect(cache.get("nobody@example.com")).toBeUndefined();
   });
 
   test("survives a restart by loading the keyring from disk", async () => {
     const dataDir = await tempDir();
-    const first = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const first = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     await first.put("alice@a.example", makeKey(5));
     await first.put("bob@b.example", makeKey(9));
 
-    const restarted = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const restarted = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     expect(restarted.get("alice@a.example")).toEqual(makeKey(5));
     expect(restarted.get("bob@b.example")).toEqual(makeKey(9));
   });
@@ -72,7 +95,11 @@ describe("SenderKeyCache", () => {
     // "a.b@c.example" and "a_b@c.example" both flatten to one filename under
     // the AgentKeyStore sanitize scheme; the injective hex filename must not.
     const dataDir = await tempDir();
-    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     await cache.put("a.b@c.example", makeKey(1));
     await cache.put("a_b@c.example", makeKey(2));
 
@@ -82,25 +109,41 @@ describe("SenderKeyCache", () => {
     const files = await fs.readdir(senderKeysDir(dataDir));
     expect(files).toHaveLength(2);
 
-    const restarted = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const restarted = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     expect(restarted.get("a.b@c.example")).toEqual(makeKey(1));
     expect(restarted.get("a_b@c.example")).toEqual(makeKey(2));
   });
 
   test("the latest write for an address wins", async () => {
     const dataDir = await tempDir();
-    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     await cache.put("rotator@example.com", makeKey(4));
     await cache.put("rotator@example.com", makeKey(8));
 
     expect(cache.get("rotator@example.com")).toEqual(makeKey(8));
-    const restarted = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const restarted = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     expect(restarted.get("rotator@example.com")).toEqual(makeKey(8));
   });
 
   test("skips a corrupt file on load without dropping the other keys", async () => {
     const dataDir = await tempDir();
-    const good = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const good = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     await good.put("good@example.com", makeKey(6));
 
     const dir = senderKeysDir(dataDir);
@@ -110,14 +153,22 @@ describe("SenderKeyCache", () => {
     // A stray temp file the way a crashed atomic write would leave one.
     await fs.writeFile(path.join(dir, "leftover.tmp.123.abcd"), "junk");
 
-    const restarted = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const restarted = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     expect(restarted.get("good@example.com")).toEqual(makeKey(6));
     expect(restarted.get("corrupt@example")).toBeUndefined();
   });
 
   test("skips a file whose envelope address does not match its filename", async () => {
     const dataDir = await tempDir();
-    await createSenderKeyCache({ dataDir, writeFileDurable });
+    await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     const dir = senderKeysDir(dataDir);
     await fs.mkdir(dir, { recursive: true });
     // File named for address A but carrying address B: a tamper/corruption the
@@ -131,14 +182,22 @@ describe("SenderKeyCache", () => {
       }),
     );
 
-    const restarted = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const restarted = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     expect(restarted.get("a@example.com")).toBeUndefined();
     expect(restarted.get("b@example.com")).toBeUndefined();
   });
 
   test("rejects a wrong-length key at put", async () => {
     const dataDir = await tempDir();
-    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     await expect(
       cache.put("short@example.com", new Uint8Array(16)),
     ).rejects.toThrow(/32/);
@@ -147,7 +206,11 @@ describe("SenderKeyCache", () => {
 
   test("reports exactly the addresses it holds a key for", async () => {
     const dataDir = await tempDir();
-    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     await cache.put("alice@a.example", makeKey(5));
     await cache.put("bob@b.example", makeKey(9));
 
@@ -159,7 +222,11 @@ describe("SenderKeyCache", () => {
 
   test("reports only rotatable (non-run) addresses for the reconnect report", async () => {
     const dataDir = await tempDir();
-    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     await cache.put("usr_alice@tenant.example", makeKey(5));
     await cache.put("run_job1@tenant.example", makeKey(9));
     await cache.put("usr_bob@tenant.example", makeKey(13));
@@ -178,13 +245,21 @@ describe("SenderKeyCache", () => {
     const dataDir = await tempDir();
     // No keyring dir exists yet, so loadFromDisk finds nothing: the cold-start
     // path the reconnect reporter hits before any key has been cached.
-    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     expect(cache.addresses()).toEqual([]);
   });
 
   test("returns a snapshot a later put does not retroactively mutate", async () => {
     const dataDir = await tempDir();
-    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     await cache.put("alice@a.example", makeKey(5));
 
     const snapshot = cache.addresses();
@@ -200,6 +275,7 @@ describe("SenderKeyCache", () => {
       writeFileDurable: async () => {
         throw new Error("disk full");
       },
+      removeFileDurable,
     });
     await expect(cache.put("faulty@example.com", makeKey(7))).rejects.toThrow(
       "disk full",
@@ -207,5 +283,66 @@ describe("SenderKeyCache", () => {
     // Memory is only updated after the durable write lands, so a failed write
     // must not leave a phantom key that a restart would not reproduce.
     expect(cache.get("faulty@example.com")).toBeUndefined();
+  });
+
+  test("evict durably removes a cached key from memory and disk", async () => {
+    const dataDir = await tempDir();
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
+    await cache.put("usr_alice@tenant.example", makeKey(5));
+    await cache.put("usr_bob@tenant.example", makeKey(9));
+
+    await cache.evict("usr_alice@tenant.example");
+
+    // Gone from memory, and its on-disk file is gone while the sibling remains.
+    expect(cache.get("usr_alice@tenant.example")).toBeUndefined();
+    expect(cache.get("usr_bob@tenant.example")).toEqual(makeKey(9));
+    const files = await fs.readdir(senderKeysDir(dataDir));
+    expect(files).toHaveLength(1);
+
+    // A restart does not resurrect the evicted key.
+    const restarted = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
+    expect(restarted.get("usr_alice@tenant.example")).toBeUndefined();
+    expect(restarted.get("usr_bob@tenant.example")).toEqual(makeKey(9));
+  });
+
+  test("evict is a no-op for an address the cache does not hold", async () => {
+    const dataDir = await tempDir();
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
+    // Idempotent: removing an absent address neither throws nor disturbs others.
+    await cache.put("usr_bob@tenant.example", makeKey(9));
+    await cache.evict("usr_ghost@tenant.example");
+    expect(cache.get("usr_bob@tenant.example")).toEqual(makeKey(9));
+  });
+
+  test("a failed durable removal keeps the key in memory", async () => {
+    const dataDir = await tempDir();
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable: async () => {
+        throw new Error("unlink failed");
+      },
+    });
+    await cache.put("usr_alice@tenant.example", makeKey(5));
+
+    // Disk-first, symmetric with put: the durable removal is awaited before the
+    // map delete, so a removal fault throws and leaves BOTH stores holding the
+    // key -- a restart would otherwise reload a key the caller believed evicted.
+    await expect(cache.evict("usr_alice@tenant.example")).rejects.toThrow(
+      "unlink failed",
+    );
+    expect(cache.get("usr_alice@tenant.example")).toEqual(makeKey(5));
   });
 });

--- a/packages/hub-agent/src/sender-key-cache.ts
+++ b/packages/hub-agent/src/sender-key-cache.ts
@@ -13,9 +13,12 @@
 // FOREIGN senders' public keys only. There is no private material here.
 //
 // The hub owns key freshness -- it re-pushes a rotated key on the next
-// grant or reconnect -- so the cache has no TTL, generation, or eviction.
-// A second entry for an address overwrites the first; the latest push
-// wins.
+// grant or reconnect -- so the cache has no TTL or generation. A second
+// entry for an address overwrites the first; the latest push wins.
+// Eviction is revocation-driven, not time-driven: the hub sends a
+// `sender.key.evict` when it re-resolves a reported cached sender to no
+// durable key (a deleted principal), and the cache durably removes it so a
+// power loss cannot resurrect a key the hub no longer vouches for.
 //
 // The whole keyring is loaded into memory at construction, so `get` is a
 // synchronous memory read on the inbound-verify path and a restart sees
@@ -52,6 +55,14 @@ export type SenderKeyCacheDeps = {
    * durable-write primitive.
    */
   writeFileDurable: (path: string, contents: string) => Promise<void>;
+  /**
+   * Durably remove the file at `path` (unlink + parent-dir fsync). Injected
+   * from the same durable-primitive owner as `writeFileDurable`. A raw unlink
+   * can be resurrected by a power loss, re-staling the cache with a key the hub
+   * revoked -- the exact failure eviction exists to prevent -- so the removal
+   * must be as durable as the write it reverses.
+   */
+  removeFileDurable: (path: string) => Promise<void>;
 };
 
 export type SenderKeyCache = {
@@ -69,6 +80,15 @@ export type SenderKeyCache = {
    * resolves.
    */
   put(address: string, publicKey: Uint8Array): Promise<void>;
+  /**
+   * Remove the cached key for `address`, durably deleting its on-disk entry
+   * before dropping it from memory. Disk-first mirrors `put`'s write-then-set:
+   * the map is rebuilt from disk on construction, so if the durable removal
+   * fails and throws, both stores still hold the key (consistent, and the next
+   * reconnect retries) rather than a memory-evicted key resurrecting from disk
+   * on restart. A no-op for an address the cache does not hold.
+   */
+  evict(address: string): Promise<void>;
   /**
    * A snapshot of every address the cache currently holds a key for. Returns a
    * fresh array, decoupled from the backing map, so a later `put` does not
@@ -94,7 +114,7 @@ export type SenderKeyCache = {
 export async function createSenderKeyCache(
   deps: SenderKeyCacheDeps,
 ): Promise<SenderKeyCache> {
-  const { dataDir, writeFileDurable } = deps;
+  const { dataDir, writeFileDurable, removeFileDurable } = deps;
   const dir = path.join(dataDir, SENDER_KEYS_DIR_NAME);
   const keys = new Map<string, Uint8Array>();
 
@@ -179,7 +199,12 @@ export async function createSenderKeyCache(
     keys.set(address, publicKey);
   }
 
+  async function evict(address: string): Promise<void> {
+    await removeFileDurable(keyPath(address));
+    keys.delete(address);
+  }
+
   await loadFromDisk();
 
-  return { get, put, addresses, rotatableAddresses };
+  return { get, put, evict, addresses, rotatableAddresses };
 }

--- a/packages/hub-agent/src/sidecar-orchestrator-probe.test.ts
+++ b/packages/hub-agent/src/sidecar-orchestrator-probe.test.ts
@@ -172,6 +172,7 @@ describe("createSidecarOrchestrator workflow-probe threading", () => {
       },
       resolveSenderCrypto: () => undefined,
       cacheSenderKey: async () => undefined,
+      evictSenderKey: async () => undefined,
       createDeployRouter: () => ({
         deploy: () => Promise.resolve({ publicKey: "aa".repeat(32) }),
       }),

--- a/packages/hub-agent/src/sidecar-orchestrator.ts
+++ b/packages/hub-agent/src/sidecar-orchestrator.ts
@@ -116,6 +116,13 @@ export type SidecarOrchestratorConfig = {
    */
   cacheSenderKey: (address: string, publicKey: string) => Promise<void>;
   /**
+   * Durably removes a sender's cached key. The host builds it over the same
+   * sender-key cache as `cacheSenderKey` and the orchestrator forwards it
+   * unchanged to `createHubLink`, where an inbound `sender.key.evict` frame
+   * drives it.
+   */
+  evictSenderKey: (address: string) => Promise<void>;
+  /**
    * Host-injected `DeployRouter` factory. The orchestrator calls it
    * once after `sessions` and `keyStore` are constructed; the
    * returned router routes every `agent.deploy` frame on the link.
@@ -245,6 +252,7 @@ export function createSidecarOrchestrator(
     cryptoOps,
     resolveSenderCrypto,
     cacheSenderKey,
+    evictSenderKey,
     createDeployRouter,
     mailInboundRouter,
     signalInboundRouter,
@@ -338,6 +346,7 @@ export function createSidecarOrchestrator(
     keyStore,
     resolveSenderCrypto,
     cacheSenderKey,
+    evictSenderKey,
     deployRouter,
     applyWorkflowRunPack,
     ...(mailInboundRouter !== undefined ? { mailInboundRouter } : {}),

--- a/packages/hub-agent/src/ws/hub-link-bootstrap-prune.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-bootstrap-prune.test.ts
@@ -298,6 +298,7 @@ describe("hub-link workflow-run pack bootstrap prune", () => {
       keyStore,
       resolveSenderCrypto: () => undefined,
       cacheSenderKey: async () => undefined,
+      evictSenderKey: async () => undefined,
       deployRouter: createTestDeployRouter(keyStore),
     });
 

--- a/packages/hub-agent/src/ws/hub-link-mail-body-cap.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-mail-body-cap.test.ts
@@ -124,6 +124,7 @@ function makeLink() {
     keyStore: unusedKeyStore,
     resolveSenderCrypto: () => undefined,
     cacheSenderKey: async () => undefined,
+    evictSenderKey: async () => undefined,
     deployRouter: unusedDeployRouter,
   });
   return { capture, link };

--- a/packages/hub-agent/src/ws/hub-link-mail-body-cap.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-mail-body-cap.test.ts
@@ -1,0 +1,252 @@
+// The sidecar refuses to emit an over-cap `mail.outbound` frame. The two send
+// paths handle it differently and this pins both: the remote-send handler
+// throws (it is awaited through the transport, so the producing agent gets a
+// real error), while the post-delivery audit handler logs and skips (a throw
+// there is swallowed by the transport's Promise.allSettled, so throwing would
+// be an invisible dead check). The hub re-enforces the cap on receive -- that
+// is the authoritative DoS backstop, covered separately in the hub-sessions
+// suite; these send-side checks are the producer-facing complement.
+//
+// The two handlers are captured through a fake transport and invoked directly,
+// so the test needs no live socket: `createHubLink` only touches the transport
+// to register these handlers.
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "bun:test";
+import { MAX_MAIL_OUTBOUND_BODY_BYTES } from "@intx/types/sidecar";
+import type {
+  HubTransport,
+  RemoteSendHandler,
+  MessageSentHandler,
+} from "@intx/mail-memory";
+import { configureSync, getConfig, resetSync } from "@intx/log";
+
+import { createHubLink, type DeployRouter } from "./hub-link";
+import type { AgentKeyStore } from "../agent-key-store";
+import type { SessionManager } from "../session-manager";
+
+// A transport that captures the two send handlers `createHubLink` registers and
+// nothing else -- construction never calls the remaining methods, so they guard
+// against accidental use rather than model real behavior.
+function createCapturingTransport(): {
+  transport: HubTransport;
+  remoteSend: () => RemoteSendHandler;
+  messageSent: () => MessageSentHandler;
+} {
+  let remoteSend: RemoteSendHandler | undefined;
+  let messageSent: MessageSentHandler | undefined;
+  const transport: HubTransport = {
+    register: () => undefined,
+    unregister: () => undefined,
+    getTransportFor: () => {
+      throw new Error("getTransportFor is not used in this test");
+    },
+    deliver: () => undefined,
+    setRemoteSendHandler: (handler) => {
+      remoteSend = handler;
+    },
+    addMessageSentHandler: (handler) => {
+      messageSent = handler;
+    },
+  };
+  return {
+    transport,
+    remoteSend: () => {
+      if (remoteSend === undefined) throw new Error("remote handler not set");
+      return remoteSend;
+    },
+    messageSent: () => {
+      if (messageSent === undefined)
+        throw new Error("messageSent handler not set");
+      return messageSent;
+    },
+  };
+}
+
+// The deploy/session/key deps are required by the config but never reached by
+// the send-cap paths; they throw if misused rather than model behavior.
+const unusedSessions: SessionManager = {
+  initRepo: () => {
+    throw new Error("sessions not used");
+  },
+  applyDeployPack: () => {
+    throw new Error("sessions not used");
+  },
+  applyAssetPack: () => {
+    throw new Error("sessions not used");
+  },
+  createStatePack: () => {
+    throw new Error("sessions not used");
+  },
+  deleteAgentDir: () => {
+    throw new Error("sessions not used");
+  },
+  getAddresses: () => [],
+  // Reached only on the within-cap audit path; returns no session id.
+  getSessionId: () => undefined,
+};
+
+const unusedKeyStore: AgentKeyStore = {
+  loadOrGenerateKey: () => {
+    throw new Error("keyStore not used");
+  },
+  recordHubKey: () => {
+    throw new Error("keyStore not used");
+  },
+  verifyDeployCommit: () => {
+    throw new Error("keyStore not used");
+  },
+  forgetAgent: () => {
+    throw new Error("keyStore not used");
+  },
+};
+
+const unusedDeployRouter: DeployRouter = {
+  deploy: () => {
+    throw new Error("deployRouter not used");
+  },
+};
+
+function makeLink() {
+  const capture = createCapturingTransport();
+  const link = createHubLink({
+    hubURL: "ws://localhost:0/ws",
+    sidecarId: "sc-body-cap",
+    token: "test-token",
+    transport: capture.transport,
+    sessions: unusedSessions,
+    keyStore: unusedKeyStore,
+    resolveSenderCrypto: () => undefined,
+    cacheSenderKey: async () => undefined,
+    deployRouter: unusedDeployRouter,
+  });
+  return { capture, link };
+}
+
+// A rawMessage whose base64 encoding exceeds the body cap. base64 inflates by
+// ~4/3, so 44MB+1 raw bytes is comfortably over the 44MB base64 ceiling.
+const overCapRaw = new Uint8Array(MAX_MAIL_OUTBOUND_BODY_BYTES + 1);
+const smallRaw = new TextEncoder().encode("a legit little message");
+
+type CapturedLog = {
+  category: readonly string[];
+  level: string;
+  message: readonly unknown[];
+};
+
+const capturedLogs: CapturedLog[] = [];
+const savedLogConfig = getConfig();
+
+beforeAll(() => {
+  configureSync({
+    reset: true,
+    sinks: {
+      capture: (record) => {
+        capturedLogs.push({
+          category: record.category,
+          level: record.level,
+          message: record.message,
+        });
+      },
+    },
+    loggers: [
+      { category: [], lowestLevel: "debug", sinks: ["capture"] },
+      {
+        category: ["logtape", "meta"],
+        lowestLevel: "warning",
+        sinks: ["capture"],
+      },
+    ],
+  });
+});
+
+afterAll(() => {
+  if (savedLogConfig) {
+    configureSync({ reset: true, ...savedLogConfig });
+  } else {
+    resetSync();
+  }
+});
+
+function capErrors(): string[] {
+  return capturedLogs
+    .filter((r) => r.level === "error")
+    .map((r) => r.message.join(""));
+}
+
+describe("hub-link mail.outbound body cap", () => {
+  beforeEach(() => {
+    capturedLogs.length = 0;
+  });
+
+  test("the remote-send handler throws on an over-cap mail", async () => {
+    const { capture, link } = makeLink();
+    try {
+      await expect(
+        capture.remoteSend()(overCapRaw, ["r@example.test"], "s@example.test"),
+      ).rejects.toThrow(/exceeds the .* cap/);
+    } finally {
+      link.close();
+    }
+  });
+
+  test("the remote-send handler passes a within-cap mail", async () => {
+    const { capture, link } = makeLink();
+    try {
+      await capture.remoteSend()(
+        smallRaw,
+        ["r@example.test"],
+        "s@example.test",
+      );
+      // A legit-sized send does not trip the cap: no throw, no error log.
+      expect(capErrors()).toEqual([]);
+    } finally {
+      link.close();
+    }
+  });
+
+  test("the audit handler logs and skips an over-cap mail without throwing", async () => {
+    const { capture, link } = makeLink();
+    try {
+      // A throw here is swallowed by the transport, so the check must LOG.
+      await capture.messageSent()({
+        senderAddress: "s@example.test",
+        rawMessage: overCapRaw,
+        messageId: "mid-over",
+        recipients: ["r@example.test"],
+        to: ["r@example.test"],
+        cc: [],
+        localOnly: true,
+      });
+      const errors = capErrors();
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatch(/exceeds the .* cap/);
+    } finally {
+      link.close();
+    }
+  });
+
+  test("the audit handler passes a within-cap mail", async () => {
+    const { capture, link } = makeLink();
+    try {
+      await capture.messageSent()({
+        senderAddress: "s@example.test",
+        rawMessage: smallRaw,
+        messageId: "mid-ok",
+        recipients: ["r@example.test"],
+        to: ["r@example.test"],
+        cc: [],
+        localOnly: true,
+      });
+      expect(capErrors()).toEqual([]);
+    } finally {
+      link.close();
+    }
+  });
+});

--- a/packages/hub-agent/src/ws/hub-link-mail-router.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-mail-router.test.ts
@@ -101,6 +101,7 @@ function withTestDeployBindings(): {
   deployRouter: DeployRouter;
   resolveSenderCrypto: () => undefined;
   cacheSenderKey: () => Promise<void>;
+  evictSenderKey: () => Promise<void>;
 } {
   const keyStore = createTestKeyStore();
   return {
@@ -108,6 +109,7 @@ function withTestDeployBindings(): {
     deployRouter: createTestDeployRouter(keyStore),
     resolveSenderCrypto: () => undefined,
     cacheSenderKey: async () => undefined,
+    evictSenderKey: async () => undefined,
   };
 }
 

--- a/packages/hub-agent/src/ws/hub-link-sender-key-refresh.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-sender-key-refresh.test.ts
@@ -88,6 +88,10 @@ async function writeFileDurable(
   await fs.writeFile(filePath, contents);
 }
 
+async function removeFileDurable(filePath: string): Promise<void> {
+  await fs.rm(filePath, { force: true });
+}
+
 const tempDirs: string[] = [];
 
 async function tempDir(): Promise<string> {
@@ -242,6 +246,15 @@ function refreshErrors(): string[] {
     .map((r) => r.message.join(""));
 }
 
+function evictErrors(): string[] {
+  return capturedLogs
+    .filter(
+      (r) =>
+        r.level === "error" && r.message.join("").includes("sender.key.evict"),
+    )
+    .map((r) => r.message.join(""));
+}
+
 function createTestLink(
   cacheSenderKey: (address: string, publicKey: string) => Promise<void>,
   sidecarId: string,
@@ -249,6 +262,7 @@ function createTestLink(
     getWorkflowAddresses?: () => string[];
     getCachedSenderAddresses?: () => string[];
   },
+  evictSenderKey: (address: string) => Promise<void> = async () => undefined,
 ) {
   return createHubLink({
     hubURL: `ws://localhost:${env.server.port}/ws`,
@@ -259,6 +273,7 @@ function createTestLink(
     keyStore: createStubKeyStore(),
     resolveSenderCrypto: () => undefined,
     cacheSenderKey,
+    evictSenderKey,
     deployRouter: createStubDeployRouter(),
     ...(report?.getWorkflowAddresses !== undefined
       ? { getWorkflowAddresses: report.getWorkflowAddresses }
@@ -284,7 +299,11 @@ describe("hub-link sender.key.refresh", () => {
 
   test("updates the cache with the refreshed key through the real edge", async () => {
     const dataDir = await tempDir();
-    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     const client = createTestLink(
       (address, publicKey) => cache.put(address, hexDecode(publicKey)),
       "sc-refresh-ok",
@@ -347,7 +366,11 @@ describe("hub-link sender.key.refresh", () => {
   test("a wrong-length key is rejected without partially updating the cache", async () => {
     capturedLogs.length = 0;
     const dataDir = await tempDir();
-    const cache = await createSenderKeyCache({ dataDir, writeFileDurable });
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
     const client = createTestLink(
       (address, publicKey) => cache.put(address, hexDecode(publicKey)),
       "sc-refresh-badkey",
@@ -377,6 +400,77 @@ describe("hub-link sender.key.refresh", () => {
       });
       await waitFor(() => cache.get(goodAddress) !== undefined);
       expect(cache.get(goodAddress)).toEqual(goodKey);
+    } finally {
+      client.close();
+    }
+  });
+});
+
+describe("hub-link sender.key.evict", () => {
+  beforeAll(() => {
+    capturedLogs.length = 0;
+  });
+
+  test("removes the cached key through the real edge", async () => {
+    const dataDir = await tempDir();
+    const cache = await createSenderKeyCache({
+      dataDir,
+      writeFileDurable,
+      removeFileDurable,
+    });
+    const address = "usr_deleted@tenant.example";
+    await cache.put(address, makeKey(11));
+
+    const client = createTestLink(
+      noopCacheSenderKey,
+      "sc-evict-ok",
+      undefined,
+      (addr) => cache.evict(addr),
+    );
+
+    client.connect();
+    try {
+      const send = await env.awaitSend();
+      send({ type: "sender.key.evict", address });
+
+      await waitFor(() => cache.get(address) === undefined);
+      expect(cache.get(address)).toBeUndefined();
+      expect(evictErrors()).toHaveLength(0);
+    } finally {
+      client.close();
+    }
+  });
+
+  test("an eviction fault is logged and does not wedge later frames", async () => {
+    capturedLogs.length = 0;
+    let calls = 0;
+    const evicted: string[] = [];
+    const evictSenderKey = async (address: string) => {
+      calls += 1;
+      // Transient fault on the first evict; the second must still be processed,
+      // proving the swallowed throw did not wedge the message chain.
+      if (calls === 1) throw new Error("unlink failed");
+      evicted.push(address);
+    };
+    const client = createTestLink(
+      noopCacheSenderKey,
+      "sc-evict-fault",
+      undefined,
+      evictSenderKey,
+    );
+
+    client.connect();
+    try {
+      const send = await env.awaitSend();
+      send({ type: "sender.key.evict", address: "usr_faulty@tenant.example" });
+      send({ type: "sender.key.evict", address: "usr_second@tenant.example" });
+
+      await waitFor(() => evicted.length > 0);
+      expect(evicted).toEqual(["usr_second@tenant.example"]);
+      expect(calls).toBe(2);
+      const errors = evictErrors();
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("usr_faulty@tenant.example");
     } finally {
       client.close();
     }

--- a/packages/hub-agent/src/ws/hub-link-sender-key-rotation.test.ts
+++ b/packages/hub-agent/src/ws/hub-link-sender-key-rotation.test.ts
@@ -82,6 +82,10 @@ async function writeFileDurable(
   await fs.writeFile(filePath, contents);
 }
 
+async function removeFileDurable(filePath: string): Promise<void> {
+  await fs.rm(filePath, { force: true });
+}
+
 const tempDirs: string[] = [];
 
 async function tempDir(): Promise<string> {
@@ -129,7 +133,7 @@ type AllocatedIdentity = Extract<
 >;
 
 function startRotationServer(
-  resolveSenderKey: (address: string) => Promise<string | null>,
+  resolveSenderKeyStrict: (address: string) => Promise<string | null>,
 ) {
   const observedHandshakes: string[] = [];
   // Memoize one mutable identity per sidecarId so the handshake frame can pin
@@ -157,7 +161,7 @@ function startRotationServer(
     validateSidecarIdentity: async () => true,
     hubPublicKey: "a".repeat(64),
     requestTimeoutMs: 5000,
-    lookups: { resolveSenderKey },
+    lookups: { resolveSenderKeyStrict },
   });
 
   function prepareHandshake(data: string): void {
@@ -234,6 +238,7 @@ describe("hub-link sender-key rotation on reconnect", () => {
       const seedCache = await createSenderKeyCache({
         dataDir,
         writeFileDurable,
+        removeFileDurable,
       });
       await seedCache.put(sender, oldKey);
 
@@ -242,6 +247,7 @@ describe("hub-link sender-key rotation on reconnect", () => {
       const firstCache = await createSenderKeyCache({
         dataDir,
         writeFileDurable,
+        removeFileDurable,
       });
       const first = createHubLink({
         hubURL,
@@ -253,6 +259,7 @@ describe("hub-link sender-key rotation on reconnect", () => {
         resolveSenderCrypto: () => undefined,
         cacheSenderKey: (address, publicKey) =>
           firstCache.put(address, hexDecode(publicKey)),
+        evictSenderKey: (address) => firstCache.evict(address),
         deployRouter: createStubDeployRouter(),
         getCachedSenderAddresses: () => firstCache.rotatableAddresses(),
       });
@@ -269,6 +276,7 @@ describe("hub-link sender-key rotation on reconnect", () => {
       const reconnectCache = await createSenderKeyCache({
         dataDir,
         writeFileDurable,
+        removeFileDurable,
       });
       expect(reconnectCache.get(sender)).toEqual(oldKey);
       const workflowAddress = "run_deploy@tenant.example";
@@ -282,6 +290,7 @@ describe("hub-link sender-key rotation on reconnect", () => {
         resolveSenderCrypto: () => undefined,
         cacheSenderKey: (address, publicKey) =>
           reconnectCache.put(address, hexDecode(publicKey)),
+        evictSenderKey: (address) => reconnectCache.evict(address),
         deployRouter: createStubDeployRouter(),
         getWorkflowAddresses: () => [workflowAddress],
         getCachedSenderAddresses: () => reconnectCache.rotatableAddresses(),
@@ -295,6 +304,105 @@ describe("hub-link sender-key rotation on reconnect", () => {
         });
         expect(reconnectCache.get(sender)).toEqual(newKey);
         expect(reconnectCache.get(sender)).not.toEqual(oldKey);
+        expect(observedHandshakes).toContain("reconnect");
+      } finally {
+        second.close();
+      }
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("a sender deleted during the offline window is evicted from the cache on reconnect", async () => {
+    const sender = "usr_deleted@tenant.example";
+    const key = makeKey(3);
+    // The sender exists on the first connection and is hard-deleted before the
+    // reconnect. The strict resolver returns the key while it exists and a
+    // confirmed null once deleted -- the deleted-vs-fault distinction the evict
+    // path turns on.
+    let deleted = false;
+    const { server, router, observedHandshakes } = startRotationServer(
+      (address) =>
+        Promise.resolve(address === sender && !deleted ? hexEncode(key) : null),
+    );
+
+    const dataDir = await tempDir();
+    const sidecarId = "sc-evict-reconnect";
+    const hubURL = `ws://localhost:${server.port}/ws`;
+
+    try {
+      // The sidecar already holds the sender's key before it ever connects.
+      const seedCache = await createSenderKeyCache({
+        dataDir,
+        writeFileDurable,
+        removeFileDurable,
+      });
+      await seedCache.put(sender, key);
+
+      // First connection: the sender still exists, so the hub refreshes the
+      // unchanged key -- a no-op that leaves the cache holding it.
+      const firstCache = await createSenderKeyCache({
+        dataDir,
+        writeFileDurable,
+        removeFileDurable,
+      });
+      const first = createHubLink({
+        hubURL,
+        sidecarId,
+        token: "test-token",
+        transport: createInMemoryTransport(),
+        sessions: createStubSessionManager(),
+        keyStore: createStubKeyStore(),
+        resolveSenderCrypto: () => undefined,
+        cacheSenderKey: (address, publicKey) =>
+          firstCache.put(address, hexDecode(publicKey)),
+        evictSenderKey: (address) => firstCache.evict(address),
+        deployRouter: createStubDeployRouter(),
+        getCachedSenderAddresses: () => firstCache.rotatableAddresses(),
+      });
+      first.connect();
+      await waitFor(() => router.getConnectedSidecars().includes(sidecarId));
+      first.close();
+      await waitFor(() => !router.getConnectedSidecars().includes(sidecarId));
+
+      // The sender's principal is hard-deleted hub-side while the sidecar is
+      // disconnected: the strict resolver now returns a confirmed null for it.
+      deleted = true;
+
+      // The sidecar reconnects, cold-loading the cache (which still holds the
+      // now-revoked key) from the same data dir. A restored workflow address
+      // makes this a genuine `reconnect` frame.
+      const reconnectCache = await createSenderKeyCache({
+        dataDir,
+        writeFileDurable,
+        removeFileDurable,
+      });
+      // Precondition: the key IS present before reconnect, so the removal
+      // assertion below is non-vacuous -- were the evict path dropped, the key
+      // would remain and `get` would keep returning it (the reconnect refresh
+      // never re-adds a deleted sender's key).
+      expect(reconnectCache.get(sender)).toEqual(key);
+      const workflowAddress = "run_deploy@tenant.example";
+      const second = createHubLink({
+        hubURL,
+        sidecarId,
+        token: "test-token",
+        transport: createInMemoryTransport(),
+        sessions: createStubSessionManager(),
+        keyStore: createStubKeyStore(),
+        resolveSenderCrypto: () => undefined,
+        cacheSenderKey: (address, publicKey) =>
+          reconnectCache.put(address, hexDecode(publicKey)),
+        evictSenderKey: (address) => reconnectCache.evict(address),
+        deployRouter: createStubDeployRouter(),
+        getWorkflowAddresses: () => [workflowAddress],
+        getCachedSenderAddresses: () => reconnectCache.rotatableAddresses(),
+      });
+      second.connect();
+      try {
+        // The evict push is fire-and-forget, so poll for the cache to drop it.
+        await waitFor(() => reconnectCache.get(sender) === undefined);
+        expect(reconnectCache.get(sender)).toBeUndefined();
         expect(observedHandshakes).toContain("reconnect");
       } finally {
         second.close();

--- a/packages/hub-agent/src/ws/hub-link.test.ts
+++ b/packages/hub-agent/src/ws/hub-link.test.ts
@@ -158,15 +158,17 @@ function withTestDeployBindings(): {
   deployRouter: DeployRouter;
   resolveSenderCrypto: () => undefined;
   cacheSenderKey: () => Promise<void>;
+  evictSenderKey: () => Promise<void>;
 } {
   const keyStore = createTestKeyStore();
   return {
     keyStore,
     deployRouter: createTestDeployRouter(keyStore),
     // These tests do not exercise the inbound signature compare, so the shadow
-    // resolves no cached key and the refresh sink is a no-op.
+    // resolves no cached key and the refresh/evict sinks are no-ops.
     resolveSenderCrypto: () => undefined,
     cacheSenderKey: async () => undefined,
+    evictSenderKey: async () => undefined,
   };
 }
 import type { KeyPair } from "@intx/types/runtime";
@@ -790,6 +792,7 @@ describe("sidecar↔hub integration", () => {
       keyStore,
       resolveSenderCrypto: () => undefined,
       cacheSenderKey: async () => undefined,
+      evictSenderKey: async () => undefined,
       deployRouter: createTestDeployRouter(keyStore),
     });
 

--- a/packages/hub-agent/src/ws/hub-link.ts
+++ b/packages/hub-agent/src/ws/hub-link.ts
@@ -11,6 +11,7 @@ import type { HubTransport } from "@intx/mail-memory";
 import { type } from "arktype";
 import {
   HubFrame,
+  MAX_MAIL_OUTBOUND_BODY_BYTES,
   type SidecarFrame,
   type RegisterFrame,
   type ReconnectFrame,
@@ -865,6 +866,17 @@ export function createHubLink(config: HubLinkConfig): HubLink {
   transport.setRemoteSendHandler(
     async (rawMessage, recipients, senderAddress) => {
       const encoded = base64Encode(rawMessage);
+      // Fail loud at the source: this send is awaited through the transport, so
+      // a throw surfaces to the producing agent as a real error rather than the
+      // silent hub-side drop it would otherwise get. The hub re-enforces the cap
+      // on receive -- that is the authoritative DoS backstop; this is the
+      // producer-facing error.
+      const bodyBytes = Buffer.byteLength(encoded, "utf8");
+      if (bodyBytes > MAX_MAIL_OUTBOUND_BODY_BYTES) {
+        throw new Error(
+          `refusing to send mail.outbound from ${senderAddress}: rawMessage of ${String(bodyBytes)} bytes exceeds the ${String(MAX_MAIL_OUTBOUND_BODY_BYTES)}-byte cap`,
+        );
+      }
       send({
         type: "mail.outbound",
         rawMessage: encoded,
@@ -880,6 +892,16 @@ export function createHubLink(config: HubLinkConfig): HubLink {
   // handled by the RemoteSendHandler above.
   transport.addMessageSentHandler(async (ctx) => {
     const encoded = base64Encode(ctx.rawMessage);
+    // This is the post-delivery audit/projection forward; the mail already went
+    // out locally, so there is nothing left to fail. A throw here is swallowed
+    // (the transport runs message-sent handlers under Promise.allSettled), so
+    // an over-cap frame is logged loudly and skipped rather than thrown -- the
+    // hub would drop it on receive regardless.
+    const bodyBytes = Buffer.byteLength(encoded, "utf8");
+    if (bodyBytes > MAX_MAIL_OUTBOUND_BODY_BYTES) {
+      logger.error`Skipping delivered mail.outbound audit frame from ${ctx.senderAddress}: rawMessage of ${String(bodyBytes)} bytes exceeds the ${String(MAX_MAIL_OUTBOUND_BODY_BYTES)}-byte cap`;
+      return;
+    }
     const sessionId = sessions.getSessionId(ctx.senderAddress);
     send({
       type: "mail.outbound",

--- a/packages/hub-agent/src/ws/hub-link.ts
+++ b/packages/hub-agent/src/ws/hub-link.ts
@@ -28,6 +28,7 @@ import {
   type SignalDeliverFrame,
   type RunGrantsFrame,
   type SenderKeyRefreshFrame,
+  type SenderKeyEvictFrame,
   type SignalCorrelationRegisterFrame,
   type SignalCorrelationRegisterAckFrame,
   type DrainDeliverFrame,
@@ -524,6 +525,16 @@ export type HubLinkConfig = {
    */
   cacheSenderKey: (address: string, publicKey: string) => Promise<void>;
   /**
+   * Durably removes the cached key for a sender address. The link calls it on
+   * an inbound `sender.key.evict` frame, when the hub has re-resolved a reported
+   * cached sender to no durable key (a deleted principal). The evicting peer of
+   * `cacheSenderKey`: the host builds it over the sidecar's sender-key cache
+   * (`evict` the address) so the link never touches the cache directly. Required
+   * for the same reason as `cacheSenderKey` -- every composition that can cache
+   * a key must be able to evict one, and both share the one cache.
+   */
+  evictSenderKey: (address: string) => Promise<void>;
+  /**
    * Routes every inbound `agent.deploy` frame. Production wiring
    * supplies a router that stages each deploy through the workflow-run
    * substrate: a provision-step frame primes a per-step repo, and a
@@ -730,6 +741,7 @@ export function createHubLink(config: HubLinkConfig): HubLink {
     keyStore,
     resolveSenderCrypto,
     cacheSenderKey,
+    evictSenderKey,
     deployRouter,
     mailInboundRouter,
     signalInboundRouter,
@@ -1300,6 +1312,23 @@ export function createHubLink(config: HubLinkConfig): HubLink {
     }
   }
 
+  async function handleSenderKeyEvict(
+    frame: SenderKeyEvictFrame,
+  ): Promise<void> {
+    // Mirror of `handleSenderKeyRefresh` for the evict direction: address-keyed,
+    // cross-run, no reply channel, awaited inline on the message chain so it
+    // serializes deterministically against a concurrent refresh/grants write for
+    // the same address. A fault swallowed after logging at ERROR keeps the STALE
+    // key cached until the next reconnect re-evicts -- the evict is best-effort,
+    // not delivery-guaranteed, exactly like the refresh it complements.
+    try {
+      await evictSenderKey(frame.address);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error`sender.key.evict cache removal failed for ${frame.address}: ${msg}`;
+    }
+  }
+
   async function handleSourcesUpdate(frame: SourcesUpdateFrame): Promise<void> {
     // `sources.update` is request/ack (the hub awaits a reply within its
     // request timeout), so every path answers `session.ack` or
@@ -1624,6 +1653,9 @@ export function createHubLink(config: HubLinkConfig): HubLink {
         break;
       case "sender.key.refresh":
         await handleSenderKeyRefresh(frame);
+        break;
+      case "sender.key.evict":
+        await handleSenderKeyEvict(frame);
         break;
       case "drain.deliver":
         await handleDrainDeliver(frame);

--- a/packages/hub-api/src/workflow-run-trigger.test.ts
+++ b/packages/hub-api/src/workflow-run-trigger.test.ts
@@ -1,6 +1,11 @@
 import { describe, test, expect } from "bun:test";
 
-import { createWorkflowRunTrigger } from "./workflow-run-trigger";
+import { MAX_MAIL_OUTBOUND_BODY_BYTES } from "@intx/types/sidecar";
+
+import {
+  createWorkflowRunTrigger,
+  MAX_MAIL_BODY_BYTES,
+} from "./workflow-run-trigger";
 import type { PrincipalRow, TenantRow } from "./context";
 
 // The signing guard runs before any dependency is touched, so each dep is a
@@ -102,5 +107,17 @@ describe("triggerWorkflowRun signing-principal guard", () => {
         message: { content: "hi" },
       }),
     ).rejects.toThrow(/db must not be used/);
+  });
+});
+
+describe("mail body cap shared policy", () => {
+  test("the HTTP body cap and the frame body cap hold the same ceiling", () => {
+    // The inbound HTTP mail route caps its whole request body at
+    // MAX_MAIL_BODY_BYTES; the mail.outbound frame caps its rawMessage at
+    // @intx/types' MAX_MAIL_OUTBOUND_BODY_BYTES. They measure different
+    // quantities but must admit one mail of the same size, so they carry the
+    // same number. This is the one place both are visible (@intx/types cannot
+    // import @intx/hub-api), so it guards the shared policy against drift.
+    expect(MAX_MAIL_OUTBOUND_BODY_BYTES).toBe(MAX_MAIL_BODY_BYTES);
   });
 });

--- a/packages/hub-sessions/src/hub-session-lookups.ts
+++ b/packages/hub-sessions/src/hub-session-lookups.ts
@@ -51,6 +51,7 @@ export function createHubSessionLookups(
     | "materializeMailTriggeredRunGrants"
     | "resyncCredentials"
     | "resolveSenderKey"
+    | "resolveSenderKeyStrict"
   >
 > {
   const { db, agentRepoStore } = deps;

--- a/packages/hub-sessions/src/ws/sidecar-events.ts
+++ b/packages/hub-sessions/src/ws/sidecar-events.ts
@@ -265,20 +265,36 @@ export type SidecarLookups = {
 
   /** Resolves the hub-held public key a sender address signs with, hex-encoded,
    * or `null` when the sender has no resolvable key (a run whose deploy is not
-   * yet acked, an address matching no known principal). Two consumers share it:
-   * the `mail.inbound` frame carries the result so a recipient verifies the
-   * signature locally against the hub-resolved key rather than the message's own
-   * spoofable From; and the register/reconnect handler re-resolves each cached
-   * sender the sidecar reports, pushing a `sender.key.refresh` so a key that
-   * rotated during the offline window reaches the sidecar cache. Returns only
+   * yet acked, an address matching no known principal). The `mail.inbound` frame
+   * carries the result so a recipient verifies the signature locally against the
+   * hub-resolved key rather than the message's own spoofable From. Returns only
    * the key string, not its source, so the recipient cannot branch on sender
    * kind.
    *
    * Best-effort: this NEVER throws. A resolution fault degrades to `null`
    * (logged at ERROR by the resolver), so a key-resolution problem can never
    * block mail delivery. The strict, throwing resolver is `resolveSenderKey`
-   * in `@intx/db`. */
+   * in `@intx/db`; the reconnect reconciliation consumes it through
+   * `resolveSenderKeyStrict` below, which needs to tell a fault from a genuine
+   * absence. */
   resolveSenderKey?: (address: string) => Promise<string | null>;
+
+  /** Strict sibling of `resolveSenderKey` for the reconnect reconciliation. The
+   * register/reconnect handler re-resolves each reported cached sender and acts
+   * on the three-way outcome the best-effort resolver collapses:
+   *   - returns the hex key when the sender resolves -> push `sender.key.refresh`;
+   *   - returns `null` for a CONFIRMED absence (no matching principal = a deleted
+   *     sender) -> push `sender.key.evict`;
+   *   - THROWS on a fault (ambiguous address, a keyless-principal invariant
+   *     break, a DB error) -> keep the stale cached key, evict nothing.
+   * Never evicting on a throw is load-bearing: dropping a live key on a
+   * transient DB fault would be worse than doing nothing. Wraps the strict
+   * `resolveSenderKey` in `@intx/db` (unwrapped to the key string). Note the
+   * naming inversion: in `@intx/db` the STRICT resolver is `resolveSenderKey`
+   * and the best-effort one is `resolveFrameSenderKey`, whereas on this lookup
+   * type the best-effort field is `resolveSenderKey` and this is the strict
+   * one. */
+  resolveSenderKeyStrict?: (address: string) => Promise<string | null>;
 
   /** Co-writes the `signal_correlation` routing row and the `approval` row
    * for a suspending workflow agent step, in one transaction. Called from

--- a/packages/hub-sessions/src/ws/sidecar-handler.mail.test.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.mail.test.ts
@@ -13,6 +13,7 @@ import {
   createSidecarRouter,
   type SidecarAuthIdentity,
 } from "./sidecar-handler";
+import { MAX_MAIL_OUTBOUND_BODY_BYTES } from "@intx/types/sidecar";
 
 const TEST_SENDER = "sender@example.test";
 
@@ -682,5 +683,71 @@ describe("SidecarRouter workflow-trigger mail gating", () => {
     const inbound = framesOfType(ws, "mail.inbound");
     expect(inbound).toHaveLength(1);
     expect(inbound[0]?.["authenticatedSender"]).toBe(TEST_SENDER);
+  });
+});
+
+describe("SidecarRouter mail.outbound body cap", () => {
+  const smallRawMessage = btoa(
+    "From: run_anchor@tenant.example\r\nTo: run_anchor@tenant.example\r\nMessage-ID: <cap-1@example.test>\r\n\r\nbody",
+  );
+
+  function createCapRouter() {
+    return createAllocatedRouter({
+      lookups: {
+        async materializeMailTriggeredRunGrants() {
+          return { outcome: "materialized", stepGrants: [] };
+        },
+        async resolveSenderKey() {
+          return "ab".repeat(32);
+        },
+      },
+    });
+  }
+
+  test("delivers a within-cap mail.outbound", async () => {
+    const router = createCapRouter();
+    const ws = await connectAllocated(router, [
+      TEST_IDENTITY.workflowRunAddress,
+    ]);
+
+    router.handleMessage(
+      ws,
+      JSON.stringify({
+        type: "mail.outbound",
+        senderAddress: TEST_IDENTITY.workflowRunAddress,
+        rawMessage: smallRawMessage,
+        recipients: [TEST_IDENTITY.workflowRunAddress],
+      }),
+    );
+    await tick();
+
+    // A legit-sized frame is delivered: the cap does not false-reject.
+    expect(framesOfType(ws, "mail.inbound")).toHaveLength(1);
+  });
+
+  test("drops an over-cap mail.outbound before either delivery path", async () => {
+    const router = createCapRouter();
+    const ws = await connectAllocated(router, [
+      TEST_IDENTITY.workflowRunAddress,
+    ]);
+
+    // The array-length ceiling admits this frame (one recipient) and the
+    // schema puts no length bound on rawMessage, so it passes the union parse
+    // and reaches dispatch -- where the app-layer byte cap drops it. The
+    // materializer/mail-inbound fan-out never runs, so no frame is emitted.
+    const oversized = "A".repeat(MAX_MAIL_OUTBOUND_BODY_BYTES + 4);
+    router.handleMessage(
+      ws,
+      JSON.stringify({
+        type: "mail.outbound",
+        senderAddress: TEST_IDENTITY.workflowRunAddress,
+        rawMessage: oversized,
+        recipients: [TEST_IDENTITY.workflowRunAddress],
+      }),
+    );
+    await tick();
+
+    expect(framesOfType(ws, "mail.inbound")).toHaveLength(0);
+    expect(framesOfType(ws, "run.grants")).toHaveLength(0);
   });
 });

--- a/packages/hub-sessions/src/ws/sidecar-handler.test.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.test.ts
@@ -9,6 +9,7 @@ import {
 
 import { deriveWorkflowRunRepoId } from "@intx/workflow-deploy";
 import { configureSync, getConfig, resetSync } from "@intx/log";
+import { MAX_CACHED_SENDER_ADDRESSES_FRAME } from "@intx/types/sidecar";
 
 import {
   createSidecarRouter,
@@ -541,5 +542,17 @@ describe("SidecarRouter sender-key resync cap", () => {
     const warnings = capWarnings();
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain(String(MAX_RESYNC_SENDER_ADDRESSES + 1));
+  });
+
+  test("the cachedSenderAddresses frame ceiling stays above the resync cap", () => {
+    // These caps live in separate packages (`@intx/types` cannot import from
+    // `@intx/hub-sessions`), so the invariant that lets this handler degrade
+    // gracefully is only enforceable here, where both are visible. If the frame
+    // ceiling ever slipped to or below the resync cap, an over-cap report would
+    // fail the frame parse and drop the whole register frame -- turning the
+    // graceful slice-and-log degrade above into a hard reconnect outage.
+    expect(MAX_CACHED_SENDER_ADDRESSES_FRAME).toBeGreaterThan(
+      MAX_RESYNC_SENDER_ADDRESSES,
+    );
   });
 });

--- a/packages/hub-sessions/src/ws/sidecar-handler.test.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.test.ts
@@ -91,14 +91,14 @@ function createAllocatedRouter(
 }
 
 function createSenderKeyRouter(
-  resolveSenderKey: (address: string) => Promise<string | null>,
+  resolveSenderKeyStrict: (address: string) => Promise<string | null>,
 ) {
   const router = createSidecarRouter({
     authenticateSidecar: async () => identity,
     validateSidecarIdentity: async () => true,
     hubPublicKey: "a".repeat(64),
     requestTimeoutMs: 500,
-    lookups: { resolveSenderKey },
+    lookups: { resolveSenderKeyStrict },
   });
   router.fenceAllocation(identity.allocationId, identity.generation);
   return router;
@@ -234,7 +234,10 @@ describe("SidecarRouter allocation routing", () => {
     expect(frame.publicKey).toBe(key);
   });
 
-  test("skips a reported sender that resolves to no key", async () => {
+  test("evicts a reported sender that resolves to no key", async () => {
+    // A CONFIRMED null from the strict resolver is a deleted sender: the hub
+    // pushes an evict so the sidecar drops the stale key, rather than the old
+    // no-op-skip that left the revoked key cached forever.
     const resolved: string[] = [];
     const router = createSenderKeyRouter((address) => {
       resolved.push(address);
@@ -243,16 +246,44 @@ describe("SidecarRouter allocation routing", () => {
     const ws = await connect(router, [], {
       cachedSenderAddresses: ["usr_ghost@exclusive"],
     });
-    // Let the detached resync task run to completion.
-    await tick();
-    await tick();
 
-    // The resolver ran (the path executed) but nothing was pushed.
+    const frame = await waitForFrame(ws, (f) => f.type === "sender.key.evict");
+    expect(frame).toEqual({
+      type: "sender.key.evict",
+      address: "usr_ghost@exclusive",
+    });
     expect(resolved).toEqual(["usr_ghost@exclusive"]);
     const refreshes = ws.sent
       .map((raw): Record<string, unknown> => JSON.parse(raw))
       .filter((f) => f.type === "sender.key.refresh");
     expect(refreshes).toEqual([]);
+  });
+
+  test("keeps the stale key (no evict) when resolution faults", async () => {
+    // THE load-bearing distinction: a THROW is a transient/data fault, not a
+    // deleted sender. Evicting a live key on a DB blip would be worse than
+    // doing nothing, so a fault pushes NEITHER a refresh nor an evict -- the
+    // sidecar keeps verifying against its cached key until the next reconnect.
+    const resolved: string[] = [];
+    const router = createSenderKeyRouter((address) => {
+      resolved.push(address);
+      return Promise.reject(new Error("simulated resolver fault"));
+    });
+    const ws = await connect(router, [], {
+      cachedSenderAddresses: ["usr_faulty@exclusive"],
+    });
+    // Let the detached resync task run to completion.
+    await tick();
+    await tick();
+
+    // The resolve was attempted, and neither a refresh nor an evict was pushed.
+    expect(resolved).toEqual(["usr_faulty@exclusive"]);
+    const reconciliations = ws.sent
+      .map((raw): Record<string, unknown> => JSON.parse(raw))
+      .filter(
+        (f) => f.type === "sender.key.refresh" || f.type === "sender.key.evict",
+      );
+    expect(reconciliations).toEqual([]);
   });
 
   test("skips a run address in the report without resolving it", async () => {
@@ -272,13 +303,18 @@ describe("SidecarRouter allocation routing", () => {
         f.type === "sender.key.refresh" && f.address === "usr_bob@exclusive",
     );
     // The run address is filtered before resolution; only the user sender is
-    // resolved and refreshed.
+    // resolved and refreshed. The run address is never resolved and thus never
+    // evicted -- its key is the immutable workflow_run.public_key.
     expect(resolved).toEqual(["usr_bob@exclusive"]);
-    const refreshed = ws.sent
+    const reconciled = ws.sent
       .map((raw): Record<string, unknown> => JSON.parse(raw))
-      .filter((f) => f.type === "sender.key.refresh")
-      .map((f) => f.address);
-    expect(refreshed).toEqual(["usr_bob@exclusive"]);
+      .filter(
+        (f) => f.type === "sender.key.refresh" || f.type === "sender.key.evict",
+      )
+      .map((f) => ({ type: f.type, address: f.address }));
+    expect(reconciled).toEqual([
+      { type: "sender.key.refresh", address: "usr_bob@exclusive" },
+    ]);
   });
 
   test("deploys only through the exact allocation target", async () => {

--- a/packages/hub-sessions/src/ws/sidecar-handler.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.ts
@@ -16,6 +16,7 @@ import type { GrantWalkSnapshot } from "@intx/types";
 import { deriveWorkflowRunRepoId } from "@intx/workflow-deploy";
 import { type } from "arktype";
 import {
+  MAX_MAIL_OUTBOUND_BODY_BYTES,
   SidecarFrame,
   type AgentDeployAckFrame,
   type AgentDeployFrame,
@@ -1035,6 +1036,17 @@ export function createSidecarRouter(
         if (conn === undefined) return;
         if (!connOwnsAddress(conn, frame.senderAddress)) {
           logger.warn`Dropping mail.outbound from ${frame.senderAddress}: not registered to this sidecar`;
+          return;
+        }
+        // The DoS backstop and the trust boundary for an untrusted sidecar's
+        // mail body: measure the true byte cost (a hostile sidecar can send
+        // multi-byte UTF-8, so `.length` would undercount) and drop an over-cap
+        // frame here before either delivery path allocates on it. The socket's
+        // maxPayloadLength has already closed the connection for a truly huge
+        // frame; this catches one between the mail cap and that ceiling.
+        const bodyBytes = Buffer.byteLength(frame.rawMessage, "utf8");
+        if (bodyBytes > MAX_MAIL_OUTBOUND_BODY_BYTES) {
+          logger.warn`Dropping mail.outbound from ${frame.senderAddress}: rawMessage of ${String(bodyBytes)} bytes exceeds the ${String(MAX_MAIL_OUTBOUND_BODY_BYTES)}-byte cap`;
           return;
         }
         if (frame.delivered !== true) {

--- a/packages/hub-sessions/src/ws/sidecar-handler.ts
+++ b/packages/hub-sessions/src/ws/sidecar-handler.ts
@@ -1317,45 +1317,64 @@ export function createSidecarRouter(
     }
     // Reconcile the sidecar's cached sender keys, closing the offline window: a
     // user-principal key that rotated while the sidecar was disconnected is
-    // re-resolved and pushed back now, so the recipient stops verifying that
-    // sender's mail against a stale key. Only allocated sidecars host a sender
-    // cache worth refreshing. Resolve and push SEQUENTIALLY in one detached
-    // task: registration is never blocked, and a large cache cannot fan out
-    // into one concurrent DB query per reported sender on every reconnect.
-    const resolveSenderKey = lookups.resolveSenderKey;
-    if (identity.kind === "allocated" && resolveSenderKey !== undefined) {
+    // re-resolved and re-pushed, and a sender whose principal was DELETED while
+    // the sidecar was disconnected is evicted, so the recipient stops verifying
+    // either against a key the hub no longer vouches for. Only allocated
+    // sidecars host a sender cache worth reconciling. Resolve and push
+    // SEQUENTIALLY in one detached task: registration is never blocked, and a
+    // large cache cannot fan out into one concurrent DB query per reported
+    // sender on every reconnect.
+    const resolveSenderKeyStrict = lookups.resolveSenderKeyStrict;
+    if (identity.kind === "allocated" && resolveSenderKeyStrict !== undefined) {
       const rotatableSenders = new Set(cachedSenderAddresses);
       // Resolve-don't-trust applied to input SIZE: bound the reported set before
       // acting on it. Run addresses count toward the cap by design -- the
       // isRunAddress skip below is inside the loop, so the iteration, and thus
       // the DB resolves, can never exceed the cap regardless of the run/non-run
-      // mix. Over the cap, refresh the first MAX_RESYNC_SENDER_ADDRESSES and log
-      // the overflow so a misbehaving sidecar is detectable.
+      // mix. Over the cap, reconcile the first MAX_RESYNC_SENDER_ADDRESSES and
+      // log the overflow so a misbehaving sidecar is detectable.
       let sendersToResync = [...rotatableSenders];
       if (sendersToResync.length > MAX_RESYNC_SENDER_ADDRESSES) {
-        logger.warn`Sidecar ${identity.sidecarId} reported ${String(sendersToResync.length)} cached sender addresses on allocation ${identity.allocationId} generation ${String(identity.generation)}, over the ${String(MAX_RESYNC_SENDER_ADDRESSES)} resync cap; refreshing the first ${String(MAX_RESYNC_SENDER_ADDRESSES)} and ignoring the rest`;
+        logger.warn`Sidecar ${identity.sidecarId} reported ${String(sendersToResync.length)} cached sender addresses on allocation ${identity.allocationId} generation ${String(identity.generation)}, over the ${String(MAX_RESYNC_SENDER_ADDRESSES)} resync cap; reconciling the first ${String(MAX_RESYNC_SENDER_ADDRESSES)} and ignoring the rest`;
         sendersToResync = sendersToResync.slice(0, MAX_RESYNC_SENDER_ADDRESSES);
       }
       void (async () => {
         for (const address of sendersToResync) {
           // The sidecar already reports only non-run senders, but do not trust
           // the report: a run sender's key is the immutable
-          // workflow_run.public_key and never needs a refresh, so skip it here
-          // too rather than couple correctness to the sidecar's filter.
+          // workflow_run.public_key and is never refreshed or evicted, so skip
+          // it here too rather than couple correctness to the sidecar's filter.
           if (isRunAddress(address)) continue;
-          // Best-effort: a deleted or unresolvable sender resolves to null (the
-          // resolver logs a genuine fault at ERROR itself), so skip it and never
-          // fail the reconnect over one sender.
-          const publicKey = await resolveSenderKey(address);
+          // Tri-state, deleted-vs-fault distinguished by the STRICT resolver:
+          //   - resolves to a key -> refresh the sidecar's cached key;
+          //   - CONFIRMED null (no matching principal = a deleted sender) ->
+          //     evict it;
+          //   - THROWS (fault: ambiguous address, keyless-principal invariant
+          //     break, DB error) -> keep the stale key, evict nothing.
+          // Never evicting on a fault is the load-bearing property: dropping a
+          // live key on a transient DB fault would be worse than doing nothing.
+          // Only the resolve is guarded here; conn.send stays outside so a
+          // socket-gone throw propagates to the outer catch and stops the loop.
+          let publicKey: string | null;
+          try {
+            publicKey = await resolveSenderKeyStrict(address);
+          } catch (cause) {
+            const message =
+              cause instanceof Error ? cause.message : String(cause);
+            logger.error`Keeping the stale cached key for ${address}: resolving it faulted (a fault, not a deleted sender): ${message}`;
+            continue;
+          }
           if (publicKey !== null) {
             conn.send({ type: "sender.key.refresh", address, publicKey });
+          } else {
+            conn.send({ type: "sender.key.evict", address });
           }
         }
       })().catch((cause) => {
-        // resolveSenderKey never throws, but conn.send (JSON.stringify + the
-        // socket write) can throw synchronously once the sidecar is gone. That
-        // means the connection left, so stop -- the remaining sends would fail
-        // the same way.
+        // The per-address resolve is guarded above, so the only throw reaching
+        // here is conn.send (JSON.stringify + the socket write) once the sidecar
+        // is gone. That means the connection left, so stop -- the remaining
+        // sends would fail the same way.
         const message = cause instanceof Error ? cause.message : String(cause);
         logger.warn`Sender-key resync for sidecar ${identity.sidecarId} stopped: ${message}`;
       });

--- a/packages/types/src/sidecar.test.ts
+++ b/packages/types/src/sidecar.test.ts
@@ -6,13 +6,21 @@ import {
   CredentialsUpdateFrame,
   DeployApplyErrorCategory,
   HubFrame,
+  MAX_AGENT_ADDRESSES_FRAME,
+  MAX_CACHED_SENDER_ADDRESSES_FRAME,
+  MAX_CREDENTIAL_REVOCATIONS_FRAME,
+  MAX_MAIL_ADDRESSES_FRAME,
+  MAX_PROBE_GRANTS_FRAME,
   MailOutboundFrame,
   PackRejectFrame,
   PackRejectReason,
+  ReconnectFrame,
+  RegisterFrame,
   RunGrantsFrame,
   SidecarFrame,
   SignalCorrelationRegisterFrame,
   SourcesUpdateFrame,
+  WorkflowProbeResultFrame,
 } from "./sidecar";
 
 describe("MailOutboundFrame sender ownership claim", () => {
@@ -466,5 +474,228 @@ describe("RunGrantsFrame senderIdentities co-delivery", () => {
   test("an identity entry missing its address is rejected", () => {
     const bad = { ...base, senderIdentities: [{ publicKey: "aa".repeat(32) }] };
     expect(RunGrantsFrame(bad) instanceof type.errors).toBe(true);
+  });
+});
+
+describe("frame array-length ceilings", () => {
+  const addresses = (n: number) =>
+    Array.from({ length: n }, (_, i) => `addr-${String(i)}@example.test`);
+
+  describe("RegisterFrame agentAddresses", () => {
+    const base = { type: "register", sidecarId: "sc-1", token: "tok" };
+
+    test("accepts a frame at the ceiling", () => {
+      const frame = {
+        ...base,
+        agentAddresses: addresses(MAX_AGENT_ADDRESSES_FRAME),
+      };
+      expect(RegisterFrame(frame) instanceof type.errors).toBe(false);
+      expect(SidecarFrame(frame) instanceof type.errors).toBe(false);
+    });
+
+    test("rejects a frame past the ceiling through the union", () => {
+      const frame = {
+        ...base,
+        agentAddresses: addresses(MAX_AGENT_ADDRESSES_FRAME + 1),
+      };
+      expect(RegisterFrame(frame) instanceof type.errors).toBe(true);
+      expect(SidecarFrame(frame) instanceof type.errors).toBe(true);
+    });
+  });
+
+  describe("RegisterFrame cachedSenderAddresses", () => {
+    const base = {
+      type: "register",
+      sidecarId: "sc-1",
+      token: "tok",
+      agentAddresses: ["wf@example.test"],
+    };
+
+    test("accepts a count above the resync handler cap but within the ceiling", () => {
+      // The ceiling sits far above the hub-sessions `MAX_RESYNC_SENDER_ADDRESSES`
+      // handler cap (2048) so a report over that cap still parses and reaches the
+      // handler's graceful "resync the first N, log the overflow" degrade rather
+      // than dropping the whole register frame and stalling the reconnect.
+      const frame = { ...base, cachedSenderAddresses: addresses(2049) };
+      expect(RegisterFrame(frame) instanceof type.errors).toBe(false);
+      expect(SidecarFrame(frame) instanceof type.errors).toBe(false);
+    });
+
+    test("rejects a report past the ceiling through the union", () => {
+      const frame = {
+        ...base,
+        cachedSenderAddresses: addresses(MAX_CACHED_SENDER_ADDRESSES_FRAME + 1),
+      };
+      expect(RegisterFrame(frame) instanceof type.errors).toBe(true);
+      expect(SidecarFrame(frame) instanceof type.errors).toBe(true);
+    });
+  });
+
+  describe("MailOutboundFrame recipients", () => {
+    const base = {
+      type: "mail.outbound",
+      senderAddress: "sender@example.test",
+      rawMessage: "bWFpbA==",
+    };
+
+    test("accepts a frame at the ceiling", () => {
+      const frame = {
+        ...base,
+        recipients: addresses(MAX_MAIL_ADDRESSES_FRAME),
+      };
+      expect(MailOutboundFrame(frame) instanceof type.errors).toBe(false);
+    });
+
+    test("rejects recipients past the ceiling through the union", () => {
+      const frame = {
+        ...base,
+        recipients: addresses(MAX_MAIL_ADDRESSES_FRAME + 1),
+      };
+      expect(MailOutboundFrame(frame) instanceof type.errors).toBe(true);
+      expect(SidecarFrame(frame) instanceof type.errors).toBe(true);
+    });
+
+    test("rejects a cc list past the ceiling", () => {
+      const frame = {
+        ...base,
+        recipients: ["recipient@example.test"],
+        cc: addresses(MAX_MAIL_ADDRESSES_FRAME + 1),
+      };
+      expect(MailOutboundFrame(frame) instanceof type.errors).toBe(true);
+    });
+  });
+
+  describe("WorkflowProbeResultFrame grants", () => {
+    const projection = {
+      id: "wf-probe",
+      triggers: [],
+      stepOrder: ["s1"],
+      steps: { s1: { kind: "step", id: "s1" } },
+    };
+    const grantWalkSnapshot = {
+      perStep: [{ stepId: "s1", grants: [], grantEffects: {} }],
+      grantRequirements: [],
+    };
+    const base = {
+      type: "workflow.probe.result",
+      requestId: "req_1",
+      projection,
+      grantWalkSnapshot,
+      wireHash: "abc123",
+    };
+
+    test("accepts a frame at the ceiling", () => {
+      const frame = {
+        ...base,
+        grants: Array.from(
+          { length: MAX_PROBE_GRANTS_FRAME },
+          (_, i) => `grant-${String(i)}`,
+        ),
+      };
+      expect(WorkflowProbeResultFrame(frame) instanceof type.errors).toBe(
+        false,
+      );
+    });
+
+    test("rejects grants past the ceiling through the union", () => {
+      const frame = {
+        ...base,
+        grants: Array.from(
+          { length: MAX_PROBE_GRANTS_FRAME + 1 },
+          (_, i) => `grant-${String(i)}`,
+        ),
+      };
+      expect(WorkflowProbeResultFrame(frame) instanceof type.errors).toBe(true);
+      expect(SidecarFrame(frame) instanceof type.errors).toBe(true);
+    });
+  });
+
+  // The bounded optional fields moved from the `"string[]"` DSL to a chained
+  // `type("string").array().atMostLength(n)` value under a `"key?"` key. The
+  // regression that mechanical change risks is losing optionality (the key
+  // becomes required) or gaining a lower bound (an empty array is rejected).
+  describe("bounded optional fields stay optional", () => {
+    test("RegisterFrame validates with cachedSenderAddresses omitted or empty", () => {
+      const base = {
+        type: "register",
+        sidecarId: "sc-1",
+        token: "tok",
+        agentAddresses: ["wf@example.test"],
+      };
+      expect(RegisterFrame(base) instanceof type.errors).toBe(false);
+      expect(
+        RegisterFrame({ ...base, cachedSenderAddresses: [] }) instanceof
+          type.errors,
+      ).toBe(false);
+    });
+
+    test("ReconnectFrame validates with cachedSenderAddresses omitted or empty", () => {
+      const base = {
+        type: "reconnect",
+        sidecarId: "sc-1",
+        token: "tok",
+        agentAddresses: ["wf@example.test"],
+      };
+      expect(ReconnectFrame(base) instanceof type.errors).toBe(false);
+      expect(
+        ReconnectFrame({ ...base, cachedSenderAddresses: [] }) instanceof
+          type.errors,
+      ).toBe(false);
+    });
+
+    test("MailOutboundFrame validates with empty to and cc lists", () => {
+      const frame = {
+        type: "mail.outbound",
+        senderAddress: "sender@example.test",
+        rawMessage: "bWFpbA==",
+        recipients: ["recipient@example.test"],
+        to: [],
+        cc: [],
+      };
+      expect(MailOutboundFrame(frame) instanceof type.errors).toBe(false);
+    });
+
+    test("CredentialsUpdateFrame validates with an empty revoke list", () => {
+      const frame = {
+        type: "credentials.update",
+        requestId: "req_1",
+        agentAddress: "dep@example.test",
+        delivery: { bindings: [], materials: [] },
+        revoke: [],
+      };
+      expect(CredentialsUpdateFrame(frame) instanceof type.errors).toBe(false);
+    });
+  });
+
+  describe("CredentialsUpdateFrame revoke", () => {
+    const base = {
+      type: "credentials.update",
+      requestId: "req_1",
+      agentAddress: "dep@example.test",
+      delivery: { bindings: [], materials: [] },
+    };
+
+    test("accepts a revoke list at the ceiling", () => {
+      const frame = {
+        ...base,
+        revoke: Array.from(
+          { length: MAX_CREDENTIAL_REVOCATIONS_FRAME },
+          (_, i) => `cred-${String(i)}`,
+        ),
+      };
+      expect(CredentialsUpdateFrame(frame) instanceof type.errors).toBe(false);
+    });
+
+    test("rejects a revoke list past the ceiling through the union", () => {
+      const frame = {
+        ...base,
+        revoke: Array.from(
+          { length: MAX_CREDENTIAL_REVOCATIONS_FRAME + 1 },
+          (_, i) => `cred-${String(i)}`,
+        ),
+      };
+      expect(CredentialsUpdateFrame(frame) instanceof type.errors).toBe(true);
+      expect(HubFrame(frame) instanceof type.errors).toBe(true);
+    });
   });
 });

--- a/packages/types/src/sidecar.test.ts
+++ b/packages/types/src/sidecar.test.ts
@@ -10,7 +10,9 @@ import {
   MAX_CACHED_SENDER_ADDRESSES_FRAME,
   MAX_CREDENTIAL_REVOCATIONS_FRAME,
   MAX_MAIL_ADDRESSES_FRAME,
+  MAX_MAIL_OUTBOUND_BODY_BYTES,
   MAX_PROBE_GRANTS_FRAME,
+  MAX_SIDECAR_FRAME_BYTES,
   MailOutboundFrame,
   PackRejectFrame,
   PackRejectReason,
@@ -697,5 +699,18 @@ describe("frame array-length ceilings", () => {
       expect(CredentialsUpdateFrame(frame) instanceof type.errors).toBe(true);
       expect(HubFrame(frame) instanceof type.errors).toBe(true);
     });
+  });
+});
+
+describe("frame payload byte limits", () => {
+  test("the sidecar frame ceiling stays above the mail body cap", () => {
+    // maxPayloadLength must clear the largest legit received frame -- a
+    // mail.outbound whose rawMessage sits at the body cap, plus framing
+    // overhead -- or Bun would close the sidecar's control socket on a
+    // legitimate max-size mail. This pins that ordering, which the whole
+    // payload-limit design depends on.
+    expect(MAX_SIDECAR_FRAME_BYTES).toBeGreaterThan(
+      MAX_MAIL_OUTBOUND_BODY_BYTES,
+    );
   });
 });

--- a/packages/types/src/sidecar.test.ts
+++ b/packages/types/src/sidecar.test.ts
@@ -19,6 +19,7 @@ import {
   ReconnectFrame,
   RegisterFrame,
   RunGrantsFrame,
+  SenderKeyEvictFrame,
   SidecarFrame,
   SignalCorrelationRegisterFrame,
   SourcesUpdateFrame,
@@ -712,5 +713,41 @@ describe("frame payload byte limits", () => {
     expect(MAX_SIDECAR_FRAME_BYTES).toBeGreaterThan(
       MAX_MAIL_OUTBOUND_BODY_BYTES,
     );
+  });
+});
+
+describe("SenderKeyEvictFrame", () => {
+  const frame = {
+    type: "sender.key.evict",
+    address: "usr_deleted@tenant.test",
+  };
+
+  test("the HubFrame union admits an evict frame and round-trips it", () => {
+    // The sidecar parses inbound frames through the HubFrame union, so the
+    // evict must reach its member and keep its address.
+    const out = HubFrame(frame);
+    if (out instanceof type.errors) {
+      throw new Error(`expected a valid HubFrame: ${out.summary}`);
+    }
+    if (out.type !== "sender.key.evict") {
+      throw new Error(`expected a sender.key.evict frame, got ${out.type}`);
+    }
+    expect(out.address).toBe("usr_deleted@tenant.test");
+  });
+
+  test("carries no publicKey (it is not a refresh)", () => {
+    // The evict frame is deliberately keyless; a stray publicKey is an
+    // undeclared key arktype passes through, so assert the parsed frame's shape
+    // holds only the address.
+    const out = SenderKeyEvictFrame(frame);
+    if (out instanceof type.errors) {
+      throw new Error(`expected a valid frame: ${out.summary}`);
+    }
+    expect("publicKey" in out).toBe(false);
+  });
+
+  test("rejects a frame with no address", () => {
+    const out = SenderKeyEvictFrame({ type: "sender.key.evict" });
+    expect(out instanceof type.errors).toBe(true);
   });
 });

--- a/packages/types/src/sidecar.ts
+++ b/packages/types/src/sidecar.ts
@@ -22,6 +22,53 @@ import { ToolPackageManifest } from "./tool-packages";
 import { WorkflowDefinitionSource } from "./workflow-sources";
 
 // ---------------------------------------------------------------------------
+// Frame array-length ceilings
+// ---------------------------------------------------------------------------
+//
+// Hostile-absurdity upper bounds on the unbounded `string[]` fields of the wire
+// frames below. They bound element COUNT, not byte size: a peer that sends a
+// `string[]` of millions of tiny elements costs little in bytes but forces the
+// receiver to allocate, iterate, dedup, or map over an absurd count. A total
+// payload byte limit is the weakest defense exactly here -- many one-character
+// elements are a huge count at a small byte cost -- so element-count caps are
+// the right tool for `string[]`. The object-typed frame arrays are out of scope
+// for these caps: their elements each carry many bytes, so an absurd count of
+// them is far costlier on the wire, and a payload-size limit is the right
+// backstop for that byte-heavy dimension. An over-count frame fails this parse
+// and routes through the existing invalid-frame drop+log path; no handler change
+// is needed.
+
+// A sidecar's reported agent addresses. The register/reconnect handler already
+// gates each reported address against the allocation's single minted workflow
+// address, so the legitimate count is ~1; this is a generous absurdity backstop.
+export const MAX_AGENT_ADDRESSES_FRAME = 512;
+
+// A sidecar's reported cached sender addresses. This MUST stay well above the
+// `MAX_RESYNC_SENDER_ADDRESSES` handler cap (currently 2048 in the hub-sessions
+// sidecar-handler): that cap drives a graceful "resync the first N, log the
+// overflow" degrade rather than dropping the frame, so a schema ceiling at or
+// below it would turn the degrade into a hard reconnect outage -- the whole
+// register frame would fail this parse and drop, and the sidecar could not
+// reconnect. The `@intx/types` package must not import from `@intx/hub-sessions`,
+// so the coupling is a documented invariant guarded by a test in that package.
+export const MAX_CACHED_SENDER_ADDRESSES_FRAME = 65536;
+
+// A mail frame's recipient / To / Cc address lists. `recipients` is the routing
+// set; `to`/`cc` are audit-only header metadata. A modest ceiling far above any
+// real recipient list.
+export const MAX_MAIL_ADDRESSES_FRAME = 1024;
+
+// A workflow probe result's flattened grant strings (the deduped union of every
+// step's grants). No enforced workflow step-count or per-step grant-count cap
+// exists to derive this from, so it is a reasonable absurdity ceiling rather
+// than a computed bound.
+export const MAX_PROBE_GRANTS_FRAME = 8192;
+
+// A credentials-update frame's revoked credential ids. A modest ceiling far
+// above any real credential set.
+export const MAX_CREDENTIAL_REVOCATIONS_FRAME = 1024;
+
+// ---------------------------------------------------------------------------
 // Sidecar → Hub
 // ---------------------------------------------------------------------------
 
@@ -34,14 +81,18 @@ export const RegisterFrame = type({
   type: "'register'",
   sidecarId: "string",
   token: "string",
-  agentAddresses: "string[]",
+  agentAddresses: type("string")
+    .array()
+    .atMostLength(MAX_AGENT_ADDRESSES_FRAME),
   // The rotatable (non-run) sender addresses this sidecar holds cached keys
   // for. The hub re-resolves each current key and re-pushes it on a
   // `sender.key.refresh`, so a user-principal rotation that landed while the
   // sidecar was disconnected reaches its cache. Additive-optional and omitted
   // when empty: a sidecar with no cached senders (or a pre-upgrade one) sends
   // no field, and the hub treats absence as "nothing to refresh".
-  "cachedSenderAddresses?": "string[]",
+  "cachedSenderAddresses?": type("string")
+    .array()
+    .atMostLength(MAX_CACHED_SENDER_ADDRESSES_FRAME),
 });
 export type RegisterFrame = typeof RegisterFrame.infer;
 
@@ -54,13 +105,17 @@ export const ReconnectFrame = type({
   type: "'reconnect'",
   sidecarId: "string",
   token: "string",
-  agentAddresses: "string[]",
+  agentAddresses: type("string")
+    .array()
+    .atMostLength(MAX_AGENT_ADDRESSES_FRAME),
   // The rotatable (non-run) sender addresses this sidecar holds cached keys
   // for; see `RegisterFrame`. Carried on both frames because the register vs
   // reconnect choice turns on workflow-address presence, not sender-cache
   // presence -- a sidecar that restored no workflow substrate still reports its
   // cached senders on a register frame. Additive-optional, omitted when empty.
-  "cachedSenderAddresses?": "string[]",
+  "cachedSenderAddresses?": type("string")
+    .array()
+    .atMostLength(MAX_CACHED_SENDER_ADDRESSES_FRAME),
 });
 export type ReconnectFrame = typeof ReconnectFrame.infer;
 
@@ -98,12 +153,12 @@ export type AgentErrorFrame = typeof AgentErrorFrame.infer;
 export const MailOutboundFrame = type({
   type: "'mail.outbound'",
   rawMessage: "string",
-  recipients: "string[]",
+  recipients: type("string").array().atMostLength(MAX_MAIL_ADDRESSES_FRAME),
   senderAddress: "string",
   "sessionId?": "string",
   "messageId?": "string",
-  "to?": "string[]",
-  "cc?": "string[]",
+  "to?": type("string").array().atMostLength(MAX_MAIL_ADDRESSES_FRAME),
+  "cc?": type("string").array().atMostLength(MAX_MAIL_ADDRESSES_FRAME),
   "delivered?": "boolean",
 });
 export type MailOutboundFrame = typeof MailOutboundFrame.infer;
@@ -646,7 +701,9 @@ export const CredentialsUpdateFrame = type({
   requestId: "string",
   agentAddress: "string",
   delivery: CredentialDelivery,
-  "revoke?": "string[]",
+  "revoke?": type("string")
+    .array()
+    .atMostLength(MAX_CREDENTIAL_REVOCATIONS_FRAME),
 });
 export type CredentialsUpdateFrame = typeof CredentialsUpdateFrame.infer;
 
@@ -993,7 +1050,7 @@ export const WorkflowProbeResultFrame = type({
   type: "'workflow.probe.result'",
   requestId: "string",
   projection: WorkflowProjectionDefinition,
-  grants: "string[]",
+  grants: type("string").array().atMostLength(MAX_PROBE_GRANTS_FRAME),
   grantWalkSnapshot: GrantWalkSnapshot,
   wireHash: "string",
 });

--- a/packages/types/src/sidecar.ts
+++ b/packages/types/src/sidecar.ts
@@ -466,6 +466,26 @@ export const SenderKeyRefreshFrame = type({
 export type SenderKeyRefreshFrame = typeof SenderKeyRefreshFrame.infer;
 
 /**
+ * Evict a cached sender key, keyed by the sender's `address`. The sidecar
+ * durably removes its cached key for `address` and touches nothing else. The
+ * hub sends it during reconnect reconciliation for a reported cached sender it
+ * re-resolves to NO durable key -- a sender whose principal was deleted while
+ * the sidecar was disconnected -- so the sidecar stops verifying that sender's
+ * mail against a key the hub no longer vouches for.
+ *
+ * A dedicated sibling of `sender.key.refresh` rather than a mode on it: that
+ * frame's doc argues against a mode-dependent shape, and a refresh always
+ * carries a key whereas an evict never does, so a shared frame would make
+ * `publicKey` conditionally present. One address per frame keeps each eviction
+ * independently fallible, the same property the refresh frame preserves.
+ */
+export const SenderKeyEvictFrame = type({
+  type: "'sender.key.evict'",
+  address: "string",
+});
+export type SenderKeyEvictFrame = typeof SenderKeyEvictFrame.infer;
+
+/**
  * Deliver a workflow-host drain control payload to a multi-step
  * deployment's supervisor. The hub forwards the frame to the sidecar
  * that hosts the deployment named by `agentAddress` (the
@@ -1148,6 +1168,7 @@ export const HubFrame = type.or(
   SignalDeliverFrame,
   RunGrantsFrame,
   SenderKeyRefreshFrame,
+  SenderKeyEvictFrame,
   SignalCorrelationRegisterAckFrame,
   DrainDeliverFrame,
   WorkflowProbeRequestFrame,

--- a/packages/types/src/sidecar.ts
+++ b/packages/types/src/sidecar.ts
@@ -69,6 +69,42 @@ export const MAX_PROBE_GRANTS_FRAME = 8192;
 export const MAX_CREDENTIAL_REVOCATIONS_FRAME = 1024;
 
 // ---------------------------------------------------------------------------
+// Frame payload byte limits
+// ---------------------------------------------------------------------------
+//
+// Byte-size ceilings on the control socket, complementary to the element-count
+// ceilings above. One layer owns each dimension: the hub sidecar websocket's
+// maxPayloadLength owns the whole-frame byte size, and the mail body cap owns
+// one mail's rawMessage.
+
+// The largest rawMessage (base64-encoded MIME) a `mail.outbound` frame may
+// carry. A shared-policy ceiling: it holds the SAME number as `@intx/hub-api`'s
+// `MAX_MAIL_BODY_BYTES`, which caps the inbound HTTP mail route's whole request
+// body, so the frame path and the HTTP path enforce the same body ceiling. The
+// two measure different quantities -- an HTTP whole request body vs the frame's
+// rawMessage alone -- so they are deliberately separate constants held equal by
+// a guard test rather than one constant conflating two policies.
+// Enforced symmetrically: the hub drops an over-cap received frame (the DoS
+// backstop) and the sidecar refuses to send one.
+export const MAX_MAIL_OUTBOUND_BODY_BYTES = 44 * 1024 * 1024;
+
+// Headroom above the largest legit received frame for its base64/JSON framing
+// and its (separately count-capped) address arrays, so `maxPayloadLength` never
+// closes the socket on a legitimate mail frame whose rawMessage sits at the body
+// cap.
+const FRAME_OVERHEAD_BYTES = 20 * 1024 * 1024;
+
+// The ceiling wired as the hub sidecar websocket's `maxPayloadLength`. Bun
+// closes the connection on a RECEIVED message larger than this, so it must clear
+// the largest legit received frame -- the `mail.outbound` frame, whose
+// rawMessage is bounded by `MAX_MAIL_OUTBOUND_BODY_BYTES`, plus framing
+// overhead. maxPayloadLength gates incoming messages only; it does NOT limit
+// what the hub sends, so the hub->sidecar inline-asset deploy does not factor
+// into this number.
+export const MAX_SIDECAR_FRAME_BYTES =
+  MAX_MAIL_OUTBOUND_BODY_BYTES + FRAME_OVERHEAD_BYTES;
+
+// ---------------------------------------------------------------------------
 // Sidecar → Hub
 // ---------------------------------------------------------------------------
 

--- a/tests/workflow-deploy/boot-restore.bench.ts
+++ b/tests/workflow-deploy/boot-restore.bench.ts
@@ -382,6 +382,7 @@ async function buildRouter(args: {
     senderKeyCache: {
       get: () => undefined,
       put: async () => undefined,
+      evict: async () => undefined,
       addresses: () => [],
       rotatableAddresses: () => [],
     },


### PR DESCRIPTION
## Summary

- **Bound the unbounded `string[]` frame fields** (INTR-525): fail-loud
  `.atMostLength` limits on `agentAddresses`, `cachedSenderAddresses`, mail
  `recipients`/`to`/`cc`, probe `grants`, and credential `revoke`, so an
  oversized wire frame is rejected at the parse boundary. The
  `cachedSenderAddresses` ceiling sits well above the reconnect resync handler
  cap, so a merely-large report still hits that graceful degrade rather than a
  hard reject.
- **Pin the frame payload limits** (INTR-526): an explicit websocket
  `maxPayloadLength` — driven by the 44 MB received `mail.outbound` frame,
  which fixes a latent truncation from Bun's 16 MB default — plus an app-layer
  byte cap on `mail.outbound` (hub-receive warn+drop as the authoritative
  backstop, send-site throw to surface to the producer, audit-site log),
  symmetric with the inbound mail-body cap.
- **Evict a deleted sender's cached key on reconnect** (INTR-524): on reconnect
  the hub re-resolves each reported cached sender and, when the sender is
  *confirmed absent* (hard-deleted), pushes a `sender.key.evict` that durably
  removes the key from the sidecar cache. A resolver *fault* keeps the stale
  key rather than dropping a live one — a strict tri-state (resolve→refresh,
  confirmed-absent→evict, throw→keep). Hard-delete only by design.

## Verification

- Lint, `tsc -b --noEmit --force`, the admin-ui bundle, and the full unit suite
  pass (7408 tests, 0 fail). The new behavior is covered by unit and
  integration tests: the frame-bound rejections and the ceiling > resync-cap
  invariant; the mail-body cap (over-cap drop, send-throw, audit-log) and the
  `maxPayloadLength` > mail-cap guard; the durable evict; and the load-bearing
  tri-state case — a resolver fault does NOT evict.
- The real-process `test-workflow` end-to-end suite (the reconnect suites
  especially, which exercise the resync loop INTR-524 touches) runs in CI as
  the authoritative end-to-end gate.

Closes INTR-524
Closes INTR-525
Closes INTR-526
